### PR TITLE
Clean up Float and BaseFloat validation

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4111,12 +4111,15 @@ check_implements:
                else {
                    double value_as_double = PyFloat_AsDouble(value);
                    if (value_as_double == -1.0 && PyErr_Occurred()) {
-                       /* Translate a TypeError to a TraitError, but pass
-                          on other exceptions. */
+                       /* TypeError indicates that we don't have a match;
+                          clear the error and continue with the next item
+                          in the complex sequence. */
                        if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                            PyErr_Clear();
                            break;
                        }
+                       /* Any other exception is unexpected and likely
+                          a code bug; propagate it. */
                        return NULL;
                    }
                    return PyFloat_FromDouble(value_as_double);

--- a/traits/tests/test_float.py
+++ b/traits/tests/test_float.py
@@ -157,6 +157,7 @@ class TestFloat(unittest.TestCase, CommonFloatTests):
     def test_exceptions_propagate_in_compound_trait(self):
         # This test doesn't currently pass for BaseFloat, which is why it's not
         # in the common tests. That's probably a bug.
+        a = self.test_class()
         with self.assertRaises(ZeroDivisionError):
             a.value_or_none = BadFloat()
 

--- a/traits/tests/test_float.py
+++ b/traits/tests/test_float.py
@@ -17,17 +17,38 @@ Tests for the Float trait type.
 """
 import sys
 
+try:
+    import numpy
+except ImportError:
+    numpy_available = False
+else:
+    numpy_available = True
+
 from traits.testing.unittest_tools import unittest
 
-from ..api import BaseFloat, Float, HasTraits
+from ..api import BaseFloat, Either, Float, HasTraits, TraitError
+
+
+class MyFloat(object):
+    def __init__(self, value):
+        self._value = value
+
+    def __float__(self):
+        return self._value
 
 
 class FloatModel(HasTraits):
     value = Float
 
+    # Assignment to the `Either` trait exercises a different C code path (see
+    # validate_trait_complex in ctraits.c).
+    value_or_none = Either(None, Float)
+
 
 class BaseFloatModel(HasTraits):
     value = BaseFloat
+
+    value_or_none = Either(None, BaseFloat)
 
 
 class CommonFloatTests(object):
@@ -38,30 +59,85 @@ class CommonFloatTests(object):
 
     def test_accepts_float(self):
         a = self.test_class()
+
         a.value = 5.6
         self.assertIs(type(a.value), float)
         self.assertEqual(a.value, 5.6)
 
+        a.value_or_none = 5.6
+        self.assertIs(type(a.value_or_none), float)
+        self.assertEqual(a.value_or_none, 5.6)
+
     def test_accepts_int(self):
         a = self.test_class()
+
         a.value = 2
         self.assertIs(type(a.value), float)
         self.assertEqual(a.value, 2.0)
 
+        a.value_or_none = 2
+        self.assertIs(type(a.value_or_none), float)
+        self.assertEqual(a.value_or_none, 2.0)
+
+    def test_rejects_string(self):
+        a = self.test_class()
+        with self.assertRaises(TraitError):
+            a.value = "2.3"
+        with self.assertRaises(TraitError):
+            a.value_or_none = "2.3"
+
+    def test_accepts_float_like(self):
+        a = self.test_class()
+
+        a.value = MyFloat(1729.0)
+        self.assertIs(type(a.value), float)
+        self.assertEqual(a.value, 1729.0)
+
+        a.value = MyFloat(594.0)
+        self.assertIs(type(a.value), float)
+        self.assertEqual(a.value, 594.0)
+
     @unittest.skipUnless(sys.version_info < (3,), "Not applicable to Python 3")
     def test_accepts_small_long(self):
         a = self.test_class()
+
         a.value = long(2)
         self.assertIs(type(a.value), float)
         self.assertEqual(a.value, 2.0)
 
+        a.value_or_none = long(2)
+        self.assertIs(type(a.value_or_none), float)
+        self.assertEqual(a.value_or_none, 2.0)
+
     @unittest.skipUnless(sys.version_info < (3,), "Not applicable to Python 3")
     def test_accepts_large_long(self):
         a = self.test_class()
+
         # Value large enough to be a long on Python 2.
         a.value = 2**64
         self.assertIs(type(a.value), float)
         self.assertEqual(a.value, 2**64)
+
+        a.value_or_none = 2**64
+        self.assertIs(type(a.value_or_none), float)
+        self.assertEqual(a.value_or_none, 2**64)
+
+    @unittest.skipUnless(numpy_available, "Test requires NumPy")
+    def test_accepts_numpy_floats(self):
+        test_values = [
+            numpy.float64(2.3),
+            numpy.float32(3.7),
+            numpy.float16(1.28),
+        ]
+        a = self.test_class()
+        for test_value in test_values:
+            a.value = test_value
+            self.assertIs(type(a.value), float)
+            self.assertEqual(a.value, test_value)
+
+            a.value_or_none = test_value
+            self.assertIs(type(a.value_or_none), float)
+            self.assertEqual(a.value_or_none, test_value)
 
 
 class TestFloat(unittest.TestCase, CommonFloatTests):

--- a/traits/tests/test_float.py
+++ b/traits/tests/test_float.py
@@ -26,7 +26,7 @@ else:
 
 from traits.testing.unittest_tools import unittest
 
-from ..api import BaseFloat, Either, Float, HasTraits, TraitError
+from ..api import BaseFloat, Either, Float, HasTraits, TraitError, Unicode
 
 
 class MyFloat(object):
@@ -49,11 +49,15 @@ class FloatModel(HasTraits):
     # validate_trait_complex in ctraits.c).
     value_or_none = Either(None, Float)
 
+    float_or_text = Either(Float, Unicode)
+
 
 class BaseFloatModel(HasTraits):
     value = BaseFloat
 
     value_or_none = Either(None, BaseFloat)
+
+    float_or_text = Either(Float, Unicode)
 
 
 class CommonFloatTests(object):
@@ -106,6 +110,13 @@ class CommonFloatTests(object):
         a = self.test_class()
         with self.assertRaises(ZeroDivisionError):
             a.value = BadFloat()
+
+    def test_compound_trait_float_conversion_fail(self):
+        # Check that a failure to convert to float doesn't terminate
+        # an assignment to a compound trait.
+        a = self.test_class()
+        a.float_or_text = u"not a float"
+        self.assertEqual(a.float_or_text, u"not a float")
 
     @unittest.skipUnless(sys.version_info < (3,), "Not applicable to Python 3")
     def test_accepts_small_long(self):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -119,6 +119,23 @@ def default_text_editor ( trait, type = None ):
                        enter_set = enter_set,
                        evaluate  = type )
 
+
+# Generic validators
+
+def _validate_float(value):
+    """
+    Convert an arbitrary Python object to a float, or raise TypeError.
+    """
+    if type(value) == float:  # fast path for common case
+        return value
+    try:
+        nb_float = type(value).__float__
+    except AttributeError:
+        raise TypeError(
+            "Object of type {!r} not convertible to float".format(type(value)))
+    return nb_float(value)
+
+
 #-------------------------------------------------------------------------------
 #  'Any' trait:
 #-------------------------------------------------------------------------------
@@ -237,6 +254,7 @@ class Long ( BaseLong ):
     #: The C-level fast validator to use:
     fast_validate = long_fast_validate
 
+
 #-------------------------------------------------------------------------------
 #  'BaseFloat' and 'Float' traits:
 #-------------------------------------------------------------------------------
@@ -258,13 +276,10 @@ class BaseFloat ( TraitType ):
 
             Note: The 'fast validator' version performs this check in C.
         """
