### PR TITLE
Fix link from Travis CI build badge to point to the actual build page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ traits: explicitly typed attributes for Python
 http://github.enthought.com/traits
 
 .. image:: https://api.travis-ci.org/enthought/traits.png?branch=master
-   :target: https://api.travis-ci.org/enthought/traits
+   :target: https://travis-ci.org/enthought/traits
    :alt: Build status
 
 The Traits project is at the center of all Enthought Tool Suite development


### PR DESCRIPTION
The link in the README pointed to https://api.travis-ci.org/enthought/traits rather than the build page at https://travis-ci.org/enthought/traits, so it just returned JSON instead of taking you to the build page.
