### PR TITLE
Fix some more uses of deprecated unittest methods.

### DIFF
--- a/traits/tests/test_clone.py
+++ b/traits/tests/test_clone.py
@@ -165,9 +165,9 @@ class CloneTestCase(unittest.TestCase):
 
         bar_copy = bar.clone_traits()
 
-        self.failIf(bar_copy is bar)
-        self.failUnless(bar_copy.other is baz)
-        self.failUnless(bar_copy.other.other is bar)
+        self.assertIsNot(bar_copy, bar)
+        self.assertIs(bar_copy.other, baz)
+        self.assertIs(bar_copy.other.other, bar)
 
     def test_Any_circular_references_deep(self):
 
@@ -179,10 +179,10 @@ class CloneTestCase(unittest.TestCase):
 
         bar_copy = bar.clone_traits(copy='deep')
 
-        self.failIf(bar_copy is bar)
-        self.failIf(bar_copy.other is baz)
-        self.failIf(bar_copy.other.other is bar)
-        self.failUnless(bar_copy.other.other is bar_copy)
+        self.assertIsNot(bar_copy, bar)
+        self.assertIsNot(bar_copy.other, baz)
+        self.assertIsNot(bar_copy.other.other, bar)
+        self.assertIs(bar_copy.other.other, bar_copy)
 
     def test_Instance_circular_references(self):
 
@@ -207,34 +207,34 @@ class CloneTestCase(unittest.TestCase):
         baz_copy = baz.clone_traits()
 
         # Check Baz and Baz attributes....
-        self.failIf(baz_copy is baz)
-        self.failIf(baz_copy.other is bar)
-        self.failIf(baz_copy.unique is baz.unique)
-        self.failIf(baz_copy.shared is baz.shared)
-        self.failUnless(baz_copy.ref is ref)
+        self.assertIsNot(baz_copy, baz)
+        self.assertIsNot(baz_copy.other, bar)
+        self.assertIsNot(baz_copy.unique, baz.unique)
+        self.assertIsNot(baz_copy.shared, baz.shared)
+        self.assertIs(baz_copy.ref, ref)
 
         # Check Bar and Bar attributes....
         bar_copy = baz_copy.other
 
         # Check the Bar owned object
-        self.failIf(bar_copy.unique is bar.unique)
+        self.assertIsNot(bar_copy.unique, bar.unique)
 
         # Check the Bar reference to an object 'outside' the cloned graph.
-        self.failUnless(bar_copy.ref is ref)
+        self.assertIs(bar_copy.ref, ref)
 
         # Check references to objects that where cloned, they should reference
         # the new clones not the original objects, except when copy is set
         # to 'ref' (as in the case of the 'other' trait).
         # When copy is set to ref, the trait does not get cloned. Therefore,
         # baz_copy.other.other is baz (and not baz_copy).
-        self.failIf(bar_copy.other is baz_copy)
-        self.failUnless(bar_copy.other is baz)
+        self.assertIsNot(bar_copy.other, baz_copy)
+        self.assertIs(bar_copy.other, baz)
 
         # 'shared' does not have copy set to 'ref', and so bar_copy.shared
         # should reference the new clone.
         # should reference the new clones
-        self.failIf(bar_copy.shared is baz.shared)
-        self.failUnless(bar_copy.shared is baz_copy.shared)
+        self.assertIsNot(bar_copy.shared, baz.shared)
+        self.assertIs(bar_copy.shared, baz_copy.shared)
 
     def test_Instance_circular_references_deep(self):
 
@@ -259,37 +259,37 @@ class CloneTestCase(unittest.TestCase):
         baz_copy = baz.clone_traits(copy='deep')
 
         # Check Baz and Baz attributes....
-        self.failIf(baz_copy is baz)
-        self.failIf(baz_copy.other is bar)
-        self.failIf(baz_copy.unique is baz.unique)
-        self.failIf(baz_copy.shared is baz.shared)
+        self.assertIsNot(baz_copy, baz)
+        self.assertIsNot(baz_copy.other, bar)
+        self.assertIsNot(baz_copy.unique, baz.unique)
+        self.assertIsNot(baz_copy.shared, baz.shared)
         # baz_copy.ref is checked below with bar_copy.ref.
 
         # Check Bar and Bar attributes....
         bar_copy = baz_copy.other
 
         # Check the Bar owned object
