### PR TITLE
BUG: Fix validation of This traits.

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -428,10 +428,6 @@ class MetaHasTraits ( type ):
         # Finish building the class using the updated class dictionary:
         klass = type.__new__( cls, class_name, bases, class_dict )
 
-        # Fix up all self referential traits to refer to this class:
-        for trait in mhto.self_referential:
-            trait.set_validate( ( 11, klass ) )
-
         # Call all listeners that registered for this specific class:
         name = '%s.%s' % ( klass.__module__, klass.__name__ )
         for listener in MetaHasTraits._listeners.get( name, [] ):
@@ -481,7 +477,6 @@ class MetaHasTraitsObject ( object ):
         prefix_list      = []
         override_bases   = bases
         view_elements    = ViewElements()
-        self_referential = []
 
         # Create a list of just those base classes that derive from HasTraits:
         hastraits_bases = [ base for base in bases
@@ -534,11 +529,6 @@ class MetaHasTraitsObject ( object ):
                            if handler.is_mapped:
                                class_traits[ name + '_' ] = _mapped_trait_for(
                                                                          value )
-
-                           if isinstance( handler, This ):
-                               handler.info_text = \
-                                   add_article( class_name ) + ' instance'
-                               self_referential.append( value )
 
                     elif value_type == 'delegate':
                         # Only add a listener if the trait.listenable metadata
@@ -760,9 +750,6 @@ class MetaHasTraitsObject ( object ):
                     depends_on = ' ' + depends_on
 
                 listeners[ name ] = ( 'property', cached, depends_on )
-
-        # Save the list of self referential traits:
-        self.self_referential = self_referential
 
         # Add the traits meta-data to the class:
         self.add_traits_meta_data(

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -20,7 +20,7 @@ import sys
 from traits.testing.unittest_tools import unittest
 
 from ..api import (Any, Bytes, CBytes, CFloat, CInt, CLong, Delegate, Float,
-                   HasTraits, Instance, Int, List, Long, Str, Trait,
+                   HasTraits, Instance, Int, List, Long, Str, This, Trait,
                    TraitError, TraitList, TraitPrefixList, TraitPrefixMap,
                    TraitRange, Tuple, pop_exception_handler,
                    push_exception_handler)
@@ -961,3 +961,33 @@ class test_list_value(test_base2):
 
     def _record_trait_list_event(self, object, name, old, new):
         self.last_event = new
+
+
+class ThisDummy(HasTraits):
+    allows_none = This()
+    disallows_none = This(allow_none=False)
+
+
+class TestThis(unittest.TestCase):
+    def test_this_none(self):
+        d = ThisDummy()
+        self.assertIsNone(d.allows_none)
+        d.allows_none = None
+        d.allows_none = ThisDummy()
+        self.assertIsNotNone(d.allows_none)
+        d.allows_none = None
+        self.assertIsNone(d.allows_none)
+
+        # Still starts out as None, unavoidably.
+        self.assertIsNone(d.disallows_none)
+        d.disallows_none = ThisDummy()
+        self.assertIsNotNone(d.disallows_none)
+        with self.assertRaises(TraitError):
+            d.disallows_none = None
+        self.assertIsNotNone(d.disallows_none)
+
+    def test_this_other_class(self):
+        d = ThisDummy()
+        with self.assertRaises(TraitError):
+            d.allows_none = object()
+        self.assertIsNone(d.allows_none)


### PR DESCRIPTION
Fixes #352. There was some stale code that "fixes up" `This` traits to act like `Instance(Foo, allow_none=False)` traits. `ctraits.c` has the codepaths to handle `This` traits as-is, so I just removed the "fixup" code.