-        if isinstance( value, float ):
-            return value
-
-        if isinstance( value, ( int, long ) ):
-            return float( value )
-
-        self.error( object, name, value )
+        try:
+            return _validate_float(value)
+        except TypeError:
+            self.error(object, name, value)
 
     def create_editor ( self ):
         """ Returns the default traits UI editor for this type of trait.
@@ -278,7 +293,7 @@ class Float ( BaseFloat ):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = float_fast_validate
+    fast_validate = ( 21, )
 
 #-------------------------------------------------------------------------------
 #  'BaseComplex' and 'Complex' traits:


### PR DESCRIPTION
This PR cleans up validation for `Float` and `BaseFloat` traits, in preparation for applying similar fixes to the `Range` traits. The changes are:

- Allow anything with a `__float__` method to be assigned to a `Float` or `BaseFloat` trait. Previously, `BaseFloat` only accepted integers or `float` instances (so e.g., a `np.float32` instance would be rejected), and `Float` only accepted integers, `float` instances or `np.floating` instances.
- On assignment, the value is converted to an object of exact type `float`.
- So on retrieval, accessing the value of a `Float` trait will only ever give a Python `float`.
- Any exception _other_ than `TypeError` raised by `__float__` is propagated. A `TypeError` is interpreted as a non-type-match, so will either get converted to a `TraitError`, or allow continued type-checking (e.g., in the case of something like `Either(Float, Int)`).

This makes the `Float` and `BaseFloat` types similar to the way that the `Int` and `BaseInt` types currently work: accept anything int-y, but only ever produce strict `int`s (and possibly `long`s on Python 2).