### PR TITLE
Attempt to fix Appveyor failures on Python 3

### DIFF
--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -2,10 +2,11 @@
 call setenv /x64
 
 rem install python packages
-pip install --cache-dir c:/egg_cache nose
-pip install --cache-dir c:/egg_cache coverage
-pip install --cache-dir c:/egg_cache numpy
-pip install --cache-dir c:/egg_cache cython
+pip install --cache-dir C:/egg_cache nose
+pip install --cache-dir C:/egg_cache coverage
+pip install --cache-dir C:/egg_cache numpy
+pip install --cache-dir C:/egg_cache cython
+pip install --cache-dir C:/egg_cache babel==1.3
 pip install --cache-dir C:/egg_cache Sphinx
 
 rem install traits

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -6,6 +6,7 @@ pip install --cache-dir C:/egg_cache nose
 pip install --cache-dir C:/egg_cache coverage
 pip install --cache-dir C:/egg_cache numpy
 pip install --cache-dir C:/egg_cache cython
+rem Work around bug in babel 2.0: see mitsuhiko/babel#174
 pip install --cache-dir C:/egg_cache babel==1.3
 pip install --cache-dir C:/egg_cache Sphinx
 


### PR DESCRIPTION
Appveyor builds have been failing recently: see #260 for an example.

The issue appears to be a bug in the newest version of babel.   See e.g., https://github.com/mitsuhiko/babel/issues/174.

This PR downgrades the babel version to 1.3 in an attempt to work around the issue.
