### PR TITLE
Unify and fix default list editors

### DIFF
--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -2273,39 +2273,9 @@ class TraitList ( TraitHandler ):
 
         return 'a list of %s%s' % ( size, info )
 
-    def get_editor ( self, trait ):
-        handler = self.item_trait.handler
-        if isinstance( handler, TraitInstance ) and (trait.mode != 'list'):
-            from .api import HasTraits
-
-            if issubclass( handler.aClass, HasTraits ):
-                try:
-                    object = handler.aClass()
-                    from traitsui.table_column import ObjectColumn
-                    from traitsui.table_filter import (EvalFilterTemplate,
-                        RuleFilterTemplate, MenuFilterTemplate, EvalTableFilter)
-                    from traitsui.api import TableEditor
-
-                    return TableEditor(
-                            columns = [ ObjectColumn( name = name )
-                                        for name in object.editable_traits() ],
-                            filters     = [ RuleFilterTemplate,
-                                            MenuFilterTemplate,
-                                            EvalFilterTemplate ],
-                            edit_view   = '',
-                            orientation = 'vertical',
-                            search      = EvalTableFilter(),
-                            deletable   = True,
-                            row_factory = handler.aClass )
-                except:
-                    pass
-
-        from traitsui.api import ListEditor
-
-        return ListEditor( trait_handler = self,
-                           rows          = trait.rows or 5,
-                           use_notebook  = trait.use_notebook is True,
-                           page_name     = trait.page_name or '' )
+    def get_editor(self, trait):
+        from traits.traits import list_editor
+        return list_editor(trait, self)
 
     def items_event ( self ):
         return items_event()

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -44,7 +44,8 @@ from .trait_handlers import (TraitType, TraitInstance, TraitListObject,
         CALLABLE_DEFAULT_VALUE, TRAIT_SET_OBJECT_DEFAULT_VALUE)
 
 from .traits import (Trait, trait_from, _TraitMaker, _InstanceArgs, code_editor,
-        html_editor, password_editor, shell_editor, date_editor, time_editor)
+        html_editor, password_editor, shell_editor, date_editor, time_editor,
+        list_editor)
 
 from .trait_errors import TraitError
 
@@ -2359,24 +2360,10 @@ class List ( TraitType ):
         return 'a list of %s which are %s' % (
                    size, self.item_trait.full_info( object, name, value ) )
 
-    def create_editor ( self ):
+    def create_editor(self):
         """ Returns the default UI editor for the trait.
         """
-        handler = self.item_trait.handler
-        if isinstance( handler, TraitInstance ) and (self.mode != 'list'):
-            from .api import HasTraits
-
-            if issubclass( handler.aClass, HasTraits ):
-                from traitsui.api import TableEditor
-
-                return TableEditor()
-
-        from traitsui.api import ListEditor
-
-        return ListEditor( trait_handler = self,
-                           rows          = self.rows or 5,
-                           use_notebook  = self.use_notebook is True,
-                           page_name     = self.page_name or '' )
+        return list_editor(self, self)
 
     def inner_traits ( self ):
         """ Returns the *inner trait* (or traits) for this trait.
@@ -2481,42 +2468,12 @@ class Set ( TraitType ):
         """
         return 'a set of %s' % self.item_trait.full_info( object, name, value )
 
-    def create_editor ( self ):
+    def create_editor(self):
         """ Returns the default UI editor for the trait.
         """
-        # fixme: Needs to be customized for sets.
-        handler = self.item_trait.handler
-        if isinstance( handler, TraitInstance ) and (self.mode != 'list'):
-            from .api import HasTraits
+        from traitsui.api import TextEditor
 
