### PR TITLE
Fix array validator

### DIFF
--- a/traits/tests/test_cythonized_traits.py
+++ b/traits/tests/test_cythonized_traits.py
@@ -17,6 +17,12 @@ def has_no_compiler():
     except:
         return True
 
+def cython_version():
+    if no_cython:
+        return None
+    from Cython.Compiler.Version import version
+    return tuple(int(v) for v in version.split('.'))
+
 SKIP_TEST = has_no_compiler()
 
 class CythonizedTraitsTestCase(unittest.TestCase, UnittestTools):
@@ -61,7 +67,7 @@ return Test()
 
 
 
-    @unittest.skipIf(SKIP_TEST, 'Missing Cython and/or compiler')
+    @unittest.skipIf(SKIP_TEST or cython_version() <= (0,19,1), 'Triggers Cython bug')
     def test_on_trait_change_decorator(self):
 
         code = """

--- a/traits/trait_numeric.py
+++ b/traits/trait_numeric.py
@@ -151,10 +151,7 @@ class AbstractArray ( TraitType ):
         """
         try:
             # Make sure the value is an array:
-            type_value = type( value )
             if not isinstance( value, ndarray ):
-                if not isinstance( value, SequenceTypes ):
-                    self.error( object, name, value )
                 if self.dtype is not None:
                     value = asarray( value, self.dtype )
                 else:


### PR DESCRIPTION
In my eyes, the behaviour of the Array-trait's validator is inconsistent with the documentation: The documentation claims that it will coerce values as if given to the `np.array` function. However, in fact, it rejects everything that is not either an `np.ndarray` instance itself or a Sequence. `np.array` on the other hand is far more lenient.

This is particularly striking with scalars: Python scalars would get converted to zero-dimensional arrays which fulfil most array-requirements perfectly fine! 
