### PR TITLE
The doc build was broken by #214. Fix it.

### DIFF
--- a/traits/__init__.py
+++ b/traits/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from ._version import full_version as __version__
+from traits._version import full_version as __version__
 
 # Add a NullHandler so 'traits' loggers don't complain when they get used.
 import logging


### PR DESCRIPTION
Our docs `conf.py` file `execfile`s `__init__.py` to get the version number; the relative import breaks in that context.
