### PR TITLE
Add a context manager for temporarily changing the trait-change-event tracer

### DIFF
--- a/traits/tests/test_trait_change_event_tracer.py
+++ b/traits/tests/test_trait_change_event_tracer.py
@@ -73,11 +73,10 @@ class TestChangeEventTracers(unittest.TestCase):
         foo.on_trait_change(_on_foo_baz_changed, 'baz')
 
         # Set the event tracer and trigger a cascade of change events.
-        trait_notifiers.set_change_event_tracers(
-            pre_tracer=self._collect_pre_notification_events,
-            post_tracer=self._collect_post_notification_events)
-
-        foo.baz = 3
+        pre_tracer=self._collect_pre_notification_events
+        post_tracer=self._collect_post_notification_events
+        with trait_notifiers.change_event_tracers(pre_tracer, post_tracer):
+            foo.baz = 3
 
         self.assertEqual(len(self.pre_change_events), 4)
         self.assertEqual(len(self.post_change_events), 4)
@@ -100,8 +99,7 @@ class TestChangeEventTracers(unittest.TestCase):
 
         self.assertEqual(self.exceptions, [None] * 4)
 
-        # Deactivate the tracer; it should not be called anymore.
-        trait_notifiers.clear_change_event_tracers()
+        # Check that the tracers are no longer active.
         foo.baz = 23
         self.assertEqual(len(self.pre_change_events), 4)
         self.assertEqual(len(self.post_change_events), 4)
@@ -116,11 +114,10 @@ class TestChangeEventTracers(unittest.TestCase):
         foo.on_trait_change(_on_foo_fuz_changed, 'fuz')
 
         # Set the event tracer and trigger a cascade of change events.
-        trait_notifiers.set_change_event_tracers(
-            pre_tracer=self._collect_pre_notification_events,
-            post_tracer=self._collect_post_notification_events)
-
-        foo.fuz = 3
+        pre_tracer=self._collect_pre_notification_events
+        post_tracer=self._collect_post_notification_events
+        with trait_notifiers.change_event_tracers(pre_tracer, post_tracer):
+            foo.fuz = 3
 
         self.assertEqual(len(self.pre_change_events), 4)
         self.assertEqual(len(self.post_change_events), 4)

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -24,6 +24,7 @@
 
 from __future__ import absolute_import
 
+import contextlib
 from threading import local as thread_local
 from threading import Thread
 from thread import get_ident
@@ -290,12 +291,30 @@ def set_change_event_tracers( pre_tracer=None, post_tracer=None ):
     _pre_change_event_tracer = pre_tracer
     _post_change_event_tracer = post_tracer
 
+
+def get_change_event_tracers():
+    """ Get the currently active global trait change event tracers. """
+    return _pre_change_event_tracer, _post_change_event_tracer
+
+
 def clear_change_event_tracers():
     """ Clear the global trait change event tracer. """
     global _pre_change_event_tracer
     global _post_change_event_tracer
     _pre_change_event_tracer = None
     _post_change_event_tracer = None
+
+
+@contextlib.contextmanager
+def change_event_tracers(pre_tracer, post_tracer):
+    """ Context manager to temporarily change the global event tracers. """
+    old_pre_tracer, old_post_tracer = get_change_event_tracers()
+    set_change_event_tracers(pre_tracer, post_tracer)
+    try:
+        yield
+    finally:
+        set_change_event_tracers(old_pre_tracer, old_post_tracer)
+
 
 #-------------------------------------------------------------------------------
 #  'AbstractStaticChangeNotifyWrapper' class:


### PR DESCRIPTION
and use the new context manager in tests, to avoid test interactions.

Fixes #363.