### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/traits/util/deprecated.py
+++ b/traits/util/deprecated.py
@@ -25,7 +25,7 @@ def deprecated(message):
             function_name = fn.__name__
 
             if (module_name, function_name) not in _cache:
-                logging.getLogger(module_name).warn(
+                logging.getLogger(module_name).warning(
                     'DEPRECATED: %s.%s, %s' % (
                         module_name, function_name, message
                     )

--- a/traits/util/tests/test_record_containers.py
+++ b/traits/util/tests/test_record_containers.py
@@ -39,7 +39,7 @@ class TestRecordContainers(unittest.TestCase):
         # save records
         container.save_to_file(self.filename)
 
-        with open(self.filename, 'Ur') as handle:
+        with open(self.filename, 'r') as handle:
             lines = handle.readlines()
         self.assertEqual(lines, ['\n'] * 7)
 
@@ -69,7 +69,7 @@ class TestRecordContainers(unittest.TestCase):
         container.save_to_directory(self.directory)
         for name in container._record_containers:
             filename = os.path.join(self.directory, '{0}.trace'.format(name))
-            with open(filename, 'Ur') as handle:
+            with open(filename, 'r') as handle:
                 lines = handle.readlines()
             self.assertEqual(lines, ['\n'])
 

--- a/traits/util/tests/test_record_events.py
+++ b/traits/util/tests/test_record_events.py
@@ -59,7 +59,7 @@ class TestRecordEvents(unittest.TestCase):
 
         filename = os.path.join(self.directory, 'MainThread.trace')
         container.save_to_file(filename)
-        with open(filename, 'Ur') as handle:
+        with open(filename, 'r') as handle:
             lines = handle.readlines()
             self.assertEqual(len(lines), 4)
             # very basic checking
@@ -90,7 +90,7 @@ class TestRecordEvents(unittest.TestCase):
         container.save_to_directory(self.directory)
         for name in container._record_containers:
             filename = os.path.join(self.directory, '{0}.trace'.format(name))
-            with open(filename, 'Ur') as handle:
+            with open(filename, 'r') as handle:
                 lines = handle.readlines()
             self.assertEqual(len(lines), 4)
             # very basic checking
@@ -118,7 +118,7 @@ class TestRecordEvents(unittest.TestCase):
         container.save_to_directory(self.directory)
         for name in container._record_containers:
             filename = os.path.join(self.directory, '{0}.trace'.format(name))
-            with open(filename, 'Ur') as handle:
+            with open(filename, 'r') as handle:
                 lines = handle.readlines()
             self.assertEqual(len(lines), 4)
             # very basic checking


### PR DESCRIPTION
- `logger.warn` -> `logger.warning`
- Remove some uses of universal newlines mode.

@itziakos: do you happen to remember why the `'U'` was used in this context?  It looks to me as though it's unnecessary.
