### PR TITLE
Fix reference counting bug (extra Py_INCREF) in _has_traits_notifiers.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,7 @@ Fixes
 * Fix incorrect behaviour of ``check_implements`` for overridden methods.
   (#192)
 * Fix error when trying to listen to traits using list bracket notation. (#195)
+* Fix reference leak in ``CHasTraits._notifiers``. (#248)
 
 
 Release 4.5.0

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1428,19 +1428,23 @@ _has_traits_notifiers ( has_traits_object * obj, PyObject * args ) {
     PyObject * list;
     int force_create;
 
-        if ( !PyArg_ParseTuple( args, "i", &force_create ) )
+    if ( !PyArg_ParseTuple( args, "i", &force_create ) )
         return NULL;
 
     result = (PyObject *) obj->notifiers;
     if ( result == NULL ) {
-        result = Py_None;
-        if ( force_create && ((list = PyList_New( 0 )) != NULL) ) {
-            obj->notifiers = (PyListObject *) (result = list);
-            Py_INCREF( result );
+        if ( force_create ) {
+            list = PyList_New(0);
+            if (list == NULL)
+                return NULL;
+            obj->notifiers = (PyListObject *)list;
+            result = list;
+        }
+        else {
+            result = Py_None;
         }
     }
     Py_INCREF( result );
-
     return result;
 }
 

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -127,6 +127,28 @@ class TestRegression(unittest.TestCase):
         list_test.b[0] = 0
         self.assertEqual(list_test.events_received, 3)
 
+    def test_has_traits_notifiers_refleak(self):
+        # Regression test for issue described in
+        # https://github.com/enthought/traits/pull/248
+        def handler():
+            pass
+
+        def f():
+            obj = HasTraits()
+            obj.on_trait_change(handler)
+
+        # Warmup.
+        for _ in xrange(10):
+            f()
+            gc.collect()
+            gc.get_objects()
+
+        refs = len(gc.get_objects())
+        f()
+        gc.collect()
+        refs2 = len(gc.get_objects())
+        self.assertEqual(refs, refs2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -141,7 +141,6 @@ class TestRegression(unittest.TestCase):
         for _ in xrange(10):
             f()
             gc.collect()
-            gc.get_objects()
 
         refs = len(gc.get_objects())
         f()


### PR DESCRIPTION
There's an extra `Py_INCREF` call going on in `_has_traits_notifiers`, leading to creation of lists that never get garbage collected (despite having no referrers).  This PR fixes that. It also adds correct behaviour in the unlikely event that the `PyList_New` call fails.

Script to reproduce (thanks @itziakos for narrowing this down):

```
import gc
from traits.api import HasTraits

def callback():
    pass

# Application entry point.
def main():
    for index in range(100):
        obj = HasTraits()
        obj.on_trait_change(callback)
        del obj
        gc.collect()
        object_count = len(gc.get_objects())
        print "Iteration {}: object_count={}".format(index, object_count)

if __name__ == '__main__':
    main()
```

To do: turn the above script into a unit test.