### PR TITLE
document effect of '__traits_version__' entry on __setstate__

### DIFF
--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -1266,6 +1266,12 @@ strategy has the advantage of generating trait change notifications for each
 attribute. These notifications are important for classes that rely on them to
 ensure that their internal object state remains consistent and up to date.
 
+**Notice:** the output dictionary of __getstate__() automatically contains
+a '__traits_version__' entry which presence is important for the
+__setstate__() method to work properly.
+If absent, the __setstate__() method falls back to a compatibility mode which
+won't restore the trait notifications properly.
+
 .. index:: __setstate__(); overriding
 
 .. _overriding-setstate:


### PR DESCRIPTION
I just ran into a nasty bug while doing json-based traits serialization. After restoring my traits, some notifications were broken.

After digging into the code (setstate: https://github.com/enthought/traits/blob/master/traits/has_traits.py#L1427), I noticed it was my fault because I had "cleaned out" the '__traits_version__' entry from the state dictionary. However, the usefulness of this entry is not documented

I propose to add this explicative warning to discourage other people from having the same idea...