-            if issubclass( handler.aClass, HasTraits ):
-                try:
-                    object = handler.aClass()
-                    from traitsui.table_column import ObjectColumn
-                    from traitsui.table_filter import (EvalFilterTemplate,
-                        RuleFilterTemplate, MenuFilterTemplate, EvalTableFilter)
-                    from traitsui.api import TableEditor
-
-                    return TableEditor(
-                            columns = [ ObjectColumn( name = name )
-                                        for name in object.editable_traits() ],
-                            filters     = [ RuleFilterTemplate,
-                                            MenuFilterTemplate,
-                                            EvalFilterTemplate ],
-                            edit_view   = '',
-                            orientation = 'vertical',
-                            search      = EvalTableFilter(),
-                            deletable   = True,
-                            row_factory = handler.aClass )
-                except:
-                    pass
-
-        from traitsui.api import ListEditor
-
-        return ListEditor( trait_handler = self,
-                           rows          = self.rows or 5,
-                           use_notebook  = self.use_notebook is True,
-                           page_name     = self.page_name or '' )
+        return TextEditor(evaluate=eval)
 
     def inner_traits ( self ):
         """ Returns the *inner trait* (or traits) for this trait.

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -207,6 +207,75 @@ def date_editor ( ):
 
     return DateEditor
 
+def _is_hastraits_instance(handler):
+    """ Does a trait handler or type expect a HasTraits subclass instance?
+    """
+    from traits.api import HasTraits, BaseInstance, TraitInstance
+
+    if isinstance(handler, TraitInstance):
+        cls = handler.aClass
+    elif isinstance(handler, BaseInstance):
+        cls = handler.klass
+    else:
+        return False
+    return issubclass(cls, HasTraits)
+
+def _is_string_trait(handler):
+    """ Is this one of the string matching trait handlers
+    """
+    from traits.api import BaseStr, String, TraitString
+    return isinstance(handler, (BaseStr, String, TraitString))
+
+def _instance_handler_factory(handler):
+    """ Get the instance factory of an Instance or TraitInstance
+    """
+    from traits.api import BaseInstance, TraitInstance
+
+    if isinstance(handler, TraitInstance):
+        return handler.aClass
+    elif isinstance(handler, BaseInstance):
+        return handler.default_value
+
+def list_editor(trait, handler):
+    """ Factory that constructs an appropriate editor for a list.
+    """
+    item_handler = handler.item_trait.handler
+    if _is_hastraits_instance(item_handler):
+        from traitsui.table_column import ObjectColumn
+        from traitsui.table_filter import (EvalFilterTemplate,
+            RuleFilterTemplate, MenuFilterTemplate, EvalTableFilter)
+        from traitsui.api import TableEditor
+
+        return TableEditor(
+            filters=[RuleFilterTemplate, MenuFilterTemplate,
+                     EvalFilterTemplate],
+            edit_view='',
+            orientation='vertical',
+            search=EvalTableFilter(),
+            deletable=True,
+            show_toolbar=True,
+            reorderable=True,
+            row_factory=_instance_handler_factory(item_handler)
+        )
+    elif _is_string_trait(item_handler):
+        from traitsui.api import ListStrEditor
+
+        return ListStrEditor(
+            auto_add=True,
+            title=trait.title if trait.title else '',
+            title_name=trait.title_name if trait.title_name else '',
+        )
+    else:
+        from traitsui.api import ListEditor
+
+        return ListEditor(
+            trait_handler=handler,
+            rows=trait.rows if trait.rows else 5,
+            use_notebook=bool(trait.use_notebook),
+            page_name=trait.page_name if trait.page_name else ''
+        )
+
+
 #-------------------------------------------------------------------------------
 #  'CTrait' class (extends the underlying cTrait c-based type):
 #-------------------------------------------------------------------------------

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -207,7 +207,7 @@ def date_editor ( ):
 
     return DateEditor
 
-def _is_hastraits_instance(handler):
+def _expects_hastraits_instance(handler):
     """ Does a trait handler or type expect a HasTraits subclass instance?
     """
     from traits.api import HasTraits, BaseInstance, TraitInstance
@@ -220,11 +220,6 @@ def _is_hastraits_instance(handler):
         return False
     return issubclass(cls, HasTraits)
 
-def _is_string_trait(handler):
-    """ Is this one of the string matching trait handlers
-    """
-    from traits.api import BaseStr, String, TraitString
-    return isinstance(handler, (BaseStr, String, TraitString))
 
 def _instance_handler_factory(handler):
     """ Get the instance factory of an Instance or TraitInstance
@@ -235,12 +230,16 @@ def _instance_handler_factory(handler):
         return handler.aClass
     elif isinstance(handler, BaseInstance):
         return handler.default_value
+    else:
+        msg = "handler should be TraitInstance or BaseInstance, but got {}"
+        raise ValueError(msg.format(repr(handler)))
+
 
 def list_editor(trait, handler):
     """ Factory that constructs an appropriate editor for a list.
     """
     item_handler = handler.item_trait.handler
-    if _is_hastraits_instance(item_handler):
+    if _expects_hastraits_instance(item_handler):
         from traitsui.table_column import ObjectColumn
         from traitsui.table_filter import (EvalFilterTemplate,
             RuleFilterTemplate, MenuFilterTemplate, EvalTableFilter)
@@ -256,14 +255,6 @@ def list_editor(trait, handler):
             show_toolbar=True,
             reorderable=True,
             row_factory=_instance_handler_factory(item_handler)
-        )
-    elif _is_string_trait(item_handler):
-        from traitsui.api import ListStrEditor
-
-        return ListStrEditor(
-            auto_add=True,
-            title=trait.title if trait.title else '',
-            title_name=trait.title_name if trait.title_name else '',
         )
     else:
         from traitsui.api import ListEditor


### PR DESCRIPTION
This now treats `List(Instance(Foo))`, `List(Foo)`, `Trait(TraitList(Foo))`, etc. all in the same way with common code to create the editor.  It also removes a broken usage of `TableEditor` for the `Set` trait, replacing it with a simple `TextEditor` for now (the same as `Dict`).