### PR TITLE
Add info build target in docs/Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -91,16 +91,14 @@ doctest:
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 texinfo:
-	mkdir -p _build/texinfo
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) _build/texinfo
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
-	@echo "Build finished. The Texinfo files are in build/texinfo."
+	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
 
 info:
-	mkdir -p _build/texinfo
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) _build/texinfo
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
-	make -C _build/texinfo info
-	@echo "makeinfo finished; the Info files are in build/texinfo."
+	make -C $(BUILDDIR)/texinfo info
+	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -178,9 +178,10 @@ latex_logo = "e-logo-rev.png"
 #latex_use_modindex = True
 
 
+# Options for Texinfo output
+# --------------------------
+
 texinfo_documents = [
-  (master_doc, 'traits', 'Traits 4 User Manual',
-   'Enthought, Inc.',
-   'Traits', 'explicitly typed attributes for Python',
-   1),
+  (master_doc, 'traits', 'Traits 4 User Manual', 'Enthought, Inc.',
+   'Traits', 'Explicitly typed attributes for Python.', 'Python'),
 ]


### PR DESCRIPTION
<del>Build fails now as it seems there is a bug in sphinx-info.  Once the bug is fixed, it should be able to build the document without any further modifications.</del>


<del>See the upstream bug report:</del> https://bitbucket.org/jonwaltman/sphinx-info/issue/2

I think it's good to go now.
