### PR TITLE
Python 3 Compatibility Fixes

### DIFF
--- a/docs/source/_extensions/refactordoc/base_doc.py
+++ b/docs/source/_extensions/refactordoc/base_doc.py
@@ -8,8 +8,8 @@
 #------------------------------------------------------------------------------
 import re
 
-from definition_items import DefinitionItem
-from line_functions import is_empty, get_indent, fix_backspace, NEW_LINE
+from .definition_items import DefinitionItem
+from .line_functions import is_empty, get_indent, fix_backspace, NEW_LINE
 
 
 underline_regex = re.compile(r'\s*\S+\s*\Z')

--- a/docs/source/_extensions/refactordoc/class_doc.py
+++ b/docs/source/_extensions/refactordoc/class_doc.py
@@ -6,9 +6,9 @@
 #  Copyright (c) 2011, Enthought, Inc.
 #  All rights reserved.
 #------------------------------------------------------------------------------
-from base_doc import BaseDoc
-from line_functions import get_indent, replace_at, add_indent
-from definition_items import (MethodItem, AttributeItem, TableLineItem,
+from .base_doc import BaseDoc
+from .line_functions import get_indent, replace_at, add_indent
+from .definition_items import (MethodItem, AttributeItem, TableLineItem,
                               max_attribute_length, max_attribute_index,
                               ListItem)
 

--- a/docs/source/_extensions/refactordoc/definition_items.py
+++ b/docs/source/_extensions/refactordoc/definition_items.py
@@ -10,7 +10,7 @@
 import collections
 import re
 
-from line_functions import (add_indent, fix_star, trim_indent, NEW_LINE,
+from .line_functions import (add_indent, fix_star, trim_indent, NEW_LINE,
                             fix_trailing_underscore)
 
 header_regex = re.compile(r'\s:\s?')

--- a/docs/source/_extensions/refactordoc/function_doc.py
+++ b/docs/source/_extensions/refactordoc/function_doc.py
@@ -7,9 +7,9 @@
 #  Copyright (c) 2011, Enthought, Inc.
 #  All rights reserved.
 #------------------------------------------------------------------------------
-from base_doc import BaseDoc
-from line_functions import get_indent, add_indent
-from definition_items import ArgumentItem, ListItem
+from .base_doc import BaseDoc
+from .line_functions import get_indent, add_indent
+from .definition_items import ArgumentItem, ListItem
 
 
 class FunctionDoc(BaseDoc):

--- a/docs/source/_extensions/refactordoc/line_functions.py
+++ b/docs/source/_extensions/refactordoc/line_functions.py
@@ -8,7 +8,8 @@
 #  All rights reserved.
 #-----------------------------------------------------------------------------
 import re
-
+import six
+import six.moves as sm
 
 #-----------------------------------------------------------------------------
 #  Pre-compiled regexes
@@ -73,7 +74,7 @@ def trim_indent(lines):
     """ Trim global indentation level from lines.
 
     """
-    non_empty_lines = filter(lambda x: not is_empty(x), lines)
+    non_empty_lines = sm.filter(lambda x: not is_empty(x), lines)
     indent = set(len(get_indent(line)) for line in non_empty_lines)
     indent.discard(0)
     global_indent = min(indent)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,8 +108,8 @@ def mock_modules():
         (mod_name, DocMock(mocked_name=mod_name)) for mod_name in MOCK_MODULES)
 
     # Report on what was mocked.
-    print 'mocking modules {0} and types {1}'.format(
-        MOCK_MODULES, [mocked[1] for mocked in MOCK_TYPES])
+    print('mocking modules {0} and types {1}'.format(
+        MOCK_MODULES, [mocked[1] for mocked in MOCK_TYPES]))
 
 mock_modules()
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,8 @@
 import sys
 import os
 
+import six
+
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
@@ -139,7 +141,7 @@ copyright = '2008-2011, Enthought'
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
 d = {}
-execfile(os.path.join('..', '..', 'traits', '__init__.py'), d)
+six.exec_(os.path.join('..', '..', 'traits', '__init__.py'), d)
 version = release = d['__version__']
 
 # There are two options for replacing |today|: either, you set today to some

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -883,9 +883,9 @@ interface and be open to extensions by adaptation as follows:
             # about adaptation.
             lines = printable.get_formatted_text(n_cols=20)
 
-            print '-- Start document --'
-            print '\n'.join(lines)
-            print '-- End of document -\n'
+            print('-- Start document --')
+            print('\n'.join(lines))
+            print('-- End of document -\n')
 
     class TextDocument(HasTraits):
         """ A text document. """

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -177,7 +177,7 @@ specifying only the wildcard character for the attribute name::
       File "all_wildcard.py", line 33, in <module>
         bill.age = 'middle age'
       File "c:\wrk\src\lib\enthought\traits\\trait_handlers.py", line 163, in error
-        raise TraitError, ( object, name, self.info(), value )
+        raise TraitError( object, name, self.info(), value )
     TraitError: The 'age' trait of a Person instance must be an integer, but a value
      of 'middle age' <type 'str'> was specified.
     """

--- a/docs/source/traits_user_manual/custom.rst
+++ b/docs/source/traits_user_manual/custom.rst
@@ -557,7 +557,7 @@ than a complete sentence::
       File "test.py", line 25, in ?
         odd_stuff.very_odd = 0
       File "C:\wrk\src\lib\enthought\traits\traits.py", line 1119, in validate
-        raise TraitError, excp
+        raise TraitError(excp)
     traits.traits.TraitError: The 'very_odd' trait of an AnOddClass instance
     must be **a positive odd integer** or -10 <= an integer <= -1, but a value
     of 0 <type 'int'> was specified.

--- a/docs/source/traits_user_manual/custom.rst
+++ b/docs/source/traits_user_manual/custom.rst
@@ -366,16 +366,16 @@ value in the dictionary corresponding to the value assigned. For example::
 
     >>> import mapped
     >>> my_shape1 = mapped.GraphicShape()
-    >>> print my_shape1.line_color, my_shape1.fill_color
+    >>> print(my_shape1.line_color, my_shape1.fill_color)
     black red
-    >>> print my_shape1.line_color_, my_shape1.fill_color_
+    >>> print(my_shape1.line_color_, my_shape1.fill_color_)
     (0.0, 0.0, 0.0, 1.0) (1.0, 0.0, 0.0, 1.0)
     >>> my_shape2 = mapped.GraphicShape()
     >>> my_shape2.line_color = 'blue'
     >>> my_shape2.fill_color = 'green'
-    >>> print my_shape2.line_color, my_shape2.fill_color
+    >>> print(my_shape2.line_color, my_shape2.fill_color)
     blue green
-    >>> print my_shape2.line_color_, my_shape2.fill_color_
+    >>> print(my_shape2.line_color_, my_shape2.fill_color_)
     (0.0, 0.0, 1.0, 1.0) (0.0, 1.0, 0.0, 1.0)
 
 This example shows how a mapped trait can be used to create a user-friendly
@@ -449,10 +449,10 @@ For example::
     ...
     >>> alf = Alien()
     >>> alf.heads = 'o'
-    >>> print alf.heads
+    >>> print(alf.heads)
     one
     >>> alf.heads = 'tw'
-    >>> print alf.heads
+    >>> print(alf.heads)
     two
     >>> alf.heads = 't'  # Error, not a unique prefix
     Traceback (most recent call last):

--- a/docs/source/traits_user_manual/deferring.rst
+++ b/docs/source/traits_user_manual/deferring.rst
@@ -78,10 +78,10 @@ DelegatesTo object. Consider the following example::
     >>> tony  = Parent(first_name='Anthony', last_name='Jones')
     >>> alice = Parent(first_name='Alice', last_name='Smith')
     >>> sally = Child( first_name='Sally', father=tony, mother=alice)
-    >>> print sally.last_name
+    >>> print(sally.last_name)
     Jones
     >>> sally.last_name = 'Cooper' # Updates delegatee
-    >>> print tony.last_name
+    >>> print(tony.last_name)
     Cooper
     >>> sally.last_name = sally.mother # ERR: string expected
     Traceback (most recent call last):
@@ -178,7 +178,7 @@ PrototypedFrom::
     >>> maria = Parent(first_name = 'Maria', family_name = 'Gonzalez',\
     ... favorite_first_name = 'Tomas', child_allowance = 10.0 )
     >>> nino = Child( father=fred, mother=maria )
-    >>> print '%s %s gets $%.2f for allowance' % (nino.first_name, \ ... nino.last_name, nino.allowance)
+    >>> print('%s %s gets $%.2f for allowance' % (nino.first_name, \ ... nino.last_name, nino.allowance))
     Tomas Lopez gets $5.00 for allowance
     """
 
@@ -236,7 +236,7 @@ example::
         last_name  = Str
 
         def _last_name_changed(self, new):
-            print "Parent's last name changed to %s." % new
+            print("Parent's last name changed to %s." % new)
 
     class Child ( HasTraits ):
 
@@ -245,7 +245,7 @@ example::
         last_name  = PrototypedFrom( 'father' )
 
         def _last_name_changed(self, new):
-            print "Child's last name changed to %s." % new
+            print("Child's last name changed to %s." % new)
 
     """
     >>> dad = Parent( first_name='William', last_name='Chase' )

--- a/docs/source/traits_user_manual/deferring.rst
+++ b/docs/source/traits_user_manual/deferring.rst
@@ -88,7 +88,7 @@ DelegatesTo object. Consider the following example::
       File "<stdin>", line 1, in ?
       File "c:\src\trunk\enthought\traits\trait_handlers.py", line
     163, in error
-        raise TraitError, ( object, name, self.info(), value )
+        raise TraitError( object, name, self.info(), value )
     traits.trait_errors.TraitError:  The 'last_name' trait of a
     Parent instance must be a string, but a value of <__main__.Parent object at
     0x014D6D80> <class '__main__.Parent'> was specified.

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -223,7 +223,7 @@ casting traits::
     traits.trait_errors.TraitError: The 'weight' trait of a Person instance
     must be a float, but a value of '180' <type 'str'> was specified.
     >>> bill.cweight = '180'  # OK, cast to float('180')
-    >>> print bill.cweight
+    >>> print(bill.cweight)
     180.0
     >>>
 
@@ -489,7 +489,7 @@ it is also a valid value for assignment.
     >>> hats = InventoryItem()
     >>> hats.name = 'Stetson'
 
-    >>> print '%s: %s' % (hats.name, hats.stock)
+    >>> print('%s: %s' % (hats.name, hats.stock))
     Stetson: None
 
     >>> hats.stock = 2      # OK
@@ -695,32 +695,32 @@ the metadata attribute::
 
     t = Test()
 
-    print t.trait( 'i' ).default                      # 99
-    print t.trait( 'i' ).default_kind                 # value
-    print t.trait( 'i' ).inner_traits                 # ()
-    print t.trait( 'i' ).is_trait_type( Int )         # True
-    print t.trait( 'i' ).is_trait_type( Float )       # False
+    print(t.trait( 'i' ).default)                      # 99
+    print(t.trait( 'i' ).default_kind)                 # value
+    print(t.trait( 'i' ).inner_traits)                 # ()
+    print(t.trait( 'i' ).is_trait_type( Int ))         # True
+    print(t.trait( 'i' ).is_trait_type( Float ))       # False
 
-    print t.trait( 'lf' ).default                     # []
-    print t.trait( 'lf' ).default_kind                # list
-    print t.trait( 'lf' ).inner_traits
+    print(t.trait( 'lf' ).default)                     # []
+    print(t.trait( 'lf' ).default_kind)                # list
+    print(t.trait( 'lf' ).inner_traits)
              # (<traits.traits.CTrait object at 0x01B24138>,)
-    print t.trait( 'lf' ).is_trait_type( List )       # True
-    print t.trait( 'lf' ).is_trait_type( TraitType )  # True
-    print t.trait( 'lf' ).is_trait_type( Float )      # False
-    print t.trait( 'lf' ).inner_traits[0].is_trait_type( Float ) # True
+    print(t.trait( 'lf' ).is_trait_type( List ))       # True
+    print(t.trait( 'lf' ).is_trait_type( TraitType ))  # True
+    print(t.trait( 'lf' ).is_trait_type( Float ))      # False
+    print(t.trait( 'lf' ).inner_traits[0].is_trait_type( Float )) # True
 
-    print t.trait( 'foo' ).default                    # <undefined>
-    print t.trait( 'foo' ).default_kind               # factory
-    print t.trait( 'foo' ).inner_traits               # ()
-    print t.trait( 'foo' ).is_trait_type( Instance )  # True
-    print t.trait( 'foo' ).is_trait_type( List  )     # False
+    print(t.trait( 'foo' ).default)                    # <undefined>
+    print(t.trait( 'foo' ).default_kind)               # factory
+    print(t.trait( 'foo' ).inner_traits)               # ()
+    print(t.trait( 'foo' ).is_trait_type( Instance ))  # True
+    print(t.trait( 'foo' ).is_trait_type( List  ))     # False
 
-    print t.trait( 'any' ).default                    # [1, 2, 3]
-    print t.trait( 'any' ).default_kind               # list
-    print t.trait( 'any' ).inner_traits               # ()
-    print t.trait( 'any' ).is_trait_type( Any )       # True
-    print t.trait( 'any' ).is_trait_type( List )      # False
+    print(t.trait( 'any' ).default)                    # [1, 2, 3]
+    print(t.trait( 'any' ).default_kind)               # list
+    print(t.trait( 'any' ).inner_traits)               # ()
+    print(t.trait( 'any' ).is_trait_type( Any ))       # True
+    print(t.trait( 'any' ).is_trait_type( List ))      # False
 
 .. rubric:: Footnotes
 .. [2] Most callable predefined traits are classes, but a few are functions.

--- a/docs/source/traits_user_manual/intro.rst
+++ b/docs/source/traits_user_manual/intro.rst
@@ -92,7 +92,7 @@ package. These features are elaborated in the rest of this guide.
 
         # NOTIFICATION: This method is called when 'age' changes:
         def _age_changed ( self, old, new ):
-            print 'Age changed from %s to %s ' % ( old, new )
+            print('Age changed from %s to %s ' % ( old, new ))
 
     # Set up the example:
     joe = Parent()
@@ -101,7 +101,7 @@ package. These features are elaborated in the rest of this guide.
     moe.father = joe
 
     # DELEGATION in action:
-    print "Moe's last name is %s " % moe.last_name
+    print("Moe's last name is %s " % moe.last_name)
     # Result:
     # Moe's last name is Johnson
 

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -357,9 +357,9 @@ some aspect of the extended trait name syntax in the name specifier.
     class Department( HasTraits ):
         employees = List(Employee)
 
-    def a_handler(): print "A handler"
-    def b_handler(): print "B handler"
-    def c_handler(): print "C handler"
+    def a_handler(): print("A handler")
+    def b_handler(): print("B handler")
+    def c_handler(): print("C handler")
 
     fred = Employee()
     mary = Employee()
@@ -377,9 +377,9 @@ some aspect of the extended trait name syntax in the name specifier.
     # c_handler is called if 'employees' or its membership change:
     dept.on_trait_change( c_handler, 'employees[]' )
 
-    print "Changing list items"
+    print("Changing list items")
     dept.employees[1] = donna     # Calls B and C
-    print "Replacing list"
+    print("Replacing list")
     dept.employees = [donna]      # Calls A and C
 
 .. index:: notification; static
@@ -502,13 +502,13 @@ illustrated in the following example::
         bmi = Float(0.0)
 
         def _weight_kg_changed(self, old, new):
-             print 'weight_kg changed from %s to %s ' % (old, new)
+             print('weight_kg changed from %s to %s ' % (old, new))
              if self.height_m != 0.0:
                  self.bmi = self.weight_kg / (self.height_m**2)
 
         def _anytrait_changed(self, name, old, new):
-             print 'The %s trait changed from %s to %s ' \
-                    % (name, old, new)
+             print('The %s trait changed from %s to %s ' \
+                    % (name, old, new))
     """
     >>> bob = Person()
     >>> bob.height_m = 1.75

--- a/docs/source/traits_user_manual/testing.rst
+++ b/docs/source/traits_user_manual/testing.rst
@@ -123,7 +123,7 @@ please follow the logic in the example below::
 
     # We can now use the mock in our tests.
     my_class.add_number(42)
-    print my_class.add_to_number.call_args_list
+    print(my_class.add_to_number.call_args_list)
 
 .. note::
 

--- a/examples/tutorials/doc_examples/examples/all_traits_features.py
+++ b/examples/tutorials/doc_examples/examples/all_traits_features.py
@@ -29,7 +29,7 @@ class Child(HasTraits):
 
     # NOTIFICATION: This method is called when 'age' changes:
     def _age_changed(self, old, new):
-        print 'Age changed from %s to %s ' % (old, new)
+        print('Age changed from %s to %s ' % (old, new))
 
 #--[Example*]------------------------------------------------------------------
 
@@ -40,7 +40,7 @@ moe = Child()
 moe.father = joe
 
 # DELEGATION in action:
-print "Moe's last name is %s " % moe.last_name
+print("Moe's last name is %s " % moe.last_name)
 # Result:
 # Moe's last name is Johnson
 

--- a/examples/tutorials/doc_examples/examples/all_wildcard.py
+++ b/examples/tutorials/doc_examples/examples/all_wildcard.py
@@ -32,11 +32,11 @@ bill.zip_code = 55212
 bill.age = 49
 
 # This should generate an error (must be an Int):
-print 'Attempting to assign a string to an Int trait object...\n'
+print('Attempting to assign a string to an Int trait object...\n')
 try:
     bill.age = 'middle age'
 except TraitError, c:
-    print 'TraitError: ', c, '\n'
+    print('TraitError: ', c, '\n')
 
 # Display the final results:
 bill.print_traits()

--- a/examples/tutorials/doc_examples/examples/all_wildcard.py
+++ b/examples/tutorials/doc_examples/examples/all_wildcard.py
@@ -35,7 +35,7 @@ bill.age = 49
 print('Attempting to assign a string to an Int trait object...\n')
 try:
     bill.age = 'middle age'
-except TraitError, c:
+except TraitError as c:
     print('TraitError: ', c, '\n')
 
 # Display the final results:

--- a/examples/tutorials/doc_examples/examples/bad_self_ref.py
+++ b/examples/tutorials/doc_examples/examples/bad_self_ref.py
@@ -14,5 +14,5 @@ try:
         # This won't work.
         # 'Employee' is not defined until the class definition is complete:
         manager = Instance(Employee)
-except NameError, excp:
-    print excp
+except NameError as excp:
+    print(excp)

--- a/examples/tutorials/doc_examples/examples/cached_prop.py
+++ b/examples/tutorials/doc_examples/examples/cached_prop.py
@@ -9,7 +9,8 @@
 # cached_prop.py - Example of @cached_property decorator
 #--[Imports]-------------------------------------------------------------------
 from traits.api import HasPrivateTraits, List, Int, Property, cached_property
-
+import six
+import six.moves as sm
 
 #--[Code]----------------------------------------------------------------------
 class TestScores(HasPrivateTraits):
@@ -20,4 +21,4 @@ class TestScores(HasPrivateTraits):
     @cached_property
     def _get_average(self):
         s = self.scores
-        return float(reduce(lambda n1, n2: n1 + n2, s, 0)) / len(s)
+        return float(sm.reduce(lambda n1, n2: n1 + n2, s, 0)) / len(s)

--- a/examples/tutorials/doc_examples/examples/cached_prop.py
+++ b/examples/tutorials/doc_examples/examples/cached_prop.py
@@ -8,9 +8,10 @@
 
 # cached_prop.py - Example of @cached_property decorator
 #--[Imports]-------------------------------------------------------------------
-from traits.api import HasPrivateTraits, List, Int, Property, cached_property
-import six
 import six.moves as sm
+
+from traits.api import HasPrivateTraits, List, Int, Property, cached_property
+
 
 #--[Code]----------------------------------------------------------------------
 class TestScores(HasPrivateTraits):

--- a/examples/tutorials/doc_examples/examples/circular_definition.py
+++ b/examples/tutorials/doc_examples/examples/circular_definition.py
@@ -20,5 +20,5 @@ try:
         # 'Chicken' won't be defined yet:
         created_by = Instance(Chicken)
 
-except NameError, excp:
-    print excp
+except NameError as excp:
+    print(excp)

--- a/examples/tutorials/doc_examples/examples/compound.py
+++ b/examples/tutorials/doc_examples/examples/compound.py
@@ -31,10 +31,10 @@ die.value = 'five'
 # Now try out some invalid values:
 try:
     die.value = 0
-except TraitError, excp:
-    print excp
+except TraitError as excp:
+    print(excp)
 
 try:
     die.value = 'zero'
-except TraitError, excp:
-    print excp
+except TraitError as excp:
+    print(excp)

--- a/examples/tutorials/doc_examples/examples/deferring_notification.py
+++ b/examples/tutorials/doc_examples/examples/deferring_notification.py
@@ -14,7 +14,7 @@ class Parent(HasTraits):
     last_name = Str
 
     def _last_name_changed(self, new):
-        print "Parent's last name changed to %s." % new
+        print("Parent's last name changed to %s." % new)
 
 
 class Child(HasTraits):
@@ -24,7 +24,7 @@ class Child(HasTraits):
     last_name = PrototypedFrom('father')
 
     def _last_name_changed(self, new):
-        print "Child's last name changed to %s." % new
+        print("Child's last name changed to %s." % new)
 
 
 #--[Example*]------------------------------------------------------------------

--- a/examples/tutorials/doc_examples/examples/delegate.py
+++ b/examples/tutorials/doc_examples/examples/delegate.py
@@ -26,20 +26,20 @@ alice = Parent(first_name='Alice', last_name='Smith')
 sally = Child(first_name='Sally', father=tony, mother=alice)
 
 # Child delegates its 'last_name' to its 'father' object's 'last_name'
-print sally.last_name
+print(sally.last_name)
 # Output: Jones
 
 # Assign an explicit value to the child's 'last_name'
 sally.last_name = 'Cooper'
-print tony.last_name
+print(tony.last_name)
 #Output: Cooper
 
 # Validation is still controlled by the father's 'last_name' trait
-print 'Attempting to assign a Parent object to a Str trait...\n'
+print('Attempting to assign a Parent object to a Str trait...\n')
 try:
     sally.last_name = sally.mother  # ERR: string expected
-except TraitError, c:
-    print 'TraitError: ', c
+except TraitError as c:
+    print('TraitError: ', c)
 
 """
 The exception printed will look similar to the following:
@@ -47,7 +47,7 @@ The exception printed will look similar to the following:
 Traceback (most recent call last):
   File "<stdin>", line 1, in ?
   File "c:\src\trunk\enthought\traits\trait_handlers.py", line 163, in error
-    raise TraitError, ( object, name, self.info(), value )
+    raise TraitError( object, name, self.info(), value )
 traits.trait_errors.TraitError: The 'last_name' trait of a Child
 instance must be a value of type 'str', but a value of <__main__.Parent object
 at 0x009DD6F0> was specified.

--- a/examples/tutorials/doc_examples/examples/dynamic_notification.py
+++ b/examples/tutorials/doc_examples/examples/dynamic_notification.py
@@ -30,5 +30,5 @@ class Widget(HasTraits):
 w = Widget()
 w.part1.cost = 2.25
 w.part2.cost = 5.31
-print w.cost
+print(w.cost)
 # Result: 7.56

--- a/examples/tutorials/doc_examples/examples/interface_implementation.py
+++ b/examples/tutorials/doc_examples/examples/interface_implementation.py
@@ -27,5 +27,5 @@ class Apartment(HasTraits):
 
 william = Person(first_name='William', last_name='Adams')
 apt1 = Apartment(renter=william)
-print 'Renter is: ', apt1.renter.get_name()
+print('Renter is: ', apt1.renter.get_name())
 # Result: Renter is: William Adams

--- a/examples/tutorials/doc_examples/examples/list_notifier.py
+++ b/examples/tutorials/doc_examples/examples/list_notifier.py
@@ -19,15 +19,15 @@ class Department(HasTraits):
 
 #--[Example*]------------------------------------------------------------------
 def a_handler():
-    print "A handler"
+    print("A handler")
 
 
 def b_handler():
-    print "B handler"
+    print("B handler")
 
 
 def c_handler():
-    print "C handler"
+    print("C handler")
 
 fred = Employee()
 mary = Employee()
@@ -45,7 +45,7 @@ dept.on_trait_change(b_handler, 'employees_items')
 # c_handler is called if 'employees' or its membership change:
 dept.on_trait_change(c_handler, '[employees]')
 
-print "Changing list items"
+print("Changing list items")
 dept.employees[1] = donna     # Calls B and C
-print "Replacing list"
+print("Replacing list")
 dept.employees = [donna]      # Calls A and C

--- a/examples/tutorials/doc_examples/examples/mapped.py
+++ b/examples/tutorials/doc_examples/examples/mapped.py
@@ -34,11 +34,11 @@ class GraphicShape(HasTraits):
 my_shape1 = GraphicShape()
 
 # Default values for normal trait attributes
-print my_shape1.line_color, my_shape1.fill_color
+print(my_shape1.line_color, my_shape1.fill_color)
 # Output: black red
 
 # Default values for shadow trait attributes
-print my_shape1.line_color_, my_shape1.fill_color_
+print(my_shape1.line_color_, my_shape1.fill_color_)
 # Output: (0.0, 0.0, 0.0, 1.0) (1.0, 0.0, 0.0, 1.0)
 
 # Non-default values
@@ -46,8 +46,8 @@ my_shape2 = GraphicShape()
 my_shape2.line_color = 'blue'
 my_shape2.fill_color = 'green'
 
-print my_shape2.line_color, my_shape2.fill_color
+print(my_shape2.line_color, my_shape2.fill_color)
 # Output: blue green
 
-print my_shape2.line_color_, my_shape2.fill_color_
+print(my_shape2.line_color_, my_shape2.fill_color_)
 # Output: (0.0, 0.0, 1.0, 1.0) (0.0, 1.0, 0.0, 1.0)

--- a/examples/tutorials/doc_examples/examples/metadata.py
+++ b/examples/tutorials/doc_examples/examples/metadata.py
@@ -23,29 +23,29 @@ class Test(HasTraits):
 t = Test()
 
 # Prints values of various metadata attributes for each of the traits.
-print t.trait('i').default                      # 99
-print t.trait('i').default_kind                 # value
-print t.trait('i').inner_traits                 # ()
-print t.trait('i').is_trait_type(Int)           # True
-print t.trait('i').is_trait_type(Float)         # False
+print(t.trait('i').default)                      # 99
+print(t.trait('i').default_kind)                 # value
+print(t.trait('i').inner_traits)                 # ()
+print(t.trait('i').is_trait_type(Int))           # True
+print(t.trait('i').is_trait_type(Float))         # False
 
-print t.trait('lf').default                     # []
-print t.trait('lf').default_kind                # list
-print t.trait('lf').inner_traits  # (<traits.traits.CTrait object at
+print(t.trait('lf').default)                     # []
+print(t.trait('lf').default_kind)                # list
+print(t.trait('lf').inner_traits)  # (<traits.traits.CTrait object at
                                   #  0x01B24138>,)
-print t.trait('lf').is_trait_type(List)         # True
-print t.trait('lf').is_trait_type(TraitType)    # True
-print t.trait('lf').is_trait_type(Float)        # False
-print t.trait('lf').inner_traits[0].is_trait_type(Float)  # True
+print(t.trait('lf').is_trait_type(List))         # True
+print(t.trait('lf').is_trait_type(TraitType))    # True
+print(t.trait('lf').is_trait_type(Float))        # False
+print(t.trait('lf').inner_traits[0].is_trait_type(Float))  # True
 
-print t.trait('foo').default                    # <undefined>
-print t.trait('foo').default_kind               # factory
-print t.trait('foo').inner_traits               # ()
-print t.trait('foo').is_trait_type(Instance)    # True
-print t.trait('foo').is_trait_type(List)        # False
+print(t.trait('foo').default)                    # <undefined>
+print(t.trait('foo').default_kind)               # factory
+print(t.trait('foo').inner_traits)               # ()
+print(t.trait('foo').is_trait_type(Instance))    # True
+print(t.trait('foo').is_trait_type(List))        # False
 
-print t.trait('any').default                    # [1, 2, 3]
-print t.trait('any').default_kind               # list
-print t.trait('any').inner_traits               # ()
-print t.trait('any').is_trait_type(Any)         # True
-print t.trait('any').is_trait_type(List)        # False
+print(t.trait('any').default)                    # [1, 2, 3]
+print(t.trait('any').default_kind)               # list
+print(t.trait('any').inner_traits)               # ()
+print(t.trait('any').is_trait_type(Any))         # True
+print(t.trait('any').is_trait_type(List))        # False

--- a/examples/tutorials/doc_examples/examples/metadata.py
+++ b/examples/tutorials/doc_examples/examples/metadata.py
@@ -31,8 +31,8 @@ print(t.trait('i').is_trait_type(Float))         # False
 
 print(t.trait('lf').default)                     # []
 print(t.trait('lf').default_kind)                # list
-print(t.trait('lf').inner_traits)  # (<traits.traits.CTrait object at
-                                  #  0x01B24138>,)
+print(t.trait('lf').inner_traits)            # (<traits.traits.CTrait object at
+                                             #  0x01B24138>,)
 print(t.trait('lf').is_trait_type(List))         # True
 print(t.trait('lf').is_trait_type(TraitType))    # True
 print(t.trait('lf').is_trait_type(Float))        # False

--- a/examples/tutorials/doc_examples/examples/minimal.py
+++ b/examples/tutorials/doc_examples/examples/minimal.py
@@ -17,18 +17,18 @@ class Person(HasTraits):
 joe = Person()
 
 # Show the default value
-print joe.weight
+print(joe.weight)
 
 # Assign new values
 joe.weight = 161.9     # OK to assign a float
-print joe.weight
+print(joe.weight)
 
 joe.weight = 162       # OK to assign an int
-print joe.weight
+print(joe.weight)
 
 # The following line causes a traceback:
 try:
     joe.weight = 'average'  # Error to assign a string
-    print "You should not see this message."
+    print("You should not see this message.")
 except TraitError:
-    print "You can't assign a string to the 'weight' trait."
+    print("You can't assign a string to the 'weight' trait.")

--- a/examples/tutorials/doc_examples/examples/prototype_prefix.py
+++ b/examples/tutorials/doc_examples/examples/prototype_prefix.py
@@ -37,5 +37,5 @@ maria = Parent(first_name='Maria',
 
 nino = Child(father=fred, mother=maria)
 
-print '%s %s gets $%.2f for allowance' % (nino.first_name, nino.last_name,
-                                          nino.allowance)
+print('%s %s gets $%.2f for allowance' % (nino.first_name, nino.last_name,
+                                          nino.allowance))

--- a/examples/tutorials/doc_examples/examples/static_notification.py
+++ b/examples/tutorials/doc_examples/examples/static_notification.py
@@ -14,12 +14,12 @@ class Person(HasTraits):
     bmi = Float(0.0)
 
     def _weight_kg_changed(self, old, new):
-        print 'weight_kg changed from %s to %s ' % (old, new)
+        print('weight_kg changed from %s to %s ' % (old, new))
         if self.height_m != 0.0:
             self.bmi = self.weight_kg / (self.height_m ** 2)
 
     def _anytrait_changed(self, name, old, new):
-        print 'The %s trait changed from %s to %s ' % (name, old, new)
+        print('The %s trait changed from %s to %s ' % (name, old, new))
 
 
 #--[Example*]------------------------------------------------------------------

--- a/examples/tutorials/traits_4.0/decorators/cached_property.py
+++ b/examples/tutorials/traits_4.0/decorators/cached_property.py
@@ -78,7 +78,7 @@ class TestScores(HasPrivateTraits):
 
     @cached_property
     def _get_average(self):
-        print "...computing average:",
+        print("...computing average:",)
         s = self.scores
         return (float(reduce(lambda n1, n2: n1 + n2, s, 0)) / len(s))
 
@@ -88,11 +88,11 @@ class TestScores(HasPrivateTraits):
 test_scores = TestScores(scores=[89, 93, 76, 84, 62, 96, 75, 81, 69, 90])
 
 # Display the average:
-print 'First average:', test_scores.average
-print 'Check that again:', test_scores.average
+print('First average:', test_scores.average)
+print('Check that again:', test_scores.average)
 
 # Now add a few more late scores into the mix:
 test_scores.scores.extend([85, 61, 70])
 
 # And display the new average:
-print 'Second average:', test_scores.average
+print('Second average:', test_scores.average)

--- a/examples/tutorials/traits_4.0/decorators/cached_property.py
+++ b/examples/tutorials/traits_4.0/decorators/cached_property.py
@@ -66,6 +66,8 @@ Use of the *cached_property* decorator also eliminates the need to add *cached
 using *depends_on* metadata with a cached property definition.
 """
 
+import six.moves as sm
+
 from traits.api import *
 from traitsui.api import *
 
@@ -80,7 +82,7 @@ class TestScores(HasPrivateTraits):
     def _get_average(self):
         print("...computing average:",)
         s = self.scores
-        return (float(reduce(lambda n1, n2: n1 + n2, s, 0)) / len(s))
+        return (float(sm.reduce(lambda n1, n2: n1 + n2, s, 0)) / len(s))
 
 
 #--[Example*]------------------------------------------------------------------

--- a/examples/tutorials/traits_4.0/decorators/on_trait_change.py
+++ b/examples/tutorials/traits_4.0/decorators/on_trait_change.py
@@ -152,8 +152,8 @@ class Corporation(HasTraits):
     # Define a corporate 'whistle blower' method:
     @on_trait_change('departments:employees.sick_days')
     def sick_again(self, object, name, old, new):
-        print '%s just took sick day number %d for this year!' % (
-              object.name, new)
+        print('%s just took sick day number %d for this year!' % (
+              object.name, new))
 
 
 #--[Example*]------------------------------------------------------------------

--- a/examples/tutorials/traits_4.0/delegation/delegation.py
+++ b/examples/tutorials/traits_4.0/delegation/delegation.py
@@ -58,29 +58,29 @@ trait and then try out various combinations of setting both the *father* and
 is called::
 
     def name_changed(name):
-        print 'Your last name has been changed to %s.' % name
+        print('Your last name has been changed to %s.' % name)
 
     # Set up a change notification handler on the son's last name:
     son.on_trait_change(name_changed, 'last_name')
 
     # This should cause the son's last name to change as well:
-    print "Changing dad's last name to Jones."
+    print("Changing dad's last name to Jones.")
     dad.last_name = 'Jones'
 
     # This change overrides the father's last name for the son:
-    print "Changing son's last name to Thomas."
+    print("Changing son's last name to Thomas.")
     son.last_name = 'Thomas'
 
     # This should no longer have any effect on the son's last name:
-    print "Changing dad's last name to Riley."
+    print("Changing dad's last name to Riley.")
     dad.last_name = 'Riley'
 
     # Son decides to revert his name back to his father's name:
-    print "Reverting son's last name."
+    print("Reverting son's last name.")
     del son.last_name
 
     # Now changing the father's name should affect the son again:
-    print "Changing dad's last name to Simmons."
+    print("Changing dad's last name to Simmons.")
     dad.last_name = 'Simmons'
 
 For the actual results of running this code, refer to the **Output** tab. Note

--- a/examples/tutorials/traits_4.0/delegation/delegation.py
+++ b/examples/tutorials/traits_4.0/delegation/delegation.py
@@ -118,27 +118,27 @@ son = Child(mother=mom, father=dad, first_name='John')
 
 
 def name_changed(name):
-    print 'Your last name has been changed to %s.' % name
+    print('Your last name has been changed to %s.' % name)
 
 # Set up a change notification handler on the son's last name:
 son.on_trait_change(name_changed, 'last_name')
 
 # This should cause the son's last name to change as well:
-print "Changing dad's last name to Jones."
+print("Changing dad's last name to Jones.")
 dad.last_name = 'Jones'
 
 # This change overrides the father's last name for the son:
-print "Changing son's last name to Thomas."
+print("Changing son's last name to Thomas.")
 son.last_name = 'Thomas'
 
 # This should no longer have any effect on the son's last name:
-print "Changing dad's last name to Riley."
+print("Changing dad's last name to Riley.")
 dad.last_name = 'Riley'
 
 # Son decides to revert his name back to his father's name:
-print "Reverting son's last name."
+print("Reverting son's last name.")
 del son.last_name
 
 # Now changing the father's name should affect the son again:
-print "Changing dad's last name to Simmons."
+print("Changing dad's last name to Simmons.")
 dad.last_name = 'Simmons'

--- a/examples/tutorials/traits_4.0/extended_trait_change/extended_trait_change.py
+++ b/examples/tutorials/traits_4.0/extended_trait_change/extended_trait_change.py
@@ -308,8 +308,8 @@ acme = Corporation(name='Acme, Inc.',
 
 # Define a corporate 'whistle blower' function:
 def sick_again(object, name, old, new):
-    print '%s just took sick day number %d for this year!' % (
-          object.name, new)
+    print('%s just took sick day number %d for this year!' % (
+          object.name, new))
 
 # Set up the function as a listener:
 acme.on_trait_change(sick_again, 'departments.employees.sick_days')

--- a/examples/tutorials/traits_4.0/extended_trait_change/properties.py
+++ b/examples/tutorials/traits_4.0/extended_trait_change/properties.py
@@ -54,6 +54,8 @@ tab's *total_hits* trait definition.
 """
 
 # FIXME redo example without traitsui
+import six
+import six.moves as sm
 
 from traits.api import *
 
@@ -124,7 +126,7 @@ class LeagueModelView(ModelView):
     def _get_total_hits(self):
         """ Returns the total number of hits across all teams and players.
         """
-        return reduce(add, [reduce(add, [p.hits for p in t.players], 0)
+        return sm.reduce(add, [sm.reduce(add, [p.hits for p in t.players], 0)
                             for t in self.model.teams], 0)
 
     view = View(

--- a/examples/tutorials/traits_4.0/extended_trait_change/properties.py
+++ b/examples/tutorials/traits_4.0/extended_trait_change/properties.py
@@ -54,7 +54,7 @@ tab's *total_hits* trait definition.
 """
 
 # FIXME redo example without traitsui
-import six
+
 import six.moves as sm
 
 from traits.api import *

--- a/examples/tutorials/traits_4.0/getstate_setstate/getstate.py
+++ b/examples/tutorials/traits_4.0/getstate_setstate/getstate.py
@@ -156,8 +156,8 @@ class Session(HasTraits):
 session = Session(name='session_1')
 
 # Display its contents:
-print 'Session name:', session.name
-print 'Session created:', session.created
+print('Session name:', session.name)
+print('Session created:', session.created)
 
 # # Simulate saving the session to a file/database:
 # saved_session = dumps(session)

--- a/examples/tutorials/traits_4.0/getstate_setstate/getstate.py
+++ b/examples/tutorials/traits_4.0/getstate_setstate/getstate.py
@@ -127,9 +127,10 @@ notifications managed by traits are correctly initialized for the object.
 Failure to call this method may result in lost change notifications.
 """
 
+from six.moves.cPickle import dumps, loads
+
 from traits.api import *
 from time import time, sleep
-from cPickle import dumps, loads
 
 
 #--[Session Class]-------------------------------------------------------------

--- a/examples/tutorials/traits_4.0/interfaces/adaptation.py
+++ b/examples/tutorials/traits_4.0/interfaces/adaptation.py
@@ -186,10 +186,10 @@ The following code shows a simple example of using adaptation::
     apt = Apartment(renter = william)
 
     # Verify that the resulting value implements 'IName' correctly:
-    print 'Renter is: ', apt.renter.get_name()
+    print('Renter is: ', apt.renter.get_name())
 
     # Check the type of object actually assigned to 'renter':
-    print apt.renter
+    print(apt.renter)
 
 Refer to the **Output** tab for the actual result of running this example.
 

--- a/examples/tutorials/traits_4.0/interfaces/adaptation.py
+++ b/examples/tutorials/traits_4.0/interfaces/adaptation.py
@@ -276,7 +276,7 @@ william = Person(first_name='William', last_name='Adams')
 apt = Apartment(renter=william)
 
 # Verify that the object works correctly:
-print 'Renter is:', apt.renter.get_name()
+print('Renter is:', apt.renter.get_name())
 
 # Check the type of object actually assigned to 'renter':
-print apt.renter
+print(apt.renter)

--- a/examples/tutorials/traits_4.0/interfaces/interfaces.py
+++ b/examples/tutorials/traits_4.0/interfaces/interfaces.py
@@ -135,4 +135,4 @@ william = Person(first_name='William', last_name='Adams')
 apt = Apartment(renter=william)
 
 # Verify that the object works correctly:
-print 'Renter is:', apt.renter.get_name()
+print('Renter is:', apt.renter.get_name())

--- a/examples/tutorials/traits_4.0/trait_types/new_types.py
+++ b/examples/tutorials/traits_4.0/trait_types/new_types.py
@@ -205,10 +205,10 @@ for i in range(10):
     craps.rolls.append((craps.die, craps.die))
 
 # Display the results:
-print craps.rolls
+print(craps.rolls)
 
 # Try to assign an invalid dice roll:
 try:
     craps.rolls.append((0, 0))
 except TraitError:
-    print 'Assigning an invalid dice roll failed.'
+    print('Assigning an invalid dice roll failed.')

--- a/examples/tutorials/traits_4.0/trait_types/trait_types.py
+++ b/examples/tutorials/traits_4.0/trait_types/trait_types.py
@@ -126,14 +126,14 @@ t = Test()
 
 # Set both traits to an odd integer value:
 t.any_int = 1
-print "t.any_int:", t.any_int
+print("t.any_int:", t.any_int)
 
 t.odd_int = 1
-print "t.odd_int:", t.odd_int
+print("t.odd_int:", t.odd_int)
 
 # Now set them both to an even value (and see what happens):
 t.any_int = 2
-print "t.any_int:", t.any_int
+print("t.any_int:", t.any_int)
 
 t.odd_int = 2
-print "t.odd_int:", t.odd_int  # Should never get here!
+print("t.odd_int:", t.odd_int)  # Should never get here!

--- a/examples/tutorials/tutor.py
+++ b/examples/tutorials/tutor.py
@@ -766,7 +766,7 @@ class Lab(ASection):
                         del values[name]
 
                 # Execute the current lab code:
-                exec module[2:] in values, values
+                exec(module[2:] in values, values)
 
                 # fixme: Hack trying to update the Traits UI view of the dict.
                 self.values = {}
@@ -1617,7 +1617,7 @@ if __name__ == '__main__':
 
     # Validate the command line arguments:
     if len(sys.argv) > 2:
-        print Usage
+        print(Usage)
         sys.exit(1)
 
     # Determine the root path to use for the tutorial files:
@@ -1631,10 +1631,10 @@ if __name__ == '__main__':
     if tutor.root is not None:
         tutor.configure_traits()
     else:
-        print """No traits tutorial found in %s.
+        print("""No traits tutorial found in %s.
 
 Correct usage is: python tutor.py [tutorial_path]
 where: tutorial_path = Path to the root of the traits tutorial.
 
 If tutorial_path is omitted, the current directory is assumed to be the root of
-the tutorial.""" % path
+the tutorial.""" % path)

--- a/examples/tutorials/tutor.py
+++ b/examples/tutorials/tutor.py
@@ -25,6 +25,8 @@ import re
 from string \
     import capwords
 
+import six
+
 from traits.api import (HasPrivateTraits, HasTraits, File, Directory, Instance,
                         Int, Str, List, Bool, Dict, Property,
                         Button, cached_property)
@@ -766,7 +768,7 @@ class Lab(ASection):
                         del values[name]
 
                 # Execute the current lab code:
-                exec(module[2:] in values, values)
+                six.exec_(module[2:] in values, values)
 
                 # fixme: Hack trying to update the Traits UI view of the dict.
                 self.values = {}
@@ -783,7 +785,7 @@ class Lab(ASection):
                 if isinstance(popup, HasTraits):
                     popup.edit_traits(kind='livemodal')
 
-            except SyntaxError, excp:
+            except SyntaxError as excp:
                 # Convert the line number of the syntax error from one in the
                 # composite module to one in the appropriate code snippet:
                 line = excp.lineno

--- a/setup.py
+++ b/setup.py
@@ -151,10 +151,8 @@ if __name__ == "__main__":
         packages=find_packages(exclude=['fixers']),
         platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
         zip_safe=False,
-        use_2to3=True,
-        use_2to3_fixers=['fixers'],
+        use_2to3=False,
         # traits_listener.ListenerItem has a trait *next* which gets
         # wrongly renamed
-        use_2to3_exclude_fixers=['lib2to3.fixes.fix_next'],
         cmdclass=additional_commands(),
     )

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ if not is_released:
 
 if __name__ == "__main__":
     write_version_py()
-    from traits import __version__
+    from traits import __version__, __requires__
 
     ctraits = Extension(
         'traits.ctraits',
@@ -143,6 +143,7 @@ if __name__ == "__main__":
         description='explicitly typed attributes for Python',
         long_description=open('README.rst').read(),
         download_url='https://github.com/enthought/traits',
+        install_requires=__requires__,
         ext_modules=[ctraits],
         license='BSD',
         maintainer='ETS Developers',

--- a/traits/__init__.py
+++ b/traits/__init__.py
@@ -5,6 +5,11 @@ from traits._version import full_version as __version__
 # Add a NullHandler so 'traits' loggers don't complain when they get used.
 import logging
 
+
+__requires__ = [
+    'six'
+]
+
 class NullHandler(logging.Handler):
 
     def handle(self, record):

--- a/traits/adaptation/adaptation_manager.py
+++ b/traits/adaptation/adaptation_manager.py
@@ -19,6 +19,8 @@ import itertools
 import sys
 import functools
 
+import six
+
 from traits.adaptation.adaptation_error import AdaptationError
 from traits.has_traits import HasTraits
 from traits.trait_types import Dict, List, Str
@@ -322,7 +324,7 @@ class AdaptationManager(HasTraits):
 
         edges = []
 
-        for from_protocol_name, offers in self._adaptation_offers.items():
+        for from_protocol_name, offers in six.iteritems(self._adaptation_offers):
             from_protocol = offers[0].from_protocol
             mro_distance = self.mro_distance_to_protocol(
                 current_protocol, from_protocol

--- a/traits/adaptation/adaptation_offer.py
+++ b/traits/adaptation/adaptation_offer.py
@@ -12,6 +12,7 @@
 #------------------------------------------------------------------------------
 """ An offer to provide adapters from one protocol to another. """
 
+import six
 
 from traits.api import Any, Bool, HasTraits, Property
 
@@ -83,7 +84,7 @@ class AdaptationOffer(HasTraits):
         """ Trait property getter. """
 
         if not self._factory_loaded:
-            if isinstance(self._factory, basestring):
+            if isinstance(self._factory, six.string_types):
                 self._factory = import_symbol(self._factory)
 
             self._factory_loaded = True
@@ -105,7 +106,7 @@ class AdaptationOffer(HasTraits):
         """ Trait property getter. """
 
         if not self._from_protocol_loaded:
-            if isinstance(self._from_protocol, basestring):
+            if isinstance(self._from_protocol, six.string_types):
                 self._from_protocol = import_symbol(self._from_protocol)
 
             self._from_protocol_loaded = True
@@ -127,7 +128,7 @@ class AdaptationOffer(HasTraits):
         """ Trait property getter. """
 
         if not self._to_protocol_loaded:
-            if isinstance(self._to_protocol, basestring):
+            if isinstance(self._to_protocol, six.string_types):
                 self._to_protocol = import_symbol(self._to_protocol)
 
             self._to_protocol_loaded = True
@@ -153,7 +154,7 @@ class AdaptationOffer(HasTraits):
 
         """
 
-        if isinstance(type_or_type_name, basestring):
+        if isinstance(type_or_type_name, six.string_types):
             type_name = type_or_type_name
 
         else:

--- a/traits/adaptation/cached_adapter_factory.py
+++ b/traits/adaptation/cached_adapter_factory.py
@@ -15,6 +15,8 @@
 
 import weakref
 
+import six
+
 from traits.api import Any, Bool, HasTraits, Property
 from traits.util.api import import_symbol
 
@@ -78,7 +80,7 @@ class CachedAdapterFactory(HasTraits):
         """ Trait property getter. """
 
         if not self._factory_loaded:
-            if isinstance(self._factory, basestring):
+            if isinstance(self._factory, six.string_types):
                 self._factory = import_symbol(self._factory)
 
             self._factory_loaded = True

--- a/traits/adaptation/tests/abc_examples.py
+++ b/traits/adaptation/tests/abc_examples.py
@@ -3,6 +3,8 @@
 
 from abc import ABCMeta
 
+import six
+
 from traits.adaptation.api import PurePythonAdapter as Adapter
 
 
@@ -10,17 +12,21 @@ from traits.adaptation.api import PurePythonAdapter as Adapter
 
 #### Protocols ################################################################
 
+@six.add_metaclass(ABCMeta)
 class UKStandard(object):
-    __metaclass__ = ABCMeta
+    pass
 
+@six.add_metaclass(ABCMeta)
 class EUStandard(object):
-    __metaclass__ = ABCMeta
+    pass
 
+@six.add_metaclass(ABCMeta)
 class JapanStandard(object):
-    __metaclass__ = ABCMeta
+    pass
 
+@six.add_metaclass(ABCMeta)
 class IraqStandard(object):
-    __metaclass__ = ABCMeta
+    pass
 
 #### Implementations ##########################################################
 
@@ -99,14 +105,17 @@ EUStandard.register(TravelPlugToEUStandard)
 class FileType(object):
     pass
 
+@six.add_metaclass(ABCMeta)
 class IEditor(object):
-    __metaclass__ = ABCMeta
+    pass
 
+@six.add_metaclass(ABCMeta)
 class IScriptable(object):
-    __metaclass__ = ABCMeta
+    pass
 
+@six.add_metaclass(ABCMeta)
 class IUndoable(object):
-    __metaclass__ = ABCMeta
+    pass
 
 
 class FileTypeToIEditor(Adapter):
@@ -123,8 +132,9 @@ IUndoable.register(IScriptableToIUndoable)
 
 #### Hierarchy example ########################################################
 
+@six.add_metaclass(ABCMeta)
 class IPrintable(object):
-    __metaclass__ = ABCMeta
+    pass
 
 class Editor(object):
     pass
@@ -145,8 +155,9 @@ IPrintable.register(TextEditorToIPrintable)
 
 #### Interface hierarchy example ##############################################
 
+@six.add_metaclass(ABCMeta)
 class IPrimate(object):
-    __metaclass__ = ABCMeta
+    pass
 
 class IHuman(IPrimate):
     pass
@@ -154,11 +165,13 @@ class IHuman(IPrimate):
 class IChild(IHuman):
     pass
 
+@six.add_metaclass(ABCMeta)
 class IIntermediate(object):
-    __metaclass__ = ABCMeta
+    pass
 
+@six.add_metaclass(ABCMeta)
 class ITarget(object):
-    __metaclass__ = ABCMeta
+    pass
 
 class Source(object):
     pass
@@ -188,17 +201,20 @@ ITarget.register(IIntermediateToITarget)
 
 #### Non-trivial chaining example #############################################
 
+@six.add_metaclass(ABCMeta)
 class IStart(object):
-    __metaclass__ = ABCMeta
+    pass
 
+@six.add_metaclass(ABCMeta)
 class IGeneric(object):
-    __metaclass__ = ABCMeta
+    pass
 
 class ISpecific(IGeneric):
     pass
 
+@six.add_metaclass(ABCMeta)
 class IEnd(object):
-    __metaclass__ = ABCMeta
+    pass
 
 class Start(object):
     pass

--- a/traits/adaptation/tests/benchmark.py
+++ b/traits/adaptation/tests/benchmark.py
@@ -11,6 +11,8 @@ from pprint import pprint
 import time
 
 import six
+import six.moves as sm
+
 
 from traits.adaptation.adaptation_manager import AdaptationManager
 from traits.api import Adapter, HasTraits, Interface, provides
@@ -29,14 +31,14 @@ class IFoo{i}(Interface):
 class Foo{i}(HasTraits):
     pass
 """
-for i in range(N_SOURCES):
+for i in sm.xrange(N_SOURCES):
     exec(create_classes_to_adapt.format(i=i))
 
 # The object that we will try to adapt!
 foo = Foo1()
 
 # Create a lot of other interfaces that we will adapt to.
-for i in range(N_PROTOCOLS):
+for i in sm.xrange(N_PROTOCOLS):
     exec('class I{i}(Interface): pass'.format(i=i))
 
 create_traits_adapter_class = """
@@ -46,8 +48,8 @@ class IFoo{source}ToI{target}(Adapter):
 """
 
 #  Create adapters from each 'IFooX' to all of the interfaces.
-for source in range(N_SOURCES):
-    for target in range(N_PROTOCOLS):
+for source in sm.xrange(N_SOURCES):
+    for target in sm.xrange(N_PROTOCOLS):
         exec(create_traits_adapter_class.format(source=source, target=target))
 
 
@@ -68,12 +70,12 @@ adaptation_manager.register_factory(
 # We register the adapters in reversed order, so that looking for the one
 # with index 0 will need traversing the whole list.
 # I.e., we're considering the worst case scenario.
-for source in range(N_SOURCES):
-    for target in reversed(range(N_PROTOCOLS)):
+for source in sm.xrange(N_SOURCES):
+    for target in reversed(sm.xrange(N_PROTOCOLS)):
         exec(register_ifoox_to_ix.format(source=source, target=target))
 
 start_time = time.time()
-for _ in range(N_ITERATIONS):
+for _ in sm.xrange(N_ITERATIONS):
     adaptation_manager.adapt(foo, I0)
 time_per_iter = (time.time() - start_time) / float(N_ITERATIONS) * 1000.0
 print('apptools using Interfaces: %.3f msec per iteration' % time_per_iter)
@@ -82,7 +84,7 @@ print('apptools using Interfaces: %.3f msec per iteration' % time_per_iter)
 #### traits.adaptation with ABCs ##############################################
 
 # Create some classes to adapt (using ABCs!).
-for i in range(N_SOURCES):
+for i in sm.xrange(N_SOURCES):
     exec(
 '''
 @six.add_metaclass(abc.ABCMeta)
@@ -96,7 +98,7 @@ class FooABC{i}(object):
 foo = Foo0()
 
 # Create a lot of other ABCs!
-for i in range(N_PROTOCOLS):
+for i in sm.xrange(N_PROTOCOLS):
     exec(
 '''
 @six.add_metaclass(abc.ABCMeta)
@@ -113,8 +115,8 @@ class FooABC{source}ToABC{target}(object):
 ABC{target}.register(FooABC{source}ToABC{target})
 """
 
-for source in range(N_SOURCES):
-    for target in range(N_PROTOCOLS):
+for source in sm.xrange(N_SOURCES):
+    for target in sm.xrange(N_PROTOCOLS):
         exec(create_abc_adapter_class.format(source=source, target=target))
 
 # Register all of the adapters.
@@ -131,12 +133,12 @@ adaptation_manager.register_factory(
 # We register the adapters in reversed order, so that looking for the one
 # with index 0 will need traversing the whole list.
 # I.e., we're considering the worst case scenario.
-for source in range(N_SOURCES):
-    for target in reversed(range(N_PROTOCOLS)):
+for source in sm.xrange(N_SOURCES):
+    for target in reversed(sm.xrange(N_PROTOCOLS)):
         exec(register_fooxabc_to_abcx.format(source=source, target=target))
 
 start_time = time.time()
-for _ in range(N_ITERATIONS):
+for _ in sm.xrange(N_ITERATIONS):
     adaptation_manager.adapt(foo, ABC0)
 time_per_iter = (time.time() - start_time) / float(N_ITERATIONS) * 1000.0
 print('apptools using ABCs: %.3f msec per iteration' % time_per_iter)

--- a/traits/category.py
+++ b/traits/category.py
@@ -31,6 +31,8 @@
 
 from __future__ import absolute_import
 
+import six
+
 from .has_traits import MetaHasTraits, MetaHasTraitsObject
 
 #-------------------------------------------------------------------------------
@@ -43,8 +45,7 @@ class MetaCategory ( MetaHasTraits ):
 
         # Make sure the correct usage is being applied:
         if len( bases ) > 2:
-            raise TypeError, \
-                  "Correct usage is: class FooCategory(Category,Foo):"
+            raise TypeError("Correct usage is: class FooCategory(Category,Foo):")
 
         # Process any traits-related information in the class dictionary:
         MetaCategoryObject( cls, class_name, bases, class_dict, True )
@@ -53,7 +54,7 @@ class MetaCategory ( MetaHasTraits ):
         # dictionary:
         if len( bases ) == 2:
             category_class = bases[1]
-            for name, value in class_dict.items():
+            for name, value in six.iteritems(class_dict):
                 if not hasattr( category_class, name ):
                     setattr( category_class, name, value )
                     del class_dict[ name ]
@@ -87,7 +88,7 @@ class MetaCategoryObject ( MetaHasTraitsObject ):
 #-------------------------------------------------------------------------------
 #  'Category' class:
 #-------------------------------------------------------------------------------
-
+@six.add_metaclass(MetaCategory)
 class Category ( object ):
     """ Used for defining "category" extensions to existing classes.
 
@@ -105,6 +106,4 @@ class Category ( object ):
         class BaseExtra(Category, Base):
             z = Str("BaseExtra z")
     """
-
-    __metaclass__ = MetaCategory
 

--- a/traits/category.py
+++ b/traits/category.py
@@ -45,7 +45,8 @@ class MetaCategory ( MetaHasTraits ):
 
         # Make sure the correct usage is being applied:
         if len( bases ) > 2:
-            raise TypeError("Correct usage is: class FooCategory(Category,Foo):")
+            raise TypeError(
+                  "Correct usage is: class FooCategory(Category,Foo):")
 
         # Process any traits-related information in the class dictionary:
         MetaCategoryObject( cls, class_name, bases, class_dict, True )
@@ -54,8 +55,10 @@ class MetaCategory ( MetaHasTraits ):
         # dictionary:
         if len( bases ) == 2:
             category_class = bases[1]
-            for name, value in six.iteritems(class_dict):
+            # This modifies the dictionary in place
+            for name in list(six.iterkeys(class_dict)):
                 if not hasattr( category_class, name ):
+                    value = class_dict[name]
                     setattr( category_class, name, value )
                     del class_dict[ name ]
 
@@ -88,6 +91,8 @@ class MetaCategoryObject ( MetaHasTraitsObject ):
 #-------------------------------------------------------------------------------
 #  'Category' class:
 #-------------------------------------------------------------------------------
+
+
 @six.add_metaclass(MetaCategory)
 class Category ( object ):
     """ Used for defining "category" extensions to existing classes.
@@ -106,4 +111,3 @@ class Category ( object ):
         class BaseExtra(Category, Base):
             z = Str("BaseExtra z")
     """
-

--- a/traits/etsconfig/api.py
+++ b/traits/etsconfig/api.py
@@ -1,1 +1,1 @@
-from etsconfig import ETSConfig, ETSToolkitError
+from .etsconfig import ETSConfig, ETSToolkitError

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -267,8 +267,8 @@ class ETSConfig(object):
         """
 
         if self._toolkit and self._toolkit != toolkit:
-            raise ValueError, "cannot set toolkit to %s because it has "\
-                            "already been set to %s" % (toolkit, self._toolkit)
+            raise ValueError("cannot set toolkit to %s because it has "\
+                            "already been set to %s" % (toolkit, self._toolkit))
 
         self._toolkit = toolkit
 
@@ -318,7 +318,7 @@ class ETSConfig(object):
         value will be a reasonable default for the given enable backend.
         """
         if self._toolkit is None:
-            raise AttributeError, "The kiva_backend attribute is dependent on toolkit, which has not been set."
+            raise AttributeError("The kiva_backend attribute is dependent on toolkit, which has not been set.")
 
         if self._kiva_backend is None:
             try:
@@ -470,7 +470,7 @@ class ETSConfig(object):
             try:
                 opt_toolkit = sys.argv[opt_idx + 1]
             except IndexError:
-                raise ValueError, "the -toolkit command line argument must be followed by a toolkit name"
+                raise ValueError("the -toolkit command line argument must be followed by a toolkit name")
 
             # Remove the option.
             del sys.argv[opt_idx:opt_idx + 2]

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -286,7 +286,7 @@ class ETSConfigTestCase(unittest.TestCase):
 
         with mock_sys_argv(test_args):
             with mock_os_environ(test_environ):
-                print repr(self.ETSConfig.toolkit)
+                print(repr(self.ETSConfig.toolkit))
                 with self.ETSConfig.provisional_toolkit('test_direct'):
                     toolkit = self.ETSConfig.toolkit
                     self.assertEqual(toolkit, 'test_direct')

--- a/traits/has_dynamic_views.py
+++ b/traits/has_dynamic_views.py
@@ -85,6 +85,8 @@ _<dynamic_name>_handler : A HasTraits instance.
 
 from __future__ import absolute_import
 
+import six
+
 # Enthought library imports:
 from traitsui.delegating_handler import DelegatingHandler
 
@@ -199,7 +201,7 @@ class HasDynamicViews ( HasTraits ):
             # If this is a request for the default view, see if one of our
             # dynamic views should be the default view:
             if (view_element is None) and (name is None or len( name ) < 1):
-                for dname, declaration in self._dynamic_view_registry.items():
+                for dname, declaration in six.iteritems(self._dynamic_view_registry):
                     if declaration.use_as_default:
                         result = self._compose_dynamic_view( dname )
                         break
@@ -336,8 +338,7 @@ class HasDynamicViews ( HasTraits ):
                     filtered[ order ] = e
 
         # Sort the contributed elements by their display ordering values:
-        ordering = filtered.keys()
-        ordering.sort()
+        ordering = sorted(six.iterkeys(filtered))
         elements = [ filtered[ order ] for order in ordering ]
 
         # Replace any dynamic sub-element with their full composition.

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1264,7 +1264,7 @@ class HasTraits ( CHasTraits ):
 
             # Merge the 'listeners':
             subclass_traits = getattr( subclass, ListenerTraits )
-            for name, value in listeners.items():
+            for name, value in six.iteritems(listeners):
                 subclass_traits.setdefault( name, value )
 
         # Copy all our new view elements into the base class's ViewElements:
@@ -1276,7 +1276,7 @@ class HasTraits ( CHasTraits ):
                     base_ve = ViewElements()
                     setattr( cls, ViewTraits, base_ve )
                 base_ve_content = base_ve.content
-                for name, value in content.items():
+                for name, value in six.iteritems(content):
                     base_ve_content.setdefault( name, value )
 
     _add_trait_category = classmethod( _add_trait_category )
@@ -2957,7 +2957,7 @@ class HasTraits ( CHasTraits ):
         traits = self.__base_traits__.copy()
         
         # Update with instance-defined traits.
-        for name, trt in self._instance_traits().items():
+        for name, trt in six.iteritems(self._instance_traits()):
             if name[-6:] != "_items":
                 traits[name] = trt
 

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3090,7 +3090,7 @@ class HasTraits ( CHasTraits ):
         This method is similar to the traits() method, but returns only the
         names of the matching trait attributes, not the trait definitions.
         """
-        return self.traits( **metadata ).keys()
+        return list(six.iterkeys(self.traits( **metadata )))
 
     def class_trait_names ( cls, **metadata ):
         """Returns a list of the names of all trait attributes whose definitions
@@ -3106,7 +3106,7 @@ class HasTraits ( CHasTraits ):
         This method is similar to the traits() method, but returns only the
         names of the matching trait attributes, not the trait definitions.
         """
-        return cls.class_traits( **metadata ).keys()
+        return list(six.iterkeys(cls.class_traits( **metadata )))
 
     class_trait_names = classmethod( class_trait_names )
 

--- a/traits/interface_checker.py
+++ b/traits/interface_checker.py
@@ -24,11 +24,11 @@
 
 from __future__ import absolute_import
 
-import six
-
 from types import FunctionType
 
 from inspect import getargspec, getmro
+
+import six
 
 from .has_traits import HasTraits
 

--- a/traits/interface_checker.py
+++ b/traits/interface_checker.py
@@ -24,6 +24,8 @@
 
 from __future__ import absolute_import
 
+import six
+
 from types import FunctionType
 
 from inspect import getargspec, getmro
@@ -147,7 +149,7 @@ class InterfaceChecker ( HasTraits ):
 
         if len( missing ) > 0:
             return self._handle_error( MISSING_TRAIT %
-                       ( self._class_name( cls ), `list( missing )`[1:-1],
+                       ( self._class_name( cls ), repr(list( missing ))[1:-1],
                          self._class_name( interface ) ), error_mode )
 
         return True
@@ -163,7 +165,7 @@ class InterfaceChecker ( HasTraits ):
             if c is HasTraits:
                 break
 
-            for name, value in c.__dict__.items():
+            for name, value in six.iteritems(c.__dict__):
                 if ((not name.startswith( '_' )) and
                         (type( value ) is FunctionType)):
                     if name not in public_methods:

--- a/traits/testing/api.py
+++ b/traits/testing/api.py
@@ -1,3 +1,3 @@
-from doctest_tools import doctest_for_module
-from nose_tools import deprecated, performance, skip
-from unittest_tools import UnittestTools
+from .doctest_tools import doctest_for_module
+from .nose_tools import deprecated, performance, skip
+from .unittest_tools import UnittestTools

--- a/traits/testing/tests/test_unittest_tools.py
+++ b/traits/testing/tests/test_unittest_tools.py
@@ -12,6 +12,9 @@ import threading
 import time
 import warnings
 
+import six
+import six.moves as sm
+
 from traits import _py2to3
 
 from traits.testing.unittest_tools import unittest
@@ -109,7 +112,7 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
                 ['flag', 'number', 'list_of_numbers[]']) as results:
             test_object.number = 2.0
 
-        events = filter(bool, (result.event for result in results))
+        events = list(filter(bool, (result.event for result in results)))
         msg = 'The assertion result is not None: {0}'.format(", ".join(events))
         self.assertFalse(events, msg=msg)
 
@@ -119,7 +122,7 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
                 ['flag']) as results:
             test_object.number = 5.0
 
-        events = filter(bool, (result.event for result in results))
+        events = list(filter(bool, (result.event for result in results)))
         msg = 'The assertion result is None'
         self.assertTrue(events, msg=msg)
 
@@ -208,7 +211,7 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
         with self.assertTraitDoesNotChange(test_object, 'number'):
             self.assertEqual(test_object.number, 16.0)
 
-        with self.assertRaisesRegexp(AssertionError, '16\.0 != 12\.0'):
+        with six.assertRaisesRegex(self, AssertionError, '16\.0 != 12\.0'):
             with self.assertTraitDoesNotChange(test_object, 'number'):
                 self.assertEqual(test_object.number, 12.0)
 
@@ -232,12 +235,12 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
 
         def thread_target(obj, count):
             "Fire obj.event 'count' times."
-            for _ in xrange(count):
+            for _ in sm.range(count):
                 obj.event = True
 
         threads = [
             threading.Thread(target=thread_target, args=(a, events_per_thread))
-            for _ in xrange(thread_count)
+            for _ in sm.range(thread_count)
         ]
 
         expected_count = thread_count * events_per_thread
@@ -262,13 +265,13 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
 
         def thread_target(obj, count):
             "Fire obj.event 'count' times."
-            for n in xrange(count):
+            for n in sm.range(count):
                 time.sleep(0.001)
                 obj.event = n
 
         threads = [
             threading.Thread(target=thread_target, args=(a, events_per_thread))
-            for _ in xrange(thread_count)
+            for _ in sm.range(thread_count)
         ]
 
         expected_count = thread_count * events_per_thread
@@ -283,7 +286,7 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
         _py2to3.assertCountEqual(
             self,
             event_collector.events,
-            range(events_per_thread) * thread_count,
+            list(sm.range(events_per_thread)) * thread_count,
         )
 
     def test_assert_trait_changes_async_failure(self):
@@ -298,12 +301,12 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
 
         def thread_target(obj, count):
             "Fire obj.event 'count' times."
-            for _ in xrange(count):
+            for _ in sm.range(count):
                 obj.event = True
 
         threads = [
             threading.Thread(target=thread_target, args=(a, events_per_thread))
-            for _ in xrange(thread_count)
+            for _ in sm.range(thread_count)
         ]
 
         expected_count = thread_count * events_per_thread

--- a/traits/tests/check_timing.py
+++ b/traits/tests/check_timing.py
@@ -221,9 +221,9 @@ def report(name, get_time, set_time, ref_get_time, ref_set_time):
 def run_benchmark(klass, ref_get_time, ref_set_time):
     benchmark_name = klass.__name__
     get_time, set_time = klass().measure()
-    print report(benchmark_name,
+    print(report(benchmark_name,
                  get_time, set_time,
-                 ref_get_time, ref_set_time)
+                 ref_get_time, ref_set_time))
 
 
 def main():

--- a/traits/tests/test_abc.py
+++ b/traits/tests/test_abc.py
@@ -3,6 +3,8 @@
 import abc
 import warnings
 
+import six
+
 from traits.testing.unittest_tools import unittest
 
 from ..api import ABCHasTraits, ABCMetaHasTraits, HasTraits, Int, Float
@@ -60,9 +62,9 @@ class FooLike(HasTraits):
 
 AbstractFoo.register(FooLike)
 
-
+@six.add_metaclass(abc.ABCMeta)
 class AbstractBar(object):
-    __metaclass__ = abc.ABCMeta
+    pass
 
     @abc.abstractmethod
     def bar(self):
@@ -84,8 +86,8 @@ class TestABC(unittest.TestCase):
         self.assertTrue(isinstance(foolike, AbstractFoo))
 
     def test_post_hoc_mixing(self):
+        @six.add_metaclass(ABCMetaHasTraits)
         class TraitedBar(HasTraits, AbstractBar):
-            __metaclass__ = ABCMetaHasTraits
             x = Int(10)
 
             def bar(self):

--- a/traits/tests/test_abc.py
+++ b/traits/tests/test_abc.py
@@ -86,8 +86,7 @@ class TestABC(unittest.TestCase):
         self.assertTrue(isinstance(foolike, AbstractFoo))
 
     def test_post_hoc_mixing(self):
-        @six.add_metaclass(ABCMetaHasTraits)
-        class TraitedBar(HasTraits, AbstractBar):
+        class TraitedBar(six.with_metaclass(ABCMetaHasTraits, HasTraits, AbstractBar)):
             x = Int(10)
 
             def bar(self):

--- a/traits/tests/test_abc.py
+++ b/traits/tests/test_abc.py
@@ -7,7 +7,7 @@ import six
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import ABCHasTraits, ABCMetaHasTraits, HasTraits, Int, Float
+from traits.api import ABCHasTraits, ABCMetaHasTraits, HasTraits, Int, Float
 
 
 class TestNew(unittest.TestCase):

--- a/traits/tests/test_array.py
+++ b/traits/tests/test_array.py
@@ -20,7 +20,7 @@ except ImportError:
 else:
     numpy_available = True
 
-from ..api import Array, Bool, HasTraits
+from traits.api import Array, Bool, HasTraits
 
 
 if numpy_available:

--- a/traits/tests/test_array_or_none.py
+++ b/traits/tests/test_array_or_none.py
@@ -28,7 +28,7 @@ else:
     numpy_available = True
 
 from traits.testing.unittest_tools import UnittestTools
-from ..api import ArrayOrNone, HasTraits, NO_COMPARE, TraitError
+from traits.api import ArrayOrNone, HasTraits, NO_COMPARE, TraitError
 
 
 if numpy_available:

--- a/traits/tests/test_bool.py
+++ b/traits/tests/test_bool.py
@@ -23,7 +23,7 @@ else:
     numpy_available = True
 
 from traits.testing.unittest_tools import unittest
-from ..api import Bool, Dict, HasTraits, Int, TraitError
+from traits.api import Bool, Dict, HasTraits, Int, TraitError
 
 
 if six.PY2:

--- a/traits/tests/test_bool.py
+++ b/traits/tests/test_bool.py
@@ -14,6 +14,7 @@
 """
 Tests for the Bool trait type.
 """
+import six
 try:
     import numpy
 except ImportError:
@@ -23,6 +24,12 @@ else:
 
 from traits.testing.unittest_tools import unittest
 from ..api import Bool, Dict, HasTraits, Int, TraitError
+
+
+if six.PY2:
+    LONG_TYPE = long
+else:
+    LONG_TYPE = int
 
 
 class A(HasTraits):
@@ -46,7 +53,7 @@ class TestBool(unittest.TestCase):
     def test_does_not_accept_int_or_float(self):
         a = A()
 
-        bad_values = [-1, 1L, "a string", 1.0]
+        bad_values = [-1, LONG_TYPE(1), "a string", 1.0]
         for bad_value in bad_values:
             with self.assertRaises(TraitError):
                 a.foo = bad_value

--- a/traits/tests/test_category.py
+++ b/traits/tests/test_category.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Category, Str
+from traits.api import HasTraits, Category, Str
 
 
 class Base(HasTraits):

--- a/traits/tests/test_class_traits.py
+++ b/traits/tests/test_class_traits.py
@@ -5,6 +5,8 @@ Unit tests for the `HasTraits.class_traits` class function.
 
 from __future__ import absolute_import
 
+import six
+
 from traits import _py2to3
 
 from traits.testing.unittest_tools import unittest
@@ -48,7 +50,7 @@ class TestClassTraits(unittest.TestCase):
         # Retrieve all traits that have the `marked` metadata
         # attribute set to True.
         traits = C.class_traits(marked=True)
-        _py2to3.assertCountEqual(self, traits.keys(), ('y', 'name'))
+        _py2to3.assertCountEqual(self, list(six.iterkeys(traits)), ('y', 'name'))
 
         # Retrieve all traits that have a `marked` metadata attribute,
         # regardless of its value.

--- a/traits/tests/test_class_traits.py
+++ b/traits/tests/test_class_traits.py
@@ -11,7 +11,7 @@ from traits import _py2to3
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Int, List, Str
+from traits.api import HasTraits, Int, List, Str
 
 
 class A(HasTraits):

--- a/traits/tests/test_clone.py
+++ b/traits/tests/test_clone.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Instance, Str, Any, Property
+from traits.api import HasTraits, Instance, Str, Any, Property
 
 
 class Foo(HasTraits):

--- a/traits/tests/test_container_events.py
+++ b/traits/tests/test_container_events.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Dict
+from traits.api import HasTraits, Dict
 
 
 class MyClass(HasTraits):

--- a/traits/tests/test_container_events.py
+++ b/traits/tests/test_container_events.py
@@ -57,7 +57,7 @@ class Callback:
 
     def __call__(self, event):
         if event.added != self.added:
-            print "\n\n******Error\nevent.added:", event.added
+            print("\n\n******Error\nevent.added:", event.added)
         else:
             self.obj.assertEqual(event.added, self.added)
         self.obj.assertEqual(event.changed, self.changed)

--- a/traits/tests/test_copy_traits.py
+++ b/traits/tests/test_copy_traits.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Instance, Str
+from traits.api import HasTraits, Instance, Str
 
 
 class Shared(HasTraits):

--- a/traits/tests/test_copyable_trait_names.py
+++ b/traits/tests/test_copyable_trait_names.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import (HasTraits, Any, Bool, Delegate, Event, Instance, Property,
+from traits.api import (HasTraits, Any, Bool, Delegate, Event, Instance, Property,
                    Str)
 
 

--- a/traits/tests/test_cythonized_traits.py
+++ b/traits/tests/test_cythonized_traits.py
@@ -17,7 +17,7 @@ except ImportError:
     no_cython = True
 
 
-from ..testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import unittest, UnittestTools
 
 
 def has_no_compiler():

--- a/traits/tests/test_delegate.py
+++ b/traits/tests/test_delegate.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import Delegate, HasTraits, Instance, Str
+from traits.api import Delegate, HasTraits, Instance, Str
 
 # global because event handlers are being called with wrong value for self
 baz_s_handler_self = None

--- a/traits/tests/test_dict.py
+++ b/traits/tests/test_dict.py
@@ -11,9 +11,9 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..trait_types import Dict, Event, Str, TraitDictObject
-from ..has_traits import HasTraits, on_trait_change
-from ..trait_errors import TraitError
+from traits.trait_types import Dict, Event, Str, TraitDictObject
+from traits.has_traits import HasTraits, on_trait_change
+from traits.trait_errors import TraitError
 
 
 # fixme: We'd like to use a callable instance for the listener so that we

--- a/traits/tests/test_editor_factories.py
+++ b/traits/tests/test_editor_factories.py
@@ -24,7 +24,7 @@ except ImportError:
 
 from traits.testing.unittest_tools import unittest
 
-from ..traits import multi_line_text_editor
+from traits.traits import multi_line_text_editor
 
 
 @unittest.skipUnless(HAS_TRAITSUI, "This test needs traitsui")

--- a/traits/tests/test_event_order.py
+++ b/traits/tests/test_event_order.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Str, Instance, Any
+from traits.api import HasTraits, Str, Instance, Any
 
 
 class TestEventOrder(unittest.TestCase):

--- a/traits/tests/test_extended_trait_change.py
+++ b/traits/tests/test_extended_trait_change.py
@@ -18,12 +18,12 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import (Any, Dict, HasTraits, Instance, Int, List, Property,
+from traits.api import (Any, Dict, HasTraits, Instance, Int, List, Property,
                    TraitDictEvent, TraitError, TraitListEvent, Undefined,
                    cached_property, on_trait_change, pop_exception_handler,
                    push_exception_handler)
 
-from ..trait_handlers import TraitListObject, TraitDictObject
+from traits.trait_handlers import TraitListObject, TraitDictObject
 
 
 class ArgCheckBase(HasTraits):

--- a/traits/tests/test_float.py
+++ b/traits/tests/test_float.py
@@ -17,6 +17,13 @@ Tests for the Float trait type.
 """
 import sys
 
+import six
+
+if six.PY2:
+    LONG_TYPE = long
+else:
+    LONG_TYPE = int
+
 from traits.testing.unittest_tools import unittest
 
 from ..api import BaseFloat, Float, HasTraits
@@ -51,7 +58,7 @@ class CommonFloatTests(object):
     @unittest.skipUnless(sys.version_info < (3,), "Not applicable to Python 3")
     def test_accepts_small_long(self):
         a = self.test_class()
-        a.value = long(2)
+        a.value = LONG_TYPE(2)
         self.assertIs(type(a.value), float)
         self.assertEqual(a.value, 2.0)
 

--- a/traits/tests/test_float.py
+++ b/traits/tests/test_float.py
@@ -26,7 +26,7 @@ else:
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import BaseFloat, Float, HasTraits
+from traits.api import BaseFloat, Float, HasTraits
 
 
 class FloatModel(HasTraits):

--- a/traits/tests/test_get_traits.py
+++ b/traits/tests/test_get_traits.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Int, Str, Undefined, ReadOnly, Float
+from traits.api import HasTraits, Int, Str, Undefined, ReadOnly, Float
 
 
 class Foo(HasTraits):

--- a/traits/tests/test_int_range_long.py
+++ b/traits/tests/test_int_range_long.py
@@ -8,6 +8,13 @@
 
 from __future__ import absolute_import
 
+import six
+
+if six.PY2:
+    LONG_TYPE = long
+else:
+    LONG_TYPE = int
+
 from traits.testing.unittest_tools import unittest
 
 from ..api import HasTraits, Int, Range, Long, TraitError
@@ -16,7 +23,7 @@ from ..api import HasTraits, Int, Range, Long, TraitError
 class A(HasTraits):
     i = Int
     l = Long
-    r = Range(2L, 9223372036854775807L)
+    r = Range(LONG_TYPE(2), LONG_TYPE(9223372036854775807))
 
 
 class TraitIntRangeLong(unittest.TestCase):
@@ -24,21 +31,21 @@ class TraitIntRangeLong(unittest.TestCase):
         "Test to make sure it is legal to set an Int trait to a long value"
         a = A()
         a.i = 1
-        a.i = 10L
+        a.i = LONG_TYPE(10)
 
     def test_long(self):
         "Test if it is legal to set a Long trait to an int value"
         a = A()
         a.l = 10
-        a.l = 100L
+        a.l = LONG_TYPE(100)
 
     def test_range(self):
         "Test a range trait with longs being set to an int value"
         a = A()
         a.r = 256
-        a.r = 20L
-        self.assertRaises(TraitError, a.trait_set, r=1L)
-        self.assertRaises(TraitError, a.trait_set, r=9223372036854775808L)
+        a.r = LONG_TYPE(20)
+        self.assertRaises(TraitError, a.trait_set, r=LONG_TYPE(1))
+        self.assertRaises(TraitError, a.trait_set, r=LONG_TYPE(9223372036854775808))
 
 if __name__ == '__main__':
     unittest.main()

--- a/traits/tests/test_int_range_long.py
+++ b/traits/tests/test_int_range_long.py
@@ -17,7 +17,7 @@ else:
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Int, Range, Long, TraitError
+from traits.api import HasTraits, Int, Range, Long, TraitError
 
 
 class A(HasTraits):

--- a/traits/tests/test_integer.py
+++ b/traits/tests/test_integer.py
@@ -21,6 +21,15 @@ from __future__ import absolute_import
 import decimal
 import sys
 
+import six
+
+if six.PY2:
+    LONG_TYPE = long
+    MAXINT = sys.maxint
+else:
+    LONG_TYPE = int
+    MAXINT = six.MAXSIZE
+
 try:
     import numpy
 except ImportError:
@@ -61,20 +70,20 @@ class TestInt(unittest.TestCase):
 
     def test_accepts_small_long(self):
         a = A()
-        a.integral = 23L
+        a.integral = LONG_TYPE(23)
         # Check that type is stored as int where possible.
         self.assertEqual(a.integral, 23)
         self.assertIs(type(a.integral), int)
 
     def test_accepts_large_long(self):
         a = A()
-        a.integral = long(sys.maxint)
-        self.assertEqual(a.integral, sys.maxint)
+        a.integral = LONG_TYPE(MAXINT)
+        self.assertEqual(a.integral, MAXINT)
         self.assertIs(type(a.integral), int)
 
-        a.integral = sys.maxint + 1
-        self.assertEqual(a.integral, sys.maxint + 1)
-        self.assertIs(type(a.integral), long)
+        a.integral = MAXINT + 1
+        self.assertEqual(a.integral, MAXINT + 1)
+        self.assertIs(type(a.integral), LONG_TYPE)
 
     def test_accepts_bool(self):
         a = A()
@@ -110,11 +119,11 @@ class TestInt(unittest.TestCase):
         a = A()
         a.integral = numpy.int32(23)
         self.assertEqual(a.integral, 23)
-        self.assertIn(type(a.integral), (int, long))
+        self.assertIn(type(a.integral), six.integer_types)
 
         a.integral = numpy.uint64(2**63 + 2)
         self.assertEqual(a.integral, 2**63 + 2)
-        self.assertIs(type(a.integral), long)
+        self.assertIs(type(a.integral), LONG_TYPE)
 
         with self.assertRaises(TraitError):
             a.integral = numpy.float32(4.0)

--- a/traits/tests/test_integer.py
+++ b/traits/tests/test_integer.py
@@ -25,10 +25,8 @@ import six
 
 if six.PY2:
     LONG_TYPE = long
-    MAXINT = sys.maxint
 else:
     LONG_TYPE = int
-    MAXINT = six.MAXSIZE
 
 try:
     import numpy
@@ -77,12 +75,12 @@ class TestInt(unittest.TestCase):
 
     def test_accepts_large_long(self):
         a = A()
-        a.integral = LONG_TYPE(MAXINT)
-        self.assertEqual(a.integral, MAXINT)
+        a.integral = LONG_TYPE(six.MAXSIZE)
+        self.assertEqual(a.integral, six.MAXSIZE)
         self.assertIs(type(a.integral), int)
 
-        a.integral = MAXINT + 1
-        self.assertEqual(a.integral, MAXINT + 1)
+        a.integral = six.MAXSIZE + 1
+        self.assertEqual(a.integral, six.MAXSIZE + 1)
         self.assertIs(type(a.integral), LONG_TYPE)
 
     def test_accepts_bool(self):

--- a/traits/tests/test_integer.py
+++ b/traits/tests/test_integer.py
@@ -39,7 +39,7 @@ else:
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Int, TraitError
+from traits.api import HasTraits, Int, TraitError
 
 
 class A(HasTraits):

--- a/traits/tests/test_keyword_args.py
+++ b/traits/tests/test_keyword_args.py
@@ -8,7 +8,7 @@
 
 from __future__ import absolute_import
 
-from ..api import HasTraits, Instance, Int
+from traits.api import HasTraits, Instance, Int
 
 from traits.testing.unittest_tools import unittest
 

--- a/traits/tests/test_list.py
+++ b/traits/tests/test_list.py
@@ -15,7 +15,7 @@ import six.moves as sm
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import CList, HasTraits, Instance, Int, List, Str, TraitError
+from traits.api import CList, HasTraits, Instance, Int, List, Str, TraitError
 
 
 class Foo(HasTraits):

--- a/traits/tests/test_list.py
+++ b/traits/tests/test_list.py
@@ -10,6 +10,9 @@ from __future__ import absolute_import
 
 import sys
 
+import six
+import six.moves as sm
+
 from traits.testing.unittest_tools import unittest
 
 from ..api import CList, HasTraits, Instance, Int, List, Str, TraitError
@@ -92,7 +95,7 @@ class ListTestCase(unittest.TestCase):
 
     def test_slice_assignment(self):
         # Exhaustive testing.
-        starts = stops = [None] + range(-10, 11)
+        starts = stops = [None] + list(sm.range(-10, 11))
         steps = list(starts)
         steps.remove(0)
         test_slices = [slice(start, stop, step)
@@ -102,7 +105,7 @@ class ListTestCase(unittest.TestCase):
             f = Foo(l=['zero', 'one', 'two', 'three', 'four'])
             plain_l = list(f.l)
             length = len(plain_l[test_slice])
-            replacements = map(str, range(length))
+            replacements = list(sm.map(str, sm.range(length)))
 
             # Plain Python list and Traits list behaviour should match.
             plain_l[test_slice] = replacements

--- a/traits/tests/test_list_events.py
+++ b/traits/tests/test_list_events.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Int, List
+from traits.api import HasTraits, Int, List
 
 
 class MyClass(HasTraits):

--- a/traits/tests/test_listeners.py
+++ b/traits/tests/test_listeners.py
@@ -20,10 +20,12 @@
 from __future__ import absolute_import
 
 import contextlib
-import cStringIO
 import sys
 import threading
 import time
+
+import six
+import six.moves as sm
 
 from traits.testing.unittest_tools import unittest
 
@@ -37,7 +39,7 @@ def captured_stderr():
     Return a context manager that directs all stderr output to a string.
 
     """
-    new_stderr = cStringIO.StringIO()
+    new_stderr = sm.cStringIO.StringIO()
     original_stderr = sys.stderr
     sys.stderr = new_stderr
     try:
@@ -184,7 +186,7 @@ class TestRaceCondition(unittest.TestCase):
         t = threading.Thread(target=foo_writer, args=(a, stop_event))
         t.start()
 
-        for _ in xrange(100):
+        for _ in sm.range(100):
             a.on_trait_change(a.foo_changed_handler, 'foo')
             time.sleep(0.0001)  # encourage thread-switch
             a.on_trait_change(a.foo_changed_handler, 'foo', remove=True)

--- a/traits/tests/test_listeners.py
+++ b/traits/tests/test_listeners.py
@@ -39,7 +39,7 @@ def captured_stderr():
     Return a context manager that directs all stderr output to a string.
 
     """
-    new_stderr = sm.cStringIO.StringIO()
+    new_stderr = sm.cStringIO()
     original_stderr = sys.stderr
     sys.stderr = new_stderr
     try:

--- a/traits/tests/test_listeners.py
+++ b/traits/tests/test_listeners.py
@@ -29,8 +29,8 @@ import six.moves as sm
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Str, Int, Float, Any, Event
-from ..api import push_exception_handler, pop_exception_handler
+from traits.api import HasTraits, Str, Int, Float, Any, Event
+from traits.api import push_exception_handler, pop_exception_handler
 
 
 @contextlib.contextmanager

--- a/traits/tests/test_new_notifiers.py
+++ b/traits/tests/test_new_notifiers.py
@@ -8,8 +8,10 @@ Most of the functionality of the class is thus already covered by the
 notification really occurs on a separate thread.
 
 """
-import thread
 import time
+
+import six
+import six.moves as sm
 
 from traits.api import Float, HasTraits
 from traits.testing.unittest_tools import unittest
@@ -26,7 +28,7 @@ class TestNewNotifiers(unittest.TestCase):
         notifications = []
 
         def on_foo_notifications(obj, name, old, new):
-            thread_id = thread.get_ident()
+            thread_id = sm._thread.get_ident()
             event = (thread_id, obj, name, old, new)
             notifications.append(event)
 
@@ -40,7 +42,7 @@ class TestNewNotifiers(unittest.TestCase):
         self.assertEqual(len(notifications), 1)
         self.assertEqual(notifications[0][1:], (obj, 'foo', 0, 3))
 
-        this_thread_id = thread.get_ident()
+        this_thread_id = sm._thread.get_ident()
         self.assertNotEqual(this_thread_id, notifications[0][0])
 
 

--- a/traits/tests/test_pickle_validated_dict.py
+++ b/traits/tests/test_pickle_validated_dict.py
@@ -12,7 +12,7 @@ import six.moves as sm
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import Dict, HasTraits, Int, List
+from traits.api import Dict, HasTraits, Int, List
 
 
 class C(HasTraits):

--- a/traits/tests/test_pickle_validated_dict.py
+++ b/traits/tests/test_pickle_validated_dict.py
@@ -8,7 +8,8 @@
 
 from __future__ import absolute_import
 
-from cPickle import dumps, loads
+import six.moves as sm
+
 from traits.testing.unittest_tools import unittest
 
 from ..api import Dict, HasTraits, Int, List
@@ -28,8 +29,8 @@ class PickleValidatedDictTestCase(unittest.TestCase):
     def test(self):
 
         # And we must unpickle one
-        x = dumps(C())
+        x = sm.cPickle.dumps(C())
         try:
-            loads(x)
-        except AttributeError, e:
+            sm.cPickle.loads(x)
+        except AttributeError as e:
             self.fail('Unpickling raised an AttributeError: %s' % e)

--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 
-from ..api import HasTraits, Property
+from traits.api import HasTraits, Property
 
 
 class Test(HasTraits):

--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -36,27 +36,27 @@ class Test(HasTraits):
 class Test_1 (Test):
 
     def value_changed(self, value):
-        print 'value_changed:', value
+        print('value_changed:', value)
 
 
 class Test_2 (Test):
 
     def anytrait_changed(self, name, value):
-        print 'anytrait_changed for %s: %s' % (name, value)
+        print('anytrait_changed for %s: %s' % (name, value))
 
 
 class Test_3 (Test_2):
 
     def value_changed(self, value):
-        print 'value_changed:', value
+        print('value_changed:', value)
 
 
 def on_value_changed(value):
-    print 'on_value_changed:', value
+    print('on_value_changed:', value)
 
 
 def on_anyvalue_changed(value):
-    print 'on_anyvalue_changed:', value
+    print('on_anyvalue_changed:', value)
 
 
 def test_property_notifications():

--- a/traits/tests/test_protocols_usage.py
+++ b/traits/tests/test_protocols_usage.py
@@ -24,7 +24,7 @@ import sys
 from traits.testing.unittest_tools import unittest
 
 # Enthought library imports.
-from ..api import (Bool, HasTraits, Int, Interface, Str, Adapter, adapts,
+from traits.api import (Bool, HasTraits, Int, Interface, Str, Adapter, adapts,
                    Property)
 
 # NOTE: There is a File class in apptools.io module, but since we want to

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Int, Range, Str, TraitError
+from traits.api import HasTraits, Int, Range, Str, TraitError
 
 
 class WithFloatRange(HasTraits):

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -5,9 +5,9 @@ import sys
 import six
 import six.moves as sm
 
-from ..has_traits import HasTraits, Property, on_trait_change
-from ..trait_types import Bool, DelegatesTo, Instance, Int, List
-from ..testing.unittest_tools import unittest
+from traits.has_traits import HasTraits, Property, on_trait_change
+from traits.trait_types import Bool, DelegatesTo, Instance, Int, List
+from traits.testing.unittest_tools import unittest
 
 
 class Dummy(HasTraits):

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -2,6 +2,9 @@
 import gc
 import sys
 
+import six
+import six.moves as sm
+
 from ..has_traits import HasTraits, Property, on_trait_change
 from ..trait_types import Bool, DelegatesTo, Instance, Int, List
 from ..testing.unittest_tools import unittest
@@ -151,7 +154,7 @@ class TestRegression(unittest.TestCase):
             obj.on_trait_change(handler)
 
         # Warmup.
-        for _ in xrange(cycles):
+        for _ in sm.range(cycles):
             f()
             gc.collect()
             counts.append(len(gc.get_objects()))
@@ -164,7 +167,7 @@ class TestRegression(unittest.TestCase):
         cycles = 10
         counts = []
 
-        for _ in xrange(cycles):
+        for _ in sm.range(cycles):
             DelegateLeak()
             gc.collect()
             counts.append(len(gc.get_objects()))

--- a/traits/tests/test_rich_compare.py
+++ b/traits/tests/test_rich_compare.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Any, Str
+from traits.api import HasTraits, Any, Str
 
 
 class IdentityCompare(HasTraits):

--- a/traits/tests/test_str_handler.py
+++ b/traits/tests/test_str_handler.py
@@ -18,8 +18,8 @@ import six
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Trait, TraitError, TraitHandler
-from ..trait_base import strx
+from traits.api import HasTraits, Trait, TraitError, TraitHandler
+from traits.trait_base import strx
 
 
 # Validation via function

--- a/traits/tests/test_str_handler.py
+++ b/traits/tests/test_str_handler.py
@@ -14,6 +14,8 @@
 
 from __future__ import absolute_import
 
+import six
+
 from traits.testing.unittest_tools import unittest
 
 from ..api import HasTraits, Trait, TraitError, TraitHandler
@@ -22,7 +24,7 @@ from ..trait_base import strx
 
 # Validation via function
 def validator(object, name, value):
-    if isinstance(value, basestring):
+    if isinstance(value, six.string_types):
         # arbitrary rule for testing
         if value.find('fail') < 0:
             return value

--- a/traits/tests/test_string.py
+++ b/traits/tests/test_string.py
@@ -24,7 +24,7 @@ else:
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, String
+from traits.api import HasTraits, String
 
 
 class A(HasTraits):

--- a/traits/tests/test_sync_traits.py
+++ b/traits/tests/test_sync_traits.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest, UnittestTools
 
-from ..api import (
+from traits.api import (
     HasTraits, Int, List, push_exception_handler, pop_exception_handler)
 
 

--- a/traits/tests/test_trait_change_event_tracer.py
+++ b/traits/tests/test_trait_change_event_tracer.py
@@ -1,4 +1,7 @@
 """ Tests for the trait change event tracer. """
+
+import six
+
 from traits.api import Float, HasTraits, on_trait_change
 from traits.testing.unittest_tools import unittest
 
@@ -59,7 +62,7 @@ class TestChangeEventTracers(unittest.TestCase):
 
     def _collect_post_notification_events(self, *args, **kwargs):
         self.post_change_events.append(args)
-        self.exceptions.extend(kwargs.values())
+        self.exceptions.extend(six.itervalues(kwargs))
 
     #### Tests ################################################################
 
@@ -84,14 +87,14 @@ class TestChangeEventTracers(unittest.TestCase):
 
         expected_pre_events = [
             (foo, 'baz', 0.0, 3.0, foo._on_baz_change_notification),
-            (foo, 'bar', 0.0, 1.0, foo._bar_changed.im_func),
+            (foo, 'bar', 0.0, 1.0, foo._bar_changed.__func__),
             (foo, 'bar', 0.0, 1.0, foo._on_bar_change_notification),
             (foo, 'baz', 0.0, 3.0, _on_foo_baz_changed),
         ]
         self.assertEqual(self.pre_change_events, expected_pre_events)
 
         expected_post_events = [
-            (foo, 'bar', 0.0, 1.0, foo._bar_changed.im_func),
+            (foo, 'bar', 0.0, 1.0, foo._bar_changed.__func__),
             (foo, 'bar', 0.0, 1.0, foo._on_bar_change_notification),
             (foo, 'baz', 0.0, 3.0, foo._on_baz_change_notification),
             (foo, 'baz', 0.0, 3.0, _on_foo_baz_changed),
@@ -127,14 +130,14 @@ class TestChangeEventTracers(unittest.TestCase):
 
         expected_pre_events = [
             (foo, 'fuz', 0.0, 3.0, foo._on_fuz_change_notification),
-            (foo, 'bar', 0.0, 1.0, foo._bar_changed.im_func),
+            (foo, 'bar', 0.0, 1.0, foo._bar_changed.__func__),
             (foo, 'bar', 0.0, 1.0, foo._on_bar_change_notification),
             (foo, 'fuz', 0.0, 3.0, _on_foo_fuz_changed),
         ]
         self.assertEqual(self.pre_change_events, expected_pre_events)
 
         expected_post_events = [
-            (foo, 'bar', 0.0, 1.0, foo._bar_changed.im_func),
+            (foo, 'bar', 0.0, 1.0, foo._bar_changed.__func__),
             (foo, 'bar', 0.0, 1.0, foo._on_bar_change_notification),
             (foo, 'fuz', 0.0, 3.0, foo._on_fuz_change_notification),
             (foo, 'fuz', 0.0, 3.0, _on_foo_fuz_changed),

--- a/traits/tests/test_trait_cycle.py
+++ b/traits/tests/test_trait_cycle.py
@@ -21,7 +21,7 @@ import time
 from traits.testing.unittest_tools import unittest
 
 # Enthought library imports
-from ..api import HasTraits, Any, DelegatesTo, Instance, Int
+from traits.api import HasTraits, Any, DelegatesTo, Instance, Int
 
 
 class TestCase(unittest.TestCase):

--- a/traits/tests/test_trait_default_initializer.py
+++ b/traits/tests/test_trait_default_initializer.py
@@ -16,8 +16,8 @@ from __future__ import absolute_import
 
 import unittest
 
-from ..trait_types import Int
-from ..has_traits import HasTraits
+from traits.trait_types import Int
+from traits.has_traits import HasTraits
 
 
 class Foo(HasTraits):

--- a/traits/tests/test_trait_get_set.py
+++ b/traits/tests/test_trait_get_set.py
@@ -18,7 +18,7 @@ import logging
 import traits.has_traits
 from traits.testing.unittest_tools import unittest, UnittestTools
 
-from ..api import HasTraits, Str, Int
+from traits.api import HasTraits, Str, Int
 
 
 class TraitsObject(HasTraits):

--- a/traits/tests/test_trait_list_dict.py
+++ b/traits/tests/test_trait_list_dict.py
@@ -9,16 +9,18 @@ TraitSetObjects.
 from __future__ import absolute_import
 
 import copy
-from cPickle import dumps, loads
+
+import six
+import six.moves as sm
 
 from ..has_traits import HasTraits, on_trait_change
 from ..trait_types import Dict, List, Set, Str, Int, Instance
 
 
 class A(HasTraits):
-    alist = List(Int, range(5))
+    alist = List(Int, list(sm.range(5)))
     adict = Dict(Str, Int, dict(a=1, b=2))
-    aset = Set(Int, range(5))
+    aset = Set(Int, list(sm.range(5)))
 
     events = List()
 
@@ -33,37 +35,37 @@ class B(HasTraits):
 
 def test_trait_list_object_persists():
     a = A()
-    list = loads(dumps(a.alist))
+    list = sm.cPickle.loads(sm.cPickle.dumps(a.alist))
     assert list.object() is None
     list.append(10)
     assert len(a.events) == 0
     a.alist.append(20)
     assert len(a.events) == 1
-    list2 = loads(dumps(list))
+    list2 = sm.cPickle.loads(sm.cPickle.dumps(list))
     assert list2.object() is None
 
 
 def test_trait_dict_object_persists():
     a = A()
-    dict = loads(dumps(a.adict))
+    dict = sm.cPickle.loads(sm.cPickle.dumps(a.adict))
     assert dict.object() is None
     dict['key'] = 10
     assert len(a.events) == 0
     a.adict['key'] = 10
     assert len(a.events) == 1
-    dict2 = loads(dumps(dict))
+    dict2 = sm.cPickle.loads(sm.cPickle.dumps(dict))
     assert dict2.object() is None
 
 
 def test_trait_set_object_persists():
     a = A()
-    set = loads(dumps(a.aset))
+    set = sm.cPickle.loads(sm.cPickle.dumps(a.aset))
     assert set.object() is None
     set.add(10)
     assert len(a.events) == 0
     a.aset.add(20)
     assert len(a.events) == 1
-    set2 = loads(dumps(set))
+    set2 = sm.cPickle.loads(sm.cPickle.dumps(set))
     assert set2.object() is None
 
 
@@ -112,9 +114,9 @@ def test_trait_set_object_copies():
 
 def test_pickle_whole():
     a = A()
-    loads(dumps(a))
+    sm.cPickle.loads(sm.cPickle.dumps(a))
     b = B(dict=dict(a=a))
-    loads(dumps(b))
+    sm.cPickle.loads(sm.cPickle.dumps(b))
 
 
 def test_trait_set_object_operations():

--- a/traits/tests/test_trait_list_dict.py
+++ b/traits/tests/test_trait_list_dict.py
@@ -13,8 +13,8 @@ import copy
 import six
 import six.moves as sm
 
-from ..has_traits import HasTraits, on_trait_change
-from ..trait_types import Dict, List, Set, Str, Int, Instance
+from traits.has_traits import HasTraits, on_trait_change
+from traits.trait_types import Dict, List, Set, Str, Int, Instance
 
 
 class A(HasTraits):

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -17,6 +17,8 @@ from __future__ import absolute_import
 
 import sys
 
+import six
+
 from traits.testing.unittest_tools import unittest
 
 from ..api import (Any, CFloat, CInt, CLong, Delegate, Float, HasTraits,
@@ -25,6 +27,11 @@ from ..api import (Any, CFloat, CInt, CLong, Delegate, Float, HasTraits,
                    Tuple, pop_exception_handler, push_exception_handler)
 
 #  Base unit test classes:
+
+if six.PY2:
+    LONG_TYPE = long
+else:
+    LONG_TYPE = int
 
 
 class BaseTest(object):
@@ -97,8 +104,8 @@ class test_base2(unittest.TestCase):
             for value in bad_values:
                 self.assertRaises(TraitError, setattr, obj, name, value)
         except:
-            print 'Failed while testing %s for value: %s(%s) in %s' % (
-                msg, value, value.__class__.__name__, self.__class__.__name__)
+            print('Failed while testing %s for value: %s(%s) in %s' % (
+                msg, value, value.__class__.__name__, self.__class__.__name__))
             raise
 
 
@@ -129,7 +136,7 @@ class CoercibleIntTest(AnyTraitTest):
     obj = CoercibleIntTrait()
 
     _default_value = 99
-    _good_values = [10, -10, 10L, -10L, 10.1, -10.1, '10', '-10', u'10',
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', u'10',
                     u'-10']
     _bad_values = ['10L', '-10L', '10.1', '-10.1', u'10L', u'-10L', u'10.1',
                    u'-10.1', 'ten', u'ten', [10], {'ten': 10}, (10, ), None,
@@ -142,7 +149,7 @@ class CoercibleIntTest(AnyTraitTest):
             try:
                 return int(float(value))
             except:
-                return int(long(value))
+                return int(LONG_TYPE(value))
 
 
 class IntTest(AnyTraitTest):
@@ -150,7 +157,7 @@ class IntTest(AnyTraitTest):
     obj = IntTrait()
 
     _default_value = 99
-    _good_values = [10, -10, 10L, -10L]
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10)]
     _bad_values = ['ten', u'ten', [10], {'ten': 10}, (10,), None, 1j,
                    10.1, -10.1, '10L', '-10L', '10.1', '-10.1', u'10L',
                    u'-10L', u'10.1', u'-10.1',  '10', '-10', u'10', u'-10']
@@ -173,52 +180,52 @@ class IntTest(AnyTraitTest):
             try:
                 return int(float(value))
             except:
-                return int(long(value))
+                return int(LONG_TYPE(value))
 
 
 class CoercibleLongTrait(HasTraits):
-    value = CLong(99L)
+    value = CLong(LONG_TYPE(99))
 
 
 class LongTrait(HasTraits):
-    value = Long(99L)
+    value = Long(LONG_TYPE(99))
 
 
 class CoercibleLongTest(AnyTraitTest):
 
     obj = CoercibleLongTrait()
 
-    _default_value = 99L
+    _default_value = LONG_TYPE(99)
     _good_values = [
-        10, -10, 10L, -10L, 10.1, -10.1, '10', '-10', u'10', u'-10']
+        10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', u'10', u'-10']
     if sys.version_info[0] < 3:
         _good_values.extend(['10L', '-10L', u'10L', u'-10L'])
     _bad_values = ['10.1', '-10.1', u'10.1', u'-10.1', 'ten', u'ten', [10],
-                   [10l], {'ten': 10}, (10,), (10L,), None, 1j]
+                   [LONG_TYPE(10)], {'ten': 10}, (10,), (LONG_TYPE(10),), None, 1j]
 
     def coerce(self, value):
         try:
-            return long(value)
+            return LONG_TYPE(value)
         except:
-            return long(float(value))
+            return LONG_TYPE(float(value))
 
 
 class LongTest(AnyTraitTest):
 
     obj = LongTrait()
 
-    _default_value = 99L
-    _good_values = [10, -10, 10L, -10L]
-    _bad_values = ['ten', u'ten', [10], [10l], {'ten': 10}, (10, ), (10L,),
+    _default_value = LONG_TYPE(99)
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10)]
+    _bad_values = ['ten', u'ten', [10], [LONG_TYPE(10)], {'ten': 10}, (10, ), (LONG_TYPE(10),),
                    None, 1j, 10.1, -10.1, '10', '-10', '10L', '-10L', '10.1',
                    '-10.1', u'10', u'-10', u'10L', u'-10L', u'10.1',
                    u'-10.1']
 
     def coerce(self, value):
         try:
-            return long(value)
+            return LONG_TYPE(value)
         except:
-            return long(float(value))
+            return LONG_TYPE(float(value))
 
 
 class CoercibleFloatTrait(HasTraits):
@@ -233,7 +240,7 @@ class CoercibleFloatTest(AnyTraitTest):
     obj = CoercibleFloatTrait()
 
     _default_value = 99.0
-    _good_values = [10, -10, 10L, -10L, 10.1, -10.1, '10', '-10', '10.1',
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', '10.1',
                     '-10.1', u'10', u'-10', u'10.1', u'-10.1']
     _bad_values = ['10L', '-10L', u'10L', u'-10L', 'ten', u'ten', [10],
                    {'ten': 10}, (10, ), None, 1j]
@@ -242,7 +249,7 @@ class CoercibleFloatTest(AnyTraitTest):
         try:
             return float(value)
         except:
-            return float(long(value))
+            return float(LONG_TYPE(value))
 
 
 class FloatTest(AnyTraitTest):
@@ -255,13 +262,13 @@ class FloatTest(AnyTraitTest):
                    u'-10', u'10L', u'-10L', u'10.1', u'-10.1']
 
     if sys.version_info[0] < 3:
-        _good_values.extend([long(-10), long(10)])
+        _good_values.extend([LONG_TYPE(-10), LONG_TYPE(10)])
 
     def coerce(self, value):
         try:
             return float(value)
         except:
-            return float(long(value))
+            return float(LONG_TYPE(value))
 
 #  Trait that can only have 'complex'(i.e. imaginary) values:
 
@@ -275,7 +282,7 @@ class ImaginaryValueTest(AnyTraitTest):
     obj = ImaginaryValueTrait()
 
     _default_value = 99.0 - 99.0j
-    _good_values = [10, -10, 10L, -10L, 10.1, -10.1, '10', '-10', '10.1',
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', '10.1',
                     '-10.1', 10j, 10 + 10j, 10 - 10j, 10.1j, 10.1 + 10.1j,
                     10.1 - 10.1j, '10j', '10+10j', '10-10j']
     _bad_values = [u'10L', u'-10L', 'ten', [10], {'ten': 10}, (10,), None]
@@ -284,7 +291,7 @@ class ImaginaryValueTest(AnyTraitTest):
         try:
             return complex(value)
         except:
-            return complex(long(value))
+            return complex(LONG_TYPE(value))
 
 
 class StringTrait(HasTraits):
@@ -296,7 +303,7 @@ class StringTest(AnyTraitTest):
     obj = StringTrait()
 
     _default_value = 'string'
-    _good_values = [10, -10, 10L, -10L, 10.1, -10.1, '10', '-10', '10L',
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', '10L',
                     '-10L', '10.1', '-10.1', 'string', u'string', 1j, [10],
                     ['ten'], {'ten': 10}, (10,), None]
     _bad_values = []
@@ -314,7 +321,7 @@ class UnicodeTest(StringTest):
     obj = UnicodeTrait()
 
     _default_value = u'unicode'
-    _good_values = [10, -10, 10L, -10L, 10.1, -10.1, '10', '-10', '10L',
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', '10L',
                     '-10L', '10.1', '-10.1', '', u'', 'string', u'string', 1j,
                     [10], ['ten'], [u'ten'], {'ten': 10}, (10,), None]
     _bad_values = []
@@ -401,7 +408,7 @@ class IntRangeTest(AnyTraitTest):
             try:
                 return int(float(value))
             except:
-                return int(long(value))
+                return int(LONG_TYPE(value))
 
 
 class FloatRangeTrait(HasTraits):
@@ -414,14 +421,14 @@ class FloatRangeTest(AnyTraitTest):
 
     _default_value = 3.0
     _good_values = [2.0, 3.0, 4.0, 5.0, 2.001, 4.999]
-    _bad_values = [0, 1, 6, 0L, 1L, 6L, 1.999, 6.01, 'two', '0.999', '6.01',
+    _bad_values = [0, 1, 6, LONG_TYPE(0), LONG_TYPE(1), LONG_TYPE(6), 1.999, 6.01, 'two', '0.999', '6.01',
                    None]
 
     def coerce(self, value):
         try:
             return float(value)
         except:
-            return float(long(value))
+            return float(LONG_TYPE(value))
 
 
 # Old style class version:
@@ -455,7 +462,7 @@ class OldInstanceTest(AnyTraitTest):
     _default_value = otrait_test1
     _good_values = [otrait_test1, OTraitTest1(), OTraitTest2(),
                     OTraitTest3(), None]
-    _bad_values = [0, 0L, 0.0, 0j, OTraitTest1, OTraitTest2, OBadTraitTest(),
+    _bad_values = [0, LONG_TYPE(0), 0.0, 0j, OTraitTest1, OTraitTest2, OBadTraitTest(),
                    'string', u'string', [otrait_test1], (otrait_test1,),
                    {'data': otrait_test1}]
 
@@ -490,7 +497,7 @@ class NewInstanceTest(AnyTraitTest):
     _default_value = ntrait_test1
     _good_values = [ntrait_test1, NTraitTest1(), NTraitTest2(), NTraitTest3(),
                     None]
-    _bad_values = [0, 0L, 0.0, 0j, NTraitTest1, NTraitTest2, NBadTraitTest(),
+    _bad_values = [0, LONG_TYPE(0), 0.0, 0j, NTraitTest1, NTraitTest2, NBadTraitTest(),
                    'string', u'string', [ntrait_test1], (ntrait_test1,),
                    {'data': ntrait_test1}]
 
@@ -560,10 +567,10 @@ class OddIntegerTest(AnyTraitTest):
 
     _default_value = 99
     _good_values = [1, 3, 5, 7, 9, 999999999,
-                    1L, 3L, 5L, 7L, 9L, 999999999L,
+                    LONG_TYPE(1), LONG_TYPE(3), LONG_TYPE(5), LONG_TYPE(7), LONG_TYPE(9), LONG_TYPE(999999999),
                     1.0, 3.0, 5.0, 7.0, 9.0, 999999999.0,
                     -1, -3, -5, -7, -9, -999999999,
-                    -1L, -3L, -5L, -7L, -9L, -999999999L,
+                    LONG_TYPE(-1), LONG_TYPE(-3), LONG_TYPE(-5), LONG_TYPE(-7), LONG_TYPE(-9), LONG_TYPE(-999999999),
                     -1.0, -3.0, -5.0, -7.0, -9.0, -999999999.0]
     _bad_values = [0, 2, -2, 1j, None, '1', [1], (1,), {1: 1}]
 

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -21,7 +21,7 @@ import six
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import (Any, CFloat, CInt, CLong, Delegate, Float, HasTraits,
+from traits.api import (Any, CFloat, CInt, CLong, Delegate, Float, HasTraits,
                    Instance, Int, List, Long, Str, Trait, TraitError,
                    TraitList, TraitPrefixList, TraitPrefixMap, TraitRange,
                    Tuple, pop_exception_handler, push_exception_handler)

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -118,7 +118,7 @@ class AnyTraitTest(BaseTest, unittest.TestCase):
     obj = AnyTrait()
 
     _default_value = None
-    _good_values = [10.0, 'ten', u'ten', [10], {'ten': 10}, (10,), None, 1j]
+    _good_values = [10.0, 'ten', six.u('ten'), [10], {'ten': 10}, (10,), None, 1j]
     _mapped_values = []
     _bad_values = []
 
@@ -136,10 +136,10 @@ class CoercibleIntTest(AnyTraitTest):
     obj = CoercibleIntTrait()
 
     _default_value = 99
-    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', u'10',
-                    u'-10']
-    _bad_values = ['10L', '-10L', '10.1', '-10.1', u'10L', u'-10L', u'10.1',
-                   u'-10.1', 'ten', u'ten', [10], {'ten': 10}, (10, ), None,
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', six.u('10'),
+                    six.u('-10')]
+    _bad_values = ['10L', '-10L', '10.1', '-10.1', six.u('10L'), six.u('-10L'), six.u('10.1'),
+                   six.u('-10.1'), 'ten', six.u('ten'), [10], {'ten': 10}, (10, ), None,
                    1j]
 
     def coerce(self, value):
@@ -158,9 +158,10 @@ class IntTest(AnyTraitTest):
 
     _default_value = 99
     _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10)]
-    _bad_values = ['ten', u'ten', [10], {'ten': 10}, (10,), None, 1j,
-                   10.1, -10.1, '10L', '-10L', '10.1', '-10.1', u'10L',
-                   u'-10L', u'10.1', u'-10.1',  '10', '-10', u'10', u'-10']
+    _bad_values = ['ten', six.u('ten'), [10], {'ten': 10}, (10,), None, 1j,
+                   10.1, -10.1, '10L', '-10L', '10.1', '-10.1', six.u('10L'),
+                   six.u('-10L'), six.u('10.1'), six.u('-10.1'),  '10', '-10',
+                   six.u('10'), six.u('-10')]
 
     try:
         import numpy as np
@@ -197,10 +198,11 @@ class CoercibleLongTest(AnyTraitTest):
 
     _default_value = LONG_TYPE(99)
     _good_values = [
-        10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', u'10', u'-10']
+        10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10',
+        six.u('10'), six.u('-10')]
     if sys.version_info[0] < 3:
-        _good_values.extend(['10L', '-10L', u'10L', u'-10L'])
-    _bad_values = ['10.1', '-10.1', u'10.1', u'-10.1', 'ten', u'ten', [10],
+        _good_values.extend(['10L', '-10L', six.u('10L'), six.u('-10L')])
+    _bad_values = ['10.1', '-10.1', six.u('10.1'), six.u('-10.1'), 'ten', six.u('ten'), [10],
                    [LONG_TYPE(10)], {'ten': 10}, (10,), (LONG_TYPE(10),), None, 1j]
 
     def coerce(self, value):
@@ -216,10 +218,11 @@ class LongTest(AnyTraitTest):
 
     _default_value = LONG_TYPE(99)
     _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10)]
-    _bad_values = ['ten', u'ten', [10], [LONG_TYPE(10)], {'ten': 10}, (10, ), (LONG_TYPE(10),),
+    _bad_values = ['ten', six.u('ten'), [10], [LONG_TYPE(10)],
+                   {'ten': 10}, (10, ), (LONG_TYPE(10),),
                    None, 1j, 10.1, -10.1, '10', '-10', '10L', '-10L', '10.1',
-                   '-10.1', u'10', u'-10', u'10L', u'-10L', u'10.1',
-                   u'-10.1']
+                   '-10.1', six.u('10'), six.u('-10'),
+                   six.u('10L'), six.u('-10L'), six.u('10.1'), six.u('-10.1')]
 
     def coerce(self, value):
         try:
@@ -240,9 +243,12 @@ class CoercibleFloatTest(AnyTraitTest):
     obj = CoercibleFloatTrait()
 
     _default_value = 99.0
-    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', '10.1',
-                    '-10.1', u'10', u'-10', u'10.1', u'-10.1']
-    _bad_values = ['10L', '-10L', u'10L', u'-10L', 'ten', u'ten', [10],
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10',
+                    '-10', '10.1',
+                    '-10.1', six.u('10'), six.u('-10'), six.u('10.1'),
+                    six.u('-10.1')]
+    _bad_values = ['10L', '-10L', six.u('10L'), six.u('-10L'), 'ten',
+                   six.u('ten'), [10],
                    {'ten': 10}, (10, ), None, 1j]
 
     def coerce(self, value):
@@ -257,9 +263,10 @@ class FloatTest(AnyTraitTest):
 
     _default_value = 99.0
     _good_values = [10, -10, 10.1, -10.1]
-    _bad_values = ['ten', u'ten', [10], {'ten': 10}, (10,), None,
-                   1j, '10', '-10', '10L', '-10L', '10.1', '-10.1', u'10',
-                   u'-10', u'10L', u'-10L', u'10.1', u'-10.1']
+    _bad_values = ['ten', six.u('ten'), [10], {'ten': 10}, (10,), None,
+                   1j, '10', '-10', '10L', '-10L', '10.1', '-10.1',
+                   six.u('10'), six.u('-10'), six.u('10L'), six.u('-10L'),
+                   six.u('10.1'), six.u('-10.1')]
 
     if sys.version_info[0] < 3:
         _good_values.extend([LONG_TYPE(-10), LONG_TYPE(10)])
@@ -282,10 +289,12 @@ class ImaginaryValueTest(AnyTraitTest):
     obj = ImaginaryValueTrait()
 
     _default_value = 99.0 - 99.0j
-    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', '10.1',
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10',
+                    '-10', '10.1',
                     '-10.1', 10j, 10 + 10j, 10 - 10j, 10.1j, 10.1 + 10.1j,
                     10.1 - 10.1j, '10j', '10+10j', '10-10j']
-    _bad_values = [u'10L', u'-10L', 'ten', [10], {'ten': 10}, (10,), None]
+    _bad_values = [six.u('10L'), six.u('-10L'), 'ten', [10],
+                   {'ten': 10}, (10,), None]
 
     def coerce(self, value):
         try:
@@ -303,9 +312,10 @@ class StringTest(AnyTraitTest):
     obj = StringTrait()
 
     _default_value = 'string'
-    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', '10L',
-                    '-10L', '10.1', '-10.1', 'string', u'string', 1j, [10],
-                    ['ten'], {'ten': 10}, (10,), None]
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1,
+                    '10', '-10', '10L',
+                    '-10L', '10.1', '-10.1', 'string', six.u('string'),
+                    1j, [10], ['ten'], {'ten': 10}, (10,), None]
     _bad_values = []
 
     def coerce(self, value):
@@ -313,17 +323,18 @@ class StringTest(AnyTraitTest):
 
 
 class UnicodeTrait(HasTraits):
-    value = Trait(u'unicode')
+    value = Trait(six.u('unicode'))
 
 
 class UnicodeTest(StringTest):
 
     obj = UnicodeTrait()
 
-    _default_value = u'unicode'
-    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1, '10', '-10', '10L',
-                    '-10L', '10.1', '-10.1', '', u'', 'string', u'string', 1j,
-                    [10], ['ten'], [u'ten'], {'ten': 10}, (10,), None]
+    _default_value = six.u('unicode')
+    _good_values = [10, -10, LONG_TYPE(10), LONG_TYPE(-10), 10.1, -10.1,
+                    '10', '-10', '10L', '-10L', '10.1', '-10.1',
+                    '', six.u(''), 'string', six.u('string'), 1j,
+                    [10], ['ten'], [six.u('ten')], {'ten': 10}, (10,), None]
     _bad_values = []
 
     def coerce(self, value):
@@ -331,7 +342,7 @@ class UnicodeTest(StringTest):
 
 
 class EnumTrait(HasTraits):
-    value = Trait([1, 'one', 2, 'two', 3, 'three', 4.4, u'four.four'])
+    value = Trait([1, 'one', 2, 'two', 3, 'three', 4.4, six.u('four.four')])
 
 
 class EnumTest(AnyTraitTest):
@@ -339,7 +350,7 @@ class EnumTest(AnyTraitTest):
     obj = EnumTrait()
 
     _default_value = 1
-    _good_values = [1, 'one', 2, 'two', 3, 'three', 4.4, u'four.four']
+    _good_values = [1, 'one', 2, 'two', 3, 'three', 4.4, six.u('four.four')]
     _bad_values = [0, 'zero', 4, None]
 
 
@@ -463,7 +474,7 @@ class OldInstanceTest(AnyTraitTest):
     _good_values = [otrait_test1, OTraitTest1(), OTraitTest2(),
                     OTraitTest3(), None]
     _bad_values = [0, LONG_TYPE(0), 0.0, 0j, OTraitTest1, OTraitTest2, OBadTraitTest(),
-                   'string', u'string', [otrait_test1], (otrait_test1,),
+                   'string', six.u('string'), [otrait_test1], (otrait_test1,),
                    {'data': otrait_test1}]
 
 
@@ -498,7 +509,7 @@ class NewInstanceTest(AnyTraitTest):
     _good_values = [ntrait_test1, NTraitTest1(), NTraitTest2(), NTraitTest3(),
                     None]
     _bad_values = [0, LONG_TYPE(0), 0.0, 0j, NTraitTest1, NTraitTest2, NBadTraitTest(),
-                   'string', u'string', [ntrait_test1], (ntrait_test1,),
+                   'string', six.u('string'), [ntrait_test1], (ntrait_test1,),
                    {'data': ntrait_test1}]
 
 

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -356,7 +356,7 @@ class BytesTest(StringTest):
     _default_value = b'bytes'
     _good_values = [b'', b'10', b'-10'] + (version_dependent
         if sys.version_info[0] == 2 else [])
-    _bad_values = [10, -10, 10L, 10.1, u'unicode', u'', [b''], [b'bytes'], [0],
+    _bad_values = [10, -10, LONG_TYPE(10), 10.1, u'unicode', u'', [b''], [b'bytes'], [0],
         {b'ten': b'10'}, (b'',), None, True] + (version_dependent
         if sys.version_info[0] == 3 else [])
 
@@ -380,7 +380,7 @@ class CoercibleBytesTest(StringTest):
 
     _default_value = b'bytes'
     _good_values = [
-        b'', b'10', b'-10', 10, 10L, [10], (10,), set([10]), {10: 'foo'},
+        b'', b'10', b'-10', 10, LONG_TYPE(10), [10], (10,), set([10]), {10: 'foo'},
         True] + (version_dependent if sys.version_info[0] == 2 else [])
     _bad_values = (version_dependent if sys.version_info[0] == 3 else [])
 

--- a/traits/tests/test_ui_notifiers.py
+++ b/traits/tests/test_ui_notifiers.py
@@ -29,9 +29,11 @@ else:
     QT_FOUND = True
 
 
-import thread
 from threading import Thread
 import time
+
+import six
+import six.moves as sm
 
 from traits.api import Callable, Float, HasTraits, on_trait_change
 from traits.testing.unittest_tools import unittest
@@ -70,7 +72,7 @@ class BaseTestUINotifiers(object):
         qt4_app.processEvents()
 
     def on_foo_notifications(self, obj, name, old, new):
-        thread_id = thread.get_ident()
+        thread_id = sm._thread.get_ident()
         event = (thread_id, (obj, name, old, new))
         self.notifications.append(event)
 

--- a/traits/tests/test_undefined.py
+++ b/traits/tests/test_undefined.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import HasTraits, Str, Undefined, ReadOnly, Float
+from traits.api import HasTraits, Str, Undefined, ReadOnly, Float
 
 
 class Foo(HasTraits):

--- a/traits/tests/test_weak_ref.py
+++ b/traits/tests/test_weak_ref.py
@@ -18,8 +18,8 @@ import gc
 
 from traits.testing.unittest_tools import unittest, UnittestTools
 
-from ..trait_types import Str, WeakRef
-from ..has_traits import HasTraits
+from traits.trait_types import Str, WeakRef
+from traits.has_traits import HasTraits
 
 
 class Eggs(HasTraits):

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -31,6 +31,8 @@ import sys
 from os import getcwd
 from os.path import dirname, exists, join
 
+import six
+
 from . import _py2to3
 
 # backwards compatibility: trait_base used to provide a patched enumerate
@@ -199,7 +201,7 @@ SequenceTypes = ( list, tuple )
 
 ComplexTypes  = ( float, int )
 
-TypeTypes     = ( str,  unicode, int, long, float, complex, list, tuple, dict, bool )
+TypeTypes     = ( str,  six.text_type, int, six.integer_types, float, complex, list, tuple, dict, bool )
 
 TraitNotifier = '__trait_notifier__'
 
@@ -326,7 +328,7 @@ def strx ( arg ):
 #  Constants:
 #-------------------------------------------------------------------------------
 
-StringTypes = ( str, unicode, int, long, float, complex )
+StringTypes = ( str, six.text_type, int, six.integer_types, float, complex )
 
 #-------------------------------------------------------------------------------
 #  Define a mapping of coercable types:
@@ -334,10 +336,10 @@ StringTypes = ( str, unicode, int, long, float, complex )
 
 # Mapping of coercable types.
 CoercableTypes = {
-    long:    ( 11, long, int ),
+    six.integer_types:    ( 11, six.integer_types, int ),
     float:   ( 11, float, int ),
     complex: ( 11, complex, float, int ),
-    unicode: ( 11, unicode, str )
+    six.text_type: ( 11, six.text_type, str )
 }
 
 #-------------------------------------------------------------------------------
@@ -350,7 +352,7 @@ def class_of ( object ):
     correct indefinite article ('a' or 'an') preceding it (e.g., 'an Image',
     'a PlotValue').
     """
-    if isinstance( object, basestring ):
+    if isinstance( object, six.string_types ):
         return add_article( object )
 
     return add_article( object.__class__.__name__ )
@@ -533,4 +535,4 @@ def not_event ( value ):
     return (value != 'event')
 
 def is_str ( value ):
-    return isinstance( value, basestring )
+    return isinstance( value, six.string_types )

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -62,12 +62,11 @@ logger = logging.getLogger( __name__ )
 #  Constants:
 #-------------------------------------------------------------------------------
 
+
 if six.PY2:
     LONG_TYPE = long
-    MAXINT = sys.maxint
 else:
     LONG_TYPE = int
-    MAXINT = sys.maxsize
 
 # Trait 'comparison_mode' enum values:
 NO_COMPARE              = 0
@@ -891,7 +890,7 @@ class TraitString ( TraitHandler ):
     must be a string of between 0 and 50 characters that consist of only
     upper and lower case letters.
     """
-    def __init__ ( self, minlen = 0, maxlen = MAXINT, regex = '' ):
+    def __init__ ( self, minlen = 0, maxlen = six.MAXSIZE, regex = '' ):
         """ Creates a TraitString handler.
 
         Parameters
@@ -912,9 +911,9 @@ class TraitString ( TraitHandler ):
     def _init ( self ):
         if self.regex != '':
             self.match = re.compile( self.regex ).match
-            if (self.minlen == 0) and (self.maxlen == MAXINT):
+            if (self.minlen == 0) and (self.maxlen == six.MAXSIZE):
                 self.validate = self.validate_regex
-        elif (self.minlen == 0) and (self.maxlen == MAXINT):
+        elif (self.minlen == 0) and (self.maxlen == six.MAXSIZE):
             self.validate = self.validate_str
         else:
             self.validate = self.validate_len
@@ -956,10 +955,10 @@ class TraitString ( TraitHandler ):
 
     def info ( self ):
         msg = ''
-        if (self.minlen != 0) and (self.maxlen != MAXINT):
+        if (self.minlen != 0) and (self.maxlen != six.MAXSIZE):
             msg = ' between %d and %d characters long' % (
                   self.minlen, self.maxlen )
-        elif self.maxlen != MAXINT:
+        elif self.maxlen != six.MAXSIZE:
             msg = ' <= %d characters long' % self.maxlen
         elif self.minlen != 0:
             msg = ' >= %d characters long' % self.minlen
@@ -2187,7 +2186,7 @@ class TraitList ( TraitHandler ):
     default_value_type = 5
     _items_event       = None
 
-    def __init__ ( self, trait = None, minlen = 0, maxlen = MAXINT,
+    def __init__ ( self, trait = None, minlen = 0, maxlen = six.MAXSIZE,
                          has_items = True ):
         """ Creates a TraitList handler.
 
@@ -2227,12 +2226,12 @@ class TraitList ( TraitHandler ):
 
     def full_info ( self, object, name, value ):
         if self.minlen == 0:
-            if self.maxlen == MAXINT:
+            if self.maxlen == six.MAXSIZE:
                 size = 'items'
             else:
                 size = 'at most %d items' % self.maxlen
         else:
-            if self.maxlen == MAXINT:
+            if self.maxlen == six.MAXSIZE:
                 size = 'at least %d items' % self.minlen
             else:
                 size = 'from %s to %s items' % (

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -73,7 +73,7 @@ NO_COMPARE              = 0
 OBJECT_IDENTITY_COMPARE = 1
 RICH_COMPARE            = 2
 
-RangeTypes    = ( int, six.integer_types, float )
+RangeTypes    = ( int, LONG_TYPE, float )
 
 CallableTypes = ( FunctionType, MethodType )
 

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -63,8 +63,10 @@ logger = logging.getLogger( __name__ )
 #-------------------------------------------------------------------------------
 
 if six.PY2:
+    LONG_TYPE = long
     MAXINT = sys.maxint
 else:
+    LONG_TYPE = int
     MAXINT = sys.maxsize
 
 # Trait 'comparison_mode' enum values:
@@ -95,9 +97,9 @@ trait_from = None  # Patched by 'traits.py' when real 'trait_from' is defined
 def _arg_count ( func ):
     """ Returns the correct argument count for a specified function or method.
     """
-    if (type( func ) is MethodType) and (func.im_self is not None):
-        return func.func_code.co_argcount - 1
-    return func.func_code.co_argcount
+    if (type( func ) is MethodType) and (func.__self__ is not None):
+        return six.get_function_code(func).co_argcount - 1
+    return six.get_function_code(func).co_argcount
 
 #-------------------------------------------------------------------------------
 #  Property error handling functions:
@@ -746,7 +748,6 @@ class TraitRange ( TraitHandler ):
         specify whether the *low* and *high* values should be exclusive (or
         inclusive).
         """
-
         vtype = type( high )
         if (low is not None) and (vtype is not float):
             vtype = type( low )
@@ -762,13 +763,13 @@ class TraitRange ( TraitHandler ):
                 low = float( low )
             if high is not None:
                 high = float( high )
-        elif vtype is six.integer_types:
+        elif vtype is LONG_TYPE:
             self.validate   = self.long_validate
             self._type_desc = 'a long integer'
             if low is not None:
-                low = six.integer_types( low )
+                low = LONG_TYPE( low )
             if high is not None:
-                high = six.integer_types( high )
+                high = LONG_TYPE( high )
         else:
             self.validate = self.int_validate
             kind = 3
@@ -782,7 +783,7 @@ class TraitRange ( TraitHandler ):
             exclude_mask |= 1
         if exclude_high:
             exclude_mask |= 2
-        if vtype is not six.integer_types:
+        if vtype is not LONG_TYPE:
             self.fast_validate = ( kind, low, high, exclude_mask )
 
         # Assign type-corrected arguments to handler attributes

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -439,8 +439,8 @@ class TraitChangeNotifyWrapper(object):
         # If target is not None and handler is a function then the handler
         # will be removed when target is deleted.
         if type( handler ) is MethodType:
-            func   = handler.im_func
-            object = handler.im_self
+            func   = six.get_method_function(handler)
+            object = six.get_method_self(handler)
             if object is not None:
                 self.object = weakref.ref( object, self.listener_deleted )
                 self.name   = handler.__name__
@@ -507,9 +507,9 @@ class TraitChangeNotifyWrapper(object):
         if handler is self:
             return True
 
-        if (type( handler ) is MethodType) and (handler.im_self is not None):
+        if (type( handler ) is MethodType) and (six.get_method_self(handler) is not None):
             return ((handler.__name__ == self.name) and
-                    (handler.im_self is self.object()))
+                    (six.get_method_self(handler) is self.object()))
 
         return ((self.name is None) and (handler == self.handler))
 

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -231,8 +231,8 @@ class NotificationExceptionHandler ( object ):
             handler = logging.StreamHandler()
             handler.setFormatter( logging.Formatter( '%(message)s' ) )
             logger.addHandler( handler )
-            print ('Exception occurred in traits notification handler.\n'
-                   'Please check the log file for details.')
+            print('Exception occurred in traits notification handler.\n'
+                  'Please check the log file for details.')
 
         try:
             logger.exception(
@@ -315,7 +315,7 @@ class AbstractStaticChangeNotifyWrapper(object):
     arguments_transforms = {}
 
     def __init__ ( self, handler ):
-        arg_count = six.function_code(handler).co_argcount
+        arg_count = six.get_function_code(handler).co_argcount
         if arg_count > 4:
             raise TraitNotificationError(
                 ('Invalid number of arguments for the static anytrait change '
@@ -426,7 +426,7 @@ class TraitChangeNotifyWrapper(object):
                 self.object = weakref.ref( object, self.listener_deleted )
                 self.name   = handler.__name__
                 self.owner  = owner
-                arg_count   = six.function_code(func).co_argcount - 1
+                arg_count   = six.get_function_code(func).co_argcount - 1
                 if arg_count > 4:
                     raise TraitNotificationError(
                         ('Invalid number of arguments for the dynamic trait '
@@ -446,7 +446,7 @@ class TraitChangeNotifyWrapper(object):
             self.object = weakref.ref( target, self.listener_deleted )
             self.owner = owner
 
-        arg_count = six.function_code(handler).co_argcount
+        arg_count = six.get_function_code(handler).co_argcount
         if arg_count > 4:
             raise TraitNotificationError(
                 ('Invalid number of arguments for the dynamic trait change '

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -24,9 +24,12 @@
 
 from __future__ import absolute_import
 
+import six
+import six.moves as sm
+
 from threading import local as thread_local
 from threading import Thread
-from thread import get_ident
+
 import traceback
 from types import MethodType
 import weakref
@@ -55,10 +58,10 @@ def set_ui_handler ( handler ):
     global ui_handler, ui_thread
 
     ui_handler = handler
-    ui_thread  = get_ident()
+    ui_thread  = sm._thread.get_ident()
 
 def ui_dispatch( handler, *args, **kw ):
-    if get_ident() == ui_thread:
+    if sm._thread.get_ident() == ui_thread:
         handler( *args, **kw )
     else:
         ui_handler( handler, *args, **kw )
@@ -162,7 +165,7 @@ class NotificationExceptionHandler ( object ):
         handler_info.handler( object, trait_name, old, new )
         if (handler_info.reraise_exceptions or
             isinstance( excp, TraitNotificationError )):
-            raise
+            raise excp
 
     def _get_handlers ( self ):
         """ Returns the handler stack associated with the currently executing
@@ -170,7 +173,7 @@ class NotificationExceptionHandler ( object ):
         """
         thread_local = self.thread_local
         if isinstance( thread_local, dict ):
-            id       = get_ident()
+            id       = sm._thread.get_ident()
             handlers = thread_local.get( id )
         else:
             handlers = getattr( thread_local, 'handlers', None )
@@ -312,7 +315,7 @@ class AbstractStaticChangeNotifyWrapper(object):
     arguments_transforms = {}
 
     def __init__ ( self, handler ):
-        arg_count = handler.func_code.co_argcount
+        arg_count = six.function_code(handler).co_argcount
         if arg_count > 4:
             raise TraitNotificationError(
                 ('Invalid number of arguments for the static anytrait change '
@@ -417,13 +420,13 @@ class TraitChangeNotifyWrapper(object):
         # If target is not None and handler is a function then the handler
         # will be removed when target is deleted.
         if type( handler ) is MethodType:
-            func   = handler.im_func
-            object = handler.im_self
+            func   = handler.__func__
+            object = handler.__self__
             if object is not None:
                 self.object = weakref.ref( object, self.listener_deleted )
                 self.name   = handler.__name__
                 self.owner  = owner
-                arg_count   = func.func_code.co_argcount - 1
+                arg_count   = six.function_code(func).co_argcount - 1
                 if arg_count > 4:
                     raise TraitNotificationError(
                         ('Invalid number of arguments for the dynamic trait '
@@ -443,7 +446,7 @@ class TraitChangeNotifyWrapper(object):
             self.object = weakref.ref( target, self.listener_deleted )
             self.owner = owner
 
-        arg_count = handler.func_code.co_argcount
+        arg_count = six.function_code(handler).co_argcount
         if arg_count > 4:
             raise TraitNotificationError(
                 ('Invalid number of arguments for the dynamic trait change '
@@ -485,9 +488,9 @@ class TraitChangeNotifyWrapper(object):
         if handler is self:
             return True
 
-        if (type( handler ) is MethodType) and (handler.im_self is not None):
+        if (type( handler ) is MethodType) and (handler.__self__ is not None):
             return ((handler.__name__ == self.name) and
-                    (handler.im_self is self.object()))
+                    (handler.__self__ is self.object()))
 
         return ((self.name is None) and (handler == self.handler))
 
@@ -610,7 +613,7 @@ class FastUITraitChangeNotifyWrapper ( TraitChangeNotifyWrapper ):
     """
 
     def dispatch ( self, handler, *args ):
-        if get_ident() == ui_thread:
+        if sm._thread.get_ident() == ui_thread:
             handler( *args )
         else:
             ui_handler( handler, *args )

--- a/traits/trait_numeric.py
+++ b/traits/trait_numeric.py
@@ -117,9 +117,9 @@ class AbstractArray ( TraitType ):
                            (item[0] <= item[1]))))):
                         continue
 
-                    raise TraitError, "shape should be a list or tuple"
+                    raise TraitError("shape should be a list or tuple")
             else:
-                raise TraitError, "shape should be a list or tuple"
+                raise TraitError("shape should be a list or tuple")
 
         if value is None:
             value = self._default_for_dtype_and_shape( dtype, shape )

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -95,8 +95,8 @@ try:
     from numpy import integer, floating, complexfloating, bool_
 
     int_fast_validate     = ( 11, int, integer )
-    long_fast_validate    = ( 11, six.integer_types, None, int, integer )
-    float_fast_validate   = ( 11, float, floating, None, int, six.integer_types, integer )
+    long_fast_validate    = ( 11, LONG_TYPE, None, int, integer )
+    float_fast_validate   = ( 11, float, floating, None, int, LONG_TYPE, integer )
     complex_fast_validate = ( 11, complex, complexfloating, None,
                                   float, floating, int, integer )
     bool_fast_validate    = ( 11, bool, bool_ )
@@ -105,8 +105,8 @@ try:
 except ImportError:
     # The standard python definitions (without numpy):
     int_fast_validate     = ( 11, int )
-    long_fast_validate    = ( 11, six.integer_types,    None, int )
-    float_fast_validate   = ( 11, float,   None, int, six.integer_types )
+    long_fast_validate    = ( 11, LONG_TYPE,    None, int )
+    float_fast_validate   = ( 11, float,   None, int, LONG_TYPE )
     complex_fast_validate = ( 11, complex, None, float, int )
     bool_fast_validate    = ( 11, bool )
     # Tuple or single type suitable for an isinstance check.
@@ -379,7 +379,7 @@ class Str ( BaseStr ):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = ( 11, six.string_types )
+    fast_validate = ( 11, six.text_type )
 
 
 class Title ( Str ):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -31,6 +31,8 @@ import sys
 from os.path import isfile, isdir
 from types import FunctionType, MethodType, ModuleType
 
+import six
+
 from . import trait_handlers
 
 from .trait_base import (strx, get_module_name, class_of, SequenceTypes, TypeTypes,
@@ -50,6 +52,17 @@ from . import _py2to3
 #-------------------------------------------------------------------------------
 #  Constants:
 #-------------------------------------------------------------------------------
+
+if six.PY2:
+
+    LONG_TYPE = long
+else:
+    LONG_TYPE = int
+
+if six.PY2:
+    MAXINT = sys.maxint
+else:
+    MAXINT = sys.maxsize
 
 MutableTypes = ( list, dict )
 SetTypes     = SequenceTypes + ( set, )
@@ -82,8 +95,8 @@ try:
     from numpy import integer, floating, complexfloating, bool_
 
     int_fast_validate     = ( 11, int, integer )
-    long_fast_validate    = ( 11, long, None, int, integer )
-    float_fast_validate   = ( 11, float, floating, None, int, long, integer )
+    long_fast_validate    = ( 11, six.integer_types, None, int, integer )
+    float_fast_validate   = ( 11, float, floating, None, int, six.integer_types, integer )
     complex_fast_validate = ( 11, complex, complexfloating, None,
                                   float, floating, int, integer )
     bool_fast_validate    = ( 11, bool, bool_ )
@@ -92,8 +105,8 @@ try:
 except ImportError:
     # The standard python definitions (without numpy):
     int_fast_validate     = ( 11, int )
-    long_fast_validate    = ( 11, long,    None, int )
-    float_fast_validate   = ( 11, float,   None, int, long )
+    long_fast_validate    = ( 11, six.integer_types,    None, int )
+    float_fast_validate   = ( 11, float,   None, int, six.integer_types )
     complex_fast_validate = ( 11, complex, None, float, int )
     bool_fast_validate    = ( 11, bool )
     # Tuple or single type suitable for an isinstance check.
@@ -167,7 +180,7 @@ class BaseInt ( TraitType ):
         """
         if type(value) is int:
             return value
-        elif type(value) is long:
+        elif type(value) is six.integer_types:
             return int(value)
 
         try:
@@ -202,10 +215,10 @@ class BaseLong ( TraitType ):
     """
 
     #: The function to use for evaluating strings to this type:
-    evaluate = long
+    evaluate = LONG_TYPE
 
     #: The default value for the trait:
-    default_value = 0L
+    default_value = LONG_TYPE(0)
 
     #: A description of the type of value this trait accepts:
     info_text = 'a long'
@@ -215,18 +228,18 @@ class BaseLong ( TraitType ):
 
             Note: The 'fast validator' version performs this check in C.
         """
-        if isinstance( value, long ):
-            return value
-
         if isinstance( value, int ):
-            return long( value )
+            return LONG_TYPE( value )
+
+        if isinstance( value, six.integer_types ):
+            return value
 
         self.error( object, name, value )
 
     def create_editor ( self ):
         """ Returns the default traits UI editor for this type of trait.
         """
-        return default_text_editor( self, long )
+        return default_text_editor( self, LONG_TYPE )
 
 
 class Long ( BaseLong ):
@@ -261,7 +274,7 @@ class BaseFloat ( TraitType ):
         if isinstance( value, float ):
             return value
 
-        if isinstance( value, ( int, long ) ):
+        if isinstance( value, six.integer_types):
             return float( value )
 
         self.error( object, name, value )
@@ -343,7 +356,7 @@ class BaseStr ( TraitType ):
 
             Note: The 'fast validator' version performs this check in C.
         """
-        if isinstance( value, basestring ):
+        if isinstance( value, six.string_types ):
             return value
 
         self.error( object, name, value )
@@ -366,7 +379,7 @@ class Str ( BaseStr ):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = ( 11, basestring )
+    fast_validate = ( 11, six.string_types )
 
 
 class Title ( Str ):
@@ -402,11 +415,11 @@ class BaseUnicode ( TraitType ):
 
             Note: The 'fast validator' version performs this check in C.
         """
-        if isinstance( value, unicode ):
+        if isinstance( value, six.text_type ):
             return value
 
         if isinstance( value, str ):
-            return unicode( value )
+            return six.text_type( value )
 
         self.error( object, name, value )
 
@@ -428,7 +441,7 @@ class Unicode ( BaseUnicode ):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = ( 11, unicode, None, str )
+    fast_validate = ( 11, six.text_type, None, str )
 
 #-------------------------------------------------------------------------------
 #  'BaseBool' and 'Bool' traits:
@@ -514,7 +527,7 @@ class BaseCLong ( BaseLong ):
     """
 
     #: The function to use for evaluating strings to this type:
-    evaluate = long
+    evaluate = LONG_TYPE
 
     def validate ( self, object, name, value ):
         """ Validates that a specified value is valid for this trait.
@@ -522,7 +535,7 @@ class BaseCLong ( BaseLong ):
             Note: The 'fast validator' version performs this check in C.
         """
         try:
-            return long( value )
+            return LONG_TYPE( value )
         except:
             self.error( object, name, value )
 
@@ -533,7 +546,7 @@ class CLong ( BaseCLong ):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = ( 12, long )
+    fast_validate = ( 12, LONG_TYPE )
 
 #-------------------------------------------------------------------------------
 #  'BaseCFloat' and 'CFloat' traits:
@@ -616,7 +629,7 @@ class BaseCStr ( BaseStr ):
             return str( value )
         except:
             try:
-                return unicode( value )
+                return six.text_type( value )
             except:
                 self.error( object, name, value )
 
@@ -628,7 +641,7 @@ class CStr ( BaseCStr ):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = ( 7, ( ( 12, str ), ( 12, unicode ) ) )
+    fast_validate = ( 7, ( ( 12, str ), ( 12, six.text_type ) ) )
 
 #-------------------------------------------------------------------------------
 #  'BaseCUnicode' and 'CUnicode' traits:
@@ -645,7 +658,7 @@ class BaseCUnicode ( BaseUnicode ):
             Note: The 'fast validator' version performs this check in C.
         """
         try:
-            return unicode( value )
+            return six.text_type( value )
         except:
             self.error( object, name, value )
 
@@ -657,7 +670,7 @@ class CUnicode ( BaseCUnicode ):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = ( 12, unicode )
+    fast_validate = ( 12, six.text_type )
 
 #-------------------------------------------------------------------------------
 #  'BaseCBool' and 'CBool' traits:
@@ -701,7 +714,7 @@ class String ( TraitType ):
         specified regular expression.
     """
 
-    def __init__ ( self, value = '', minlen = 0, maxlen = sys.maxint,
+    def __init__ ( self, value = '', minlen = 0, maxlen = MAXINT,
                    regex = '', **metadata ):
         """ Creates a String trait.
 
@@ -730,9 +743,9 @@ class String ( TraitType ):
         self._validate = 'validate_all'
         if self.regex != '':
             self.match = re.compile( self.regex ).match
-            if (self.minlen == 0) and (self.maxlen == sys.maxint):
+            if (self.minlen == 0) and (self.maxlen == MAXINT):
                 self._validate = 'validate_regex'
-        elif (self.minlen == 0) and (self.maxlen == sys.maxint):
+        elif (self.minlen == 0) and (self.maxlen == MAXINT):
             self._validate = 'validate_str'
         else:
             self._validate = 'validate_len'
@@ -796,10 +809,10 @@ class String ( TraitType ):
         """ Returns a description of the trait.
         """
         msg = ''
-        if (self.minlen != 0) and (self.maxlen != sys.maxint):
+        if (self.minlen != 0) and (self.maxlen != MAXINT):
             msg = ' between %d and %d characters long' % (
                   self.minlen, self.maxlen )
-        elif self.maxlen != sys.maxint:
+        elif self.maxlen != MAXINT:
             msg = ' <= %d characters long' % self.maxlen
         elif self.minlen != 0:
             msg = ' >= %d characters long' % self.minlen
@@ -1134,8 +1147,7 @@ class Constant ( TraitType ):
             because those types have mutable values.
         """
         if type( value ) in MutableTypes:
-            raise TraitError, \
-                  "Cannot define a constant using a mutable list or dictionary"
+            raise TraitError("Cannot define a constant using a mutable list or dictionary")
 
         super( Constant, self ).__init__( value, **metadata )
 
@@ -1455,7 +1467,7 @@ class File ( BaseFile ):
         """
         if not exists:
             # Define the C-level fast validator to use:
-            fast_validate = ( 11, basestring )
+            fast_validate = ( 11, six.string_types )
 
         super( File, self ).__init__( value, filter, auto_set, entries, exists,
                                       **metadata )
@@ -1545,7 +1557,7 @@ class Directory ( BaseDirectory ):
         # Define the C-level fast validator to use if the directory existence
         #: test is not required:
         if not exists:
-            self.fast_validate = ( 11, basestring )
+            self.fast_validate = ( 11, six.string_types )
 
         super( Directory, self ).__init__( value, auto_set, entries, exists,
                                            **metadata )
@@ -1596,12 +1608,12 @@ class BaseRange ( TraitType ):
 
         vtype = type( high )
         if ((low is not None) and
-            (not issubclass( vtype, ( float, basestring ) ))):
+            (not issubclass( vtype, ( float, six.string_types ) ))):
             vtype = type( low )
 
-        is_static = (not issubclass( vtype, basestring ))
+        is_static = (not issubclass( vtype, six.string_types ))
         if is_static and (vtype not in RangeTypes):
-            raise TraitError, ("Range can only be use for int, long or float "
+            raise TraitError("Range can only be use for int, long or float "
                                "values, but a value of type %s was specified." %
                                vtype)
 
@@ -1618,14 +1630,14 @@ class BaseRange ( TraitType ):
             if high is not None:
                 high = float( high )
 
-        elif vtype is long:
+        elif vtype is LONG_TYPE:
             self._validate  = 'long_validate'
             self._type_desc = 'a long integer'
             if low is not None:
-                low = long( low )
+                low = LONG_TYPE( low )
 
             if high is not None:
-                high = long( high )
+                high = LONG_TYPE( high )
 
         elif vtype is int:
             self._validate  = 'int_validate'
@@ -1641,19 +1653,19 @@ class BaseRange ( TraitType ):
             self._vtype     = None
             self._type_desc = 'a number'
 
-            if isinstance( high, basestring ):
+            if isinstance( high, six.string_types ):
                 self._high_name = high = 'object.' + high
             else:
                 self._vtype = type( high )
             high = compile( str( high ), '<string>', 'eval' )
 
-            if isinstance( low, basestring ):
+            if isinstance( low, six.string_types ):
                 self._low_name = low = 'object.' + low
             else:
                 self._vtype = type( low )
             low = compile( str( low ), '<string>', 'eval' )
 
-            if isinstance( value, basestring ):
+            if isinstance( value, six.string_types ):
                 value = 'object.' + value
             self._value = compile( str( value ), '<string>', 'eval' )
 
@@ -1667,7 +1679,7 @@ class BaseRange ( TraitType ):
         if exclude_high:
             exclude_mask |= 2
 
-        if is_static and (vtype is not long):
+        if is_static and (vtype is not LONG_TYPE):
             self.init_fast_validator( kind, low, high, exclude_mask )
 
         #: Assign type-corrected arguments to handler attributes:
@@ -1765,7 +1777,7 @@ class BaseRange ( TraitType ):
     def _set ( self, object, name, value ):
         """ Sets the current value of a dynamic range trait.
         """
-        if not isinstance( value, basestring ):
+        if not isinstance( value, six.string_types ):
             try:
                 low  = eval( self._low )
                 high = eval( self._high )
@@ -1894,7 +1906,7 @@ class BaseEnum ( TraitType ):
         values[0]
         """
         values = metadata.pop( 'values', None )
-        if isinstance( values, basestring ):
+        if isinstance( values, six.string_types ):
             n = len( args )
             if n == 0:
                 default_value = None
@@ -2202,7 +2214,7 @@ class List ( TraitType ):
     _items_event       = None
 
     def __init__ ( self, trait = None, value = None, minlen = 0,
-                   maxlen = sys.maxint, items = True, **metadata ):
+                   maxlen = MAXINT, items = True, **metadata ):
         """ Returns a List trait.
 
         Parameters
@@ -2265,12 +2277,12 @@ class List ( TraitType ):
         """ Returns a description of the trait.
         """
         if self.minlen == 0:
-            if self.maxlen == sys.maxint:
+            if self.maxlen == MAXINT:
                 size = 'items'
             else:
                 size = 'at most %d items' % self.maxlen
         else:
-            if self.maxlen == sys.maxint:
+            if self.maxlen == MAXINT:
                 size = 'at least %d items' % self.minlen
             else:
                 size = 'from %s to %s items' % (
@@ -2728,7 +2740,7 @@ class BaseInstance ( BaseClass ):
         self.adapt       = AdaptMap[ adapt ]
         self.module      = module or get_module_name()
 
-        if isinstance( klass, basestring ):
+        if isinstance( klass, six.string_types ):
             self.klass = klass
         else:
             if not isinstance( klass, ClassTypes ):
@@ -2752,7 +2764,7 @@ class BaseInstance ( BaseClass ):
                 raise TraitError( "The 'kw' argument must be a dictionary." )
 
             if ((not callable( factory )) and
-                (not isinstance( factory, basestring ))):
+                (not isinstance( factory, six.string_types ))):
                 if (len( args ) > 0) or (len( kw ) > 0):
                     raise TraitError( "'factory' must be callable" )
             else:
@@ -2773,7 +2785,7 @@ class BaseInstance ( BaseClass ):
 
             self.validate_failed( object, name, value )
 
-        if isinstance( self.klass, basestring ):
+        if isinstance( self.klass, six.string_types ):
             self.resolve_class( object, name, value )
 
         if self.adapt == 0:
@@ -2809,7 +2821,7 @@ class BaseInstance ( BaseClass ):
         """ Returns a description of the trait.
         """
         klass = self.klass
-        if not isinstance( klass, basestring ):
+        if not isinstance( klass, six.string_types ):
             klass = klass.__name__
 
         if self.adapt == 0:
@@ -2852,10 +2864,10 @@ class BaseInstance ( BaseClass ):
 
     def create_default_value ( self, *args, **kw ):
         klass = args[0]
-        if isinstance( klass, basestring ):
+        if isinstance( klass, six.string_types ):
             klass = self.validate_class( self.find_class( klass ) )
             if klass is None:
-                raise TraitError, 'Unable to locate class: ' + args[0]
+                raise TraitError('Unable to locate class: ' + args[0])
 
         return klass( *args[1:], **kw )
 
@@ -3017,7 +3029,7 @@ class Type ( BaseClass ):
         elif klass is None:
             klass = value
 
-        if isinstance( klass, basestring ):
+        if isinstance( klass, six.string_types ):
             self.validate = self.resolve
 
         elif not isinstance( klass, ClassTypes ):
@@ -3046,7 +3058,7 @@ class Type ( BaseClass ):
             class, then resets the trait so that future calls will be handled by
             the normal validate method.
         """
-        if isinstance( self.klass, basestring ):
+        if isinstance( self.klass, six.string_types ):
             self.resolve_class( object, name, value )
             del self.validate
 
@@ -3056,7 +3068,7 @@ class Type ( BaseClass ):
         """ Returns a description of the trait.
         """
         klass = self.klass
-        if not isinstance( klass, basestring ):
+        if not isinstance( klass, six.string_types ):
             klass = klass.__name__
 
         result = 'a subclass of ' + klass
@@ -3070,7 +3082,7 @@ class Type ( BaseClass ):
         """ Returns a tuple of the form: ( default_value_type, default_value )
             which describes the default value for this trait.
         """
-        if not isinstance( self.default_value, basestring ):
+        if not isinstance( self.default_value, six.string_types ):
             return super( Type, self ).get_default_value()
 
         return ( 7, ( self.resolve_default_value, (), None ) )
@@ -3079,7 +3091,7 @@ class Type ( BaseClass ):
         """ Resolves a class name into a class so that it can be used to
             return the class as the default value of the trait.
         """
-        if isinstance( self.klass, basestring ):
+        if isinstance( self.klass, six.string_types ):
             try:
                 self.resolve_class( None, None, None )
                 del self.validate
@@ -3268,7 +3280,7 @@ class Symbol ( TraitType ):
                 object.__dict__[ cache ] = ref = \
                     object.trait( name ).default_value_for( object, name )
 
-            if isinstance( ref, basestring ):
+            if isinstance( ref, six.string_types ):
                 object.__dict__[ name ] = value = self._resolve( ref )
 
         return value
@@ -3276,7 +3288,7 @@ class Symbol ( TraitType ):
     def set ( self, object, name, value ):
         dict = object.__dict__
         old  = dict.get( name, Undefined )
-        if isinstance( value, basestring ):
+        if isinstance( value, six.string_types ):
             dict.pop( name, None )
             dict[ TraitsCache + name ] = value
             object.trait_property_changed( name, old )
@@ -3446,7 +3458,7 @@ ListFloat = List( float )
 ListStr = List( str )
 
 #: List of Unicode string values; default value is [].
-ListUnicode = List( unicode )
+ListUnicode = List( six.text_type )
 
 #: List of complex values; default value is [].
 ListComplex = List( complex )
@@ -3488,7 +3500,7 @@ DictStrInt = Dict( str, int )
 
 #: Only a dictionary of string:long-integer values can be assigned; only string
 #: keys with long-integer values can be inserted. The default value is {}.
-DictStrLong = Dict( str, long )
+DictStrLong = Dict( str, LONG_TYPE )
 
 #: Only a dictionary of string:float values can be assigned; only string keys
 #: with float values can be inserted. The default value is {}.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -59,11 +59,6 @@ if six.PY2:
 else:
     LONG_TYPE = int
 
-if six.PY2:
-    MAXINT = sys.maxint
-else:
-    MAXINT = sys.maxsize
-
 MutableTypes = ( list, dict )
 SetTypes     = SequenceTypes + ( set, )
 
@@ -405,7 +400,7 @@ class BaseUnicode ( TraitType ):
     """
 
     #: The default value for the trait:
-    default_value = u''
+    default_value = six.u('')
 
     #: A description of the type of value this trait accepts:
     info_text = 'a unicode string'
@@ -714,7 +709,7 @@ class String ( TraitType ):
         specified regular expression.
     """
 
-    def __init__ ( self, value = '', minlen = 0, maxlen = MAXINT,
+    def __init__ ( self, value = '', minlen = 0, maxlen = six.MAXSIZE,
                    regex = '', **metadata ):
         """ Creates a String trait.
 
@@ -743,9 +738,9 @@ class String ( TraitType ):
         self._validate = 'validate_all'
         if self.regex != '':
             self.match = re.compile( self.regex ).match
-            if (self.minlen == 0) and (self.maxlen == MAXINT):
+            if (self.minlen == 0) and (self.maxlen == six.MAXSIZE):
                 self._validate = 'validate_regex'
-        elif (self.minlen == 0) and (self.maxlen == MAXINT):
+        elif (self.minlen == 0) and (self.maxlen == six.MAXSIZE):
             self._validate = 'validate_str'
         else:
             self._validate = 'validate_len'
@@ -809,10 +804,10 @@ class String ( TraitType ):
         """ Returns a description of the trait.
         """
         msg = ''
-        if (self.minlen != 0) and (self.maxlen != MAXINT):
+        if (self.minlen != 0) and (self.maxlen != six.MAXSIZE):
             msg = ' between %d and %d characters long' % (
                   self.minlen, self.maxlen )
-        elif self.maxlen != MAXINT:
+        elif self.maxlen != six.MAXSIZE:
             msg = ' <= %d characters long' % self.maxlen
         elif self.minlen != 0:
             msg = ' >= %d characters long' % self.minlen
@@ -2214,7 +2209,7 @@ class List ( TraitType ):
     _items_event       = None
 
     def __init__ ( self, trait = None, value = None, minlen = 0,
-                   maxlen = MAXINT, items = True, **metadata ):
+                   maxlen = six.MAXSIZE, items = True, **metadata ):
         """ Returns a List trait.
 
         Parameters
@@ -2277,12 +2272,12 @@ class List ( TraitType ):
         """ Returns a description of the trait.
         """
         if self.minlen == 0:
-            if self.maxlen == MAXINT:
+            if self.maxlen == six.MAXSIZE:
                 size = 'items'
             else:
                 size = 'at most %d items' % self.maxlen
         else:
-            if self.maxlen == MAXINT:
+            if self.maxlen == six.MAXSIZE:
                 size = 'at least %d items' % self.minlen
             else:
                 size = 'from %s to %s items' % (

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -374,7 +374,7 @@ class Str ( BaseStr ):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = ( 11, six.text_type )
+    fast_validate = ( 11, six.string_types[0] )
 
 
 class Title ( Str ):
@@ -1609,8 +1609,8 @@ class BaseRange ( TraitType ):
         is_static = (not issubclass( vtype, six.string_types ))
         if is_static and (vtype not in RangeTypes):
             raise TraitError("Range can only be use for int, long or float "
-                               "values, but a value of type %s was specified." %
-                               vtype)
+                             "values, but a value of type %s was specified." %
+                             vtype)
 
         self._low_name = self._high_name = ''
         self._vtype    = Undefined

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -437,7 +437,7 @@ TraitTypes       = ( TraitHandler, CTrait )
 
 DefaultValues = {
     str:  '',
-    six.text_type: u'',
+    six.text_type: six.u(''),
     int:     0,
     LONG_TYPE:    LONG_TYPE(0),
     float:   0.0,

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -735,7 +735,6 @@ def Trait ( *value_type, **metadata ):
 
 
     """
-    print(value_type, metadata)
     return _TraitMaker( *value_type, **metadata ).as_ctrait()
 
 #  Handle circular module dependencies:
@@ -969,7 +968,6 @@ class _TraitMaker ( object ):
             validate      = getattr( handler, 'fast_validate', None )
             if validate is None:
                 validate = handler.validate
-            print("before validate", validate)
             trait.set_validate( validate )
 
             post_setattr = getattr( handler, 'post_setattr', None )

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -72,7 +72,6 @@ from .trait_handlers import (TraitHandler, TraitInstance, TraitFunction,
 #-------------------------------------------------------------------------------
 
 if six.PY2:
-
     LONG_TYPE = long
 else:
     LONG_TYPE = int
@@ -736,6 +735,7 @@ def Trait ( *value_type, **metadata ):
 
 
     """
+    print(value_type, metadata)
     return _TraitMaker( *value_type, **metadata ).as_ctrait()
 
 #  Handle circular module dependencies:
@@ -969,7 +969,7 @@ class _TraitMaker ( object ):
             validate      = getattr( handler, 'fast_validate', None )
             if validate is None:
                 validate = handler.validate
-
+            print("before validate", validate)
             trait.set_validate( validate )
 
             post_setattr = getattr( handler, 'post_setattr', None )

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -50,6 +50,9 @@ from __future__ import absolute_import
 
 import sys
 from types import FunctionType, MethodType
+
+import six
+
 NoneType = type(None)   # Python 3's types does not include NoneType
 
 from . import trait_handlers
@@ -67,6 +70,12 @@ from .trait_handlers import (TraitHandler, TraitInstance, TraitFunction,
 #-------------------------------------------------------------------------------
 #  Constants:
 #-------------------------------------------------------------------------------
+
+if six.PY2:
+
+    LONG_TYPE = long
+else:
+    LONG_TYPE = int
 
 # Mapping from 'ctrait' default value types to a string representation:
 KindMap = {
@@ -413,9 +422,9 @@ ctraits._ctrait( CTrait )
 #  Constants:
 #-------------------------------------------------------------------------------
 
-ConstantTypes    = ( NoneType, int, long, float, complex, str, unicode )
+ConstantTypes    = ( NoneType, int, LONG_TYPE, float, complex, str, six.text_type )
 
-PythonTypes      = ( str, unicode, int, long, float, complex, list, tuple,
+PythonTypes      = ( str, six.text_type, int, LONG_TYPE, float, complex, list, tuple,
                      dict, FunctionType, MethodType, type, NoneType )
 
 if sys.version_info[0] < 3:
@@ -429,9 +438,9 @@ TraitTypes       = ( TraitHandler, CTrait )
 
 DefaultValues = {
     str:  '',
-    unicode: u'',
+    six.text_type: u'',
     int:     0,
-    long:    0L,
+    LONG_TYPE:    LONG_TYPE(0),
     float:   0.0,
     complex: 0j,
     list:    [],
@@ -791,7 +800,7 @@ class _TraitMaker ( object ):
                 else:
                     typeValue = type( default_value )
 
-                    if isinstance(default_value, basestring):
+                    if isinstance(default_value, six.string_types):
                         string_options = self.extract( metadata, 'min_len',
                                                        'max_len', 'regex' )
                         if len( string_options ) == 0:
@@ -868,7 +877,7 @@ class _TraitMaker ( object ):
                     for i, item in enumerate( other ):
                         if isinstance( item, CTrait ):
                             if item.type != 'trait':
-                                raise TraitError, ("Cannot create a complex "
+                                raise TraitError("Cannot create a complex "
                                     "trait containing %s trait." %
                                     add_article( item.type ) )
                             handler = item.handler

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -1143,6 +1143,7 @@ class ListenerParser ( HasPrivateTraits ):
     #-- object Method Overrides ------------------------------------------------
 
     def __init__ ( self, text = '', **traits ):
+        print(text)
         self.text = text
         super( ListenerParser, self ).__init__( **traits )
 

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -32,6 +32,8 @@ from weakref import WeakKeyDictionary
 from string import whitespace
 from types import MethodType
 
+import six
+
 from .has_traits import HasPrivateTraits
 from .trait_base import Undefined, Uninitialized
 from .traits import Property
@@ -415,7 +417,7 @@ class ListenerItem ( ListenerBase ):
 
         # For each item, determine its type (simple, list, dict):
         self.active[ new ] = active = []
-        for name, trait in traits.items():
+        for name, trait in six.iteritems(traits):
 
             # Determine whether the trait type is simple, list, set or
             # dictionary:
@@ -524,11 +526,11 @@ class ListenerItem ( ListenerBase ):
         """
         if old is not Uninitialized:
             unregister = self.next.unregister
-            for obj in old.values():
+            for obj in six.itervalues(old):
                 unregister( obj )
 
         register = self.next.register
-        for obj in new.values():
+        for obj in six.itervalues(new):
             register( obj )
 
     #---------------------------------------------------------------------------
@@ -552,7 +554,7 @@ class ListenerItem ( ListenerBase ):
             dict = getattr( object, name )
             unregister = self.next.unregister
             register = self.next.register
-            for key, obj in new.changed.items():
+            for key, obj in six.iteritems(new.changed):
                 unregister( obj )
                 register( dict[ key ] )
 
@@ -904,7 +906,7 @@ class ListenerItem ( ListenerBase ):
         else:
             handler = next.register
 
-        for obj in getattr( object, name ).values():
+        for obj in six.itervalues(getattr( object, name )):
             handler( obj )
 
         return INVALID_DESTINATION
@@ -919,7 +921,7 @@ class ListenerItem ( ListenerBase ):
         # Set if the new trait matches our prefix and metadata:
         if new_trait.startswith( self.name[:-1] ):
             trait = object.base_trait( new_trait )
-            for meta_name, meta_eval in self._metadata.items():
+            for meta_name, meta_eval in six.iteritems(self._metadata):
                 if not meta_eval( getattr( trait, meta_name ) ):
                     return
 
@@ -1345,7 +1347,7 @@ class ListenerHandler ( object ):
 
     def __init__ ( self, handler ):
         if type( handler ) is MethodType:
-            object = handler.im_self
+            object = handler.__self__
             if object is not None:
                 self.object = weakref.ref( object, self.listener_deleted )
                 self.name   = handler.__name__

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -1143,7 +1143,6 @@ class ListenerParser ( HasPrivateTraits ):
     #-- object Method Overrides ------------------------------------------------
 
     def __init__ ( self, text = '', **traits ):
-        print(text)
         self.text = text
         super( ListenerParser, self ).__init__( **traits )
 

--- a/traits/ustr_trait.py
+++ b/traits/ustr_trait.py
@@ -26,6 +26,8 @@
 
 from __future__ import absolute_import
 
+import six
+
 from .trait_base import is_str
 from .has_traits import HasTraits
 from .trait_value import TraitValue, TypeValue
@@ -66,7 +68,7 @@ class UStr ( TraitType ):
     def validate ( self, object, name, value ):
         """ Ensures that a value being assigned to a trait is a unique string.
         """
-        if isinstance( value, basestring ):
+        if isinstance( value, six.string_types ):
             names    = self.names
             old_name = getattr( object, name )
             if names.get( old_name ) is object:
@@ -167,7 +169,7 @@ class HasUniqueStrings ( HasTraits ):
         """
         super( HasUniqueStrings, self ).traits_init()
 
-        for name, trait in self.traits( unique_string = is_str ).items():
+        for name, trait in six.iteritems(self.traits( unique_string = is_str )):
             for str_name in trait.unique_string.split( ',' ):
                 self._ustr_traits.append( UStr( self, name, str_name.strip() ) )
 

--- a/traits/util/camel_case.py
+++ b/traits/util/camel_case.py
@@ -4,6 +4,9 @@
 # Standard library imports.
 import re
 
+import six
+import six.moves as sm
+
 ###############################################################################
 # Classes
 ###############################################################################
@@ -63,4 +66,4 @@ def camel_case_to_words(s):
 
         return s + c
 
-    return reduce(add_space_between_words, s, '')
+    return sm.reduce(add_space_between_words, s, '')

--- a/traits/util/clean_strings.py
+++ b/traits/util/clean_strings.py
@@ -25,7 +25,7 @@ def clean_filename(name):
     wordparts = re.split('[^\w\.\-]+', name)
 
     # Filter out empty strings at the beginning or end of the list.
-    wordparts = filter(None, wordparts)
+    wordparts = [x for x in wordparts if x]
 
     # Make sure this is an ASCII-encoded string, not a Unicode string.
     filename = '_'.join(wordparts).encode('ascii')

--- a/traits/util/event_tracer.py
+++ b/traits/util/event_tracer.py
@@ -26,12 +26,12 @@ from traits import trait_notifiers
 
 
 CHANGEMSG = (
-    u"{time} {direction:-{direction}{length}} {name!r} changed from "
-    u"{old!r} to {new!r} in {class_name!r}\n")
-CALLINGMSG = u"{time} {action:>{gap}}: {handler!r} in {source}\n"
+    six.u("{time} {direction:-{direction}{length}} {name!r} changed from "
+          "{old!r} to {new!r} in {class_name!r}\n"))
+CALLINGMSG = six.u("{time} {action:>{gap}}: {handler!r} in {source}\n")
 EXITMSG = (
-    u"{time} {direction:-{direction}{length}} "
-    u"EXIT: {handler!r}{exception}\n")
+    six.u("{time} {direction:-{direction}{length}} "
+          "EXIT: {handler!r}{exception}\n"))
 SPACES_TO_ALIGN_WITH_CHANGE_MESSAGE = 9
 
 
@@ -43,7 +43,7 @@ class SentinelRecord(object):
     __slots__ = ()
 
     def __str__(self):
-        return u'\n'
+        return six.u('\n')
 
 
 @six.python_2_unicode_compatible

--- a/traits/util/event_tracer.py
+++ b/traits/util/event_tracer.py
@@ -20,6 +20,8 @@ import threading
 from contextlib import contextmanager
 from datetime import datetime
 
+import six
+
 from traits import trait_notifiers
 
 
@@ -33,16 +35,18 @@ EXITMSG = (
 SPACES_TO_ALIGN_WITH_CHANGE_MESSAGE = 9
 
 
+@six.python_2_unicode_compatible
 class SentinelRecord(object):
     """ Sentinel record to separate groups of chained change event dispatches.
 
     """
     __slots__ = ()
 
-    def __unicode__(self):
+    def __str__(self):
         return u'\n'
 
 
+@six.python_2_unicode_compatible
 class ChangeMessageRecord(object):
     """ Message record for a change event dispatch.
 
@@ -64,7 +68,7 @@ class ChangeMessageRecord(object):
         #: The name of the class that the trait change took place.
         self.class_name = class_name
 
-    def __unicode__(self):
+    def __str__(self):
         length = self.indent * 2
         return CHANGEMSG.format(
             time=self.time,
@@ -77,6 +81,7 @@ class ChangeMessageRecord(object):
         )
 
 
+@six.python_2_unicode_compatible
 class CallingMessageRecord(object):
     """ Message record for a change handler call.
 
@@ -94,7 +99,7 @@ class CallingMessageRecord(object):
         #: The source file where the handler was defined.
         self.source = source
 
-    def __unicode__(self):
+    def __str__(self):
         gap = self.indent * 2 + SPACES_TO_ALIGN_WITH_CHANGE_MESSAGE
         return CALLINGMSG.format(
             time=self.time,
@@ -104,6 +109,7 @@ class CallingMessageRecord(object):
             gap=gap)
 
 
+@six.python_2_unicode_compatible
 class ExitMessageRecord(object):
     """ Message record for returning from a change event dispatch.
 
@@ -121,7 +127,7 @@ class ExitMessageRecord(object):
         #: The exception type (if one took place)
         self.exception = exception
 
-    def __unicode__(self):
+    def __str__(self):
         length = self.indent * 2
         return EXITMSG.format(
             time=self.time,
@@ -155,7 +161,7 @@ class RecordContainer(object):
         """
         with open(filename, 'w') as fh:
             for record in self._records:
-                fh.write(unicode(record))
+                fh.write(six.text_type(record))
 
 
 class MultiThreadRecordContainer(object):
@@ -195,7 +201,7 @@ class MultiThreadRecordContainer(object):
         """
         with self._creation_lock:
             containers = self._record_containers
-            for thread_name, container in containers.iteritems():
+            for thread_name, container in six.iteritems(containers):
                 filename = os.path.join(
                     directory_name, '{0}.trace'.format(thread_name))
                 container.save_to_file(filename)

--- a/traits/util/tests/test_async_trait_wait.py
+++ b/traits/util/tests/test_async_trait_wait.py
@@ -3,6 +3,9 @@ import threading
 import time
 import unittest
 
+import six
+import six.moves as sm
+
 from traits.api import Enum, HasStrictTraits
 
 from traits.util.async_trait_wait import wait_for_condition
@@ -19,7 +22,7 @@ class TrafficLights(HasStrictTraits):
     }
 
     def make_random_changes(self, change_count):
-        for _ in xrange(change_count):
+        for _ in sm.range(change_count):
             time.sleep(random.uniform(0.1, 0.3))
             self.colour = self._next_colour[self.colour]
 

--- a/traits/util/tests/test_message_records.py
+++ b/traits/util/tests/test_message_records.py
@@ -25,7 +25,7 @@ class TestMessageRecords(unittest.TestCase):
         record = SentinelRecord()
 
         # Check unicode output
-        self.assertEqual(six.text_type(record), u'\n')
+        self.assertEqual(six.text_type(record), six.u('\n'))
 
         # Check initialization
         self.assertRaises(TypeError, SentinelRecord, sdd=0)
@@ -38,7 +38,7 @@ class TestMessageRecords(unittest.TestCase):
         # Check unicode output
         self.assertEqual(
             six.text_type(record),
-            u"1 -----> 'john' changed from 1 to 1 in 'MyClass'\n")
+            six.u("1 -----> 'john' changed from 1 to 1 in 'MyClass'\n"))
 
         # Check initialization
         self.assertRaises(TypeError, ChangeMessageRecord, sdd=0)
@@ -49,7 +49,7 @@ class TestMessageRecords(unittest.TestCase):
 
         # Check unicode output
         self.assertEqual(
-            six.text_type(record), u"7 <--------- EXIT: 'john'sssss\n")
+            six.text_type(record), six.u("7 <--------- EXIT: 'john'sssss\n"))
 
         # Check initialization
         self.assertRaises(TypeError, ExitMessageRecord, sdd=0)
@@ -60,7 +60,8 @@ class TestMessageRecords(unittest.TestCase):
 
         # Check unicode output
         self.assertEqual(
-            six.text_type(record), u"7             CALLING: 'john' in sssss\n")
+            six.text_type(record),
+            six.u("7             CALLING: 'john' in sssss\n"))
 
         # Check initialization
         self.assertRaises(TypeError, CallingMessageRecord, sdd=0)

--- a/traits/util/tests/test_message_records.py
+++ b/traits/util/tests/test_message_records.py
@@ -11,6 +11,9 @@
 #
 #----------------------------------------------------------------------------
 import unittest
+
+import six
+
 from traits.util.event_tracer import (
     SentinelRecord, ChangeMessageRecord, CallingMessageRecord,
     ExitMessageRecord)
@@ -22,7 +25,7 @@ class TestMessageRecords(unittest.TestCase):
         record = SentinelRecord()
 
         # Check unicode output
-        self.assertEqual(unicode(record), u'\n')
+        self.assertEqual(six.text_type(record), u'\n')
 
         # Check initialization
         self.assertRaises(TypeError, SentinelRecord, sdd=0)
@@ -34,7 +37,7 @@ class TestMessageRecords(unittest.TestCase):
 
         # Check unicode output
         self.assertEqual(
-            unicode(record),
+            six.text_type(record),
             u"1 -----> 'john' changed from 1 to 1 in 'MyClass'\n")
 
         # Check initialization
@@ -46,7 +49,7 @@ class TestMessageRecords(unittest.TestCase):
 
         # Check unicode output
         self.assertEqual(
-            unicode(record), u"7 <--------- EXIT: 'john'sssss\n")
+            six.text_type(record), u"7 <--------- EXIT: 'john'sssss\n")
 
         # Check initialization
         self.assertRaises(TypeError, ExitMessageRecord, sdd=0)
@@ -57,7 +60,7 @@ class TestMessageRecords(unittest.TestCase):
 
         # Check unicode output
         self.assertEqual(
-            unicode(record), u"7             CALLING: 'john' in sssss\n")
+            six.text_type(record), u"7             CALLING: 'john' in sssss\n")
 
         # Check initialization
         self.assertRaises(TypeError, CallingMessageRecord, sdd=0)

--- a/traits/util/tests/test_record_containers.py
+++ b/traits/util/tests/test_record_containers.py
@@ -15,6 +15,9 @@ import shutil
 import tempfile
 import threading
 import unittest
+
+import six
+
 from traits.util.event_tracer import (
     SentinelRecord, RecordContainer, MultiThreadRecordContainer)
 
@@ -60,7 +63,7 @@ class TestRecordContainers(unittest.TestCase):
         thread_1.join()
 
         self.assertEqual(len(container._record_containers), 3)
-        for collector in container._record_containers.itervalues():
+        for collector in six.itervalues(container._record_containers):
             self.assertTrue(
                 isinstance(collector._records[0], SentinelRecord))
             self.assertEqual(len(collector._records), 1)

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -1,8 +1,10 @@
 """ Tests for the trait documenter. """
 
-import StringIO
+
 import sys
 import tokenize
+
+import six
 
 from traits.testing.unittest_tools import unittest
 
@@ -31,7 +33,7 @@ class TestTraitDocumenter(unittest.TestCase):
     depth_interval = Property(Tuple(Float, Float),
                               depends_on="_depth_interval")
 """
-        string_io = StringIO.StringIO(self.source)
+        string_io = six.StringIO(self.source)
         tokens = tokenize.generate_tokens(string_io.readline)
         self.tokens = tokens
 

--- a/traits/util/toposort.py
+++ b/traits/util/toposort.py
@@ -17,6 +17,8 @@
 """ A simple topological sort on a dictionary graph.
 """
 
+import six
+
 class CyclicGraph(Exception):
     """
     Exception for cyclic graphs.
@@ -45,7 +47,7 @@ def topological_sort(graph):
         explored[node] = 1
         order.append(node)
 
-    for node in graph.keys():
+    for node in six.iterkeys(graph):
         if node not in explored:
             explore(node)
     order.reverse()

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -11,7 +11,8 @@ import sys
 import inspect
 import tokenize
 import token
-import StringIO
+import six
+
 
 from sphinx.ext.autodoc import ClassLevelDocumenter
 
@@ -88,7 +89,7 @@ class TraitDocumenter(ClassLevelDocumenter):
         # this used to only catch SyntaxError, ImportError and
         # AttributeError, but importing modules with side effects can raise
         # all kinds of errors.
-        except Exception, err:
+        except Exception as err:
             if self.env.app and not self.env.app.quiet:
                 self.env.app.info(traceback.format_exc().rstrip())
             msg = ('autodoc can\'t import/find {0} {r1}, it reported error: '
@@ -116,7 +117,7 @@ class TraitDocumenter(ClassLevelDocumenter):
 
         # Get the class source and tokenize it.
         source = inspect.getsource(self.parent)
-        string_io = StringIO.StringIO(source)
+        string_io = six.StringIO(source)
         tokens = tokenize.generate_tokens(string_io.readline)
 
         # find the trait definition start

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -106,7 +106,7 @@ class TraitDocumenter(ClassLevelDocumenter):
         """
         ClassLevelDocumenter.add_directive_header(self, sig)
         definition = self._get_trait_definition()
-        self.add_line(u'   :annotation: = {0}'.format(definition),
+        self.add_line(six.u('   :annotation: = {0}'.format(definition)),
                       '<autodoc>')
 
     # Private Interface #####################################################


### PR DESCRIPTION
As per my issue in the [chaco issue]https://github.com/enthought/chaco/issues/368)

This is a PR to completely get rid of the 2to3 using the six library

Most of the fixes are pretty mechanical and should be pretty straightforward to review:

* print statement to print function
* new raise syntax
* relative imports
* whenever I could, I converted the list iteration to an iterator
   * items(), keys(), values() to six.iteritems(), iterkeys() and itervalues() (Some of the loops are playing with 
the list, dictionary in the loop and those have been explicitely converted)
    * range to xrange

* LONG_TYPE instead of long
* six.u instead of u''
* and a lot more

The branch has been tested on python 2.7 and python 3.6.