### PR TITLE
MAINT: Backport #243

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - 3.3
   - 3.4
   - 3.5
+branches:
+  only:
+    master
 cache:
   directories:
     - $HOME/.cache

--- a/traits/ctraits.pyx
+++ b/traits/ctraits.pyx
@@ -152,10 +152,13 @@ cdef object set_readonly_error(obj, name):
         "object.".format(name, type(obj))
     )
 
-cdef object invalid_attribute_error():
-    """ Raise an "attribute is not a string" error. """
 
-    raise TypeError('Attribute name must be a string.')
+cdef object invalid_attribute_error(name):
+    """ Raise an "attribute is not a string" error. """
+    raise TypeError(
+        (u"attribute name must be an instance of <type 'str'>. "
+         u"Got {0:!r} ({1:.200}).").format(name, str(type(name)))
+    )
 
 
 cdef object unknown_attribute_error(obj, name):
@@ -170,7 +173,7 @@ cdef int set_disallow_error(obj, name) except? -1:
     """Raises an undefined attribute error.
     """
     if not isinstance(name, basestring):
-        invalid_attribute_error()
+        invalid_attribute_error(name)
     else:
         raise TraitError(
             (u"Cannot set the undefined '{0:.400}' attribute of a "
@@ -999,7 +1002,7 @@ cdef class CHasTraits:
             raise TraitError('Invalid argment to trait constructor.')
 
         if not PyString_Check(name):
-            raise TypeError('Attribute name must be a string.')
+            invalid_attribute_error(name)
 
         if (self.itrait_dict is None or name not in self.itrait_dict) and \
             name not in self.ctrait_dict:
@@ -1316,7 +1319,7 @@ cdef object getattr_trait(cTrait trait, CHasTraits obj, object name):
         if rc == 0:
             return result
     else:
-        raise TypeError('Attribute name must be a string')
+        invalid_attribute_error(name)
 
 cdef object getattr_event(cTrait trait, CHasTraits obj, object name):
     """  Returns the value assigned to an event trait. """
@@ -1378,15 +1381,14 @@ cdef object getattr_delegate(cTrait trait, CHasTraits obj, object name):
                     " '%.400s'." % (type(obj), name, tp, delegate_attr_name))
 
     # FIXME: needs support for unicode
-
-    raise TypeError('Attribute name must be a string.')
+    invalid_attribute_error(name)
 
 
 cdef object getattr_disallow(cTrait trait, CHasTraits obj, object name):
     if isinstance(name, basestring):
         unknown_attribute_error(obj, name)
     else:
-        invalid_attribute_error()
+        invalid_attribute_error(name)
 
 
 cdef object getattr_constant(cTrait trait, CHasTraits obj, object name):
@@ -1491,7 +1493,7 @@ cdef int setattr_trait(cTrait traito, cTrait traitd, CHasTraits obj, object name
 
     # FIXME: support unicode
     if not PyString_Check(name):
-        raise ValueError('Attribute name must be a string.')
+        invalid_attribute_error(name)
 
     # TRAIT_SETATTR_ORIGINAL_VALUE: Make 'setattr' store the original
     # unvalidated value
@@ -1666,7 +1668,7 @@ cdef int setattr_readonly(cTrait traito, cTrait traitd, CHasTraits obj, object n
 
     # FIXME: add support for Unicode
     if not PyString_Check(name):
-        raise invalid_attribute_error()
+        raise invalid_attribute_error(name)
 
     cdef PyObject* result = PyDict_GetItem(obj.obj_dict, name)
     if result is NULL or result == <PyObject*>Undefined:

--- a/traits/ctraits.pyx
+++ b/traits/ctraits.pyx
@@ -157,14 +157,14 @@ cdef object invalid_attribute_error(name):
     """ Raise an "attribute is not a string" error. """
     raise TypeError(
         (u"attribute name must be an instance of <type 'str'>. "
-         u"Got {0:!r} ({1:.200}).").format(name, str(type(name)))
+         u"Got {0!r:.200} ({1!s:.200}).").format(name, type(name))
     )
 
 
 cdef object unknown_attribute_error(obj, name):
     raise AttributeError(
-        u"'{0:.50}' object has no attribute '{1:.400}'".format(
-            str(type(obj)), name
+        u"'{0!s:.50}' object has no attribute '{1:.400}'".format(
+            type(obj), name
         )
     )
 

--- a/traits/tests/test_bool.py
+++ b/traits/tests/test_bool.py
@@ -1,0 +1,84 @@
+# -----------------------------------------------------------------------------
+#
+#  Copyright (c) 2016, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in /LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+# -----------------------------------------------------------------------------
+"""
+Tests for the Bool trait type.
+"""
+try:
+    import numpy
+except ImportError:
+    numpy_available = False
+else:
+    numpy_available = True
+
+from traits.testing.unittest_tools import unittest
+from ..api import Bool, Dict, HasTraits, Int, TraitError
+
+
+class A(HasTraits):
+    foo = Bool
+
+
+class TestBool(unittest.TestCase):
+    def test_default_value(self):
+        a = A()
+        # We should get something of exact type bool.
+        self.assertEqual(type(a.foo), bool)
+        self.assertFalse(a.foo)
+
+    def test_accepts_bool(self):
+        a = A()
+        a.foo = True
+        self.assertTrue(a.foo)
+        a.foo = False
+        self.assertFalse(a.foo)
+
+    def test_does_not_accept_int_or_float(self):
+        a = A()
+
+        bad_values = [-1, 1L, "a string", 1.0]
+        for bad_value in bad_values:
+            with self.assertRaises(TraitError):
+                a.foo = bad_value
+
+        # Double check that foo didn't actually change
+        self.assertEqual(type(a.foo), bool)
+        self.assertFalse(a.foo)
+
+    @unittest.skipUnless(numpy_available, "numpy not available")
+    def test_accepts_numpy_bool(self):
+        # A bool trait should accept a NumPy bool_.
+        a = A()
+        a.foo = numpy.bool_(True)
+        self.assertTrue(a.foo)
+
+    @unittest.skipUnless(numpy_available, "numpy not available")
+    def test_numpy_bool_accepted_as_dict_value(self):
+        # Regression test for enthought/traits#299.
+        class HasBoolDict(HasTraits):
+            foo = Dict(Int, Bool)
+
+        has_bool_dict = HasBoolDict()
+        has_bool_dict.foo[1] = numpy.bool_(True)
+        self.assertTrue(has_bool_dict.foo[1])
+
+    @unittest.skipUnless(numpy_available, "numpy not available")
+    def test_numpy_bool_accepted_as_dict_key(self):
+        # Regression test for enthought/traits#299.
+        class HasBoolDict(HasTraits):
+            foo = Dict(Bool, Int)
+
+        has_bool_dict = HasBoolDict()
+        key = numpy.bool_(True)
+        has_bool_dict.foo[key] = 1
+        self.assertEqual(has_bool_dict.foo[key], 1)

--- a/traits/tests/test_list.py
+++ b/traits/tests/test_list.py
@@ -90,6 +90,58 @@ class ListTestCase(unittest.TestCase):
         self.assertEqual(f.l[:-1], ['zero', 'one', 'two'])
         return
 
+    def test_slice_assignment(self):
+        # Exhaustive testing.
+        starts = stops = [None] + range(-10, 11)
+        steps = list(starts)
+        steps.remove(0)
+        test_slices = [slice(start, stop, step)
+                       for start in starts for stop in stops for step in steps]
+
+        for test_slice in test_slices:
+            f = Foo(l=['zero', 'one', 'two', 'three', 'four'])
+            plain_l = list(f.l)
+            length = len(plain_l[test_slice])
+            replacements = map(str, range(length))
+
+            # Plain Python list and Traits list behaviour should match.
+            plain_l[test_slice] = replacements
+            f.l[test_slice] = replacements
+            self.assertEqual(
+                f.l, plain_l, "failed for slice {0!r}".format(test_slice))
+
+    def test_slice_assignments_of_different_length(self):
+        # Test slice assignments where rhs has a different length
+        # to the slice. These should work only for slices of step 1.
+        test_list = ['zero', 'one', 'two', 'three']
+        f = Foo(l=test_list)
+        f.l[1:3] = '01234'
+        self.assertEqual(f.l, ['zero', '0', '1', '2', '3', '4', 'three'])
+        f.l[4:] = []
+        self.assertEqual(f.l, ['zero', '0', '1', '2'])
+        f.l[:] = 'abcde'
+        self.assertEqual(f.l, ['a', 'b', 'c', 'd', 'e'])
+        f.l[:] = []
+        self.assertEqual(f.l, [])
+
+        f = Foo(l=test_list)
+        with self.assertRaises(ValueError):
+            f.l[::2] = ['a', 'b', 'c']
+        self.assertEqual(f.l, test_list)
+        with self.assertRaises(ValueError):
+            f.l[::-1] = []
+        self.assertEqual(f.l, test_list)
+
+    def test_slice_deletion_bad_length_computation(self):
+        # Regression test for enthought/traits#283.
+        class IHasConstrainedList(HasTraits):
+            foo = List(Str, minlen=3)
+
+        f = IHasConstrainedList(foo=['zero', 'one', 'two', 'three'])
+        # We're deleting two items; this should raise.
+        with self.assertRaises(TraitError):
+            del f.foo[::3]
+
     def test_retrieve_reference(self):
         f = Foo(l=['initial', 'value'])
 

--- a/traits/tests/test_trait_exceptions.py
+++ b/traits/tests/test_trait_exceptions.py
@@ -1,0 +1,34 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2015, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in enthought/LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+#------------------------------------------------------------------------------
+
+from traits.testing.unittest_tools import unittest
+from traits.api import HasTraits, Int
+
+
+class A(HasTraits):
+    x = Int(5)
+
+
+class TestGetAttr(unittest.TestCase):
+    def setUp(self):
+        self.a = A()
+
+    def test_bad__getattribute__(self):
+        # Argument to __getattribute__ must be a string
+        self.assertEqual(self.a.__getattribute__("x"), 5)
+
+        with self.assertRaises(TypeError) as e:
+            self.a.__getattribute__(2)
+
+        # Error message contains value and type of bad attribute name
+        exception_msg = str(e.exception)
+        self.assertIn("2", exception_msg)
+        self.assertIn("int", exception_msg)

--- a/traits/tests/test_trait_exceptions.py
+++ b/traits/tests/test_trait_exceptions.py
@@ -28,7 +28,6 @@ class TestGetAttr(unittest.TestCase):
         with self.assertRaises(TypeError) as e:
             self.a.__getattribute__(2)
 
-        # Error message contains value and type of bad attribute name
+        # Error message contains type of bad attribute name
         exception_msg = str(e.exception)
-        self.assertIn("2", exception_msg)
         self.assertIn("int", exception_msg)

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -2348,14 +2348,11 @@ class TraitListObject ( list ):
 
             if isinstance(key, slice):
                 values = value
-                try:
-                    key = slice(*key.indices(len( self )))
-                except (ValueError, TypeError):
-                    raise TypeError('must assign sequence (not "%s") to slice' % (
-                                    values.__class__.__name__ ))
-                slice_len = max(0, (key.stop - key.start) // key.step)
+                slice_len = len(removed)
+
                 delta = len( values ) - slice_len
-                if key.step != 1 and delta != 0:
+                step = 1 if key.step is None else key.step
+                if step != 1 and delta != 0:
                     raise ValueError(
                         'attempt to assign sequence of size %d to extended slice of size %d' % (
                         len( values ), slice_len
@@ -2369,7 +2366,7 @@ class TraitListObject ( list ):
                     values = [ validate( object, name, value )
                                for value in values ]
                 value = values
-                if key.step == 1:
+                if step == 1:
                     # FIXME: Bug-for-bug compatibility with old __setslice__ code.
                     # In this case, we return a TraitListEvent with an
                     # index=key.start and the removed and added lists as they
@@ -2423,10 +2420,10 @@ class TraitListObject ( list ):
             removed = []
 
         if isinstance(key,slice):
-            key = slice(*key.indices(len( self )))
-            slice_len = max(0, (key.stop - key.start) // key.step)
+            slice_len = len(removed)
             delta = slice_len
-            if key.step == 1:
+            step = 1 if key.step is None else key.step
+            if step == 1:
                 # FIXME: See corresponding comment in __setitem__() for
                 # explanation.
                 index = key.start

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -87,6 +87,8 @@ try:
     complex_fast_validate = ( 11, complex, complexfloating, None,
                                   float, floating, int, integer )
     bool_fast_validate    = ( 11, bool, bool_ )
+    # Tuple or single type suitable for an isinstance check.
+    _BOOL_TYPES = (bool, bool_)
 except ImportError:
     # The standard python definitions (without numpy):
     int_fast_validate     = ( 11, int )
@@ -94,6 +96,8 @@ except ImportError:
     float_fast_validate   = ( 11, float,   None, int, long )
     complex_fast_validate = ( 11, complex, None, float, int )
     bool_fast_validate    = ( 11, bool )
+    # Tuple or single type suitable for an isinstance check.
+    _BOOL_TYPES = bool
 
 #-------------------------------------------------------------------------------
 #  Returns a default text editor:
@@ -448,7 +452,7 @@ class BaseBool ( TraitType ):
 
             Note: The 'fast validator' version performs this check in C.
         """
-        if isinstance( value, bool ):
+        if isinstance( value, _BOOL_TYPES ):
             return value
 
         self.error( object, name, value )


### PR DESCRIPTION
Contains a master merge and changes to `ctraits.pyx` to accommodate #243.

Note: The error message generated by an invalid attribute lookup in Cython is different from the message generated by the code in master (but it's still a `TypeError`). The reason is that the Cython-generated code first does a `PyObject_GenericGetAttr` before calling `__getattr__`, and if you supply an attribute name that is not a string, the former will catch the error and display a (slightly) different message. As a result, I had to change `test_trait_exceptions.py` a little to stop looking for the offending value in the error message. 