### PR TITLE
Make String trait type accept NumPy strings.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,8 @@ Changes
  
 Fixes
 
+* Fix ``String`` trait to accept ``str`` subclasses (like ``numpy.str_``).
+  (#267)
 * Fixed incorrect in list events for ``insert`` operations with an index
   outside the range [``-len(target_list)``, ``len(target_list)``]. (#165)
 * Fix incorrect behaviour of ``check_implements`` for overridden methods.

--- a/traits/tests/test_string.py
+++ b/traits/tests/test_string.py
@@ -34,7 +34,7 @@ class A(HasTraits):
 class TestString(unittest.TestCase):
     @unittest.skipUnless(numpy_available, "numpy not available")
     def test_accepts_numpy_string(self):
-        numpy_string = numpy.string_("this is a numpy string!")
+        numpy_string = numpy.str_("this is a numpy string!")
         a = A()
         a.string = numpy_string
         self.assertEqual(a.string, numpy_string)

--- a/traits/tests/test_string.py
+++ b/traits/tests/test_string.py
@@ -38,3 +38,4 @@ class TestString(unittest.TestCase):
         a = A()
         a.string = numpy_string
         self.assertEqual(a.string, numpy_string)
+        self.assertIs(type(a.string), str)

--- a/traits/tests/test_string.py
+++ b/traits/tests/test_string.py
@@ -15,8 +15,6 @@
 Tests for the String trait type.
 
 """
-import unittest
-
 try:
     import numpy
 except ImportError:
@@ -24,7 +22,9 @@ except ImportError:
 else:
     numpy_available = True
 
-from traits.api import HasTraits, String
+from traits.testing.unittest_tools import unittest
+
+from ..api import HasTraits, String
 
 
 class A(HasTraits):

--- a/traits/tests/test_string.py
+++ b/traits/tests/test_string.py
@@ -1,0 +1,40 @@
+#------------------------------------------------------------------------------
+#
+#  Copyright (c) 2015, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in /LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+#------------------------------------------------------------------------------
+"""
+Tests for the String trait type.
+
+"""
+import unittest
+
+try:
+    import numpy
+except ImportError:
+    numpy_available = False
+else:
+    numpy_available = True
+
+from traits.api import HasTraits, String
+
+
+class A(HasTraits):
+    string = String
+
+
+class TestString(unittest.TestCase):
+    @unittest.skipUnless(numpy_available, "numpy not available")
+    def test_accepts_numpy_string(self):
+        numpy_string = numpy.string_("this is a numpy string!")
+        a = A()
+        a.string = numpy_string
+        self.assertEqual(a.string, numpy_string)

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -318,7 +318,7 @@ def strx ( arg ):
     """ Wraps the built-in str() function to raise a TypeError if the
     argument is not of a type in StringTypes.
     """
-    if type( arg ) in StringTypes:
+    if isinstance( arg, StringTypes ):
        return str( arg )
     raise TypeError
 


### PR DESCRIPTION
Currently, the `String` trait type doesn't accept NumPy `string_` instances, even though those instances are instances of `str`:

```python
Python 2.7.9 |Master 2.1.0.dev1806-fbbe7a1 (64-bit)| (default, May 20 2015, 20:01:56) 
[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> from traits.api import HasTraits, String
>>> class A(HasTraits):
...     foo = String
... 
>>> a = A()
>>> a.foo = np.string_('bob')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "build/bdist.macosx-10.6-x86_64/egg/traits/trait_types.py", line 739, in validate
  File "build/bdist.macosx-10.6-x86_64/egg/traits/trait_types.py", line 763, in validate_str
  File "build/bdist.macosx-10.6-x86_64/egg/traits/trait_handlers.py", line 172, in error
traits.trait_errors.TraitError: The 'foo' trait of an A instance must be a string, but a value of 'bob' <type 'numpy.string_'> was specified.
```

This PR fixes that.