### PR TITLE
FIX: Support unicode on trait documenter on Python 2.7

### DIFF
--- a/appveyor/appveyor-install.cmd
+++ b/appveyor/appveyor-install.cmd
@@ -6,6 +6,7 @@ pip install --cache-dir C:/egg_cache cython
 rem Work around bug in babel 2.0: see mitsuhiko/babel#174
 pip install --cache-dir C:/egg_cache babel==1.3
 pip install --cache-dir C:/egg_cache Sphinx
+pip install --cache-dir C:/egg_cache mock
 
 rem install traits
 python setup.py develop

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -72,6 +72,8 @@ class TestTraitDocumenter(unittest.TestCase):
             ):
                 documenter.add_directive_header('')
 
+        documenter.directive.result.append.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -30,25 +30,23 @@ def _python_version_is_32():
 class TestTraitDocumenter(unittest.TestCase):
     """ Tests for the trait documenter. """
 
-    def setUp(self):
-        self.source = """
-    depth_interval = Property(Tuple(Float, Float),
-                              depends_on="_depth_interval")
-"""
-        string_io = StringIO.StringIO(self.source)
-        tokens = tokenize.generate_tokens(string_io.readline)
-        self.tokens = tokens
-
     def test_get_definition_tokens(self):
 
         from traits.util.trait_documenter import _get_definition_tokens
 
-        definition_tokens = _get_definition_tokens(self.tokens)
+        src = textwrap.dedent("""\
+        depth_interval = Property(Tuple(Float, Float),
+                                  depends_on="_depth_interval")
+        """)
+        string_io = StringIO.StringIO(src)
+        tokens = tokenize.generate_tokens(string_io.readline)
+
+        definition_tokens = _get_definition_tokens(tokens)
 
         # Check if they are correctly untokenized. This should not raise.
         string = tokenize.untokenize(definition_tokens)
 
-        self.assertEqual(self.source.rstrip(), string)
+        self.assertEqual(src.rstrip(), string)
 
     def test_add_line(self):
 

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -1,8 +1,12 @@
+# -*- coding: utf-8 -*-
 """ Tests for the trait documenter. """
 
 import StringIO
 import sys
+import textwrap
 import tokenize
+
+import mock
 
 from traits.testing.unittest_tools import unittest
 
@@ -45,6 +49,29 @@ class TestTraitDocumenter(unittest.TestCase):
         string = tokenize.untokenize(definition_tokens)
 
         self.assertEqual(self.source.rstrip(), string)
+
+    def test_add_line(self):
+
+        from traits.util.trait_documenter import TraitDocumenter
+
+        src = textwrap.dedent("""\
+        class Fake(HasTraits):
+
+            #: Test attribute
+            test = Property(Bool, label=u"ミスあり")
+        """)
+        mocked_directive = mock.MagicMock()
+
+        documenter = TraitDocumenter(mocked_directive, 'test', '   ')
+        documenter.object_name = 'Property'
+
+        with mock.patch(
+                'traits.util.trait_documenter.inspect.getsource',
+                return_value=src):
+            with mock.patch(
+                    'traits.util.trait_documenter.ClassLevelDocumenter'):
+                documenter.add_directive_header('')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -67,7 +67,9 @@ class TestTraitDocumenter(unittest.TestCase):
                 'traits.util.trait_documenter.inspect.getsource',
                 return_value=src):
             with mock.patch(
-                    'traits.util.trait_documenter.ClassLevelDocumenter'):
+                ('traits.util.trait_documenter.ClassLevelDocumenter'
+                 '.add_directive_header')
+            ):
                 documenter.add_directive_header('')
 
 

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -105,8 +105,11 @@ class TraitDocumenter(ClassLevelDocumenter):
         """
         ClassLevelDocumenter.add_directive_header(self, sig)
         definition = self._get_trait_definition()
-        self.add_line(u'   :annotation: = {0}'.format(definition),
-                      '<autodoc>')
+        line = u'   :annotation: = {0}'
+        try:
+            self.add_line(line.format(definition), '<autodoc>')
+        except UnicodeDecodeError:
+            self.add_line(line.format(definition.decode('utf-8')), '<autodoc>')
 
     # Private Interface #####################################################
 

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -6,12 +6,12 @@
     :copyright: Copyright 2012 by Enthought, Inc
 
 """
-import traceback
-import sys
 import inspect
-import tokenize
-import token
 import StringIO
+import sys
+import token
+import tokenize
+import traceback
 
 from sphinx.ext.autodoc import ClassLevelDocumenter
 

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -19,6 +19,9 @@ from ..trait_handlers import TraitType
 from ..has_traits import MetaHasTraits
 
 
+IS_PY3 = sys.version_info >= (3, 0)
+
+
 def _is_class_trait(name, cls):
     """ Check if the name is in the list of class defined traits of ``cls``.
     """
@@ -105,11 +108,7 @@ class TraitDocumenter(ClassLevelDocumenter):
         """
         ClassLevelDocumenter.add_directive_header(self, sig)
         definition = self._get_trait_definition()
-        line = u'   :annotation: = {0}'
-        try:
-            self.add_line(line.format(definition), '<autodoc>')
-        except UnicodeDecodeError:
-            self.add_line(line.format(definition.decode('utf-8')), '<autodoc>')
+        self.add_line(u'   :annotation: = {0}'.format(definition), '<autodoc>')
 
     # Private Interface #####################################################
 
@@ -135,7 +134,11 @@ class TraitDocumenter(ClassLevelDocumenter):
 
         # Retrieve the trait definition.
         definition_tokens = _get_definition_tokens(tokens)
-        return tokenize.untokenize(definition_tokens).strip()
+        definition = tokenize.untokenize(definition_tokens).strip()
+        if not IS_PY3:
+            definition = unicode(definition, 'utf-8')
+
+        return definition
 
 
 def _get_definition_tokens(tokens):

--- a/travis-ci-requirements.txt
+++ b/travis-ci-requirements.txt
@@ -4,3 +4,4 @@ Sphinx
 coverage
 coveralls
 numpy ; python_version >= '3.4'
+mock


### PR DESCRIPTION
I have applied the following patch in our project to work around #380 and figured I would submit the fix upstream as well in case it was something you all wanted to incorporate. 

I also tried to add some testing, but it required adding mock to the CI requirements. Let me know if that is going to cause issues.

Closes #380 