### PR TITLE
Fix TraitDocumenter for Python 3

### DIFF
--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -123,7 +123,7 @@ class TraitDocumenter(ClassLevelDocumenter):
         trait_found = False
         name_found = False
         while not trait_found:
-            item = tokens.next()
+            item = next(tokens)
             if name_found and item[:2] == (token.OP, '='):
                 trait_found = True
                 continue


### PR DESCRIPTION
Replace `.next()` method with the `next()` builtin. This allows the traits documenter to work correctly in Python 3.