### PR TITLE
Add Sphinx to the CI dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - if ! [[ $TRAVIS_PYTHON_VERSION > '2.6' ]]; then pip install unittest2 ; fi
   - if [[ $TRAVIS_PYTHON_VERSION > '3.' ]]; then pip install numpy ; fi
   - pip install --install-option="--no-cython-compile" cython
+  - pip install Sphinx
   - pip install coverage
   - pip install coveralls
   - python setup.py develop

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -6,6 +6,7 @@ pip install --cache-dir c:/egg_cache nose
 pip install --cache-dir c:/egg_cache coverage
 pip install --cache-dir c:/egg_cache numpy
 pip install --cache-dir c:/egg_cache cython
+pip install --cache-dir C:/egg_cache Sphinx
 
 rem install traits
 python setup.py develop

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import re
 import subprocess
+import sys
 
 from setuptools import setup, Extension, find_packages
 
@@ -105,6 +106,11 @@ if __name__ == "__main__":
         )
 
     def additional_commands():
+        # Pygments 2 isn't supported on Python 3 versions earlier than 3.3, so
+        # don't make the documentation command available there.
+        if (3,) <= sys.version_info < (3, 3):
+            return {}
+
         try:
             from sphinx.setup_command import BuildDoc
         except ImportError:


### PR DESCRIPTION
We'd like to write tests for trait_documenter (see issue #250 and PR #251).  But for that, we need Sphinx.