### PR TITLE
Document the 'provides' decorator

### DIFF
--- a/docs/source/traits_api_reference/has_traits.rst
+++ b/docs/source/traits_api_reference/has_traits.rst
@@ -67,14 +67,16 @@ ABC classes
 Functions
 ---------
 
+.. autofunction:: cached_property
+
 .. autofunction:: get_delegate_pattern
 
-.. autofunction:: weak_arg
-
-.. autofunction:: property_depends_on
-
-.. autofunction:: cached_property
+.. autofunction:: implements
 
 .. autofunction:: on_trait_change
 
-.. autofunction:: implements
+.. autofunction:: property_depends_on
+
+.. autofunction:: provides
+
+.. autofunction:: weak_arg

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3607,6 +3607,10 @@ def implements( *interfaces ):
     interface that the containing class implements. Each specified interface
     must be a subclass of **Interface**. This function should only be
     called from directly within a class body.
+
+    .. deprecated:: 4.4
+       Use the ``provides`` class decorator instead.
+
     """
 
     callback = provides(*interfaces)


### PR DESCRIPTION
- Add autodoc reference for the 'provides' decorator.
- Order functions alphabetically in the docs.
- Add doc note that use of 'implements' is deprecated.
