### PR TITLE
Add __dir__ method to HasTraits to allow for IPython tab completion

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1647,11 +1647,8 @@ class HasTraits ( CHasTraits ):
             the object. This enables tab-completion in IPython.
         """
         trait_names = self.trait_names()
-        blacklist = ('trait_added', 'trait_modified')
-        filtered_trait_names = [
-            name for name in trait_names if name not in blacklist
-        ]
-        return filtered_trait_names
+        method_names = [method for method in self._each_trait_method(self)]
+        return trait_names + method_names
 
     #---------------------------------------------------------------------------
     #  Copies another object's traits into this one:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1648,7 +1648,8 @@ class HasTraits ( CHasTraits ):
         """
         trait_names = self.trait_names()
         method_names = [method for method in self._each_trait_method(self)]
-        return trait_names + method_names
+        class_attrs = vars(self.__class__).keys()
+        return trait_names + method_names + class_attrs
 
     #---------------------------------------------------------------------------
     #  Copies another object's traits into this one:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -171,20 +171,20 @@ if sys.version_info[0] >= 3:
         """
         if method[0:2] == '__':
             method = '_%s%s' % ( class_name, method )
-    
+
         result = class_dict.get( method )
         if ((result is not None) and
             is_function_type(result) and
             (getattr( result, 'on_trait_change', None ) is None)):
             return result
-    
+
         for base in bases:
             result = getattr( base, method, None )
             if ((result is not None) and
                 is_unbound_method_type(result) and \
                 (getattr( result, 'on_trait_change', None ) is None)):
                 return result
-    
+
         return None
 else:
     def _get_def ( class_name, class_dict, bases, method ):
@@ -192,20 +192,20 @@ else:
         """
         if method[0:2] == '__':
             method = '_%s%s' % ( class_name, method )
-    
+
         result = class_dict.get( method )
         if ((result is not None) and
             is_function_type(result) and
             (getattr( result, 'on_trait_change', None ) is None)):
             return result
-    
+
         for base in bases:
             result = getattr( base, method, None )
             if ((result is not None) and
                 is_unbound_method_type(result) and \
                 (getattr( result.im_func, 'on_trait_change', None ) is None)):
                 return result
-    
+
         return None
 
 
@@ -1637,6 +1637,22 @@ class HasTraits ( CHasTraits ):
         """
         return self.__class_traits__.keys()
 
+    #--------------------------------------------------------------------------
+    #  Returns the list of trait names when calling the dir() builtin on the
+    #  object. This enables tab-completion in IPython.
+    #--------------------------------------------------------------------------
+
+    def __dir__(self):
+        """ Returns the list of trait names when calling the dir() builtin on
+            the object. This enables tab-completion in IPython.
+        """
+        trait_names = self.trait_names()
+        blacklist = ('trait_added', 'trait_modified')
+        filtered_trait_names = [
+            name for name in trait_names if name not in blacklist
+        ]
+        return filtered_trait_names
+
     #---------------------------------------------------------------------------
     #  Copies another object's traits into this one:
     #---------------------------------------------------------------------------
@@ -2191,7 +2207,7 @@ class HasTraits ( CHasTraits ):
         return names
 
     class_editable_traits = classmethod( class_editable_traits )
-    
+
     def visible_traits ( self ):
         """Returns an alphabetically sorted list of the names of non-event
         trait attributes associated with the current object, that should be GUI visible
@@ -2971,7 +2987,7 @@ class HasTraits ( CHasTraits ):
         values of all keywords to be included in the result.
         """
         traits = self.__base_traits__.copy()
-        
+
         # Update with instance-defined traits.
         for name, trt in self._instance_traits().items():
             if name[-6:] != "_items":

--- a/traits/tests/test_get_traits.py
+++ b/traits/tests/test_get_traits.py
@@ -67,10 +67,9 @@ class GetTraitTestCase(unittest.TestCase):
 
     def test_dir(self):
         b = Foo()
-        self.assertEqual(
-            sorted(dir(b)),
-            ['bar', 'num']
-        )
+        self.assertIn('bar', dir(b))
+        self.assertIn('num', dir(b))
+        self.assertIn('edit_traits', dir(b))
 
 
 ### EOF #######################################################################

--- a/traits/tests/test_get_traits.py
+++ b/traits/tests/test_get_traits.py
@@ -33,6 +33,10 @@ class Bar(HasTraits):
     # Force visibility of a private trait.
     PrivT2  = Str( private=True, visible=True )
 
+class FooBar(HasTraits):
+    num = Int
+    baz = 'non-trait class attribute'
+
 
 class GetTraitTestCase(unittest.TestCase):
 
@@ -66,8 +70,8 @@ class GetTraitTestCase(unittest.TestCase):
                           sorted(["PubT1", "PrivT2"]) )
 
     def test_dir(self):
-        b = Foo()
-        self.assertIn('bar', dir(b))
+        b = FooBar()
+        self.assertIn('baz', dir(b))
         self.assertIn('num', dir(b))
         self.assertIn('edit_traits', dir(b))
 

--- a/traits/tests/test_get_traits.py
+++ b/traits/tests/test_get_traits.py
@@ -65,6 +65,13 @@ class GetTraitTestCase(unittest.TestCase):
         self.assertEqual( sorted(b.visible_traits()),
                           sorted(["PubT1", "PrivT2"]) )
 
+    def test_dir(self):
+        b = Foo()
+        self.assertEqual(
+            sorted(dir(b)),
+            ['bar', 'num']
+        )
+
 
 ### EOF #######################################################################
 


### PR DESCRIPTION
Closes #320

This PR adds a `__dir__` method to the `HasTraits` class which returns the list of `trait_names` minus the `trait_added` and `trait_modified` attributes which most users will not be looking for when trying to tab complete.

GIF below:
![hastraits_tabcomplete](https://user-images.githubusercontent.com/8642896/31412689-b0d26a5e-addb-11e7-8f69-bf8e6d779732.gif)