-        self.failIf(bar_copy.unique is bar.unique)
+        self.assertIsNot(bar_copy.unique, bar.unique)
 
         # Since the two original 'ref' links were to a shared object,
         # the cloned links should be to a shared object. Also, the shared
         # object should be the original 'ref' object, since copy was set to
         # 'ref'.
-        self.failUnless(baz_copy.ref is bar_copy.ref)
-        self.failUnless(bar_copy.ref is ref)
+        self.assertIs(baz_copy.ref, bar_copy.ref)
+        self.assertIs(bar_copy.ref,ref)
 
         # Check references to objects that where cloned, they should reference
         # the new clones not the original objects, except when copy is set
         # to 'ref' (as in the case of the 'other' trait). That is, the 'deep'
         # flag on clone_traits should not override the 'copy' metadata on
         # the trait.
-        self.failIf(bar_copy.other is baz_copy)
-        self.failUnless(bar_copy.other is baz)
+        self.assertIsNot(bar_copy.other, baz_copy)
+        self.assertIs(bar_copy.other, baz)
 
         # 'shared' does not have copy set to 'ref', and so bar_copy.shared
         # should reference the new clone.
-        self.failIf(bar_copy.shared is baz.shared)
-        self.failUnless(bar_copy.shared is baz_copy.shared)
+        self.assertIsNot(bar_copy.shared, baz.shared)
+        self.assertIs(bar_copy.shared, baz_copy.shared)
 
 #
 # support running this test individually, from the command-line as a script

--- a/traits/tests/test_copy_traits.py
+++ b/traits/tests/test_copy_traits.py
@@ -93,54 +93,54 @@ class TestCopyTraitsSetup(CopyTraitsBase):
         return
 
     def test_setup(self):
-        self.failUnless(self.foo is self.bar.foo)
-        self.failUnless(self.bar is self.baz.bar)
-        self.failUnless(self.foo.shared is self.shared)
-        self.failUnless(self.bar.shared is self.shared)
-        self.failUnless(self.baz.shared is self.shared)
+        self.assertIs(self.foo, self.bar.foo)
+        self.assertIs(self.bar, self.baz.bar)
+        self.assertIs(self.foo.shared, self.shared)
+        self.assertIs(self.bar.shared, self.shared)
+        self.assertIs(self.baz.shared, self.shared)
 
-        self.failUnless(self.foo2 is self.bar2.foo)
-        self.failUnless(self.bar2 is self.baz2.bar)
-        self.failUnless(self.foo2.shared is self.shared2)
-        self.failUnless(self.bar2.shared is self.shared2)
-        self.failUnless(self.baz2.shared is self.shared2)
+        self.assertIs(self.foo2, self.bar2.foo)
+        self.assertIs(self.bar2, self.baz2.bar)
+        self.assertIs(self.foo2.shared, self.shared2)
+        self.assertIs(self.bar2.shared, self.shared2)
+        self.assertIs(self.baz2.shared, self.shared2)
         return
 
 
 class CopyTraits:
 
     def test_baz2_s(self):
-        self.failUnlessEqual(self.baz2.s, 'baz')
-        self.failUnlessEqual(self.baz2.s, self.baz.s)
+        self.assertEqual(self.baz2.s, 'baz')
+        self.assertEqual(self.baz2.s, self.baz.s)
 
     def test_baz2_bar_s(self):
-        self.failUnlessEqual(self.baz2.bar.s, 'bar')
-        self.failUnlessEqual(self.baz2.bar.s, self.baz.bar.s)
+        self.assertEqual(self.baz2.bar.s, 'bar')
+        self.assertEqual(self.baz2.bar.s, self.baz.bar.s)
 
     def test_baz2_bar_foo_s(self):
-        self.failUnlessEqual(self.baz2.bar.foo.s, 'foo')
-        self.failUnlessEqual(self.baz2.bar.foo.s, self.baz.bar.foo.s)
+        self.assertEqual(self.baz2.bar.foo.s, 'foo')
+        self.assertEqual(self.baz2.bar.foo.s, self.baz.bar.foo.s)
 
     def test_baz2_shared_s(self):
-        self.failUnlessEqual(self.baz2.shared.s, 'shared')
-        self.failUnlessEqual(self.baz2.bar.shared.s, 'shared')
-        self.failUnlessEqual(self.baz2.bar.foo.shared.s, 'shared')
+        self.assertEqual(self.baz2.shared.s, 'shared')
+        self.assertEqual(self.baz2.bar.shared.s, 'shared')
+        self.assertEqual(self.baz2.bar.foo.shared.s, 'shared')
 
     def test_baz2_bar(self):
         # First hand Instance trait is different and
         # is not the same object as the source.
 
