### PR TITLE
Add `dispatch` and `priority` kwargs to `on_trait_change` decorator.

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -831,15 +831,14 @@ def _trait_monitor_index ( cls, handler ):
 #  'HasTraits' decorators:
 #-------------------------------------------------------------------------------
 
-def on_trait_change ( name, post_init = False, dispatch = 'same',
-                      priority = False ):
+def on_trait_change ( name, post_init = False, dispatch = 'same' ):
     """ Marks the following method definition as being a handler for the
         extended trait change specified by *name(s)*.
 
         Refer to the documentation for the on_trait_change() method of
         the **HasTraits** class for information on the correct syntax for
-        the *name* argument and the semantics of the *dispatch* and
-        *priority* keyword arguments.
+        the *name* argument and the semantics of the *dispatch* keyword
+        argument.
 
         A handler defined using this decorator is normally effective
         immediately. However, if *post_init* is **True**, then the handler only
@@ -851,8 +850,7 @@ def on_trait_change ( name, post_init = False, dispatch = 'same',
 
         function.on_trait_change = {'pattern': name,
                                     'post_init': post_init,
-                                    'dispatch': dispatch,
-                                    'priority': priority}
+                                    'dispatch': dispatch}
 
         return function
 
@@ -3277,8 +3275,7 @@ class HasTraits ( CHasTraits ):
                     self.on_trait_change( getattr( self, name ),
                                           config['pattern'],
                                           deferred = True,
-                                          dispatch=config['dispatch'],
-                                          priority=config['priority'])
+                                          dispatch=config['dispatch'])
 
     def _init_trait_listeners ( self ):
         """ Initializes the object's statically parsed, but dynamically
@@ -3295,8 +3292,7 @@ class HasTraits ( CHasTraits ):
         if not config['post_init']:
             self.on_trait_change( getattr( self, name ), config['pattern'],
                                   deferred = True,
-                                  dispatch=config['dispatch'],
-                                  priority=config['priority'])
+                                  dispatch=config['dispatch'])
 
     def _init_trait_event_listener ( self, name, kind, pattern ):
         """ Sets up the listener for an event with on_trait_change metadata.

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3275,7 +3275,7 @@ class HasTraits ( CHasTraits ):
                     self.on_trait_change( getattr( self, name ),
                                           config['pattern'],
                                           deferred = True,
-                                          dispatch=config['dispatch'])
+                                          dispatch=config['dispatch'] )
 
     def _init_trait_listeners ( self ):
         """ Initializes the object's statically parsed, but dynamically
@@ -3290,9 +3290,10 @@ class HasTraits ( CHasTraits ):
             decorator.
         """
         if not config['post_init']:
-            self.on_trait_change( getattr( self, name ), config['pattern'],
+            self.on_trait_change( getattr( self, name ),
+                                  config['pattern'],
                                   deferred = True,
-                                  dispatch=config['dispatch'])
+                                  dispatch=config['dispatch'] )
 
     def _init_trait_event_listener ( self, name, kind, pattern ):
         """ Sets up the listener for an event with on_trait_change metadata.

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -831,7 +831,8 @@ def _trait_monitor_index ( cls, handler ):
 #  'HasTraits' decorators:
 #-------------------------------------------------------------------------------
 
-def on_trait_change ( name, post_init = False, dispatch='same' ):
+def on_trait_change ( name, post_init = False, dispatch = 'same',
+                      priority = False ):
     """ Marks the following method definition as being a handler for the
         extended trait change specified by *name(s)*.
 
@@ -850,7 +851,8 @@ def on_trait_change ( name, post_init = False, dispatch='same' ):
 
         function.on_trait_change = {'pattern': name,
                                     'post_init': post_init,
-                                    'dispatch': dispatch}
+                                    'dispatch': dispatch,
+                                    'priority': priority}
 
         return function
 
@@ -3275,7 +3277,8 @@ class HasTraits ( CHasTraits ):
                     self.on_trait_change( getattr( self, name ),
                                           config['pattern'],
                                           deferred = True,
-                                          dispatch=config['dispatch'] )
+                                          dispatch=config['dispatch'],
+                                          priority=config['priority'])
 
     def _init_trait_listeners ( self ):
         """ Initializes the object's statically parsed, but dynamically
