### PR TITLE
Fix for issue 250: Trait documenter failure for multiline traits.

### DIFF
--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -1,57 +1,52 @@
 """ Tests for the trait documenter. """
 
+import StringIO
+import sys
 import tokenize
+from unittest import skipIf
 
 from traits.testing.unittest_tools import unittest
 
+
+def _sphinx_present():
+    try:
+        import sphinx
+    except ImportError:
+        return False
+
+    return True
+
+# Skipping for python 3.2 because sphinx does not work on it.
+def python_version_is_32():
+    return "{}.{}".format(
+        sys.version_info.major,
+        sys.version_info.minor) == "3.2"
+
+
+@skipIf(not _sphinx_present() or python_version_is_32(),
+        "Sphinx not available. Cannot test documenter")
 class TestTraitDocumenter(unittest.TestCase):
     """ Tests for the trait documenter. """
 
     def setUp(self):
-        self.tokens = [
-            (1, 'Property', (12, 21), (12, 29),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (51, '(', (12, 29), (12, 30),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (1, 'Tuple', (12, 30), (12, 35),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (51, '(', (12, 35), (12, 36),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (1, 'Float', (12, 36), (12, 41),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (51, ',', (12, 41), (12, 42),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (1, 'Float', (12, 43), (12, 48),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (51, ')', (12, 48), (12, 49),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (51, ',', (12, 49), (12, 50),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (54, '\n', (12, 50), (12, 51),
-             '    depth_interval = Property(Tuple(Float, Float),\n'),
-            (1, 'depends_on', (13, 30), (13, 40),
-             '                              depends_on="_depth_interval")\n'),
-            (51, '=', (13, 40), (13, 41),
-             '                              depends_on="_depth_interval")\n'),
-            (3, '"_depth_interval"', (13, 41), (13, 58),
-             '                              depends_on="_depth_interval")\n'),
-            (51, ')', (13, 58), (13, 59),
-             '                              depends_on="_depth_interval")\n'),
-            (4, '\n', (13, 59), (13, 60),
-             '                              depends_on="_depth_interval")\n')]
+        self.source = """
+    depth_interval = Property(Tuple(Float, Float),
+                              depends_on="_depth_interval")
+"""
+        string_io = StringIO.StringIO(self.source)
+        tokens = tokenize.generate_tokens(string_io.readline)
+        self.tokens = tokens
 
     def test_get_definition_tokens(self):
-        try:
-            import sphinx
-        except ImportError:
-            self.skipTest("Sphinx not available. Cannot import documenter")
 
         from traits.util.trait_documenter import _get_definition_tokens
 
         definition_tokens = _get_definition_tokens(self.tokens)
 
         # Check if they are correctly untokenized. This should not raise.
-        tokenize.untokenize(definition_tokens)
+        string = tokenize.untokenize(definition_tokens)
+
+        self.assertEqual(self.source.rstrip(), string)
 
 if __name__ == '__main__':
     unittest.main()

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -16,12 +16,12 @@ def _sphinx_present():
     return True
 
 
-def python_version_is_32():
+def _python_version_is_32():
     return sys.version_info[:2] == (3, 2)
 
 
 # Skipping for python 3.2 because sphinx does not work on it.
-@unittest.skipIf(not _sphinx_present() or python_version_is_32(),
+@unittest.skipIf(not _sphinx_present() or _python_version_is_32(),
                  "Sphinx not available. Cannot test documenter")
 class TestTraitDocumenter(unittest.TestCase):
     """ Tests for the trait documenter. """

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -23,6 +23,8 @@ def sphinx_mock_import():
 
     yield
 
+    del sys.modules["sphinx"]
+    del sys.modules["sphinx.ext"]
     del sys.modules["sphinx.ext.autodoc"]
 
 

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -3,12 +3,11 @@
 import StringIO
 import sys
 import tokenize
-from unittest import skipIf
 
 from traits.testing.unittest_tools import unittest
 
-
 def _sphinx_present():
+
     try:
         import sphinx
     except ImportError:
@@ -16,14 +15,11 @@ def _sphinx_present():
 
     return True
 
-# Skipping for python 3.2 because sphinx does not work on it.
 def python_version_is_32():
-    return "{}.{}".format(
-        sys.version_info.major,
-        sys.version_info.minor) == "3.2"
+    return sys.version_info[:2] == (3, 2)
 
-
-@skipIf(not _sphinx_present() or python_version_is_32(),
+# Skipping for python 3.2 because sphinx does not work on it.
+@unittest.skipIf(not _sphinx_present() or python_version_is_32(),
         "Sphinx not available. Cannot test documenter")
 class TestTraitDocumenter(unittest.TestCase):
     """ Tests for the trait documenter. """

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -6,21 +6,23 @@ import tokenize
 
 from traits.testing.unittest_tools import unittest
 
-def _sphinx_present():
 
+def _sphinx_present():
     try:
-        import sphinx
+        import sphinx  # noqa
     except ImportError:
         return False
 
     return True
 
+
 def python_version_is_32():
     return sys.version_info[:2] == (3, 2)
 
+
 # Skipping for python 3.2 because sphinx does not work on it.
 @unittest.skipIf(not _sphinx_present() or python_version_is_32(),
-        "Sphinx not available. Cannot test documenter")
+                 "Sphinx not available. Cannot test documenter")
 class TestTraitDocumenter(unittest.TestCase):
     """ Tests for the trait documenter. """
 

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -1,32 +1,8 @@
 """ Tests for the trait documenter. """
 
-import contextlib
-import sys
 import tokenize
-import types
-from mock import Mock
 
 from traits.testing.unittest_tools import unittest
-
-@contextlib.contextmanager
-def sphinx_mock_import():
-    try:
-        from sphinx.ext.autodoc import ClassLevelDocumenter
-    except ImportError:
-        sphinx = types.ModuleType("sphinx")
-        sphinx.ext = types.ModuleType("sphinx.ext")
-        sphinx.ext.autodoc = types.ModuleType("sphinx.ext.autodoc")
-        sys.modules["sphinx"] = sphinx
-        sys.modules["sphinx.ext"] = sphinx.ext
-        sys.modules["sphinx.ext.autodoc"] = sphinx.ext.autodoc
-        sphinx.ext.autodoc.__dict__["ClassLevelDocumenter"] = Mock()
-
-    yield
-
-    del sys.modules["sphinx"]
-    del sys.modules["sphinx.ext"]
-    del sys.modules["sphinx.ext.autodoc"]
-
 
 class TestTraitDocumenter(unittest.TestCase):
     """ Tests for the trait documenter. """
@@ -65,13 +41,17 @@ class TestTraitDocumenter(unittest.TestCase):
              '                              depends_on="_depth_interval")\n')]
 
     def test_get_definition_tokens(self):
-        with sphinx_mock_import():
-            from traits.util.trait_documenter import _get_definition_tokens
+        try:
+            import sphinx
+        except ImportError:
+            self.skipTest("Sphinx not available. Cannot import documenter")
 
-            definition_tokens = _get_definition_tokens(self.tokens)
+        from traits.util.trait_documenter import _get_definition_tokens
 
-            # Check if they are correctly untokenized. This should not raise.
-            tokenize.untokenize(definition_tokens)
+        definition_tokens = _get_definition_tokens(self.tokens)
+
+        # Check if they are correctly untokenized. This should not raise.
+        tokenize.untokenize(definition_tokens)
 
 if __name__ == '__main__':
     unittest.main()

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -1,0 +1,54 @@
+""" Tests for the trait documenter. """
+
+import tokenize
+
+from traits.util.trait_documenter import _get_definition_tokens
+from traits.testing.unittest_tools import unittest
+
+
+class TestTraitDocumenter(unittest.TestCase):
+    """ Tests for the trait documenter. """
+
+    def setUp(self):
+        self.tokens = [
+            (1, 'Property', (12, 21), (12, 29),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (51, '(', (12, 29), (12, 30),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (1, 'Tuple', (12, 30), (12, 35),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (51, '(', (12, 35), (12, 36),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (1, 'Float', (12, 36), (12, 41),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (51, ',', (12, 41), (12, 42),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (1, 'Float', (12, 43), (12, 48),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (51, ')', (12, 48), (12, 49),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (51, ',', (12, 49), (12, 50),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (54, '\n', (12, 50), (12, 51),
+             '    depth_interval = Property(Tuple(Float, Float),\n'),
+            (1, 'depends_on', (13, 30), (13, 40),
+             '                              depends_on="_depth_interval")\n'),
+            (51, '=', (13, 40), (13, 41),
+             '                              depends_on="_depth_interval")\n'),
+            (3, '"_depth_interval"', (13, 41), (13, 58),
+             '                              depends_on="_depth_interval")\n'),
+            (51, ')', (13, 58), (13, 59),
+             '                              depends_on="_depth_interval")\n'),
+            (4, '\n', (13, 59), (13, 60),
+             '                              depends_on="_depth_interval")\n')]
+
+    def test_get_definition_tokens(self):
+        definition_tokens = _get_definition_tokens(self.tokens)
+
+        # Check if they are correctly untokenized. This should not raise.
+        tokenize.untokenize(definition_tokens)
+
+if __name__ == '__main__':
+    unittest.main()
+
+# ## EOF ######################################################################

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -41,7 +41,7 @@ class TraitDocumenter(ClassLevelDocumenter):
 
     """
 
-    ### ClassLevelDocumenter interface #####################################
+    # ClassLevelDocumenter interface #####################################
 
     objtype = 'traitattribute'
     directivetype = 'attribute'
@@ -94,7 +94,7 @@ class TraitDocumenter(ClassLevelDocumenter):
             msg = ('autodoc can\'t import/find {0} {r1}, it reported error: '
                    '"{2}", please check your spelling and sys.path')
             self.directive.warn(msg.format(self.objtype, str(self.fullname),
-                                                                        err))
+                                err))
             self.env.note_reread()
             return False
 
@@ -108,7 +108,7 @@ class TraitDocumenter(ClassLevelDocumenter):
         self.add_line(u'   :annotation: = {0}'.format(definition),
                       '<autodoc>')
 
-    ### Private Interface #####################################################
+    # Private Interface #####################################################
 
     def _get_trait_definition(self):
         """ Retrieve the Trait attribute definition
@@ -133,6 +133,7 @@ class TraitDocumenter(ClassLevelDocumenter):
         # Retrieve the trait definition.
         definition_tokens = _get_definition_tokens(tokens)
         return tokenize.untokenize(definition_tokens).strip()
+
 
 def _get_definition_tokens(tokens):
     """ Given the tokens, extracts the definition tokens.
@@ -166,6 +167,7 @@ def _get_definition_tokens(tokens):
         definition_tokens.append(item)
 
     return definition_tokens
+
 
 def setup(app):
     """ Add the TraitDocumenter in the current sphinx autodoc instance. """

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -139,8 +139,8 @@ def _get_definition_tokens(tokens):
 
     Parameters
     ----------
-    tokens : list
-        A list of tokens.
+    tokens : iterator
+        An iterator producing tokens.
 
     Returns
     -------
@@ -148,16 +148,22 @@ def _get_definition_tokens(tokens):
     """
     # Retrieve the trait definition.
     definition_tokens = []
-    line = 1
+    first_line = None
+
     for type, name, start, stop, line_text in tokens:
+        if first_line is None:
+            first_line = start[0]
+
         if type == token.NEWLINE:
             break
 
-        item = (type, name, (line, start[1]), (line, stop[1]), line_text)
-        definition_tokens.append(item)
+        item = (type,
+                name,
+                (start[0] - first_line + 1, start[1]),
+                (stop[0] - first_line + 1, stop[1]),
+                line_text)
 
-        if type == tokenize.NL:
-            line += 1
+        definition_tokens.append(item)
 
     return definition_tokens
 

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -131,20 +131,35 @@ class TraitDocumenter(ClassLevelDocumenter):
                 name_found = True
 
         # Retrieve the trait definition.
-        definition_tokens = []
-        line = 1
-        for type, name, start, stop, line_text in tokens:
-            if type == token.NEWLINE:
-                break
-
-            item = (type, name, (line, start[1]), (line, stop[1]), line_text)
-            definition_tokens.append(item)
-
-            if type == tokenize.NL:
-                line += 1
-
+        definition_tokens = _get_definition_tokens(tokens)
         return tokenize.untokenize(definition_tokens).strip()
 
+def _get_definition_tokens(tokens):
+    """ Given the tokens, extracts the definition tokens.
+
+    Parameters
+    ----------
+    tokens : list
+        A list of tokens.
+
+    Returns
+    -------
+    A list of tokens for the definition.
+    """
+    # Retrieve the trait definition.
+    definition_tokens = []
+    line = 1
+    for type, name, start, stop, line_text in tokens:
+        if type == token.NEWLINE:
+            break
+
+        item = (type, name, (line, start[1]), (line, stop[1]), line_text)
+        definition_tokens.append(item)
+
+        if type == tokenize.NL:
+            line += 1
+
+    return definition_tokens
 
 def setup(app):
     """ Add the TraitDocumenter in the current sphinx autodoc instance. """

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -132,11 +132,16 @@ class TraitDocumenter(ClassLevelDocumenter):
 
         # Retrieve the trait definition.
         definition_tokens = []
-        for type, name, start, stop, line in tokens:
+        line = 1
+        for type, name, start, stop, line_text in tokens:
             if type == token.NEWLINE:
                 break
-            item = (type, name, (1, start[1]), (1, stop[1]), line)
+
+            item = (type, name, (line, start[1]), (line, stop[1]), line_text)
             definition_tokens.append(item)
+
+            if type == tokenize.NL:
+                line += 1
 
         return tokenize.untokenize(definition_tokens).strip()
 


### PR DESCRIPTION
Fixes the behavior from #250, by checking NL entries and adding the following entries to the next line. This way, the untokenizer does not complain for lack of order in the tokens.

For testing, I extracted the functionality in a private routine to simplify testing (which would depend on the sphinx infrastructure). Do we have a policy when it comes to testing private routines? Should I make it public if its public use is only through testing?
