### PR TITLE
Don't segfault when asked for the default value of a trait that doesn't have one.

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1609,6 +1609,11 @@ default_value_for ( trait_object      * trait,
         case 0:
         case 1:
             result = trait->default_value;
+            if (result == NULL) {
+                PyErr_SetString(
+                    PyExc_ValueError, "CTrait object has no default value.");
+                return NULL;
+            }
             Py_INCREF( result );
             break;
         case 2:

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1610,9 +1610,7 @@ default_value_for ( trait_object      * trait,
         case 1:
             result = trait->default_value;
             if (result == NULL) {
-                PyErr_SetString(
-                    PyExc_ValueError, "CTrait object has no default value.");
-                return NULL;
+                result = Py_None;
             }
             Py_INCREF( result );
             break;

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -102,8 +102,7 @@ class TestRegression(unittest.TestCase):
         # Regression test for enthought/traits#336.
         y_trait = SimpleProperty.class_traits()['y']
         simple_property = SimpleProperty
-        with self.assertRaises(ValueError):
-            y_trait.default_value_for(simple_property, "y")
+        self.assertIsNone(y_trait.default_value_for(simple_property, "y"))
 
     def test_subclasses_weakref(self):
         """ Make sure that dynamically created subclasses are not held

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -73,6 +73,15 @@ class ListUpdatesTest(HasTraits):
         self.events_received += 1
 
 
+class SimpleProperty(HasTraits):
+    x = Int
+
+    y = Property(Int, depends_on='x')
+
+    def _get_y(self):
+        return self.x + 1
+
+
 class TestRegression(unittest.TestCase):
 
     def test_default_value_for_no_cache(self):
@@ -86,6 +95,15 @@ class TestRegression(unittest.TestCase):
         default = ctrait.default_value_for(dummy, 'x')
         self.assertEqual(default, 10)
         self.assertEqual(dummy.__dict__, {})
+
+    def test_default_value_for_property(self):
+        """ Don't segfault when calling default_value_for on a Property trait.
+        """
+        # Regression test for enthought/traits#336.
+        y_trait = SimpleProperty.class_traits()['y']
+        simple_property = SimpleProperty
+        with self.assertRaises(ValueError):
+            y_trait.default_value_for(simple_property, "y")
 
     def test_subclasses_weakref(self):
         """ Make sure that dynamically created subclasses are not held


### PR DESCRIPTION
This PR modifies `cTrait.default_value_for` to raise `ValueError` when asked for the default value of a trait that doesn't have one (for example, a `Property` trait).

Fixes #336.

---

EDIT: Updated to return `None` rather than raising `ValueError`.