### PR TITLE
Context manager that provisionally sets the ETSConfig toolkit

### DIFF
--- a/traits/etsconfig/api.py
+++ b/traits/etsconfig/api.py
@@ -1,1 +1,1 @@
-from etsconfig import ETSConfig
+from etsconfig import ETSConfig, ETSToolkitError

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -206,7 +206,7 @@ class ETSConfig(object):
             If the toolkit attribute is already set, then an AttributeError
             will be raised when entering the context manager.
         """
-        if not self.toolkit:
+        if self.toolkit:
             raise AttributeError("ETSConfig toolkit is already set")
         self.toolkit = toolkit
         try:

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -5,6 +5,7 @@
 import sys
 import os
 from os import path
+from contextlib import contextmanager
 
 
 class ETSConfig(object):
@@ -182,6 +183,38 @@ class ETSConfig(object):
 
 
     company = property(_get_company, _set_company)
+
+
+    @contextmanager
+    def provisional_toolkit(self, toolkit):
+        """ Perform an operation with toolkit provisionally set
+
+        This sets the toolkit attribute of the ETSConfig object set to the
+        provided value. If the operation fails with an exception, the toolkit
+        is reset to nothing.
+
+        This method should only be called if the toolkit is not currently set.
+
+        Parameters
+        ----------
+        toolkit : string
+            The name of the toolkit to provisionally use.
+
+        Raises
+        ------
+        AttributeError
+            If the toolkit attribute is already set, then an AttributeError
+            will be raised when entering the context manager.
+        """
+        if not self.toolkit:
+            raise AttributeError("ETSConfig toolkit is already set")
+        self.toolkit = toolkit
+        try:
+            yield
+        except:
+            # reset the toolkit state
+            self._toolkit = ''
+            raise
 
 
     def _get_toolkit(self):

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -22,7 +22,7 @@ class ETSToolkitError(RuntimeError):
 
     def __init__(self, message='', toolkit=None, *args):
         if not message and toolkit:
-            message = "could not import toolkit '{}'".format(toolkit)
+            message = "could not import toolkit '{0}'".format(toolkit)
         self.toolkit = toolkit
         self.message = message
         if message:

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -8,6 +8,30 @@ from os import path
 from contextlib import contextmanager
 
 
+class ETSToolkitError(RuntimeError):
+    """ Error raised by issues importing ETS toolkits
+
+    Attributes
+    ----------
+    message : str
+        The message detailing the error.
+
+    toolkit : str or None
+        The toolkit associated with the error.
+    """
+
+    def __init__(self, message='', toolkit=None, *args):
+        if not message and toolkit:
+            message = "could not import toolkit '{}'".format(toolkit)
+        self.toolkit = toolkit
+        self.message = message
+        if message:
+            if toolkit:
+                args = (toolkit,) + args
+            args = (message,) + args
+        self.args = args
+
+
 class ETSConfig(object):
     """
     Enthought Tool Suite configuration information.
@@ -202,12 +226,13 @@ class ETSConfig(object):
 
         Raises
         ------
-        AttributeError
-            If the toolkit attribute is already set, then an AttributeError
+        ETSToolkitError
+            If the toolkit attribute is already set, then an ETSToolkitError
             will be raised when entering the context manager.
         """
         if self.toolkit:
-            raise AttributeError("ETSConfig toolkit is already set")
+            msg = "ETSConfig toolkit is already set to '{}'"
+            raise ETSToolkitError(msg.format(self.toolkit))
         self.toolkit = toolkit
         try:
             yield

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -231,7 +231,7 @@ class ETSConfig(object):
             will be raised when entering the context manager.
         """
         if self.toolkit:
-            msg = "ETSConfig toolkit is already set to '{}'"
+            msg = "ETSConfig toolkit is already set to '{0}'"
             raise ETSToolkitError(msg.format(self.toolkit))
         self.toolkit = toolkit
         try:

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -448,7 +448,7 @@ class ETSConfig(object):
                 raise ValueError, "the -toolkit command line argument must be followed by a toolkit name"
 
             # Remove the option.
