### PR TITLE
Add Bytes Trait and Related Traits

### DIFF
--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -37,6 +37,10 @@ Traits
 
 .. autoclass:: Unicode
 
+.. autoclass:: BaseBytes
+
+.. autoclass:: Bytes
+
 .. autoclass:: BaseBool
 
 .. autoclass:: Bool
@@ -64,6 +68,10 @@ Traits
 .. autoclass:: BaseCUnicode
 
 .. autoclass:: CUnicode
+
+.. autoclass:: BaseCBytes
+
+.. autoclass:: CBytes
 
 .. autoclass:: BaseCBool
 

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -133,7 +133,7 @@ in the following table.
 .. index:: Boolean type, Bool trait, CBool trait, Complex trait, CComplex trait
 .. index:: complex number type, Float trait, CFloat trait, Int trait, CInt trait
 .. index:: floating point number type, Long trait, CLong trait, Str trait
-.. index:: CStr trait, Unicode; trait, CUnicode trait
+.. index:: CStr trait, Unicode; trait, CUnicode trait, Bytes trait, CBytes trait
 
 .. _predefined-defaults-for-simple-types-table:
 
@@ -149,6 +149,7 @@ Int            CInt          Plain integer          0
 Long           CLong         Long integer           0L
 Str            CStr          String                 ''
 Unicode        CUnicode      Unicode                u''
+Bytes          CBytes        Bytes                  b''
 ============== ============= ====================== ======================
 
 .. index::
@@ -202,6 +203,7 @@ Python built-in functions for type conversion:
 * int()
 * str()
 * unicode()
+* bytes()
 
 .. index::
    single: examples; coercing vs. casting