@@ -3293,7 +3296,8 @@ class HasTraits ( CHasTraits ):
         if not config['post_init']:
             self.on_trait_change( getattr( self, name ), config['pattern'],
                                   deferred = True,
-                                  dispatch=config['dispatch'] )
+                                  dispatch=config['dispatch'],
+                                  priority=config['priority'])
 
     def _init_trait_event_listener ( self, name, kind, pattern ):
         """ Sets up the listener for an event with on_trait_change metadata.

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3292,7 +3292,6 @@ class HasTraits ( CHasTraits ):
         """ Sets up the listener for a method with the @on_trait_change
             decorator.
         """
-        print self, name, kind, config
         if not config['post_init']:
             self.on_trait_change( getattr( self, name ), config['pattern'],
                                   deferred = True,

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -838,8 +838,8 @@ def on_trait_change ( name, post_init = False, dispatch = 'same',
 
         Refer to the documentation for the on_trait_change() method of
         the **HasTraits** class for information on the correct syntax for
-        the *name(s)* argument and the semantics of the *dispatch* keyword
-        argument.
+        the *name(s)* argument and the semantics of the *dispatch* and 
+        *priority* keyword arguments.
 
         A handler defined using this decorator is normally effective
         immediately. However, if *post_init* is **True**, then the handler only

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -838,7 +838,7 @@ def on_trait_change ( name, post_init = False, dispatch = 'same',
 
         Refer to the documentation for the on_trait_change() method of
         the **HasTraits** class for information on the correct syntax for
-        the *name(s)* argument and the semantics of the *dispatch* and 
+        the *name* argument and the semantics of the *dispatch* and
         *priority* keyword arguments.
 
         A handler defined using this decorator is normally effective

--- a/traits/tests/test_dynamic_notifiers.py
+++ b/traits/tests/test_dynamic_notifiers.py
@@ -73,19 +73,15 @@ class DynamicNotifiers(HasTraits):
         self.exceptions_from.append(4)
         raise Exception('error')
 
-    @on_trait_change('priority_test')
     def low_priority_first(self):
         self.prioritized_notifications.append(0)
 
-    @on_trait_change('priority_test', priority=True)
     def high_priority_first(self):
         self.prioritized_notifications.append(1)
 
-    @on_trait_change('priority_test')
     def low_priority_second(self):
         self.prioritized_notifications.append(2)
 
-    @on_trait_change('priority_test', priority=True)
     def high_priority_second(self):
         self.prioritized_notifications.append(3)
 
@@ -229,6 +225,13 @@ class TestDynamicNotifiers(unittest.TestCase):
 
         expected_high = set([1, 3])
         expected_low = set([0, 2])
+
+        obj.on_trait_change(obj.low_priority_first, 'priority_test')
+        obj.on_trait_change(obj.high_priority_first, 'priority_test',
+                            priority=True)
+        obj.on_trait_change(obj.low_priority_second, 'priority_test')
+        obj.on_trait_change(obj.high_priority_second, 'priority_test',
+                            priority=True)
 
         obj.priority_test = None
 

--- a/traits/tests/test_dynamic_notifiers.py
+++ b/traits/tests/test_dynamic_notifiers.py
@@ -227,11 +227,16 @@ class TestDynamicNotifiers(unittest.TestCase):
 
         obj = DynamicNotifiers()
 
-        expected_sequence = [1, 3, 2, 0]
+        expected_high = set([1, 3])
+        expected_low = set([0, 2])
 
         obj.priority_test = None
 
-        self.assertListEqual(expected_sequence, obj.prioritized_notifications)
+        high = set(obj.prioritized_notifications[:2])
+        low = set(obj.prioritized_notifications[2:])
+
+        self.assertSetEqual(expected_high, high)
+        self.assertSetEqual(expected_low, low)
 
 
     def test_dynamic_notifiers_functions_failing(self):


### PR DESCRIPTION
This PR gets rid of the `*names` argument to the decorator, which never worked, and replaces the magic prefix on the pattern with a dictionary of explicit data and values.

The default values of the kwargs match those of the normal method.