### PR TITLE
Remove extraneous installed files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,4 +13,5 @@ recursive-exclude examples *.pyc
 include traits/ctraits.c
 include traits/py2to3.h
 include traits/protocols/README.txt
+recursive-include fixers *.py
 recursive-include traits *.py

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,6 @@ if __name__ == "__main__":
             'http://www.enthought.com/repo/ets/traits-%s.tar.gz' %
             __version__),
         ext_modules=[ctraits],
-        include_package_data=True,
         license='BSD',
         maintainer='ETS Developers',
         maintainer_email='enthought-dev@enthought.com',

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
         license='BSD',
         maintainer='ETS Developers',
         maintainer_email='enthought-dev@enthought.com',
-        packages=find_packages(),
+        packages=find_packages(exclude=['fixers']),
         platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
         zip_safe= False,
         use_2to3=True,


### PR DESCRIPTION
This PR:

- removes `ctraits.c`, `py2to3.h`, the `fixers` package, and an unnecessary `README.txt` from the installed traits package.
- explicitly includes `fixers` in `MANIFEST.in` for the source distribution.

Fixes #128.
