### PR TITLE
Fix slice length bug in TraitListObject.__setitem__ and TraitListObject.__delitem__

### DIFF
--- a/traits/tests/test_list.py
+++ b/traits/tests/test_list.py
@@ -110,6 +110,28 @@ class ListTestCase(unittest.TestCase):
             self.assertEqual(
                 f.l, plain_l, "failed for slice {0!r}".format(test_slice))
 
+    def test_slice_assignments_of_different_length(self):
+        # Test slice assignments where rhs has a different length
+        # to the slice. These should work only for slices of step 1.
+        test_list = ['zero', 'one', 'two', 'three']
+        f = Foo(l=test_list)
+        f.l[1:3] = '01234'
+        self.assertEqual(f.l, ['zero', '0', '1', '2', '3', '4', 'three'])
+        f.l[4:] = []
+        self.assertEqual(f.l, ['zero', '0', '1', '2'])
+        f.l[:] = 'abcde'
+        self.assertEqual(f.l, ['a', 'b', 'c', 'd', 'e'])
+        f.l[:] = []
+        self.assertEqual(f.l, [])
+
+        f = Foo(l=test_list)
+        with self.assertRaises(ValueError):
+            f.l[::2] = ['a', 'b', 'c']
+        self.assertEqual(f.l, test_list)
+        with self.assertRaises(ValueError):
+            f.l[::-1] = []
+        self.assertEqual(f.l, test_list)
+
     def test_slice_deletion_bad_length_computation(self):
         # Regression test for enthought/traits#283.
         class IHasConstrainedList(HasTraits):

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -2348,14 +2348,11 @@ class TraitListObject ( list ):
 
             if isinstance(key, slice):
                 values = value
-                try:
-                    key = slice(*key.indices(len( self )))
-                except (ValueError, TypeError):
-                    raise TypeError('must assign sequence (not "%s") to slice' % (
-                                    values.__class__.__name__ ))
-                slice_len = max(0, (key.stop - key.start) // key.step)
+                slice_len = len(removed)
+
                 delta = len( values ) - slice_len
-                if key.step != 1 and delta != 0:
+                step = 1 if key.step is None else key.step
+                if step != 1 and delta != 0:
                     raise ValueError(
                         'attempt to assign sequence of size %d to extended slice of size %d' % (
                         len( values ), slice_len
@@ -2369,7 +2366,7 @@ class TraitListObject ( list ):
                     values = [ validate( object, name, value )
                                for value in values ]
                 value = values
-                if key.step == 1:
+                if step == 1:
                     # FIXME: Bug-for-bug compatibility with old __setslice__ code.
                     # In this case, we return a TraitListEvent with an
                     # index=key.start and the removed and added lists as they
@@ -2423,10 +2420,10 @@ class TraitListObject ( list ):
             removed = []
 
         if isinstance(key,slice):
-            key = slice(*key.indices(len( self )))
-            slice_len = max(0, (key.stop - key.start) // key.step)
+            slice_len = len(removed)
             delta = slice_len
-            if key.step == 1:
+            step = 1 if key.step is None else key.step
+            if step == 1:
                 # FIXME: See corresponding comment in __setitem__() for
                 # explanation.
                 index = key.start


### PR DESCRIPTION
Fix for issue #283.

Also removes an odd-looking `try/except` where the exception message is about the values being assigned but the body of the `try` block has nothing to do with those values.