### PR TITLE
Remove command-line option for setting toolkit

### DIFF
--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -245,8 +245,7 @@ class ETSConfig(object):
     def _get_toolkit(self):
         """
         Property getter for the GUI toolkit.  The value returned is, in order
-        of preference: the value set by the application; the value passed on
-        the command line using the '-toolkit' option; the value specified by
+        of preference: the value set by the application; the value specified by
         the 'ETS_TOOLKIT' environment variable; otherwise the empty string.
 
         """
@@ -282,8 +281,7 @@ class ETSConfig(object):
         Deprecated: This property is no longer used.
 
         Property getter for the Enable backend.  The value returned is, in order
-        of preference: the value set by the application; the value passed on
-        the command line using the '-toolkit' option; the value specified by
+        of preference: the value set by the application; the value specified by
         the 'ENABLE_TOOLKIT' environment variable; otherwise the empty string.
         """
         from warnings import warn

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -213,7 +213,7 @@ class ETSConfig(object):
     def provisional_toolkit(self, toolkit):
         """ Perform an operation with toolkit provisionally set
 
-        This sets the toolkit attribute of the ETSConfig object set to the
+        This sets the toolkit attribute of the ETSConfig object to the
         provided value. If the operation fails with an exception, the toolkit
         is reset to nothing.
 
@@ -461,26 +461,8 @@ class ETSConfig(object):
         Initializes the toolkit.
 
         """
-        # We handle the command line option even though it doesn't have the
-        # highest precedence because we always want to remove it from the
-        # command line.
-        if '-toolkit' in sys.argv:
-            opt_idx = sys.argv.index('-toolkit')
-
-            try:
-                opt_toolkit = sys.argv[opt_idx + 1]
-            except IndexError:
-                raise ValueError, "the -toolkit command line argument must be followed by a toolkit name"
-
-            # Remove the option.
-            del sys.argv[opt_idx:opt_idx + 2]
-        else:
-            opt_toolkit = None
-
         if self._toolkit is not None:
             toolkit = self._toolkit
-        elif opt_toolkit is not None:
-            toolkit = opt_toolkit
         else:
             toolkit = os.environ.get('ETS_TOOLKIT', '')
 

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -223,20 +223,6 @@ class ETSConfigTestCase(unittest.TestCase):
         self.assertEqual(dirname, self.ETSConfig.application_data)
         self.assertEqual(app_name, 'tests')
 
-    def test_toolkit_argv(self):
-        test_args = ['something', '-toolkit', 'test', 'something_else']
-        with mock_sys_argv(test_args):
-            toolkit = self.ETSConfig.toolkit
-
-        self.assertEqual(toolkit, 'test')
-        self.assertEqual(test_args, ['something', 'something_else'])
-
-    def test_toolkit_argv_missing(self):
-        test_args = ['something', '-toolkit']
-        with mock_sys_argv(test_args):
-            with self.assertRaises(ValueError):
-                self.ETSConfig.toolkit
-
     def test_toolkit_environ(self):
         test_args = ['something']
         test_environ = {'ETS_TOOLKIT': 'test'}
@@ -254,16 +240,6 @@ class ETSConfigTestCase(unittest.TestCase):
                 toolkit = self.ETSConfig.toolkit
 
         self.assertEqual(toolkit, '')
-
-    def test_toolkit_argv_wins(self):
-        test_args = ['something', '-toolkit', 'test_args', 'something_else']
-        test_environ = {'ETS_TOOLKIT': 'test_environ'}
-        with mock_sys_argv(test_args):
-            with mock_os_environ(test_environ):
-                toolkit = self.ETSConfig.toolkit
-
-        self.assertEqual(toolkit, 'test_args')
-        self.assertEqual(test_args, ['something', 'something_else'])
 
     def test_set_toolkit(self):
         test_args = ['something', '-toolkit', 'test_args', 'something_else']

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -242,7 +242,7 @@ class ETSConfigTestCase(unittest.TestCase):
         self.assertEqual(toolkit, '')
 
     def test_set_toolkit(self):
-        test_args = ['something', '-toolkit', 'test_args', 'something_else']
+        test_args = []
         test_environ = {'ETS_TOOLKIT': 'test_environ'}
 
         with mock_sys_argv(test_args):
@@ -251,10 +251,6 @@ class ETSConfigTestCase(unittest.TestCase):
                 toolkit = self.ETSConfig.toolkit
 
         self.assertEqual(toolkit, 'test_direct')
-        # XXX this is a bit of a dodgy outcome...
-        self.assertEqual(test_args,
-                         ['something', '-toolkit', 'test_args',
-                          'something_else'])
 
     def test_provisional_toolkit(self):
         test_args = []

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -97,7 +97,6 @@ except:
             """
             Property getter for the GUI toolkit.  The value returned is, in
             order of preference: the value set by the application; the value
-            passed on the command line using the '-toolkit' option; the value
             specified by the 'ETS_TOOLKIT' environment variable; otherwise the
             empty string.
             """
@@ -161,27 +160,8 @@ except:
         def _initialize_toolkit ( self ):
             """ Initializes the toolkit.
             """
-            # We handle the command line option even though it doesn't have the
-            # highest precedence because we always want to remove it from the
-            # command line:
-            if '-toolkit' in sys.argv:
-                opt_idx = sys.argv.index( '-toolkit' )
-
-                try:
-                    opt_toolkit = sys.argv[ opt_idx + 1 ]
-                except IndexError:
-                    raise ValueError( 'The -toolkit command line argument must '
-                                      'be followed by a toolkit name' )
-
-                # Remove the option:
-                del sys.argv[ opt_idx: opt_idx + 1 ]
-            else:
-                opt_toolkit = None
-
             if self._toolkit is not None:
                 toolkit = self._toolkit
-            elif opt_toolkit is not None:
-                toolkit = opt_toolkit
             else:
                 toolkit = os.environ.get( 'ETS_TOOLKIT', '' )
 


### PR DESCRIPTION
At present the ETSConfig option looks to see if there is are items `-toolkit` and a toolkit name adjacent in `sys.argv`; if so it removes them and uses the supplied toolkit.  This is completely independent of any other command-line argument processing done by other code, and the processing is done when the toolkit is first requested (which could occur in any number of places, possibly as a side-effect of imports), which may or may not be before any other argument parsing is done.  This is a potential source of subtle bugs.

Additionally, the use of `-toolkit` vs. `--toolkit` may be surprising to some, as it goes against some conventions for command-line argument use.

This PR removes this code and corresponding tests.

This is obviously a backward-incompatible change, although I have never seen the `-toolkit` option used.

Furthermore, this PR shouldn't be merged without the blessing of either @rkern or @mdickinson.