### PR TITLE
Drop support for older Python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
 branches:
   only:
     master

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,9 @@ inherited by any subclass derived from the class.
 Dependencies
 ------------
 
+Traits runs on both Python 2 and Python 3. It requires Python 2.7
+or Python >= 3.4.
+
 Traits has the following optional dependencies:
 
 * `NumPy <http://pypi.python.org/pypi/numpy>`_ to support the trait types

--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -1,5 +1,5 @@
-"%sdkverpath%" -q -version:"%sdkver%"
-call setenv /x64
+:: "%sdkverpath%" -q -version:"%sdkver%"
+:: call setenv /x64
 
 rem install python packages
 pip install --cache-dir C:/egg_cache nose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,21 +2,31 @@ build: false
 shallow_clone: true
 environment:
 
-  matrix:
-    - python: "C:/Python35-x64"
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
-    - python: "C:/Python36-x64"
+  matrix:
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
 
 cache:
   - c:\egg_cache
 
 init:
-  - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:path
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 install:
   - ps: if ((Test-Path "c:/egg_cache") -eq 0) { mkdir c:/egg_cache }
   - ps: python -m pip install --upgrade --no-binary wheel pip
   - ps: pip install --upgrade wheel
   - ps: pip --version
-  - cmd /v:on /e:on /c ".\appveyor-install.cmd"
+  - "%CMD_IN_ENV% .\\appveyor\\appveyor-install.cmd"
 test_script:
-  - cmd /v:on /e:on /c ".\appveyor-test.cmd"
+  - "%CMD_IN_ENV% .\\appveyor\\appveyor-test.cmd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,6 @@ environment:
     - python: "C:/Python27-x64"
       sdkver: "v7.0"
 
-    - python: "C:/Python33-x64"
-      sdkver: "v7.1"
-
     - python: "C:/Python34-x64"
       sdkver: "v7.1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,14 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,29 +2,16 @@ build: false
 shallow_clone: true
 environment:
 
-  global:
-    distutils_use_sdk: 1
-
   matrix:
-    - python: "C:/Python27-x64"
-      sdkver: "v7.0"
-
-    - python: "C:/Python34-x64"
-      sdkver: "v7.1"
-
     - python: "C:/Python35-x64"
-      sdkver: "v7.1"
 
     - python: "C:/Python36-x64"
-      sdkver: "v7.1"
 
 cache:
   - c:\egg_cache
 
 init:
-  - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"
-  - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
-  - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
+  - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:path
 install:
   - ps: if ((Test-Path "c:/egg_cache") -eq 0) { mkdir c:/egg_cache }
   - ps: python -m pip install --upgrade --no-binary wheel pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,12 @@ environment:
     - python: "C:/Python34-x64"
       sdkver: "v7.1"
 
+    - python: "C:/Python35-x64"
+      sdkver: "v7.1"
+
+    - python: "C:/Python36-x64"
+      sdkver: "v7.1"
+
 cache:
   - c:\egg_cache
 

--- a/appveyor/appveyor-install.cmd
+++ b/appveyor/appveyor-install.cmd
@@ -1,6 +1,3 @@
-:: "%sdkverpath%" -q -version:"%sdkver%"
-:: call setenv /x64
-
 rem install python packages
 pip install --cache-dir C:/egg_cache nose
 pip install --cache-dir C:/egg_cache coverage==3.7.1

--- a/appveyor/appveyor-test.cmd
+++ b/appveyor/appveyor-test.cmd
@@ -1,6 +1,3 @@
-"%sdkverpath%" -q -version:"%sdkver%"
-call setenv /x64
-
 mkdir testrun
 copy .coveragerc testrun
 cd testrun

--- a/appveyor/run_with_env.cmd
+++ b/appveyor/run_with_env.cmd
@@ -1,0 +1,88 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: Notes about batch files for Python people:
+::
+:: Quotes in values are literally part of the values:
+::      SET FOO="bar"
+:: FOO is now five characters long: " b a r "
+:: If you don't want quotes, don't include them on the right-hand side.
+::
+:: The CALL lines at the end of this file look redundant, but if you move them
+:: outside of the IF clauses, they do not run properly in the SET_SDK_64==Y
+:: case, I don't know why.
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+SET WIN_WDK=c:\Program Files (x86)\Windows Kits\10\Include\wdf
+
+:: Extract the major and minor versions, and allow for the minor version to be
+:: more than 9.  This requires the version number to have two dots in it.
+SET MAJOR_PYTHON_VERSION=%PYTHON_VERSION:~0,1%
+IF "%PYTHON_VERSION:~3,1%" == "." (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,1%
+) ELSE (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,2%
+)
+
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %MAJOR_PYTHON_VERSION% == 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
+) ELSE (
+    IF %MAJOR_PYTHON_VERSION% == 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %MINOR_PYTHON_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+            IF EXIST "%WIN_WDK%" (
+                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+                REN "%WIN_WDK%" 0wdf
+            )
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+        EXIT 1
+    )
+)
+
+IF %PYTHON_ARCH% == 64 (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,28 @@ if not is_released:
                                  git_revision=git_rev,
                                  is_released=IS_RELEASED))
 
+
+def check_python_version():
+    """
+    Check that this version of Python is supported.
+
+    Raise SystemExit for unsupported Python versions.
+    """
+    supported_python_version = (
+        (2, 7) <= sys.version_info < (3,)
+        or (3, 4) <= sys.version_info
+    )
+    if not supported_python_version:
+        sys.exit(
+            (
+                "Python version {0} is not supported by Traits. "
+                "Traits requires Python >= 2.7 or Python >= 3.4."
+            ).format(sys.version_info)
+        )
+
+
 if __name__ == "__main__":
+    check_python_version()
     write_version_py()
     from traits import __version__
 
@@ -136,6 +157,13 @@ if __name__ == "__main__":
             Operating System :: Unix
             Programming Language :: C
             Programming Language :: Python
+            Programming Language :: Python :: 2
+            Programming Language :: Python :: 2.7
+            Programming Language :: Python :: 3
+            Programming Language :: Python :: 3.4
+            Programming Language :: Python :: 3.5
+            Programming Language :: Python :: 3.6
+            Programming Language :: Python :: Implementation :: CPython
             Topic :: Scientific/Engineering
             Topic :: Software Development
             Topic :: Software Development :: Libraries

--- a/travis-ci-requirements.txt
+++ b/travis-ci-requirements.txt
@@ -3,5 +3,4 @@ cython
 Sphinx
 coverage
 coveralls
-unittest2 ; python_version == '2.6'
-numpy ; python_version >= '3.2'
+numpy ; python_version >= '3.4'


### PR DESCRIPTION
This PR drops support for Python 2.6 and Python 3.x with x < 4.

WIP because I want to add 3.5 (and possibly 3.6) to the CI setups before this is merged.