### PR TITLE
[#321] pass exception directly to NotificationExceptionHandler._handle_exception()

### DIFF
--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -209,7 +209,7 @@ class NotificationExceptionHandler ( object ):
     #  It logs any exceptions generated in a trait notification handler.
     #---------------------------------------------------------------------------
 
-    def _log_exception ( self, object, trait_name, old, new ):
+    def _log_exception ( self, object, trait_name, old, new, excp ):
         """ Logs any exceptions generated in a trait notification handler.
         """
         # When the stack depth is too great, the logger can't always log the


### PR DESCRIPTION
A proposed fix for #321.  If desired, a more-sophisticated version could
1. retain the existing call to `sys.exc_info()` when (i.e., in Python 2) it can be relied upon not to return `(None, None, None)`; and/or
2. emulate the `AbstractStateChangeNotifyWrapper` class for backwards compatibility with exception-handlers that don't take the new `excp` argument.

Let me know if there's interest in either or  both of these amendments.
