### PR TITLE
Fix a bug where metadata were shared between different TraitType instances.

### DIFF
--- a/traits/tests/test_trait_types.py
+++ b/traits/tests/test_trait_types.py
@@ -27,6 +27,8 @@
 
 import unittest
 
+from traits.api import Float, TraitType
+
 #-------------------------------------------------------------------------------
 #  'TraitTypesTest' unit test class:
 #-------------------------------------------------------------------------------
@@ -57,6 +59,18 @@ class TraitTypesTest ( unittest.TestCase ):
 
     def test_ ( self ):
         pass
+
+    def test_traits_shared_transient(self):
+        # Regression test for a bug in traits where the same _metadata
+        # dictionary was shared between different trait types.
+        class LazyProperty(TraitType):
+            def get(self, obj, name):
+                return 1729
+
+        self.assertFalse(Float().transient)
+        LazyProperty().as_ctrait()
+        self.assertFalse(Float().transient)
+
 
 # Run the unit tests (if invoked from the command line):
 if __name__ == '__main__':

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -531,7 +531,7 @@ class TraitType ( BaseTraitHandler ):
             else:
                 self._metadata = metadata
         else:
-            self._metadata = self.metadata
+            self._metadata = self.metadata.copy()
 
         self.init()
 


### PR DESCRIPTION
This PR appears to fix a bug where creating a subclass of `TraitType` and calling its `as_ctrait` method changed the metadata on `TraitTypes` itself.

I'm not familiar with this part of traits, so it would be great if someone more familiar with the code could review for sanity.  All tests pass on my machine with this change.
