### PR TITLE
Make Range validation consistent with Int and Float validation.

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3301,7 +3301,14 @@ _check_in_range(PyObject *value, PyObject *range_info) {
     int low_in_range, high_in_range;
     long exclude_mask;
 
+#if PY_MAJOR_VERSION < 3
     exclude_mask = PyInt_AS_LONG(PyTuple_GET_ITEM(range_info, 3));
+#else
+    exclude_mask = PyLong_AsLong(PyTuple_GET_ITEM(range_info, 3));
+    if (exclude_mask == -1 && PyErr_Occurred()) {
+        return -1;
+    }
+#endif  // #if PY_MAJOR_VERSION < 3
 
     low = PyTuple_GET_ITEM(range_info, 1);
     if (low == Py_None) {

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3215,8 +3215,13 @@ static PyObject *
 _validate_integer(PyObject *value) {
     PyObject *index_of_value, *integer_index_of_value;
 
-    /* Fast path for common case. */
+    /* Fast path for common case. (longs on Python 2 don't count as
+       a common case) */
+#if PY_MAJOR_VERSION < 3
     if (PyInt_CheckExact(value)) {
+#else
+    if (PyLong_CheckExact(value)) {
+#endif // PY_MAJOR_VERSION < 3
         Py_INCREF(value);
         return value;
     }

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3342,7 +3342,7 @@ validate_trait_integer_range ( trait_object * trait, has_traits_object * obj,
     if (high == Py_None) {
         high_in_range = 1;
     }
-    else if (exclude_mask & 1) {
+    else if (exclude_mask & 2) {
         high_in_range = PyObject_RichCompareBool(int_value, high, Py_LT);
     }
     else {
@@ -3468,7 +3468,7 @@ validate_trait_float_range ( trait_object * trait, has_traits_object * obj,
     if (high == Py_None) {
         high_in_range = 1;
     }
-    else if (exclude_mask & 1) {
+    else if (exclude_mask & 2) {
         high_in_range = PyObject_RichCompareBool(float_value, high, Py_LT);
     }
     else {

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4164,9 +4164,15 @@ _trait_set_validate ( trait_object * trait, PyObject * args ) {
                         v1 = PyTuple_GET_ITEM( validate, 1 );
                         v2 = PyTuple_GET_ITEM( validate, 2 );
                         v3 = PyTuple_GET_ITEM( validate, 3 );
+#if PY_MAJOR_VERSION < 3
                         if ( ((v1 == Py_None) || PyInt_Check( v1 ) || PyLong_Check(v1)) &&
                              ((v2 == Py_None) || PyInt_Check( v2 ) || PyLong_Check(v2)) &&
                              Py2to3_PyNum_Check( v3 ) )
+#else
+                        if ( ((v1 == Py_None) || PyLong_Check(v1)) &&
+                             ((v2 == Py_None) || PyLong_Check(v2)) &&
+                             Py2to3_PyNum_Check( v3 ) )
+#endif // #if PY_MAJOR_VERSION < 3
                             goto done;
                     }
                     break;

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4111,12 +4111,15 @@ check_implements:
                else {
                    double value_as_double = PyFloat_AsDouble(value);
                    if (value_as_double == -1.0 && PyErr_Occurred()) {
-                       /* Translate a TypeError to a TraitError, but pass
-                          on other exceptions. */
+                       /* TypeError indicates that we don't have a match;
+                          clear the error and continue with the next item
+                          in the complex sequence. */
                        if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                            PyErr_Clear();
                            break;
                        }
+                       /* Any other exception is unexpected and likely
+                          a code bug; propagate it. */
                        return NULL;
                    }
                    return PyFloat_FromDouble(value_as_double);

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3285,13 +3285,15 @@ _validate_integer(PyObject *value) {
 
 static PyObject *
 _validate_float(PyObject *value) {
+    double value_as_double;
+
     /* Fast path: avoid creating a new object if it's not necessary. */
     if (PyFloat_CheckExact(value)) {
         Py_INCREF(value);
         return value;
     }
 
-    double value_as_double = PyFloat_AsDouble(value);
+    value_as_double = PyFloat_AsDouble(value);
     if (value_as_double == -1.0 && PyErr_Occurred()) {
         return NULL;
     }

--- a/traits/tests/test_float.py
+++ b/traits/tests/test_float.py
@@ -157,6 +157,7 @@ class TestFloat(unittest.TestCase, CommonFloatTests):
     def test_exceptions_propagate_in_compound_trait(self):
         # This test doesn't currently pass for BaseFloat, which is why it's not
         # in the common tests. That's probably a bug.
+        a = self.test_class()
         with self.assertRaises(ZeroDivisionError):
             a.value_or_none = BadFloat()
 

--- a/traits/tests/test_float.py
+++ b/traits/tests/test_float.py
@@ -17,17 +17,38 @@ Tests for the Float trait type.
 """
 import sys
 
+try:
+    import numpy
+except ImportError:
+    numpy_available = False
+else:
+    numpy_available = True
+
 from traits.testing.unittest_tools import unittest
 
-from ..api import BaseFloat, Float, HasTraits
+from ..api import BaseFloat, Either, Float, HasTraits, TraitError
+
+
+class MyFloat(object):
+    def __init__(self, value):
+        self._value = value
+
+    def __float__(self):
+        return self._value
 
 
 class FloatModel(HasTraits):
     value = Float
 
+    # Assignment to the `Either` trait exercises a different C code path (see
+    # validate_trait_complex in ctraits.c).
+    value_or_none = Either(None, Float)
+
 
 class BaseFloatModel(HasTraits):
     value = BaseFloat
+
+    value_or_none = Either(None, BaseFloat)
 
 
 class CommonFloatTests(object):
@@ -38,30 +59,85 @@ class CommonFloatTests(object):
 
     def test_accepts_float(self):
         a = self.test_class()
+
         a.value = 5.6
         self.assertIs(type(a.value), float)
         self.assertEqual(a.value, 5.6)
 
+        a.value_or_none = 5.6
+        self.assertIs(type(a.value_or_none), float)
+        self.assertEqual(a.value_or_none, 5.6)
+
     def test_accepts_int(self):
         a = self.test_class()
+
         a.value = 2
         self.assertIs(type(a.value), float)
         self.assertEqual(a.value, 2.0)
 
+        a.value_or_none = 2
+        self.assertIs(type(a.value_or_none), float)
+        self.assertEqual(a.value_or_none, 2.0)
+
+    def test_rejects_string(self):
+        a = self.test_class()
+        with self.assertRaises(TraitError):
+            a.value = "2.3"
+        with self.assertRaises(TraitError):
+            a.value_or_none = "2.3"
+
+    def test_accepts_float_like(self):
+        a = self.test_class()
+
+        a.value = MyFloat(1729.0)
+        self.assertIs(type(a.value), float)
+        self.assertEqual(a.value, 1729.0)
+
+        a.value = MyFloat(594.0)
+        self.assertIs(type(a.value), float)
+        self.assertEqual(a.value, 594.0)
+
     @unittest.skipUnless(sys.version_info < (3,), "Not applicable to Python 3")
     def test_accepts_small_long(self):
         a = self.test_class()
+
         a.value = long(2)
         self.assertIs(type(a.value), float)
         self.assertEqual(a.value, 2.0)
 
+        a.value_or_none = long(2)
+        self.assertIs(type(a.value_or_none), float)
+        self.assertEqual(a.value_or_none, 2.0)
+
     @unittest.skipUnless(sys.version_info < (3,), "Not applicable to Python 3")
     def test_accepts_large_long(self):
         a = self.test_class()
+
         # Value large enough to be a long on Python 2.
         a.value = 2**64
         self.assertIs(type(a.value), float)
         self.assertEqual(a.value, 2**64)
+
+        a.value_or_none = 2**64
+        self.assertIs(type(a.value_or_none), float)
+        self.assertEqual(a.value_or_none, 2**64)
+
+    @unittest.skipUnless(numpy_available, "Test requires NumPy")
+    def test_accepts_numpy_floats(self):
+        test_values = [
+            numpy.float64(2.3),
+            numpy.float32(3.7),
+            numpy.float16(1.28),
+        ]
+        a = self.test_class()
+        for test_value in test_values:
+            a.value = test_value
+            self.assertIs(type(a.value), float)
+            self.assertEqual(a.value, test_value)
+
+            a.value_or_none = test_value
+            self.assertIs(type(a.value_or_none), float)
+            self.assertEqual(a.value_or_none, test_value)
 
 
 class TestFloat(unittest.TestCase, CommonFloatTests):

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -188,7 +188,6 @@ class RangeTestCase(unittest.TestCase):
 
         for good_value in good_values:
             obj.r = good_value
-            print("good value: ", good_value, type(good_value))
             self.assertIs(type(obj.r), int)
             self.assertEqual(obj.r, operator.index(good_value))
 

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -255,7 +255,7 @@ class RangeTestCase(unittest.TestCase):
             CompoundFloatRange(),
             SimpleFloatBaseRange(),
         ]
-        for obj in test_objects():
+        for obj in test_objects:
             self._check_bounds(obj, 0.0, 100.0)
 
     def test_bounds_exclusion_int_range(self):

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -24,7 +24,7 @@ from ..api import BaseRange, Either, HasTraits, Int, Range, Str, TraitError
 
 # We need a lot of similar-looking test classes; use a factory to create them.
 
-def range_test_class(range_factory, low, high):
+def hastraits_range_class(range_factory, low, high):
     """
     Create a HasTraits subclass containing Range traits based
     on the given range_factory.
@@ -46,18 +46,18 @@ def range_test_class(range_factory, low, high):
     return RangeTestClass
 
 
-SimpleFloatRange = range_test_class(Range, 0.0, 100.0)
-SimpleIntRange = range_test_class(Range, 0, 100)
-SimpleFloatBaseRange = range_test_class(BaseRange, 0.0, 100.0)
-SimpleIntBaseRange = range_test_class(BaseRange, 0, 100)
+SimpleFloatRange = hastraits_range_class(Range, 0.0, 100.0)
+SimpleIntRange = hastraits_range_class(Range, 0, 100)
+SimpleFloatBaseRange = hastraits_range_class(BaseRange, 0.0, 100.0)
+SimpleIntBaseRange = hastraits_range_class(BaseRange, 0, 100)
 
 # The Either(None, Range) traits exercise a different code-path in ctraits.c:
 # see validate_trait_complex.
-CompoundFloatRange = range_test_class(
+CompoundFloatRange = hastraits_range_class(
     lambda *args, **kwargs: Either(None, Range(*args, **kwargs)),
     0.0, 100.0,
 )
-CompoundIntRange = range_test_class(
+CompoundIntRange = hastraits_range_class(
     lambda *args, **kwargs: Either(None, Range(*args, **kwargs)),
     0, 100,
 )

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -30,6 +30,9 @@ class SimpleFloatRange(HasTraits):
     r_open = Range(0.0, 100.0, exclude_low=True, exclude_high=True)
     r_closed = Range(0.0, 100.0, exclude_low=False, exclude_high=False)
 
+    r_nonnegative = Range(0.0, None)
+    r_nonpositive = Range(None, 0.0)
+
 
 class SimpleIntRange(HasTraits):
     r = Range(0, 100)
@@ -38,6 +41,9 @@ class SimpleIntRange(HasTraits):
     r_open_on_left = Range(0, 100, exclude_low=True, exclude_high=False)
     r_open = Range(0, 100, exclude_low=True, exclude_high=True)
     r_closed = Range(0, 100, exclude_low=False, exclude_high=False)
+
+    r_nonnegative = Range(0, None)
+    r_nonpositive = Range(None, 0)
 
 
 class WithFloatRange(HasTraits):
@@ -248,6 +254,16 @@ class RangeTestCase(unittest.TestCase):
         obj.r_closed = 100
         self.assertEqual(obj.r_closed, 100)
 
+        obj.r_nonnegative = 10**100
+        self.assertEqual(obj.r_nonnegative, 10**100)
+        with self.assertRaises(TraitError):
+            obj.r_nonnegative = -10**100
+
+        with self.assertRaises(TraitError):
+            obj.r_nonpositive = 10**100
+        obj.r_nonpositive = -10**100
+        self.assertEqual(obj.r_nonpositive, -10**100)
+
         # Default case: both bounds included.
         obj.r = 0
         self.assertEqual(obj.r, 0)
@@ -276,6 +292,16 @@ class RangeTestCase(unittest.TestCase):
         self.assertEqual(obj.r_closed, 0.0)
         obj.r_closed = 100.0
         self.assertEqual(obj.r_closed, 100.0)
+
+        obj.r_nonnegative = 1e100
+        self.assertEqual(obj.r_nonnegative, 1e100)
+        with self.assertRaises(TraitError):
+            obj.r_nonnegative = -1e100
+
+        with self.assertRaises(TraitError):
+            obj.r_nonpositive = 1e100
+        obj.r_nonpositive = -1e100
+        self.assertEqual(obj.r_nonpositive, -1e100)
 
         # Default case: both bounds included.
         obj.r = 0.0

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -248,6 +248,12 @@ class RangeTestCase(unittest.TestCase):
         obj.r_closed = 100
         self.assertEqual(obj.r_closed, 100)
 
+        # Default case: both bounds included.
+        obj.r = 0
+        self.assertEqual(obj.r, 0)
+        obj.r = 100
+        self.assertEqual(obj.r, 100)
+
     def test_bounds_exclusion_float_range(self):
         obj = SimpleFloatRange()
 
@@ -270,3 +276,9 @@ class RangeTestCase(unittest.TestCase):
         self.assertEqual(obj.r_closed, 0.0)
         obj.r_closed = 100.0
         self.assertEqual(obj.r_closed, 100.0)
+
+        # Default case: both bounds included.
+        obj.r = 0.0
+        self.assertEqual(obj.r, 0.0)
+        obj.r = 100.0
+        self.assertEqual(obj.r, 100.0)

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -25,9 +25,19 @@ from ..api import HasTraits, Int, Range, Str, TraitError
 class SimpleFloatRange(HasTraits):
     r = Range(0.0, 100.0)
 
+    r_open_on_right = Range(0.0, 100.0, exclude_low=False, exclude_high=True)
+    r_open_on_left = Range(0.0, 100.0, exclude_low=True, exclude_high=False)
+    r_open = Range(0.0, 100.0, exclude_low=True, exclude_high=True)
+    r_closed = Range(0.0, 100.0, exclude_low=False, exclude_high=False)
+
 
 class SimpleIntRange(HasTraits):
     r = Range(0, 100)
+
+    r_open_on_right = Range(0, 100, exclude_low=False, exclude_high=True)
+    r_open_on_left = Range(0, 100, exclude_low=True, exclude_high=False)
+    r_open = Range(0, 100, exclude_low=True, exclude_high=True)
+    r_closed = Range(0, 100, exclude_low=False, exclude_high=False)
 
 
 class WithFloatRange(HasTraits):
@@ -214,3 +224,49 @@ class RangeTestCase(unittest.TestCase):
         for bad_value in bad_values:
             with self.assertRaises(TraitError):
                 obj.r = bad_value
+
+    def test_bounds_exclusion_int_range(self):
+        obj = SimpleIntRange()
+
+        obj.r_open_on_right = 0
+        self.assertEqual(obj.r_open_on_right, 0)
+        with self.assertRaises(TraitError):
+            obj.r_open_on_right = 100
+
+        with self.assertRaises(TraitError):
+            obj.r_open_on_left = 0
+        obj.r_open_on_left = 100
+        self.assertEqual(obj.r_open_on_left, 100)
+
+        with self.assertRaises(TraitError):
+            obj.r_open = 0
+        with self.assertRaises(TraitError):
+            obj.r_open = 100
+
+        obj.r_closed = 0
+        self.assertEqual(obj.r_closed, 0)
+        obj.r_closed = 100
+        self.assertEqual(obj.r_closed, 100)
+
+    def test_bounds_exclusion_float_range(self):
+        obj = SimpleFloatRange()
+
+        obj.r_open_on_right = 0.0
+        self.assertEqual(obj.r_open_on_right, 0.0)
+        with self.assertRaises(TraitError):
+            obj.r_open_on_right = 100.0
+
+        with self.assertRaises(TraitError):
+            obj.r_open_on_left = 0.0
+        obj.r_open_on_left = 100.0
+        self.assertEqual(obj.r_open_on_left, 100.0)
+
+        with self.assertRaises(TraitError):
+            obj.r_open = 0.0
+        with self.assertRaises(TraitError):
+            obj.r_open = 100.0
+
+        obj.r_closed = 0.0
+        self.assertEqual(obj.r_closed, 0.0)
+        obj.r_closed = 100.0
+        self.assertEqual(obj.r_closed, 100.0)

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -50,6 +50,9 @@ SimpleFloatRange = range_test_class(Range, 0.0, 100.0)
 SimpleIntRange = range_test_class(Range, 0, 100)
 SimpleFloatBaseRange = range_test_class(BaseRange, 0.0, 100.0)
 SimpleIntBaseRange = range_test_class(BaseRange, 0, 100)
+
+# The Either(None, Range) traits exercise a different code-path in ctraits.c:
+# see validate_trait_complex.
 CompoundFloatRange = range_test_class(
     lambda *args, **kwargs: Either(None, Range(*args, **kwargs)),
     0.0, 100.0,
@@ -190,32 +193,19 @@ class RangeTestCase(unittest.TestCase):
             MyIntLike(17),
         ]
 
-        obj = SimpleFloatRange()
-        for good_value in good_values:
-            obj.r = good_value
-            self.assertIs(type(obj.r), float)
-            self.assertEqual(obj.r, float(good_value))
-        for bad_value in bad_values:
-            with self.assertRaises(TraitError):
-                obj.r = bad_value
-
-        obj = CompoundFloatRange()
-        for good_value in good_values:
-            obj.r = good_value
-            self.assertIs(type(obj.r), float)
-            self.assertEqual(obj.r, float(good_value))
-        for bad_value in bad_values:
-            with self.assertRaises(TraitError):
-                obj.r = bad_value
-
-        obj = SimpleFloatBaseRange()
-        for good_value in good_values:
-            obj.r = good_value
-            self.assertIs(type(obj.r), float)
-            self.assertEqual(obj.r, float(good_value))
-        for bad_value in bad_values:
-            with self.assertRaises(TraitError):
-                obj.r = bad_value
+        test_objects = [
+            SimpleFloatRange(),
+            CompoundFloatRange(),
+            SimpleFloatBaseRange(),
+        ]
+        for obj in test_objects:
+            for good_value in good_values:
+                obj.r = good_value
+                self.assertIs(type(obj.r), float)
+                self.assertEqual(obj.r, float(good_value))
+            for bad_value in bad_values:
+                with self.assertRaises(TraitError):
+                    obj.r = bad_value
 
     def test_type_validation_int_range(self):
         good_values = [23, 0, 100, MyIntLike(17), True]
@@ -245,54 +235,42 @@ class RangeTestCase(unittest.TestCase):
                 numpy.complex_(1+0j),
             ])
 
-        obj = SimpleIntRange()
-        for good_value in good_values:
-            obj.r = good_value
-            self.assertIs(type(obj.r), int)
-            self.assertEqual(obj.r, operator.index(good_value))
-        for bad_value in bad_values:
-            with self.assertRaises(TraitError):
-                obj.r = bad_value
-
-        obj = CompoundIntRange()
-        for good_value in good_values:
-            obj.r = good_value
-            self.assertIs(type(obj.r), int)
-            self.assertEqual(obj.r, operator.index(good_value))
-        for bad_value in bad_values:
-            with self.assertRaises(TraitError):
-                obj.r = bad_value
-
-        obj = SimpleIntBaseRange()
-        for good_value in good_values:
-            obj.r = good_value
-            self.assertIs(type(obj.r), int)
-            self.assertEqual(obj.r, operator.index(good_value))
-        for bad_value in bad_values:
-            with self.assertRaises(TraitError):
-                obj.r = bad_value
-
-    def test_bounds_exclusion_int_range(self):
-        obj = SimpleIntRange()
-        self._check_bounds(obj, 0, 100)
-
-        obj = CompoundIntRange()
-        self._check_bounds(obj, 0, 100)
-
-        obj = SimpleIntBaseRange()
-        self._check_bounds(obj, 0, 100)
+        test_objects = [
+            SimpleIntRange(),
+            CompoundIntRange(),
+            SimpleIntBaseRange(),
+        ]
+        for obj in test_objects:
+            for good_value in good_values:
+                obj.r = good_value
+                self.assertIs(type(obj.r), int)
+                self.assertEqual(obj.r, operator.index(good_value))
+            for bad_value in bad_values:
+                with self.assertRaises(TraitError):
+                    obj.r = bad_value
 
     def test_bounds_exclusion_float_range(self):
-        obj = SimpleFloatRange()
-        self._check_bounds(obj, 0.0, 100.0)
+        test_objects = [
+            SimpleFloatRange(),
+            CompoundFloatRange(),
+            SimpleFloatBaseRange(),
+        ]
+        for obj in test_objects():
+            self._check_bounds(obj, 0.0, 100.0)
 
-        obj = CompoundFloatRange()
-        self._check_bounds(obj, 0, 100)
-
-        obj = SimpleFloatBaseRange()
-        self._check_bounds(obj, 0.0, 100.0)
+    def test_bounds_exclusion_int_range(self):
+        test_objects = [
+            SimpleIntRange(),
+            CompoundIntRange(),
+            SimpleIntBaseRange(),
+        ]
+        for obj in test_objects:
+            self._check_bounds(obj, 0, 100)
 
     def _check_bounds(self, obj, low, high):
+        """
+        Helper function to check bound validation.
+        """
         obj.r_open_on_right = low
         self.assertEqual(obj.r_open_on_right, low)
         with self.assertRaises(TraitError):

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -101,21 +101,31 @@ class WithDynamicRange(HasTraits):
     def _r_changed(self, old, new):
         self._changed_handler_calls += 1
 
+    r_high_dynamic = Range(value='value', low=0, high='high')
 
-class MyFloat(object):
+    r_low_dynamic = Range(value='value', low='low', high=10.0)
+
+
+class FloatLike(object):
+    """
+    Object coercable to a float via __float__.
+    """
     def __init__(self, value):
         self._value = value
 
     def __float__(self):
-        return self._value
+        return float(self._value)
 
 
-class MyIntLike(object):
+class IntLike(object):
+    """
+    Object coercable to an int via __index__.
+    """
     def __init__(self, value):
         self._value = value
 
     def __index__(self):
-        return self._value
+        return int(operator.index(self._value))
 
 
 class RangeTestCase(unittest.TestCase):
@@ -168,7 +178,7 @@ class RangeTestCase(unittest.TestCase):
     def test_type_validation_float_range(self):
         good_values = [
             1.47,
-            MyFloat(2.35),
+            FloatLike(2.35),
             23, 0, 100,
             23.5, 0.0, 100.0,
             True,
@@ -190,7 +200,7 @@ class RangeTestCase(unittest.TestCase):
             150.0,  # also out of range
             -50,
             150,
-            MyIntLike(17),
+            IntLike(17),
         ]
 
         test_objects = [
@@ -208,7 +218,7 @@ class RangeTestCase(unittest.TestCase):
                     obj.r = bad_value
 
     def test_type_validation_int_range(self):
-        good_values = [23, 0, 100, MyIntLike(17), True]
+        good_values = [23, 0, 100, IntLike(17), True]
         if numpy_available:
             good_values.extend([
                 numpy.int8(23), numpy.uint8(24),
@@ -224,10 +234,10 @@ class RangeTestCase(unittest.TestCase):
             -50.0,
             150.0,
             1.47,
-            MyFloat(2.35),
+            FloatLike(2.35),
             -50,  # out of range
             150,  # also out of range
-            MyIntLike(127),
+            IntLike(127),
         ]
         if numpy_available:
             bad_values.extend([
@@ -266,6 +276,132 @@ class RangeTestCase(unittest.TestCase):
         ]
         for obj in test_objects:
             self._check_bounds(obj, 0, 100)
+
+    def test_value_type_inference(self):
+        self.assertIsIntRange(Range(2, 3))
+        self.assertIsFloatRange(Range(2, 3.0))
+        self.assertIsFloatRange(Range(2.0, 3))
+        self.assertIsFloatRange(Range(2.0, 3.0))
+        self.assertIsIntRange(Range(None, 3))
+        self.assertIsIntRange(Range(2, None))
+        self.assertIsFloatRange(Range(None, 3.0))
+        self.assertIsFloatRange(Range(2.0, None))
+
+        # The type of the default value doesn't get taken into account
+        self.assertIsIntRange(Range(2, 4, 3.0))
+
+        # It's illegal to fail to give either bound, or to use non-inty
+        # and non-floaty bounds.
+        with self.assertRaises(TraitError):
+            Range(None, None)
+
+        with self.assertRaises(TraitError):
+            Range(5.6, 1+2j)
+        with self.assertRaises(TraitError):
+            Range((1, 2), None)
+        with self.assertRaises(TraitError):
+            Range(IntLike(23), FloatLike(45.0))
+        with self.assertRaises(TraitError):
+            Range(FloatLike(23.0), IntLike(45))
+
+    def test_static_validation_bounds_conversion(self):
+        r = Range(IntLike(23), IntLike(45))
+        self.assertIsIntRange(r)
+        self.assertIs(type(r._low), int)
+        self.assertEqual(r._low, 23)
+        self.assertIs(type(r._high), int)
+        self.assertEqual(r._high, 45)
+
+        r = Range(None, IntLike(45))
+        self.assertIsIntRange(r)
+        self.assertIs(r._low, None)
+        self.assertIs(type(r._high), int)
+        self.assertEqual(r._high, 45)
+
+        r = Range(IntLike(23), None)
+        self.assertIsIntRange(r)
+        self.assertIs(type(r._low), int)
+        self.assertEqual(r._low, 23)
+        self.assertIs(r._high, None)
+
+        r = Range(FloatLike(23.0), FloatLike(45.0))
+        self.assertIsFloatRange(r)
+        self.assertIs(type(r._low), float)
+        self.assertEqual(r._low, 23.0)
+        self.assertIs(type(r._high), float)
+        self.assertEqual(r._high, 45.0)
+
+        r = Range(None, FloatLike(45.0))
+        self.assertIsFloatRange(r)
+        self.assertIs(r._low, None)
+        self.assertIs(type(r._high), float)
+        self.assertEqual(r._high, 45.0)
+
+        r = Range(FloatLike(23.0), None)
+        self.assertIsFloatRange(r)
+        self.assertIs(type(r._low), float)
+        self.assertEqual(r._low, 23.0)
+        self.assertIs(r._high, None)
+
+        r = Range(23, FloatLike(45.0))
+        self.assertIsFloatRange(r)
+        self.assertIs(type(r._low), float)
+        self.assertEqual(r._low, 23.0)
+        self.assertIs(type(r._high), float)
+        self.assertEqual(r._high, 45.0)
+
+        r = Range(FloatLike(23.0), 45)
+        self.assertIsFloatRange(r)
+        self.assertIs(type(r._low), float)
+        self.assertEqual(r._low, 23.0)
+        self.assertIs(type(r._high), float)
+        self.assertEqual(r._high, 45.0)
+
+    def test_semi_dynamic_range(self):
+        obj = WithDynamicRange()
+        obj.r_high_dynamic = 5
+        self.assertEqual(obj.r_high_dynamic, 5)
+        # Current range is [0, 10]
+        with self.assertRaises(TraitError):
+            obj.r_high_dynamic = -10
+        with self.assertRaises(TraitError):
+            obj.r_high_dynamic = 15
+
+        # Change the upper limit.
+        obj.high = 20
+        obj.r_high_dynamic = 15
+        self.assertEqual(obj.r_high_dynamic, 15)
+        with self.assertRaises(TraitError):
+            obj.r_high_dynamic = 25
+
+        obj = WithDynamicRange()
+        obj.r_low_dynamic = 5.0
+        self.assertEqual(obj.r_low_dynamic, 5.0)
+        # Current range is [0.0, 10.0]
+        with self.assertRaises(TraitError):
+            obj.r_low_dynamic = -5.0
+        with self.assertRaises(TraitError):
+            obj.r_low_dynamic = 15.0
+
+        obj.low = -10
+        obj.r_low_dynamic = -5.0
+        self.assertEqual(obj.r_low_dynamic, -5.0)
+        with self.assertRaises(TraitError):
+            obj.r_low_dynamic = -15.0
+
+    # assertions and helper methods
+
+    def assertIsIntRange(self, range):
+        """
+        Assert that the given range is static and integer-based.
+        """
+        self.assertEqual(range._validate, "integer_validate")
+
+    def assertIsFloatRange(self, range):
+        """
+        Assert that the given range is static and float-based.
+        """
+        self.assertEqual(range._validate, "float_validate")
 
     def _check_bounds(self, obj, low, high):
         """

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1705,7 +1705,7 @@ class BaseRange ( TraitType ):
 
         if vtype is float:
             self._validate  = 'float_validate'
-            kind            = 4
+            kind = 4
             self._type_desc = 'a floating point number'
             if low is not None:
                 low = float( low )
@@ -1715,7 +1715,8 @@ class BaseRange ( TraitType ):
 
         elif vtype is long:
             self._validate  = 'long_validate'
-            self._type_desc = 'a long integer'
+            kind = 3
+            self._type_desc = 'an integer'
             if low is not None:
                 low = long( low )
 
@@ -1724,7 +1725,7 @@ class BaseRange ( TraitType ):
 
         elif vtype is int:
             self._validate  = 'int_validate'
-            kind            = 3
+            kind = 3
             self._type_desc = 'an integer'
             if low is not None:
                 low = int( low )
@@ -1762,7 +1763,7 @@ class BaseRange ( TraitType ):
         if exclude_high:
             exclude_mask |= 2
 
-        if is_static and (vtype is not long):
+        if is_static:
             self.init_fast_validator( kind, low, high, exclude_mask )
 
         #: Assign type-corrected arguments to handler attributes:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1698,9 +1698,9 @@ class BaseRange ( TraitType ):
 
         is_static = (not issubclass( vtype, basestring ))
         if is_static and (vtype not in RangeTypes):
-            raise TraitError, ("Range can only be use for int, long or float "
-                               "values, but a value of type %s was specified." %
-                               vtype)
+            raise TraitError("Range can only be use for int, long or float "
+                             "values, but a value of type %s was specified." %
+                             vtype)
 
         self._low_name = self._high_name = ''
         self._vtype    = Undefined
@@ -1749,14 +1749,14 @@ class BaseRange ( TraitType ):
             self.default_value_type = CALLABLE_DEFAULT_VALUE
             self.default_value      = self._get_default_value
 
-        exclude_mask = 0
-        if exclude_low:
-            exclude_mask |= 1
-
-        if exclude_high:
-            exclude_mask |= 2
-
         if is_static:
+            exclude_mask = 0
+            if exclude_low:
+                exclude_mask |= 1
+
+            if exclude_high:
+                exclude_mask |= 2
+
             self.init_fast_validator( kind, low, high, exclude_mask )
 
         #: Assign type-corrected arguments to handler attributes:
@@ -1784,7 +1784,7 @@ class BaseRange ( TraitType ):
         except TypeError:
             self.error( object, name, value )
 
-        if not self._check_in_range(float_value):
+        if not self._contains(float_value):
             self.error( object, name, value )
         return float_value
 
@@ -1796,11 +1796,11 @@ class BaseRange ( TraitType ):
         except TypeError:
             self.error( object, name, value )
 
-        if not self._check_in_range(integer_value):
+        if not self._contains(integer_value):
             self.error( object, name, value )
         return integer_value
 
-    def _check_in_range(self, value):
+    def _contains(self, value):
         """
         Determine whether a value is within the range specified.
         """

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -119,6 +119,23 @@ def default_text_editor ( trait, type = None ):
                        enter_set = enter_set,
                        evaluate  = type )
 
+
+# Generic validators
+
+def _validate_float(value):
+    """
+    Convert an arbitrary Python object to a float, or raise TypeError.
+    """
+    if type(value) == float:  # fast path for common case
+        return value
+    try:
+        nb_float = type(value).__float__
+    except AttributeError:
+        raise TypeError(
+            "Object of type {!r} not convertible to float".format(type(value)))
+    return nb_float(value)
+
+
 #-------------------------------------------------------------------------------
 #  'Any' trait:
 #-------------------------------------------------------------------------------
@@ -237,6 +254,7 @@ class Long ( BaseLong ):
     #: The C-level fast validator to use:
     fast_validate = long_fast_validate
 
+
 #-------------------------------------------------------------------------------
 #  'BaseFloat' and 'Float' traits:
 #-------------------------------------------------------------------------------
@@ -258,13 +276,10 @@ class BaseFloat ( TraitType ):
 
             Note: The 'fast validator' version performs this check in C.
         """
-        if isinstance( value, float ):
-            return value
-
-        if isinstance( value, ( int, long ) ):
-            return float( value )
-
-        self.error( object, name, value )
+        try:
+            return _validate_float(value)
+        except TypeError:
+            self.error(object, name, value)
 
     def create_editor ( self ):
         """ Returns the default traits UI editor for this type of trait.
@@ -278,7 +293,7 @@ class Float ( BaseFloat ):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = float_fast_validate
+    fast_validate = ( 21, )
 
 #-------------------------------------------------------------------------------
 #  'BaseComplex' and 'Complex' traits:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -151,32 +151,6 @@ def _validate_float(value):
     return nb_float(value)
 
 
-def _check_in_range(value, range_trait):
-    """
-    Determine whether a value is within the range specified by a Range trait.
-    """
-    low = range_trait._low
-    if low is None:
-        low_in_range = True
-    elif range_trait._exclude_low:
-        low_in_range = value > low
-    else:
-        low_in_range = value >= low
-
-    if not low_in_range:
-        return low_in_range
-
-    high = range_trait._high
-    if high is None:
-        high_in_range = True
-    elif range_trait._exclude_high:
-        high_in_range = value < high
-    else:
-        high_in_range = value <= high
-
-    return high_in_range
-
-
 #-------------------------------------------------------------------------------
 #  'Any' trait:
 #-------------------------------------------------------------------------------
@@ -1810,7 +1784,7 @@ class BaseRange ( TraitType ):
         except TypeError:
             self.error( object, name, value )
 
-        if not _check_in_range(float_value, self):
+        if not self._check_in_range(float_value):
             self.error( object, name, value )
         return float_value
 
@@ -1822,9 +1796,32 @@ class BaseRange ( TraitType ):
         except TypeError:
             self.error( object, name, value )
 
-        if not _check_in_range(integer_value, self):
+        if not self._check_in_range(integer_value):
             self.error( object, name, value )
         return integer_value
+
+    def _check_in_range(self, value):
+        """
+        Determine whether a value is within the range specified.
+        """
+        low = self._low
+        if low is None:
+            low_in_range = True
+        elif self._exclude_low:
+            low_in_range = value > low
+        else:
+            low_in_range = value >= low
+        if not low_in_range:
+            return low_in_range
+
+        high = self._high
+        if high is None:
+            high_in_range = True
+        elif self._exclude_high:
+            high_in_range = value < high
+        else:
+            high_in_range = value <= high
+        return high_in_range
 
     def _get_default_value ( self, object ):
         """ Returns the default value of the range.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -257,7 +257,6 @@ class Long ( BaseLong ):
     #: The C-level fast validator to use:
     fast_validate = long_fast_validate
 
-
 #-------------------------------------------------------------------------------
 #  'BaseFloat' and 'Float' traits:
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This PR:

- Makes `Range` static validation follow the same rules as `Int` or `Float`-validation, as appropriate.
- Refactors `ctraits.c` to remove duplication for integer and float validation functions.
- Adds extra tests for range validation.

The PR doesn't change the semantics of (a) dynamic Ranges (where the `low` and/or `high` are references to traits), or (b) the `traits.trait_handlers.TraitRange` class.

Builds on #393
Fixes #395 
Fixes #391 
Fixes #292