-        self.failIf(self.baz2.bar is None)
-        self.failIf(self.baz2.bar is self.bar2)
-        self.failIf(self.baz2.bar is self.baz.bar)
+        self.assertIsNot(self.baz2.bar, None)
+        self.assertIsNot(self.baz2.bar, self.bar2)
+        self.assertIsNot(self.baz2.bar, self.baz.bar)
 
     def test_baz2_bar_foo(self):
         # Second hand Instance trait is a different object and
         # is not the same object as the source.
 
-        self.failIf(self.baz2.bar.foo is None)
-        self.failIf(self.baz2.bar.foo is self.foo2)
-        self.failIf(self.baz2.bar.foo is self.baz.bar.foo)
+        self.assertIsNot(self.baz2.bar.foo, None)
+        self.assertIsNot(self.baz2.bar.foo, self.foo2)
+        self.assertIsNot(self.baz2.bar.foo, self.baz.bar.foo)
 
 
 class CopyTraitsSharedCopyNone:
@@ -148,9 +148,9 @@ class CopyTraitsSharedCopyNone:
         # First hand Instance trait is a different object and
         # is not the same object as the source.
 
-        self.failIf(self.baz2.shared is None)
-        self.failIf(self.baz2.shared is self.shared2)
-        self.failIf(self.baz2.shared is self.shared)
+        self.assertIsNot(self.baz2.shared, None)
+        self.assertIsNot(self.baz2.shared, self.shared2)
+        self.assertIsNot(self.baz2.shared, self.shared)
 
     def test_baz2_bar_shared(self):
         # Second hand Instance that was shared is a different object and
@@ -158,10 +158,10 @@ class CopyTraitsSharedCopyNone:
         # not the same object as the new first hand instance that was the same.
         # I.e. There are now (at least) two copies of one original object.
 
-        self.failIf(self.baz2.bar.shared is None)
-        self.failIf(self.baz2.bar.shared is self.shared2)
-        self.failIf(self.baz2.bar.shared is self.shared)
-        self.failIf(self.baz2.bar.shared is self.baz2.shared)
+        self.assertIsNot(self.baz2.bar.shared, None)
+        self.assertIsNot(self.baz2.bar.shared, self.shared2)
+        self.assertIsNot(self.baz2.bar.shared, self.shared)
+        self.assertIsNot(self.baz2.bar.shared, self.baz2.shared)
 
     def test_baz2_bar_foo_shared(self):
         # Third hand Instance that was shared is a different object and
@@ -169,10 +169,10 @@ class CopyTraitsSharedCopyNone:
         # not the same object as the new first hand instance that was the same.
         # I.e. There are now (at least) two copies of one original object.
 
-        self.failIf(self.baz2.bar.foo.shared is None)
-        self.failIf(self.baz2.bar.foo.shared is self.shared2)
-        self.failIf(self.baz2.bar.foo.shared is self.shared)
-        self.failIf(self.baz2.bar.foo.shared is self.baz2.shared)
+        self.assertIsNot(self.baz2.bar.foo.shared, None)
+        self.assertIsNot(self.baz2.bar.foo.shared, self.shared2)
+        self.assertIsNot(self.baz2.bar.foo.shared, self.shared)
+        self.assertIsNot(self.baz2.bar.foo.shared, self.baz2.shared)
 
     def test_baz2_bar_and_foo_shared(self):
         #
@@ -186,8 +186,8 @@ class CopyTraitsSharedCopyNone:
         # first hand reference which is a different copy.
         # I.e. The shared relationship has been fubarred by copy_traits: it's
         # not maintained, but not completely destroyed.
