### PR TITLE
Added an identifier trait that constraints to python ASCII identifiers.

### DIFF
--- a/traits/api.py
+++ b/traits/api.py
@@ -41,8 +41,9 @@ from .trait_types import (Any, Generic, Int, Long, Float, Complex, Str, Title,
         Method, Module, Python, ReadOnly, Disallow, Constant,
         Delegate, DelegatesTo, PrototypedFrom, Expression, PythonValue, File,
         Directory, Range, Enum, Tuple, List, CList, Set, CSet, Dict, Instance,
-        AdaptedTo, AdaptsTo, Event, Button, ToolbarButton, Either, Type,
-        Symbol, WeakRef, Date, Time, false, true, undefined, Supports)
+        IdentifierStr, AdaptedTo, AdaptsTo, Event, Button, ToolbarButton,
+        Either, Type, Symbol, WeakRef, Date, Time, false, true, undefined,
+        Supports)
 
 from .trait_types import (ListInt, ListFloat, ListStr, ListUnicode,
         ListComplex, ListBool, ListFunction, ListMethod,

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -20,9 +20,10 @@ import sys
 from traits.testing.unittest_tools import unittest
 
 from ..api import (Any, CFloat, CInt, CLong, Delegate, Float, HasTraits,
-                   Instance, Int, List, Long, Str, Trait, TraitError,
-                   TraitList, TraitPrefixList, TraitPrefixMap, TraitRange,
-                   Tuple, pop_exception_handler, push_exception_handler)
+                   IdentifierStr, Instance, Int, List, Long, Str, Trait,
+                   TraitError, TraitList, TraitPrefixList, TraitPrefixMap,
+                   TraitRange, Tuple, Undefined, pop_exception_handler,
+                   push_exception_handler)
 
 #  Base unit test classes:
 
@@ -302,6 +303,21 @@ class StringTest(AnyTraitTest):
                     '-10L', '10.1', '-10.1', 'string', u'string', 1j, [10],
                     ['ten'], {'ten': 10}, (10,), None]
     _bad_values = []
+
+    def coerce(self, value):
+        return str(value)
+
+
+class IdentifierStrTrait(HasTraits):
+    value = IdentifierStr
+
+
+class IdentifierStrTest(AnyTraitTest):
+    obj = IdentifierStrTrait()
+
+    _default_value = Undefined
+    _good_values = ['i', '_i', 'foo_bar']
+    _bad_values = [None, '1', 1, u'unicode', 'for', "0chupacabra", '']
 
     def coerce(self, value):
         return str(value)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 
 import datetime
 import operator
+import keyword
 import re
 import sys
 from os.path import isfile, isdir
@@ -363,6 +364,30 @@ class Str ( BaseStr ):
 
     #: The C-level fast validator to use:
     fast_validate = ( 11, basestring )
+
+
+class IdentifierStr(BaseStr):
+    #: A description of the type of value this trait accepts:
+    info_text = 'an ASCII identifier string'
+
+    #: The default value when first created
+    default_value = Undefined
+
+    # Regexp for identifier recognition
+    _identifier_regex = re.compile("[_A-Za-z][_a-zA-Z0-9]*$")
+
+    def validate ( self, object, name, value ):
+        """ Validates that a specified value is valid for this trait.
+        """
+
+        if (isinstance( value, str ) and
+                len(value) > 0 and
+                not keyword.iskeyword(value) and
+                self._identifier_regex.match(value)):
+
+            return value
+
+        self.error( object, name, value )
 
 
 class Title ( Str ):
@@ -825,6 +850,8 @@ class String ( TraitType ):
         """
         self.__dict__.update( state )
         self._init()
+
+
 
 #-------------------------------------------------------------------------------
 #  'Regex' trait:


### PR DESCRIPTION
Accepts strings in the format "_identifier" or "value", but not invalid identifier such as
"for", "", "0hello".