### PR TITLE
use develop instead of install so coveralls can find the right path when showing the source coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip install cython
   - pip install coverage
   - pip install coveralls
-  - python setup.py install
+  - python setup.py develop
 before_script:
   - mkdir testrunner
   - cp .coveragerc testrunner/


### PR DESCRIPTION
The coveralls report cannot show the line coverage view (https://coveralls.io/files/308442682) because the package is system installed. This PR attempts to fix that
