### PR TITLE
Add back stub documentation for the traits.protocols package

### DIFF
--- a/docs/source/traits_api_reference/index.rst
+++ b/docs/source/traits_api_reference/index.rst
@@ -31,6 +31,7 @@ Subpackages
 
     traits.adaptation
     traits.etsconfig
+    traits.protocols
     traits.testing
     traits.util
 

--- a/docs/source/traits_api_reference/traits.protocols.rst
+++ b/docs/source/traits_api_reference/traits.protocols.rst
@@ -1,0 +1,10 @@
+:mod:`protocols` Package
+========================
+
+.. note:: The :mod:`traits.protocols` package is deprecated.  Use the :mod:`traits.adaptation` package instead in new code.
+
+
+.. automodule:: traits.protocols
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/traits/protocols/__init__.py
+++ b/traits/protocols/__init__.py
@@ -1,8 +1,8 @@
 """Trivial Interfaces and Adaptation from PyProtocols.
 
-This package used to be a subset of the files from Phillip J. Eby's
-PyProtocols package. The package has been substituted by `traits.adaptation` as
-of Traits 4.4.0.
+This package used to be a subset of the files from Phillip J. Eby's PyProtocols
+package. The package has been substituted by :mod:`traits.adaptation` as of
+Traits 4.4.0.
 
 Currently, the package contains deprecated aliases for backward compatibility,
 and will be removed in Traits 5.0 .

--- a/traits/protocols/api.py
+++ b/traits/protocols/api.py
@@ -1,8 +1,8 @@
 """Trivial Interfaces and Adaptation from PyProtocols.
 
-This package used to be a subset of the files from Phillip J. Eby's
-PyProtocols package. The package has been substituted by `traits.adaptation` as
-of Traits 4.4.0.
+This package used to be a subset of the files from Phillip J. Eby's PyProtocols
+package. The package has been substituted by :mod:`traits.adaptation` as of
+Traits 4.4.0.
 
 Currently, the package contains deprecated aliases for backward compatibility,
 and will be removed in Traits 5.0 .


### PR DESCRIPTION
This PR adds back minimal documentation for the `traits.protocols` package.

@pberkes: Thoughts?
