### PR TITLE
DEV: run tests via Tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py{26,27,33,34,35}
+
+[testenv]
+deps = -rtravis-ci-requirements.txt
+
+changedir = .tox
+commands = python -m nose.core -v traits


### PR DESCRIPTION
Allows for running the tests via [Tox](http://tox.readthedocs.io/en/latest/). Assuming that tox is installed,  the test suite can be run against all supported Pythons via `tox`, or against one specific Python via `tox -e pyXY`, where XY is one of 26, 27, 33, 34, 35.