### PR TITLE
Add note about possibly ill-defined ordering in assertTraitChanges events.

### DIFF
--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -192,7 +192,7 @@ class UnittestTools(object):
 
     def assertTraitChanges(self, obj, trait, count=None, callableObj=None,
                            *args, **kwargs):
-        """Assert an object trait changes a given number of times.
+        """ Assert an object trait changes a given number of times.
 
         Assert that the class trait changes exactly `count` times during
         execution of the provided function.

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -192,12 +192,12 @@ class UnittestTools(object):
 
     def assertTraitChanges(self, obj, trait, count=None, callableObj=None,
                            *args, **kwargs):
-        """ Assert an object trait changes a given number of times.
+        """Assert an object trait changes a given number of times.
 
         Assert that the class trait changes exactly `count` times during
         execution of the provided function.
 
-        Method can also be used in a with statement to assert that the
+        This method can also be used in a with statement to assert that
         a class trait has changed during the execution of the code inside
         the with statement (similar to the assertRaises method). Please note
         that in that case the context manager returns itself and the user
@@ -208,6 +208,11 @@ class UnittestTools(object):
 
         - All the fired events by accessing the ``events`` attribute of
           the return object.
+
+        Note that in the case of chained properties (trait 'foo' depends on
+        'bar', which in turn depends on 'baz'), the order in which the
+        corresponding trait events appear in the ``events`` attribute is
+        not well-defined, and may depend on dictionary ordering.
 
         **Example**::
 


### PR DESCRIPTION
As discussed in #212, the order of Trait event firings is not always well-defined.  This PR adds a note to the `assertTraitChanges` docstring.

Closes #212.