-            del sys.argv[opt_idx:opt_idx + 1]
+            del sys.argv[opt_idx:opt_idx + 2]
         else:
             opt_toolkit = None
 

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -277,6 +277,54 @@ class ETSConfigTestCase(unittest.TestCase):
                          ['something', '-toolkit', 'test_args',
                           'something_else'])
 
+    def test_provisional_toolkit(self):
+        test_args = []
+        test_environ = {}
+
+        with mock_sys_argv(test_args):
+            with mock_os_environ(test_environ):
+                print repr(self.ETSConfig.toolkit)
+                with self.ETSConfig.provisional_toolkit('test_direct'):
+                    toolkit = self.ETSConfig.toolkit
+                    self.assertEqual(toolkit, 'test_direct')
+
+        # should stay set, since no exception raised
+        toolkit = self.ETSConfig.toolkit
+        self.assertEqual(toolkit, 'test_direct')
+
+    def test_provisional_toolkit_exception(self):
+        test_args = []
+        test_environ = {'ETS_TOOLKIT': ''}
+
+        with mock_sys_argv(test_args):
+            with mock_os_environ(test_environ):
+                try:
+                    with self.ETSConfig.provisional_toolkit('test_direct'):
+                        toolkit = self.ETSConfig.toolkit
+                        self.assertEqual(toolkit, 'test_direct')
+                        raise Exception("Test exception")
+                except Exception as exc:
+                    if not exc.message == "Test exception":
+                        raise
+
+                # should be reset, since exception raised
+                toolkit = self.ETSConfig.toolkit
+                self.assertEqual(toolkit, '')
+
+    def test_provisional_toolkit_already_set(self):
+        test_args = []
+        test_environ = {'ETS_TOOLKIT': 'test_environ'}
+
+        with mock_sys_argv(test_args):
+            with mock_os_environ(test_environ):
+                with self.assertRaises(AttributeError):
+                    with self.ETSConfig.provisional_toolkit('test_direct'):
+                        pass
+
+                # should come from the environment
+                toolkit = self.ETSConfig.toolkit
+                self.assertEqual(toolkit, 'test_environ')
+
     def test_user_data(self):
         """
         user data

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -14,7 +14,7 @@ else:
     import unittest
 
 # Enthought library imports.
-from traits.etsconfig.api import ETSConfig
+from traits.etsconfig.etsconfig import ETSConfig, ETSToolkitError
 
 
 @contextlib.contextmanager
@@ -305,8 +305,8 @@ class ETSConfigTestCase(unittest.TestCase):
                     with self.ETSConfig.provisional_toolkit('test_direct'):
                         toolkit = self.ETSConfig.toolkit
                         self.assertEqual(toolkit, 'test_direct')
-                        raise Exception("Test exception")
-                except Exception as exc:
+                        raise ETSToolkitError("Test exception")
+                except ETSToolkitError as exc:
                     if not exc.message == "Test exception":
                         raise
 
@@ -320,7 +320,7 @@ class ETSConfigTestCase(unittest.TestCase):
 
         with mock_sys_argv(test_args):
             with mock_os_environ(test_environ):
-                with self.assertRaises(AttributeError):
+                with self.assertRaises(ETSToolkitError):
                     with self.ETSConfig.provisional_toolkit('test_direct'):
                         pass
 

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -8,7 +8,10 @@ import shutil
 import sys
 import tempfile
 import time
-import unittest
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 # Enthought library imports.
 from traits.etsconfig.api import ETSConfig


### PR DESCRIPTION
With the change in the default ETSConfig toolkit in TraitsUI a pre-existing bug was uncovered where, if the toolkit isn't expressly set, you can:

* attempt to import a preferred toolkit implementation in one library (eg. wx backend for enable)
* have it incidentally (and sometimes sub-optimally, but that's a separate issue) import another library with a different backend preference (eg. qt backend for pyface)
* things go badly from there

This PR adds a new context manager method to the ETSConfig object that allows a library to provisionally choose a backend that other libraries will respect, but then undo that selection if a problem occurs in the context manager's block.  The intent is to wrap the import methods in the various toolkit selection methods with this context manager.

This is not a perfect fix, but will help somewhat with this particular pain point.