-        self.failUnless(self.baz2.bar.shared is self.baz2.bar.foo.shared)
-        self.failIf(self.baz2.shared is self.baz2.bar.foo.shared)
+        self.assertIs(self.baz2.bar.shared, self.baz2.bar.foo.shared)
+        self.assertIsNot(self.baz2.shared, self.baz2.bar.foo.shared)
 
 
 class TestCopyTraitsSharedCopyNone(CopyTraits,
@@ -245,25 +245,25 @@ class CopyTraitsSharedCopyRef:
         # First hand Instance trait is a different object and
         # is the same object as the source.
 
-        self.failIf(self.baz2.shared is None)
-        self.failIf(self.baz2.shared is self.shared2)
-        self.failUnless(self.baz2.shared is self.shared)
+        self.assertIsNot(self.baz2.shared, None)
+        self.assertIsNot(self.baz2.shared, self.shared2)
+        self.assertIs(self.baz2.shared, self.shared)
 
     def test_baz2_bar_shared(self):
-        self.failIf(self.baz2.bar.shared is None)
-        self.failIf(self.baz2.bar.shared is self.shared2)
-        self.failUnless(self.baz2.bar.shared is self.shared)
-        self.failUnless(self.baz2.bar.shared is self.baz2.shared)
+        self.assertIsNot(self.baz2.bar.shared, None)
+        self.assertIsNot(self.baz2.bar.shared, self.shared2)
+        self.assertIs(self.baz2.bar.shared, self.shared)
+        self.assertIs(self.baz2.bar.shared, self.baz2.shared)
 
     def test_baz2_bar_foo_shared(self):
-        self.failIf(self.baz2.bar.foo.shared is None)
-        self.failIf(self.baz2.bar.foo.shared is self.shared2)
-        self.failUnless(self.baz2.bar.foo.shared is self.shared)
-        self.failUnless(self.baz2.bar.foo.shared is self.baz2.shared)
+        self.assertIsNot(self.baz2.bar.foo.shared, None)
+        self.assertIsNot(self.baz2.bar.foo.shared, self.shared2)
+        self.assertIs(self.baz2.bar.foo.shared, self.shared)
+        self.assertIs(self.baz2.bar.foo.shared, self.baz2.shared)
 
     def test_baz2_bar_and_foo_shared(self):
-        self.failUnless(self.baz2.bar.shared is self.baz2.bar.foo.shared)
-        self.failUnless(self.baz2.shared is self.baz2.bar.foo.shared)
+        self.assertIs(self.baz2.bar.shared, self.baz2.bar.foo.shared)
+        self.assertIs(self.baz2.shared, self.baz2.bar.foo.shared)
 
 
 class TestCopyTraitsSharedCopyRef(CopyTraits,

--- a/traits/tests/test_copyable_trait_names.py
+++ b/traits/tests/test_copyable_trait_names.py
@@ -53,13 +53,13 @@ class TestCopyableTraitNames(unittest.TestCase):
         self.names = foo.copyable_trait_names()
 
     def test_events_not_copyable(self):
-        self.failIf('e' in self.names)
+        self.assertNotIn('e', self.names)
 
     def test_read_only_property_not_copyable(self):
-        self.failIf('p_ro' in self.names)
+        self.assertNotIn('p_ro', self.names)
 
     def test_write_only_property_not_copyable(self):
-        self.failIf('p_wo' in self.names)
+        self.assertNotIn('p_wo', self.names)
 
     def test_any_copyable(self):
         self.assertIn('a', self.names)
@@ -90,13 +90,13 @@ class TestCopyableTraitNameQueries(unittest.TestCase):
             'type': 'trait'
         })
 
-        self.failUnlessEqual(['a', 'b', 'i', 's'], sorted(names))
+        self.assertEqual(['a', 'b', 'i', 's'], sorted(names))
 
         names = self.foo.copyable_trait_names(**{
             'type': lambda t: t in ('trait', 'property',)
         })
 
-        self.failUnlessEqual(['a', 'b', 'i', 'p', 's'], sorted(names))
+        self.assertEqual(['a', 'b', 'i', 'p', 's'], sorted(names))
 
     def test_property_query(self):
         names = self.foo.copyable_trait_names(**{

--- a/traits/tests/test_event_order.py
+++ b/traits/tests/test_event_order.py
@@ -35,7 +35,7 @@ class TestEventOrder(unittest.TestCase):
                 'Baz._effect_changed',
                 'Baz._caused_changed']
 
-        self.failUnlessEqual(self.events_delivered, lifo)
+        self.assertEqual(self.events_delivered, lifo)
         return
 
     def test_not_fifo_order(self):
@@ -43,7 +43,7 @@ class TestEventOrder(unittest.TestCase):
                 'Baz._caused_changed',
                 'Baz._effect_changed']
 
-        self.failIfEqual(self.events_delivered, fifo)
+        self.assertNotEqual(self.events_delivered, fifo)
         return
 
 

--- a/traits/tests/test_interface_checker.py
+++ b/traits/tests/test_interface_checker.py
@@ -101,7 +101,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             def foo(self, x):
                 pass
 
