### PR TITLE
Use travis ci containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - 2.6
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip install -U nose
   - if ! [[ $TRAVIS_PYTHON_VERSION > '2.6' ]]; then pip install unittest2 ; fi
   - if [[ $TRAVIS_PYTHON_VERSION > '3.' ]]; then pip install numpy ; fi
-  - pip install --install-option="--no-cython-compile" cython
+  - pip install cython
   - pip install Sphinx
   - pip install coverage
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_install:
   - export PATH=/usr/lib/ccache:${PATH}
   - pip install --upgrade pip
 install:
-  - pip install -U wheel
   - pip install -U nose
   - if ! [[ $TRAVIS_PYTHON_VERSION > '2.6' ]]; then pip install unittest2 ; fi
   - if [[ $TRAVIS_PYTHON_VERSION > '3.' ]]; then pip install numpy ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,16 @@ python:
   - 3.2
   - 3.3
   - 3.4
+cache:
+  directories:
+    - $HOME/.cache
+    - $HOME/.ccache
+before_install:
+  - ccache -s
+  - export PATH=/usr/lib/ccache:${PATH}
+  - pip install --upgrade pip
 install:
+  - pip install -U wheel
   - pip install -U nose
   - if ! [[ $TRAVIS_PYTHON_VERSION > '2.6' ]]; then pip install unittest2 ; fi
   - if [[ $TRAVIS_PYTHON_VERSION > '3.' ]]; then pip install numpy ; fi


### PR DESCRIPTION
This PR updates the travis-ci configuration to use the new docker based builds and caching. The PR builds should now start faster and run in parallel in roughly 1 minutes (total cumulative build time is now around 5 minutes vs 9 minutes using VMs).

