### PR TITLE
Ensure that the result of retrieving a Bool trait is a Python bool

### DIFF
--- a/traits/tests/test_bool.py
+++ b/traits/tests/test_bool.py
@@ -63,6 +63,15 @@ class TestBool(unittest.TestCase):
         self.assertTrue(a.foo)
 
     @unittest.skipUnless(numpy_available, "numpy not available")
+    def test_numpy_bool_retrieved_as_bool(self):
+        a = A()
+        a.foo = numpy.bool_(True)
+        self.assertIsInstance(a.foo, bool)
+
+        a.foo = numpy.bool_(False)
+        self.assertIsInstance(a.foo, bool)
+
+    @unittest.skipUnless(numpy_available, "numpy not available")
     def test_numpy_bool_accepted_as_dict_value(self):
         # Regression test for enthought/traits#299.
         class HasBoolDict(HasTraits):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -86,7 +86,7 @@ try:
     float_fast_validate   = ( 11, float, floating, None, int, long, integer )
     complex_fast_validate = ( 11, complex, complexfloating, None,
                                   float, floating, int, integer )
-    bool_fast_validate    = ( 11, bool, bool_ )
+    bool_fast_validate    = ( 11, bool, None, bool_ )
     # Tuple or single type suitable for an isinstance check.
     _BOOL_TYPES = (bool, bool_)
 except ImportError:
@@ -453,7 +453,7 @@ class BaseBool ( TraitType ):
             Note: The 'fast validator' version performs this check in C.
         """
         if isinstance( value, _BOOL_TYPES ):
-            return value
+            return bool(value)
 
         self.error( object, name, value )
 


### PR DESCRIPTION
This PR changes the `Bool` trait type so that even when an `np.bool_` is put in, a Python `bool` comes out:

```
>>> from traits.api import HasTraits, Bool; import numpy as np
>>> class A(HasTraits):
...     foo = Bool
... 
>>> a = A(foo=np.bool_(True))
>>> type(a.foo)
<type 'bool'>
```
The motivation is twofold:

(1) Consistency with the `Int` trait type, where retrieval always gives a Python `int` or `long`. (Not a particularly strong argument, given that `Float` is a get-out-exactly-what-you-put-in type.)
(2) Avoid bugs of the form `do_something_with(a.foo)` where `do_something_with` expects a Python `bool` and breaks with an `np.bool_`. (#299 was a particular case of this that we ran into, since fixed, but it's not at all implausible that other examples of `np.bool_` intolerance exist in libraries outside our control.)



Addresses #304.

