### PR TITLE
Fix validation of numpy types depending on numpy being imported.

### DIFF
--- a/traits/tests/test_trait_types.py
+++ b/traits/tests/test_trait_types.py
@@ -21,44 +21,11 @@
 """ Unit test case for testing trait types created by subclassing TraitType.
 """
 
-#-------------------------------------------------------------------------------
-#  Imports:
-#-------------------------------------------------------------------------------
-
 from traits.testing.unittest_tools import unittest
 
 from traits.api import Float, TraitType
 
-#-------------------------------------------------------------------------------
-#  'TraitTypesTest' unit test class:
-#-------------------------------------------------------------------------------
-
 class TraitTypesTest ( unittest.TestCase ):
-
-    #---------------------------------------------------------------------------
-    #  Test fixture set-up:
-    #---------------------------------------------------------------------------
-
-    def setUp ( self ):
-        """ Test fixture set-up.
-        """
-        pass
-
-    #---------------------------------------------------------------------------
-    #  Test fixture tear-down:
-    #---------------------------------------------------------------------------
-
-    def tearDown ( self ):
-        """ Test fixture tear-down.
-        """
-        pass
-
-    #---------------------------------------------------------------------------
-    #  Individual unit test methods:
-    #---------------------------------------------------------------------------
-
-    def test_ ( self ):
-        pass
 
     def test_traits_shared_transient(self):
         # Regression test for a bug in traits where the same _metadata
@@ -70,6 +37,24 @@ class TraitTypesTest ( unittest.TestCase ):
         self.assertFalse(Float().transient)
         LazyProperty().as_ctrait()
         self.assertFalse(Float().transient)
+
+    def test_numpy_validators_loaded_if_numpy_present(self):
+        # If 'numpy' is available, the numpy validators should be loaded.
+
+        # Make sure that numpy is present on this machine.
+        try:
+            import numpy
+        except ImportError:
+            self.skipTest("numpy library not found.")
+
+        # Remove numpy from the list of imported modules.
+        import sys
+        del sys.modules['numpy']
+
+        # Check that the validators contain the numpy types.
+        from traits.trait_types import float_fast_validate
+        import numpy
+        self.assertIn(numpy.floating, float_fast_validate)
 
 
 # Run the unit tests (if invoked from the command line):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -59,7 +59,24 @@ SetTypes     = SequenceTypes + ( set, )
 #  Numeric type fast validator definitions:
 #-------------------------------------------------------------------------------
 
-if sys.modules.get( 'numpy' ) is not None:
+# Validator #11 is a generic validator for possibly coercible types
+# (see validate_trait_coerce_type in ctraits.c).
+#
+# The tuples below are of the form
+# (11, type1, [type2, type3, ...], [None, ctype1, [ctype2, ...]])
+#
+# 'type1' corresponds to the main type for the trait
+# 'None' acts as the separator between 'types' and 'ctypes' (coercible types)
+#
+# The validation passes if:
+# 1) The trait value type is (a subtype of) one of 'type1', 'type2',  ...
+#    in which case the value is returned as-is
+# or
+# 2) The trait value type is (a subtype of) one of 'ctype1', 'ctype2', ...
+#    in which case the value is returned coerced to trait type using
+#    'return type1(value')
+
+try:
     # The numpy enhanced definitions:
     from numpy import integer, floating, complexfloating, bool_
 
@@ -69,7 +86,7 @@ if sys.modules.get( 'numpy' ) is not None:
     complex_fast_validate = ( 11, complex, complexfloating, None,
                                   float, floating, int, integer )
     bool_fast_validate    = ( 11, bool, bool_ )
-else:
+except ImportError:
     # The standard python definitions (without numpy):
     int_fast_validate     = ( 11, int )
     long_fast_validate    = ( 11, long,    None, int )


### PR DESCRIPTION
If numpy was not imported before traits, validators did not consider
numpy types.

E.g.

```
import numpy
from traits.api import Float, HasTraits

class A(HasTraits):
    n = Float

a = A()
a.n = numpy.float32(0.5)  # suceeds
```

```
from traits.api import Float, HasTraits
import numpy

class A(HasTraits):
    n = Float

a = A()
a.n = numpy.float32(0.5)  # fails
```
