### PR TITLE
MAINT: Instantiate HasTraits object in test.

### DIFF
--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -101,7 +101,7 @@ class TestRegression(unittest.TestCase):
         """
         # Regression test for enthought/traits#336.
         y_trait = SimpleProperty.class_traits()['y']
-        simple_property = SimpleProperty
+        simple_property = SimpleProperty()
         self.assertIsNone(y_trait.default_value_for(simple_property, "y"))
 
     def test_subclasses_weakref(self):


### PR DESCRIPTION
@mdickinson Would you mind giving this a quick review? This came up while I was trying to merge master in the Cython branch; the first argument of `default_value_for` should apparently be a `HasTraits` object, but it looks like a class was passed in instead in this particular test. The C implementation is happy with this (it just casts a pointer) but the Cython implementation stumbled over the types...