### PR TITLE
Add workaround for frequent Travis build failures during Cython compilation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install -U nose
   - if ! [[ $TRAVIS_PYTHON_VERSION > '2.6' ]]; then pip install unittest2 ; fi
   - if [[ $TRAVIS_PYTHON_VERSION > '3.' ]]; then pip install numpy ; fi
-  - pip install cython
+  - pip install --install-option="--no-cython-compile" cython
   - pip install coverage
   - pip install coveralls
   - python setup.py develop


### PR DESCRIPTION
We're seeing frequent Travis failures due to Cython build problems.  An example is below (from [this build](https://travis-ci.org/enthought/traits/jobs/44182256)).

This PR works around this problem in the manner [suggested by Nathaniel Smith](https://mail.python.org/pipermail/cython-devel/2014-November/004263.html).

```
gcc -pthread -shared -L/opt/python/3.2.5/lib -Wl,-rpath=/opt/python/3.2.5/lib build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Plex/Scanners.o -L/opt/python/3.2.5/lib -lpython3.2mu -o build/lib.linux-x86_64-3.2/Cython/Plex/Scanners.cpython-32mu.so

skipping '/home/travis/virtualenv/python3.2.5/build/cython/Cython/Plex/Actions.c' Cython extension (up-to-date)

building 'Cython.Plex.Actions' extension

gcc -pthread -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.2.5/include/python3.2mu -c /home/travis/virtualenv/python3.2.5/build/cython/Cython/Plex/Actions.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Plex/Actions.o

gcc -pthread -shared -L/opt/python/3.2.5/lib -Wl,-rpath=/opt/python/3.2.5/lib build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Plex/Actions.o -L/opt/python/3.2.5/lib -lpython3.2mu -o build/lib.linux-x86_64-3.2/Cython/Plex/Actions.cpython-32mu.so

skipping '/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Lexicon.c' Cython extension (up-to-date)

building 'Cython.Compiler.Lexicon' extension

creating build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler

gcc -pthread -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.2.5/include/python3.2mu -c /home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Lexicon.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Lexicon.o

gcc -pthread -shared -L/opt/python/3.2.5/lib -Wl,-rpath=/opt/python/3.2.5/lib build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Lexicon.o -L/opt/python/3.2.5/lib -lpython3.2mu -o build/lib.linux-x86_64-3.2/Cython/Compiler/Lexicon.cpython-32mu.so

skipping '/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Scanning.c' Cython extension (up-to-date)

building 'Cython.Compiler.Scanning' extension

gcc -pthread -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.2.5/include/python3.2mu -c /home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Scanning.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Scanning.o

gcc -pthread -shared -L/opt/python/3.2.5/lib -Wl,-rpath=/opt/python/3.2.5/lib build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Scanning.o -L/opt/python/3.2.5/lib -lpython3.2mu -o build/lib.linux-x86_64-3.2/Cython/Compiler/Scanning.cpython-32mu.so

skipping '/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Parsing.c' Cython extension (up-to-date)

building 'Cython.Compiler.Parsing' extension

gcc -pthread -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.2.5/include/python3.2mu -c /home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Parsing.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Parsing.o

gcc -pthread -shared -L/opt/python/3.2.5/lib -Wl,-rpath=/opt/python/3.2.5/lib build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Parsing.o -L/opt/python/3.2.5/lib -lpython3.2mu -o build/lib.linux-x86_64-3.2/Cython/Compiler/Parsing.cpython-32mu.so

skipping '/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Visitor.c' Cython extension (up-to-date)

building 'Cython.Compiler.Visitor' extension

gcc -pthread -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.2.5/include/python3.2mu -c /home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Visitor.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Visitor.o

gcc -pthread -shared -L/opt/python/3.2.5/lib -Wl,-rpath=/opt/python/3.2.5/lib build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Visitor.o -L/opt/python/3.2.5/lib -lpython3.2mu -o build/lib.linux-x86_64-3.2/Cython/Compiler/Visitor.cpython-32mu.so

skipping '/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/FlowControl.c' Cython extension (up-to-date)

building 'Cython.Compiler.FlowControl' extension

gcc -pthread -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.2.5/include/python3.2mu -c /home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/FlowControl.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/FlowControl.o

gcc -pthread -shared -L/opt/python/3.2.5/lib -Wl,-rpath=/opt/python/3.2.5/lib build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/FlowControl.o -L/opt/python/3.2.5/lib -lpython3.2mu -o build/lib.linux-x86_64-3.2/Cython/Compiler/FlowControl.cpython-32mu.so

cythoning /home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Code.py to /home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Code.c

Traceback (most recent call last):

  File "<string>", line 1, in <module>

  File "/home/travis/virtualenv/python3.2.5/build/cython/setup.py", line 337, in <module>

    **setup_args

  File "/opt/python/3.2.5/lib/python3.2/distutils/core.py", line 148, in setup

    dist.run_commands()

  File "/opt/python/3.2.5/lib/python3.2/distutils/dist.py", line 917, in run_commands

    self.run_command(cmd)

  File "/opt/python/3.2.5/lib/python3.2/distutils/dist.py", line 936, in run_command

    cmd_obj.run()

  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/setuptools/command/install.py", line 54, in run

    return _install.run(self)

  File "/opt/python/3.2.5/lib/python3.2/distutils/command/install.py", line 569, in run

    self.run_command('build')

  File "/opt/python/3.2.5/lib/python3.2/distutils/cmd.py", line 313, in run_command

    self.distribution.run_command(command)

  File "/opt/python/3.2.5/lib/python3.2/distutils/dist.py", line 936, in run_command

    cmd_obj.run()

  File "/opt/python/3.2.5/lib/python3.2/distutils/command/build.py", line 126, in run

    self.run_command(cmd_name)

  File "/opt/python/3.2.5/lib/python3.2/distutils/cmd.py", line 313, in run_command

    self.distribution.run_command(command)

  File "/opt/python/3.2.5/lib/python3.2/distutils/dist.py", line 936, in run_command

    cmd_obj.run()

  File "Cython/Distutils/build_ext.py", line 163, in run

    _build_ext.build_ext.run(self)

  File "/opt/python/3.2.5/lib/python3.2/distutils/command/build_ext.py", line 344, in run

    self.build_extensions()

  File "/home/travis/virtualenv/python3.2.5/build/cython/setup.py", line 169, in build_extensions

    build_ext_orig.build_extensions(self)

  File "Cython/Distutils/build_ext.py", line 170, in build_extensions

    ext.sources = self.cython_sources(ext.sources, ext)

  File "Cython/Distutils/build_ext.py", line 319, in cython_sources

    full_module_name=module_name)

  File "/home/travis/virtualenv/python3.2.5/build/cython/build/lib.linux-x86_64-3.2/Cython/Compiler/Main.py", line 627, in compile

    return compile_single(source, options, full_module_name)

  File "/home/travis/virtualenv/python3.2.5/build/cython/build/lib.linux-x86_64-3.2/Cython/Compiler/Main.py", line 580, in compile_single

    return run_pipeline(source, options, full_module_name)

  File "/home/travis/virtualenv/python3.2.5/build/cython/build/lib.linux-x86_64-3.2/Cython/Compiler/Main.py", line 406, in run_pipeline

    context = options.create_context()

  File "/home/travis/virtualenv/python3.2.5/build/cython/build/lib.linux-x86_64-3.2/Cython/Compiler/Main.py", line 527, in create_context

    self.cplus, self.language_level, options=self)

  File "/home/travis/virtualenv/python3.2.5/build/cython/build/lib.linux-x86_64-3.2/Cython/Compiler/Main.py", line 69, in __init__

    from . import Builtin, CythonScope

  File "/home/travis/virtualenv/python3.2.5/build/cython/build/lib.linux-x86_64-3.2/Cython/Compiler/CythonScope.py", line 5, in <module>

    from .UtilityCode import CythonUtilityCode

  File "/home/travis/virtualenv/python3.2.5/build/cython/build/lib.linux-x86_64-3.2/Cython/Compiler/UtilityCode.py", line 3, in <module>

    from .TreeFragment import parse_from_strings, StringParseContext

  File "/home/travis/virtualenv/python3.2.5/build/cython/build/lib.linux-x86_64-3.2/Cython/Compiler/TreeFragment.py", line 20, in <module>

    from . import Parsing

  File "Cython/Plex/Actions.pxd", line 2, in init Cython.Compiler.Parsing (/home/travis/virtualenv/python3.2.5/build/cython/Cython/Compiler/Parsing.c:55686)

    cdef class Action:

ValueError: Cython.Plex.Actions.Action has the wrong size, try recompiling
```
