### PR TITLE
Fix issue #342

### DIFF
--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -17,17 +17,11 @@ import contextlib
 import threading
 import sys
 import warnings
+import unittest  # noqa
 
 from traits.api import (
     Any, Event, HasStrictTraits, Instance, Int, List, Str, Property)
 from traits.util.async_trait_wait import wait_for_condition
-
-# Compatibility layer for Python 2.6: try loading unittest2
-from traits import _py2to3
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest  # noqa
 
 
 class _AssertTraitChangesContext(object):

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -385,7 +385,7 @@ class UnittestTools(object):
             of changes. None can be used to indicate no timeout.
 
         """
-        collector = _TraitsChangeCollector(obj=obj, trait=trait)
+        collector = _TraitsChangeCollector(obj=obj, monitor_traits=trait)
 
         # Pass control to body of the with statement.
         collector.start_collecting()

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -22,6 +22,7 @@ import unittest  # noqa
 from traits.api import (
     Any, Event, HasStrictTraits, Instance, Int, List, Str, Property)
 from traits.util.async_trait_wait import wait_for_condition
+from traits import _py2to3 
 
 
 class _AssertTraitChangesContext(object):

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -151,8 +151,8 @@ class _TraitsChangeCollector(HasStrictTraits):
     _lock = Instance(threading.Lock, ())
 
     def __init__(self, **traits):
-        value = traits.pop('trait', None)
-        if value is not None:
+        if 'trait' in traits:
+            value = traits.pop('trait')
             message = (
                 "The `trait` keyword is deprecated."
                 " please use `monitor_traits`")

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -18,8 +18,8 @@ import threading
 import sys
 import warnings
 
-from traits.api import (Any, Event, HasStrictTraits, Instance, Int, List,
-        Property, Str)
+from traits.api import (
+    Any, Event, HasStrictTraits, Instance, Int, List, Str, Property)
 from traits.util.async_trait_wait import wait_for_condition
 
 # Compatibility layer for Python 2.6: try loading unittest2
@@ -27,7 +27,7 @@ from traits import _py2to3
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
 else:
-    import unittest
+    import unittest  # noqa
 
 
 class _AssertTraitChangesContext(object):
@@ -157,12 +157,14 @@ class _TraitsChangeCollector(HasStrictTraits):
     _lock = Instance(threading.Lock, ())
 
     def __init__(self, **traits):
-        value = traits.pop('trait', None):
+        value = traits.pop('trait', None)
         if value is not None:
-            message = "The `trait` keyword is deprecated please use `monitor_traits`"
+            message = (
+                "The `trait` keyword is deprecated."
+                " please use `monitor_traits`")
             warnings.warn(message, DeprecationWarning, stacklevel=2)
             traits['monitor_traits'] = value
-        super(_TraitChangeCollector, self).__init__(**traits)
+        super(_TraitsChangeCollector, self).__init__(**traits)
 
     def start_collecting(self):
         self.obj.on_trait_change(

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -22,7 +22,7 @@ import unittest  # noqa
 from traits.api import (
     Any, Event, HasStrictTraits, Instance, Int, List, Str, Property)
 from traits.util.async_trait_wait import wait_for_condition
-from traits import _py2to3 
+from traits import _py2to3
 
 
 class _AssertTraitChangesContext(object):
@@ -135,8 +135,8 @@ class _TraitsChangeCollector(HasStrictTraits):
     # The object we're listening to.
     obj = Any
 
-    # The (possibly extended) trait name.
-    monitor_traits = Str
+    # The (possibly extended) trait name(s).
+    trait_name = Str
 
     # Read-only event count.
     event_count = Property(Int)
@@ -156,21 +156,21 @@ class _TraitsChangeCollector(HasStrictTraits):
             value = traits.pop('trait')
             message = (
                 "The `trait` keyword is deprecated."
-                " please use `monitor_traits`")
+                " please use `trait_name`")
             warnings.warn(message, DeprecationWarning, stacklevel=2)
-            traits['monitor_traits'] = value
+            traits['trait_name'] = value
         super(_TraitsChangeCollector, self).__init__(**traits)
 
     def start_collecting(self):
         self.obj.on_trait_change(
             self._event_handler,
-            self.monitor_traits,
+            self.trait_name,
         )
 
     def stop_collecting(self):
         self.obj.on_trait_change(
             self._event_handler,
-            self.monitor_traits,
+            self.trait_name,
             remove=True,
         )
 
@@ -382,7 +382,7 @@ class UnittestTools(object):
             of changes. None can be used to indicate no timeout.
 
         """
-        collector = _TraitsChangeCollector(obj=obj, monitor_traits=trait)
+        collector = _TraitsChangeCollector(obj=obj, trait_name=trait)
 
         # Pass control to body of the with statement.
         collector.start_collecting()

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -141,7 +141,7 @@ class _TraitsChangeCollector(HasStrictTraits):
     obj = Any
 
     # The (possibly extended) trait name.
-    trait = Str
+    monitor_traits = Str
 
     # Read-only event count.
     event_count = Property(Int)
@@ -156,16 +156,24 @@ class _TraitsChangeCollector(HasStrictTraits):
     # simultaneously.
     _lock = Instance(threading.Lock, ())
 
+    def __init__(self, **traits):
+        value = traits.pop('trait', None):
+        if value is not None:
+            message = "The `trait` keyword is deprecated please use `monitor_traits`"
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            traits['monitor_traits'] = value
+        super(_TraitChangeCollector, self).__init__(**traits)
+
     def start_collecting(self):
         self.obj.on_trait_change(
             self._event_handler,
-            self.trait,
+            self.monitor_traits,
         )
 
     def stop_collecting(self):
         self.obj.on_trait_change(
             self._event_handler,
-            self.trait,
+            self.monitor_traits,
             remove=True,
         )
 


### PR DESCRIPTION
This PR renames the `trait` attribute of `_TraitsChangeCollector` to fix #342. There is no change at the constructor signature but I add a deprecation warning that prompts users to stop using `trait`