### PR TITLE
Fix a misuse of the unittest.expectedFailure decorator.

### DIFF
--- a/traits/tests/test_get_traits.py
+++ b/traits/tests/test_get_traits.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Int, Str, Undefined, ReadOnly, Float
+from ..api import Float, HasTraits, Int, ReadOnly, Str, TraitError, Undefined
 
 
 class Foo(HasTraits):
@@ -36,12 +36,12 @@ class Bar(HasTraits):
 
 class GetTraitTestCase(unittest.TestCase):
 
-    @unittest.expectedFailure
     def test_trait_set_bad(self):
-        b = Foo()
+        b = Foo(num=23)
         # This should fail before and after #234.
-        b.num = 'first'
-        self.assertEqual(b.num, 'first')
+        with self.assertRaises(TraitError):
+            b.num = 'first'
+        self.assertEqual(b.num, 23)
 
     def test_trait_set_replaced(self):
         b = Foo()


### PR DESCRIPTION
Besides being inappropriate here, this `expectedFailure` decorator also results in the following odd-looking output from our test suite, since nose [doesn't understand it](https://github.com/nose-devs/nose/issues/33):
```
/opt/python/2.7.9/lib/python2.7/unittest/case.py:340: RuntimeWarning: TestResult has no addExpectedFailure method, reporting as passes
```