### PR TITLE
BUG: Clear the exception when raising a TraitError.

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -296,6 +296,10 @@ static PyObject *
 raise_trait_error ( trait_object * trait, has_traits_object * obj,
                                     PyObject * name, PyObject * value ) {
 
+    /* Clear any current exception. We are handling it by raising
+     * a TraitError. */
+    PyErr_Clear();
+
     PyObject * result = PyObject_CallMethod( trait->handler,
                                           "error", "(OOO)", obj, name, value );
     Py_XDECREF( result );
@@ -3541,8 +3545,6 @@ validate_trait_cast_type ( trait_object * trait, has_traits_object * obj,
     if ( (result = type_converter( type, value )) != NULL )
         return result;
 
-    PyErr_Clear();
-
     return raise_trait_error( trait, obj, name, value );
 }
 
@@ -3560,8 +3562,6 @@ validate_trait_function ( trait_object * trait, has_traits_object * obj,
                              obj, name, value );
     if ( result != NULL )
         return result;
-
-    PyErr_Clear();
 
     return raise_trait_error( trait, obj, name, value );
 }


### PR DESCRIPTION
When we call raise_trait_error(), we are usually doing so after some other exception has been raised. In Python code, we would be catching this error using `try: except: raise TraitError()`. In C, we should use `PyErr_Clear(); raise_trait_error();`. Since we always want to clear the exception when we raise the `TraitError`, this PR moves the call into `raise_trait_error()`.

In most code, you will not see a difference in behavior. However, when we run the unit tests under `coverage`, something about the tracing hooks is prodding places that should not be prodded without having a consistent exception state. So we get test failures when we test Trait validation that look like this:

```
/Users/rkern/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/traits/trait_handlers.py:331: RuntimeWarning: tp_compare didn't return -1 or -2 for exception
  return self.info()
...
======================================================================
ERROR: test_assignment (traits.tests.test_traits.FloatRangeTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rkern/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/traits/tests/test_traits.py", line 71, in test_assignment
    self.assertRaises(TraitError, self.assign, value)
  File "/Applications/Canopy.app/appdata/canopy-1.1.0.1371.macosx-x86_64/Canopy.app/Contents/lib/python2.7/unittest/case.py", line 471, in assertRaises
    callableObj(*args, **kwargs)
  File "/Users/rkern/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/traits/tests/test_traits.py", line 37, in assign
    self.obj.value = value
  File "/Users/rkern/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/traits/trait_handlers.py", line 172, in error
    raise TraitError( object, name, self.full_info( object, name, value ),
  File "/Users/rkern/Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/traits/trait_handlers.py", line 331, in full_info
    return self.info()
TypeError
```