--- a/traits/api.py
+++ b/traits/api.py
@@ -36,9 +36,9 @@ from .traits import (CTrait, Trait, Property, TraitFactory, Default, Color,
         RGBColor, Font)
 
 from .trait_types import (Any, Generic, Int, Long, Float, Complex, Str, Title,
-        Unicode, Bool, CInt, CLong, CFloat, CComplex, CStr, CUnicode, CBool,
-        String, Regex, Code, HTML, Password, Callable, This, self, Function,
-        Method, Module, Python, ReadOnly, Disallow, Constant,
+        Unicode, Bytes, Bool, CInt, CLong, CFloat, CComplex, CStr, CUnicode,
+        CBool, String, Regex, Code, HTML, Password, Callable, This, self,
+        Function, Method, Module, Python, ReadOnly, Disallow, Constant,
         Delegate, DelegatesTo, PrototypedFrom, Expression, PythonValue, File,
         Directory, Range, Enum, Tuple, List, CList, Set, CSet, Dict, Instance,
         AdaptedTo, AdaptsTo, Event, Button, ToolbarButton, Either, Type,

--- a/traits/api.py
+++ b/traits/api.py
@@ -37,8 +37,8 @@ from .traits import (CTrait, Trait, Property, TraitFactory, Default, Color,
 
 from .trait_types import (Any, Generic, Int, Long, Float, Complex, Str, Title,
         Unicode, Bytes, Bool, CInt, CLong, CFloat, CComplex, CStr, CUnicode,
-        CBool, String, Regex, Code, HTML, Password, Callable, This, self,
-        Function, Method, Module, Python, ReadOnly, Disallow, Constant,
+        CBytes, CBool, String, Regex, Code, HTML, Password, Callable, This,
+        self, Function, Method, Module, Python, ReadOnly, Disallow, Constant,
         Delegate, DelegatesTo, PrototypedFrom, Expression, PythonValue, File,
         Directory, Range, Enum, Tuple, List, CList, Set, CSet, Dict, Instance,
         AdaptedTo, AdaptsTo, Event, Button, ToolbarButton, Either, Type,
@@ -58,9 +58,9 @@ except ImportError:
     pass
 
 from .trait_types import (BaseInt, BaseLong, BaseFloat, BaseComplex, BaseStr,
-        BaseUnicode, BaseBool, BaseCInt, BaseCLong, BaseCFloat, BaseCComplex,
-        BaseCStr, BaseCUnicode, BaseCBool, BaseFile, BaseDirectory, BaseRange,
-        BaseEnum, BaseTuple, BaseInstance)
+        BaseUnicode, BaseBytes, BaseBool, BaseCInt, BaseCLong, BaseCFloat,
+        BaseCComplex, BaseCStr, BaseCUnicode, BaseCBool, BaseFile,
+        BaseDirectory, BaseRange, BaseEnum, BaseTuple, BaseInstance)
 
 from .trait_types import UUID, ValidatedTuple
 

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -19,7 +19,7 @@ import sys
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import (Any, CFloat, CInt, CLong, Delegate, Float, HasTraits,
+from ..api import (Any, Bytes, CFloat, CInt, CLong, Delegate, Float, HasTraits,
                    Instance, Int, List, Long, Str, Trait, TraitError,
                    TraitList, TraitPrefixList, TraitPrefixMap, TraitRange,
                    Tuple, pop_exception_handler, push_exception_handler)
@@ -321,6 +321,26 @@ class UnicodeTest(StringTest):
 
     def coerce(self, value):
         return str(value)
+
+
+class BytesTrait(HasTraits):
+    value = Bytes(b'bytes')
+
+version_dependent = ['', 'string']
+
+class BytesTest(StringTest):
+
+    obj = BytesTrait()
+
+    _default_value = b'bytes'
+    _good_values = [b'', b'10', b'-10'] + (version_dependent
+        if sys.version_info.major == 2 else [])
+    _bad_values = [10, -10, 10L, 10.1, u'unicode', u'', [b''], [b'bytes'], [0],
+        {b'ten': b'10'}, (b'',), None, True] + (version_dependent
+        if sys.version_info.major == 3 else [])
+
+    def coerce(self, value):
+        return bytes(value)
 
 
 class EnumTrait(HasTraits):

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -351,7 +351,8 @@ class CoercibleBytesTrait(HasTraits):
 
 version_dependent = [
     '', 'string', u'unicode', u'', -10, 10.1, [b''], [b'bytes'],
-    [-10], (-10,), {-10: 'foo'}, {-10}, [256], (256,), {256: 'foo'}, {256},
+    [-10], (-10,), {-10: 'foo'}, set([-10]),
+    [256], (256,), {256: 'foo'}, set([256]),
     {b'ten': b'10'}, (b'',), None,
 ]
 
@@ -360,7 +361,8 @@ class CoercibleBytesTest(StringTest):
     obj = CoercibleBytesTrait()
 
     _default_value = b'bytes'
-    _good_values = [b'', b'10', b'-10', 10, 10L, [10], (10,), {10}, {10: 'foo'},
+    _good_values = [
+        b'', b'10', b'-10', 10, 10L, [10], (10,), set([10]), {10: 'foo'},
         True] + (version_dependent if sys.version_info[0] == 2 else [])
     _bad_values = (version_dependent if sys.version_info[0] == 3 else [])
 

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -19,10 +19,11 @@ import sys
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import (Any, Bytes, CFloat, CInt, CLong, Delegate, Float, HasTraits,
-                   Instance, Int, List, Long, Str, Trait, TraitError,
-                   TraitList, TraitPrefixList, TraitPrefixMap, TraitRange,
-                   Tuple, pop_exception_handler, push_exception_handler)
+from ..api import (Any, Bytes, CBytes, CFloat, CInt, CLong, Delegate, Float,
+                   HasTraits, Instance, Int, List, Long, Str, Trait,
+                   TraitError, TraitList, TraitPrefixList, TraitPrefixMap,
+                   TraitRange, Tuple, pop_exception_handler,
+                   push_exception_handler)
 
 #  Base unit test classes:
 
@@ -340,6 +341,23 @@ class BytesTest(StringTest):
     _bad_values = [10, -10, 10L, 10.1, u'unicode', u'', [b''], [b'bytes'], [0],
         {b'ten': b'10'}, (b'',), None, True] + (version_dependent
         if sys.version_info[0] == 3 else [])
+
+    def coerce(self, value):
+        return bytes(value)
+
+
+class CoercibleBytesTrait(HasTraits):
+    value = CBytes(b'bytes')
+
+
+class CoercibleBytesTest(StringTest):
+
+    obj = CoercibleBytesTrait()
+
+    _default_value = b'bytes'
+    _good_values = [b'', b'10', b'-10', 10, -10, 10L, 10.1, u'unicode', u'', [b''], [b'bytes'], [0],
+        {b'ten': b'10'}, (b'',), None, True]
+    _bad_values = []
 
     def coerce(self, value):
         return bytes(value)

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -350,8 +350,9 @@ class CoercibleBytesTrait(HasTraits):
     value = CBytes(b'bytes')
 
 version_dependent = [
-    -10, 10.1, [b''], [b'bytes'], [-10], (-10,), {-10: 'foo'}, {-10},
-    [256], (256,), {256: 'foo'}, {256}, {b'ten': b'10'}, (b'',), None,
+    '', 'string', u'unicode', u'', -10, 10.1, [b''], [b'bytes'],
+    [-10], (-10,), {-10: 'foo'}, {-10}, [256], (256,), {256: 'foo'}, {256},
+    {b'ten': b'10'}, (b'',), None,
 ]
 
 class CoercibleBytesTest(StringTest):
@@ -359,9 +360,8 @@ class CoercibleBytesTest(StringTest):
     obj = CoercibleBytesTrait()
 
     _default_value = b'bytes'
-    _good_values = [b'', b'10', b'-10', '', 'string', 10, 10L,
-        u'unicode', u'', [10], (10), {10}, {10: 'foo'}, True] + (
-        version_dependent if sys.version_info[0] == 2 else [])
+    _good_values = [b'', b'10', b'-10', 10, 10L, [10], (10,), {10}, {10: 'foo'},
+        True] + (version_dependent if sys.version_info[0] == 2 else [])
     _bad_values = (version_dependent if sys.version_info[0] == 3 else [])
 
     def coerce(self, value):

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -326,7 +326,9 @@ class UnicodeTest(StringTest):
 class BytesTrait(HasTraits):
     value = Bytes(b'bytes')
 
+
 version_dependent = ['', 'string']
+
 
 class BytesTest(StringTest):
 
@@ -334,10 +336,10 @@ class BytesTest(StringTest):
 
     _default_value = b'bytes'
     _good_values = [b'', b'10', b'-10'] + (version_dependent
-        if sys.version_info.major == 2 else [])
+        if sys.version_info[0] == 2 else [])
     _bad_values = [10, -10, 10L, 10.1, u'unicode', u'', [b''], [b'bytes'], [0],
         {b'ten': b'10'}, (b'',), None, True] + (version_dependent
-        if sys.version_info.major == 3 else [])
+        if sys.version_info[0] == 3 else [])
 
     def coerce(self, value):
         return bytes(value)

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -349,15 +349,20 @@ class BytesTest(StringTest):
 class CoercibleBytesTrait(HasTraits):
     value = CBytes(b'bytes')
 
+version_dependent = [
+    -10, 10.1, [b''], [b'bytes'], [-10], (-10,), {-10: 'foo'}, {-10},
+    [256], (256,), {256: 'foo'}, {256}, {b'ten': b'10'}, (b'',), None,
+]
 
 class CoercibleBytesTest(StringTest):
 
     obj = CoercibleBytesTrait()
 
     _default_value = b'bytes'
-    _good_values = [b'', b'10', b'-10', 10, -10, 10L, 10.1, u'unicode', u'', [b''], [b'bytes'], [0],
-        {b'ten': b'10'}, (b'',), None, True]
-    _bad_values = []
+    _good_values = [b'', b'10', b'-10', '', 'string', 10, 10L,
+        u'unicode', u'', [10], (10), {10}, {10: 'foo'}, True] + (
+        version_dependent if sys.version_info[0] == 2 else [])
+    _bad_values = (version_dependent if sys.version_info[0] == 3 else [])
 
     def coerce(self, value):
         return bytes(value)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -709,8 +709,8 @@ class CUnicode ( BaseCUnicode ):
 #-------------------------------------------------------------------------------
 
 class BaseCBytes(BaseBytes):
-    """ Defines a trait whose value must be a Python unicode string and which
-        supports coercions of non-unicode values to unicode.
+    """ Defines a trait whose value must be a Python bytes object and which
+        supports coercions of non-bytes values to bytes.
     """
 
     def validate(self, object, name, value):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -458,13 +458,13 @@ class BaseBytes(TraitType):
     def create_editor(self):
         """ Returns the default traits UI editor for this type of trait.
         """
-        from .traits import multi_line_text_editor
+        from .traits import hex_editor
         auto_set = self.auto_set
         if auto_set is None:
             auto_set = True
         enter_set = self.enter_set or False
 
-        return multi_line_text_editor(auto_set, enter_set)
+        return hex_editor(auto_set, enter_set)
 
 
 class Bytes(BaseBytes):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -719,7 +719,7 @@ class BaseCBytes(BaseBytes):
             Note: The 'fast validator' version performs this check in C.
         """
         try:
-            return unicode(value)
+            return bytes(value)
         except:
             self.error(object, name, value)
 
@@ -731,7 +731,7 @@ class CBytes(BaseCBytes):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = ( 12, unicode )
+    fast_validate = (12, bytes)
 
 #-------------------------------------------------------------------------------
 #  'BaseCBool' and 'CBool' traits:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -430,6 +430,51 @@ class Unicode ( BaseUnicode ):
     #: The C-level fast validator to use:
     fast_validate = ( 11, unicode, None, str )
 
+
+#-------------------------------------------------------------------------------
+#  'BaseBytes' and 'Bytes' traits:
+#-------------------------------------------------------------------------------
+
+class BaseBytes(TraitType):
+    """ Defines a trait whose value must be a Python bytes string.
+    """
+
+    #: The default value for the trait:
+    default_value = b''
+
+    #: A description of the type of value this trait accepts:
+    info_text = 'a bytes string'
+
+    def validate(self, object, name, value):
+        """ Validates that a specified value is valid for this trait.
+
+            Note: The 'fast validator' version performs this check in C.
+        """
+        if isinstance(value, bytes):
+            return value
+
+        self.error(object, name, value)
+
+    def create_editor(self):
+        """ Returns the default traits UI editor for this type of trait.
+        """
+        from .traits import multi_line_text_editor
+        auto_set = self.auto_set
+        if auto_set is None:
+            auto_set = True
+        enter_set = self.enter_set or False
+
+        return multi_line_text_editor(auto_set, enter_set)
+
+
+class Bytes(BaseBytes):
+    """ Defines a trait whose value must be a Python bytes string using a
+        C-level fast validator.
+    """
+
+    #: The C-level fast validator to use:
+    fast_validate = (11, bytes)
+
 #-------------------------------------------------------------------------------
 #  'BaseBool' and 'Bool' traits:
 #-------------------------------------------------------------------------------
@@ -651,6 +696,35 @@ class BaseCUnicode ( BaseUnicode ):
 
 
 class CUnicode ( BaseCUnicode ):
+    """ Defines a trait whose value must be a Python unicode string and which
+        supports coercions of non-unicode values to unicode using a C-level
+        fast validator.
+    """
+
+    #: The C-level fast validator to use:
+    fast_validate = ( 12, unicode )
+
+#-------------------------------------------------------------------------------
+#  'BaseCBytes' and 'CBytes' traits:
+#-------------------------------------------------------------------------------
+
+class BaseCBytes(BaseBytes):
+    """ Defines a trait whose value must be a Python unicode string and which
+        supports coercions of non-unicode values to unicode.
+    """
+
+    def validate(self, object, name, value):
+        """ Validates that a specified value is valid for this trait.
+
+            Note: The 'fast validator' version performs this check in C.
+        """
+        try:
+            return unicode(value)
+        except:
+            self.error(object, name, value)
+
+
+class CBytes(BaseCBytes):
     """ Defines a trait whose value must be a Python unicode string and which
         supports coercions of non-unicode values to unicode using a C-level
         fast validator.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -445,6 +445,9 @@ class BaseBytes(TraitType):
     #: A description of the type of value this trait accepts:
     info_text = 'a bytes string'
 
+    #: An encoding to use with TraitsUI editors
+    encoding = None
+
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
@@ -458,13 +461,13 @@ class BaseBytes(TraitType):
     def create_editor(self):
         """ Returns the default traits UI editor for this type of trait.
         """
-        from .traits import hex_editor
+        from .traits import bytes_editor
         auto_set = self.auto_set
         if auto_set is None:
             auto_set = True
         enter_set = self.enter_set or False
 
-        return hex_editor(auto_set, enter_set)
+        return bytes_editor(auto_set, enter_set, self.encoding)
 
 
 class Bytes(BaseBytes):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -725,8 +725,8 @@ class BaseCBytes(BaseBytes):
 
 
 class CBytes(BaseCBytes):
-    """ Defines a trait whose value must be a Python unicode string and which
-        supports coercions of non-unicode values to unicode using a C-level
+    """ Defines a trait whose value must be a Python bytes and which
+        supports coercions of non-bytes values bytes using a C-level
         fast validator.
     """
 

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -87,6 +87,7 @@ KindMap = {
 
 PasswordEditor      = None
 MultilineTextEditor = None
+HexEditor           = None
 SourceCodeEditor    = None
 HTMLTextEditor      = None
 PythonShellEditor   = None
@@ -118,6 +119,41 @@ def multi_line_text_editor ( auto_set=True, enter_set=False ):
                                           enter_set  = enter_set )
 
     return MultilineTextEditor
+
+def hex_editor(auto_set=True, enter_set=False):
+    """ Factory function that returns a text editor for multi-line strings.
+    """
+    global HexEditor, format_bytes
+
+    if HexEditor is None:
+        try:
+            from traitsui.api import HexEditor
+        except ImportError:
+            from traitsui.api import TextEditor
+
+            if sys.version_info[0] == 2:
+                byte_to_hex = lambda b: "{:x}".format(ord(b))
+                hex_to_byte = lambda h: chr(int(h, base=16))
+            else:
+                byte_to_hex = lambda b: "{:x}".format(b)
+                hex_to_byte = lambda h: int(h, base=16)
+
+            def format_bytes(value):
+                """ Return bytes as hex values separated by spaces """
+                return ' '.join(byte_to_hex(b) for b in value)
+
+            def evaluate_bytes(text):
+                return b''.join(hex_to_byte(h) for h in text.split())
+
+            HexEditor = TextEditor(
+                multi_line=True,
+                format_func=format_bytes,
+                evaluate=evaluate_bytes,
+                auto_set=auto_set,
+                enter_set=enter_set
+            )
+
+    return HexEditor
 
 def code_editor ( ):
     """ Factory function that returns an editor that treats a multi-line string
@@ -1033,10 +1069,10 @@ def Property ( fget = None, fset = None, fvalidate = None, force = False,
     attribute this trait is assigned to. For example::
 
         class Bar(HasTraits):
-            
+
             # A float traits Property that should be always positive.
             foo = Property(Float)
-            
+
             # Shadow trait attribute
             _foo = Float
 
@@ -1249,4 +1285,3 @@ def Font ( *args, **metadata ):
     return FontTrait( *args, **metadata )
 
 Font = TraitFactory( Font )
-


### PR DESCRIPTION
Does what it says.  Resolves #328.

The `Bytes` trait is given an `encoding` attribute.  If this is not `None` it is used to specify a codec that the editor uses to decode the bytes to a unicode string, and to re-encode when changed.  If the encoding is none, the bytes are displayed as a hexadecimal value (with no spaces).

To do:
- [x] tests for `CBytes`
- [x] determine appropriate default editor settings.
- [x] add to documentation.