-        self.failUnlessRaises(InterfaceError, check_implements, Foo, IFoo, 2)
+        self.assertRaises(InterfaceError, check_implements, Foo, IFoo, 2)
 
         return
 
@@ -116,7 +116,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
         class Foo(HasTraits):
             pass
 
-        self.failUnlessRaises(InterfaceError, check_implements, Foo, IFoo, 2)
+        self.assertRaises(InterfaceError, check_implements, Foo, IFoo, 2)
         return
 
     def test_single_interface_with_missing_method(self):
@@ -131,7 +131,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
         class Foo(HasTraits):
             pass
 
-        self.failUnlessRaises(InterfaceError, check_implements, Foo, IFoo, 2)
+        self.assertRaises(InterfaceError, check_implements, Foo, IFoo, 2)
 
         return
 
@@ -189,7 +189,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             def baz(self, x):
                 pass
 
-        self.failUnlessRaises(
+        self.assertRaises(
             InterfaceError, check_implements, Foo, [IFoo, IBar, IBaz], 2
         )
 
@@ -214,7 +214,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             x = Int
             y = Int
 
-        self.failUnlessRaises(
+        self.assertRaises(
             InterfaceError, check_implements, Foo, [IFoo, IBar, IBaz], 2
         )
 
@@ -245,7 +245,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             def bar(self):
                 pass
 
-        self.failUnlessRaises(
+        self.assertRaises(
             InterfaceError, check_implements, Foo, [IFoo, IBar, IBaz], 2
         )
 
@@ -305,7 +305,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             def baz(self, x):
                 pass
 
-        self.failUnlessRaises(InterfaceError, check_implements, Foo, IBaz, 2)
+        self.assertRaises(InterfaceError, check_implements, Foo, IBaz, 2)
 
         return
 
@@ -328,7 +328,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             x = Int
             y = Int
 
-        self.failUnlessRaises(InterfaceError, check_implements, Foo, IBaz, 2)
+        self.assertRaises(InterfaceError, check_implements, Foo, IBaz, 2)
 
         return
 
@@ -357,7 +357,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             def bar(self):
                 pass
 
-        self.failUnlessRaises(InterfaceError, check_implements, Foo, IBaz, 2)
+        self.assertRaises(InterfaceError, check_implements, Foo, IBaz, 2)
 
         return
 

--- a/traits/tests/test_list.py
+++ b/traits/tests/test_list.py
@@ -48,60 +48,60 @@ class ListTestCase(unittest.TestCase):
 
     def test_initialized(self):
         f = Foo()
-        self.failIfEqual(f.l, None)
-        self.failUnlessEqual(len(f.l), 0)
+        self.assertNotEqual(f.l, None)
+        self.assertEqual(len(f.l), 0)
         return
 
     def test_initializer(self):
         f = Foo(l=['a', 'list'])
-        self.failIfEqual(f.l, None)
-        self.failUnlessEqual(f.l, ['a', 'list'])
+        self.assertNotEqual(f.l, None)
+        self.assertEqual(f.l, ['a', 'list'])
         return
 
     def test_type_check(self):
         f = Foo()
         f.l.append('string')
 
-        self.failUnlessRaises(TraitError, f.l.append, 123.456)
+        self.assertRaises(TraitError, f.l.append, 123.456)
         return
 
     def test_append(self):
         f = Foo()
         f.l.append('bar')
-        self.failUnlessEqual(f.l, ['bar'])
+        self.assertEqual(f.l, ['bar'])
         return
 
     def test_remove(self):
         f = Foo()
         f.l.append('bar')
         f.l.remove('bar')
-        self.failUnlessEqual(f.l, [])
+        self.assertEqual(f.l, [])
         return
 
     def test_slice(self):
         f = Foo(l=['zero', 'one', 'two', 'three'])
-        self.failUnlessEqual(f.l[0], 'zero')
-        self.failUnlessEqual(f.l[:0], [])
-        self.failUnlessEqual(f.l[:1], ['zero'])
-        self.failUnlessEqual(f.l[0:1], ['zero'])
-        self.failUnlessEqual(f.l[1:], ['one', 'two', 'three'])
-        self.failUnlessEqual(f.l[-1], 'three')
-        self.failUnlessEqual(f.l[-2], 'two')
-        self.failUnlessEqual(f.l[:-1], ['zero', 'one', 'two'])
+        self.assertEqual(f.l[0], 'zero')
+        self.assertEqual(f.l[:0], [])
+        self.assertEqual(f.l[:1], ['zero'])
+        self.assertEqual(f.l[0:1], ['zero'])
+        self.assertEqual(f.l[1:], ['one', 'two', 'three'])
+        self.assertEqual(f.l[-1], 'three')
+        self.assertEqual(f.l[-2], 'two')
+        self.assertEqual(f.l[:-1], ['zero', 'one', 'two'])
         return
 
     def test_retrieve_reference(self):
         f = Foo(l=['initial', 'value'])
 
         l = f.l
-        self.failUnless(l is f.l)
+        self.assertIs(l, f.l)
 
         # no copy on change behavior, l is always a reference
         l.append('change')
-        self.failUnlessEqual(f.l, ['initial', 'value', 'change'])
+        self.assertEqual(f.l, ['initial', 'value', 'change'])
 
         f.l.append('more change')
-        self.failUnlessEqual(l, ['initial', 'value', 'change', 'more change'])
+        self.assertEqual(l, ['initial', 'value', 'change', 'more change'])
         return
 
     def test_assignment_makes_copy(self):
@@ -110,17 +110,17 @@ class ListTestCase(unittest.TestCase):
 
         f.l = l
         # same content
-        self.failUnlessEqual(l, f.l)
+        self.assertEqual(l, f.l)
 
         # different objects
-        self.failIf(l is f.l)
+        self.assertIsNot(l, f.l)
 
         # which means behaviorally...
         l.append('l change')
-        self.failIf('l change' in f.l)
+        self.assertNotIn('l change', f.l)
 
         f.l.append('f.l change')
-        self.failIf('f.l change' in l)
+        self.assertNotIn('f.l change', l)
 
         return
 
@@ -140,18 +140,18 @@ class ListTestCase(unittest.TestCase):
         # Clone will clone baz, the bars list, and the objects in the list
         baz_copy = baz.clone_traits()
 
-        self.failIf(baz_copy is baz)
-        self.failIf(baz_copy.bars is baz.bars)
+        self.assertIsNot(baz_copy, baz)
+        self.assertIsNot(baz_copy.bars, baz.bars)
 
-        self.failUnlessEqual(len(baz_copy.bars), len(baz.bars))
+        self.assertEqual(len(baz_copy.bars), len(baz.bars))
         for bar in baz.bars:
-            self.failIf(bar in baz_copy.bars)
+            self.assertNotIn(bar, baz_copy.bars)
 
         baz_bar_names = [bar.name for bar in baz.bars]
         baz_copy_bar_names = [bar.name for bar in baz_copy.bars]
         baz_bar_names.sort()
         baz_copy_bar_names.sort()
-        self.failUnlessEqual(baz_copy_bar_names, baz_bar_names)
+        self.assertEqual(baz_copy_bar_names, baz_bar_names)
 
         return
 
@@ -164,12 +164,12 @@ class ListTestCase(unittest.TestCase):
         # will not be cloned because the copy metatrait of the List is 'ref'
         baz_copy = baz.clone_traits()
 
-        self.failIf(baz_copy is baz)
-        self.failIf(baz_copy.bars is baz.bars)
+        self.assertIsNot(baz_copy, baz)
+        self.assertIsNot(baz_copy.bars, baz.bars)
 
-        self.failUnlessEqual(len(baz_copy.bars), len(baz.bars))
+        self.assertEqual(len(baz_copy.bars), len(baz.bars))
         for bar in baz.bars:
-            self.failUnless(bar in baz_copy.bars)
+            self.assertIn(bar, baz_copy.bars)
 
         return
 
@@ -184,23 +184,23 @@ class ListTestCase(unittest.TestCase):
         # and the objects in the list
         deep_baz_copy = deep_baz.clone_traits()
 
-        self.failIf(deep_baz_copy is deep_baz)
-        self.failIf(deep_baz_copy.baz is deep_baz.baz)
+        self.assertIsNot(deep_baz_copy, deep_baz)
+        self.assertIsNot(deep_baz_copy.baz, deep_baz.baz)
 
         baz_copy = deep_baz_copy.baz
 
-        self.failIf(baz_copy is baz)
-        self.failIf(baz_copy.bars is baz.bars)
+        self.assertIsNot(baz_copy, baz)
+        self.assertIsNot(baz_copy.bars, baz.bars)
 
-        self.failUnlessEqual(len(baz_copy.bars), len(baz.bars))
+        self.assertEqual(len(baz_copy.bars), len(baz.bars))
         for bar in baz.bars:
-            self.failIf(bar in baz_copy.bars)
+            self.assertNotIn(bar, baz_copy.bars)
 
         baz_bar_names = [bar.name for bar in baz.bars]
         baz_copy_bar_names = [bar.name for bar in baz_copy.bars]
         baz_bar_names.sort()
         baz_copy_bar_names.sort()
-        self.failUnlessEqual(baz_copy_bar_names, baz_bar_names)
+        self.assertEqual(baz_copy_bar_names, baz_bar_names)
         return
 
     def test_clone_deep_baz_ref(self):
@@ -212,17 +212,17 @@ class ListTestCase(unittest.TestCase):
 
         deep_baz_copy = deep_baz.clone_traits()
 
-        self.failIf(deep_baz_copy is deep_baz)
-        self.failIf(deep_baz_copy.baz is deep_baz.baz)
+        self.assertIsNot(deep_baz_copy, deep_baz)
+        self.assertIsNot(deep_baz_copy.baz, deep_baz.baz)
 
         baz_copy = deep_baz_copy.baz
 
-        self.failIf(baz_copy is baz)
-        self.failIf(baz_copy.bars is baz.bars)
+        self.assertIsNot(baz_copy, baz)
+        self.assertIsNot(baz_copy.bars, baz.bars)
 
-        self.failUnlessEqual(len(baz_copy.bars), len(baz.bars))
+        self.assertEqual(len(baz_copy.bars), len(baz.bars))
         for bar in baz.bars:
-            self.failUnless(bar in baz_copy.bars)
+            self.assertIn(bar, baz_copy.bars)
         return
 
     def test_coercion(self):
@@ -231,14 +231,14 @@ class ListTestCase(unittest.TestCase):
         # Test coercion from basic built-in types
         f.ints = [1, 2, 3]
         desired = [1, 2, 3]
-        self.failUnlessEqual(f.ints, desired)
+        self.assertEqual(f.ints, desired)
         f.ints = (1, 2, 3)
-        self.failUnlessEqual(f.ints, desired)
+        self.assertEqual(f.ints, desired)
 
         f.strs = ("abc", "def", "ghi")
-        self.failUnlessEqual(f.strs, ["abc", "def", "ghi"])
+        self.assertEqual(f.strs, ["abc", "def", "ghi"])
         f.strs = "abcdef"
-        self.failUnlessEqual(f.strs, list("abcdef"))
+        self.assertEqual(f.strs, list("abcdef"))
 
         try:
             from numpy import array
@@ -247,14 +247,14 @@ class ListTestCase(unittest.TestCase):
         else:
             if sys.version_info[0] < 3:
                 f.ints = array([1, 2, 3])
-                self.failUnlessEqual(f.ints, [1, 2, 3])
+                self.assertEqual(f.ints, [1, 2, 3])
             else:
                 # These would fail due to np.int_ being an invalid vallue
                 # for the Int-trait.
                 pass
 
             f.strs = array(("abc", "def", "ghi"))
-            self.failUnlessEqual(f.strs, ["abc", "def", "ghi"])
+            self.assertEqual(f.strs, ["abc", "def", "ghi"])
 
     def test_extend(self):
         f = Foo()

--- a/traits/tests/test_rich_compare.py
+++ b/traits/tests/test_rich_compare.py
@@ -44,11 +44,11 @@ class RichCompareTests:
         self.changed_count = 0
 
     def check_tracker(self, object, trait, old, new, count):
-        self.failUnlessEqual(count, self.changed_count)
-        self.failUnless(object is self.changed_object)
-        self.failUnlessEqual(trait, self.changed_trait)
-        self.failUnless(old is self.changed_old)
-        self.failUnless(new is self.changed_new)
+        self.assertEqual(count, self.changed_count)
+        self.assertIs(object, self.changed_object)
+        self.assertEqual(trait, self.changed_trait)
+        self.assertIs(old, self.changed_old)
+        self.assertIs(new, self.changed_new)
         return
 
     def test_id_first_assignment(self):
@@ -182,10 +182,10 @@ class RichCompareHasTraitsTestCase(unittest.TestCase, RichCompareTests):
         return
 
     def test_assumptions(self):
-        self.failIf(self.a is self.same_as_a)
-        self.failIf(self.a is self.different_from_a)
+        self.assertIsNot(self.a, self.same_as_a)
+        self.assertIsNot(self.a, self.different_from_a)
 
-        self.failUnless(self.a.name == self.same_as_a.name)
-        self.failIf(self.a.name == self.different_from_a.name)
+        self.assertEqual(self.a.name, self.same_as_a.name)
+        self.assertNotEqual(self.a.name, self.different_from_a.name)
         return
 ### EOF

--- a/traits/tests/test_special_event_handlers.py
+++ b/traits/tests/test_special_event_handlers.py
@@ -15,7 +15,7 @@ class TestSpecialEvent(unittest.TestCase):
         self.foo.val = 'CHANGE'
 
         values = ['CHANGE']
-        self.failUnlessEqual(self.change_events, values)
+        self.assertEqual(self.change_events, values)
 
     def test_instance_events(self):
         foo = self.foo
@@ -23,7 +23,7 @@ class TestSpecialEvent(unittest.TestCase):
         foo.val2 = 'CHANGE2'
 
         values = ['CHANGE2']
-        self.failUnlessEqual(self.change_events, values)
+        self.assertEqual(self.change_events, values)
 
 
 class Foo(HasStrictTraits):

--- a/traits/tests/test_str_handler.py
+++ b/traits/tests/test_str_handler.py
@@ -63,25 +63,25 @@ class StrHandlerCase(unittest.TestCase):
 
     def test_validator_function(self):
         f = Foo()
-        self.failUnlessEqual(f.s, '')
+        self.assertEqual(f.s, '')
 
         f.s = 'ok'
-        self.failUnlessEqual(f.s, 'ok')
+        self.assertEqual(f.s, 'ok')
 
-        self.failUnlessRaises(TraitError, setattr, f, 's', 'should fail.')
-        self.failUnlessEqual(f.s, 'ok')
+        self.assertRaises(TraitError, setattr, f, 's', 'should fail.')
+        self.assertEqual(f.s, 'ok')
 
         return
 
     def test_validator_handler(self):
         b = Bar()
-        self.failUnlessEqual(b.s, '')
+        self.assertEqual(b.s, '')
 
         b.s = 'ok'
-        self.failUnlessEqual(b.s, 'ok')
+        self.assertEqual(b.s, 'ok')
 
-        self.failUnlessRaises(TraitError, setattr, b, 's', 'should fail.')
-        self.failUnlessEqual(b.s, 'ok')
+        self.assertRaises(TraitError, setattr, b, 's', 'should fail.')
+        self.assertEqual(b.s, 'ok')
 
         return
 

--- a/traits/tests/test_undefined.py
+++ b/traits/tests/test_undefined.py
@@ -38,28 +38,28 @@ class Bar(HasTraits):
 class UndefinedTestCase(unittest.TestCase):
     def test_initial_value(self):
         b = Bar()
-        self.failUnlessEqual(b.name, Undefined)
+        self.assertEqual(b.name, Undefined)
         return
 
     def test_name_change(self):
         b = Bar()
         b.name = 'first'
-        self.failUnlessEqual(b.name, 'first')
+        self.assertEqual(b.name, 'first')
         return
 
     def test_read_only_write_once(self):
         f = Foo()
 
-        self.failUnlessEqual(f.name, '')
-        self.failUnless(f.original_name is Undefined)
+        self.assertEqual(f.name, '')
+        self.assertIs(f.original_name, Undefined)
 
         f.name = 'first'
-        self.failUnlessEqual(f.name, 'first')
-        self.failUnlessEqual(f.original_name, 'first')
+        self.assertEqual(f.name, 'first')
+        self.assertEqual(f.original_name, 'first')
 
         f.name = 'second'
-        self.failUnlessEqual(f.name, 'second')
-        self.failUnlessEqual(f.original_name, 'first')
+        self.assertEqual(f.name, 'second')
+        self.assertEqual(f.original_name, 'first')
 
         return
 
@@ -67,12 +67,12 @@ class UndefinedTestCase(unittest.TestCase):
         f = Foo(name='first')
 
         f.name = 'first'
-        self.failUnlessEqual(f.name, 'first')
-        self.failUnlessEqual(f.original_name, 'first')
+        self.assertEqual(f.name, 'first')
+        self.assertEqual(f.original_name, 'first')
 
         f.name = 'second'
-        self.failUnlessEqual(f.name, 'second')
-        self.failUnlessEqual(f.original_name, 'first')
+        self.assertEqual(f.name, 'second')
+        self.assertEqual(f.original_name, 'first')
 
         return
 


### PR DESCRIPTION
The last round of fixes missed uses of `self.failUnless` and friends.
