### PR TITLE
Fix invalid tokens (with line number zero) in trait_documenter machinery.

### DIFF
--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -135,7 +135,7 @@ class TraitDocumenter(ClassLevelDocumenter):
         for type, name, start, stop, line in tokens:
             if type == token.NEWLINE:
                 break
-            item = (type, name, (0, start[1]), (0, stop[1]), line)
+            item = (type, name, (1, start[1]), (1, stop[1]), line)
             definition_tokens.append(item)
 
         return tokenize.untokenize(definition_tokens).strip()


### PR DESCRIPTION
The docs build was failing on Python 2.7.7 and later, thanks to a combination of [this fix](http://bugs.python.org/issue12691) in the Python core and our use of a line number of zero.  This PR fixes that.

@itziakos: Do you have time to review?