### PR TITLE
Free HasTraits subclasses from hashing/comparing by identity

### DIFF
--- a/traits/adaptation/cached_adapter_factory.py
+++ b/traits/adaptation/cached_adapter_factory.py
@@ -13,10 +13,9 @@
 """ An adapter factory that caches adapters per instance. """
 
 
-import weakref
-
 from traits.api import Any, Bool, HasTraits, Property
 from traits.util.api import import_symbol
+from traits.util.weakiddict import WeakIDKeyDict
 
 
 class CachedAdapterFactory(HasTraits):
@@ -68,7 +67,7 @@ class CachedAdapterFactory(HasTraits):
 
     _adapter_cache = Any
     def __adapter_cache_default(self):
-        return weakref.WeakKeyDictionary()
+        return WeakIDKeyDict()
 
     #: Shadow trait for the corresponding property.
     _factory = Any

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import
 import re
 import string
 import weakref
-from weakref import WeakKeyDictionary
 from string import whitespace
 from types import MethodType
 
@@ -41,6 +40,7 @@ from .trait_handlers import (
 from .trait_types import Str, Int, Bool, Instance, List, Enum, Any
 from .trait_errors import TraitError
 from .trait_notifiers import TraitChangeNotifyWrapper
+from .util.weakiddict import WeakIDKeyDict
 
 #---------------------------------------------------------------------------
 #  Constants:
@@ -291,7 +291,7 @@ class ListenerItem ( ListenerBase ):
     #: A dictionary mapping objects to a list of all current active
     #: (*name*, *type*) listener pairs, where *type* defines the type of
     #: listener, one of: (SIMPLE_LISTENER, LIST_LISTENER, DICT_LISTENER).
-    active = Instance( WeakKeyDictionary, () )
+    active = Instance( WeakIDKeyDict, () )
 
     #-- 'ListenerBase' Class Method Implementations ----------------------------
 

--- a/traits/util/tests/test_weakidddict.py
+++ b/traits/util/tests/test_weakidddict.py
@@ -1,0 +1,128 @@
+import gc
+import unittest
+
+import six
+
+from ..weakiddict import WeakIDDict, WeakIDKeyDict
+
+
+class AllTheSame(object):
+    def __hash__(self):
+        return 42
+
+    def __eq__(self, other):
+        return isinstance(other, type(self))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class WeakreffableInt(object):
+    def __init__(self, value):
+        self.value = value
+
+    def __hash__(self):
+        return hash(self.value)
+
+    def __eq__(self, other):
+        if isinstance(other, int):
+            return self.value == other
+        else:
+            return self.value == other.value
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class TestWeakIDDict(unittest.TestCase):
+    if six.PY2:
+        assertCountEqual = unittest.TestCase.assertItemsEqual
+
+    def test_weak_keys(self):
+        wd = WeakIDKeyDict()
+
+        keep = []
+        dont_keep = []
+        values = list(range(10))
+        for n, i in enumerate(values, 1):
+            key = AllTheSame()
+            if not (i % 2):
+                keep.append(key)
+            else:
+                dont_keep.append(key)
+            wd[key] = i
+            del key
+            # No keys or values have been deleted, yet.
+            self.assertEqual(len(wd), n)
+
+        # Delete half of the keys.
+        self.assertEqual(len(wd), 10)
+        del dont_keep
+        self.assertEqual(len(wd), 5)
+
+        # Check the remaining values.
+        self.assertCountEqual(
+            list(wd.values()),
+            list(range(0, 10, 2)))
+        self.assertEqual(
+            [wd[k] for k in keep],
+            list(range(0, 10, 2)))
+
+        # Check the remaining keys.
+        self.assertCountEqual(
+            [id(k) for k in wd.keys()],
+            [id(k) for k in wd])
+        self.assertCountEqual(
+            [id(k) for k in wd.keys()],
+            [id(k) for k in keep])
+
+    def test_weak_keys_values(self):
+        wd = WeakIDDict()
+
+        keep = []
+        dont_keep = []
+        values = list(map(WeakreffableInt, range(10)))
+        for n, i in enumerate(values, 1):
+            key = AllTheSame()
+            if not (i.value % 2):
+                keep.append(key)
+            else:
+                dont_keep.append(key)
+            wd[key] = i
+            del key
+            # No keys or values have been deleted, yet.
+            self.assertEqual(len(wd), n)
+
+        # Delete half of the keys.
+        self.assertEqual(len(wd), 10)
+        del dont_keep
+        self.assertEqual(len(wd), 5)
+
+        # Check the remaining values.
+        self.assertCountEqual(
+            list(wd.values()),
+            list(map(WeakreffableInt, [0, 2, 4, 6, 8])))
+        self.assertEqual(
+            [wd[k] for k in keep],
+            list(map(WeakreffableInt, [0, 2, 4, 6, 8])))
+
+        # Check the remaining keys.
+        self.assertCountEqual(
+            [id(k) for k in wd.keys()],
+            [id(k) for k in wd])
+        self.assertCountEqual(
+            [id(k) for k in wd.keys()],
+            [id(k) for k in keep])
+
+        # Delete the weak values progressively and ensure that the
+        # corresponding entries disappear.
+        del values[0:2]
+        self.assertEqual(len(wd), 4)
+        del values[0:2]
+        self.assertEqual(len(wd), 3)
+        del values[0:2]
+        self.assertEqual(len(wd), 2)
+        del values[0:2]
+        self.assertEqual(len(wd), 1)
+        del values[0:2]
+        self.assertEqual(len(wd), 0)

--- a/traits/util/weakiddict.py
+++ b/traits/util/weakiddict.py
@@ -1,0 +1,65 @@
+import collections
+from weakref import ref
+
+
+def _remover(key_id, id_dict_ref):
+    def callback(wr, id_dict_ref=id_dict_ref):
+        id_dict = id_dict_ref()
+        if id_dict is not None:
+            id_dict.data.pop(key_id, None)
+    return callback
+
+
+class WeakIDDict(collections.MutableMapping):
+    """ Make a weak-key-value dictionary that uses the id() of the key for
+    comparisons.
+    """
+
+    def __init__(self, dict=None):
+        self.data = {}
+        if dict is not None:
+            self.update(dict)
+
+    def __repr__(self):
+        return '<WeakIDDict at 0x{0:x}>'.format(id(self))
+
+    def __delitem__(self, key):
+        del self.data[id(key)]
+
+    def __getitem__(self, key):
+        return self.data[id(key)][1]()
+
+    def __setitem__(self, key, value):
+        self.data[id(key)] = (
+            ref(key, _remover(id(key), ref(self))),
+            ref(value, _remover(id(key), ref(self))))
+
+    def __len__(self):
+        return len(self.data)
+
+    def __contains__(self, key):
+        return id(key) in self.data
+
+    def __iter__(self):
+        for id_key in self.data:
+            wr_key = self.data[id_key][0]
+            key = wr_key()
+            if key is not None:
+                yield key
+
+
+class WeakIDKeyDict(WeakIDDict):
+    """ Make a weak-key dictionary that uses the id() of the key for
+    comparisons.
+
+    This differs from `WeakIDDict` in that it does not try to make a weakref to
+    the values.
+    """
+
+    def __getitem__(self, key):
+        return self.data[id(key)][1]
+
+    def __setitem__(self, key, value):
+        self.data[id(key)] = (
+            ref(key, _remover(id(key), ref(self))),
+            value)

--- a/traits/util/weakiddict.py
+++ b/traits/util/weakiddict.py
@@ -1,3 +1,14 @@
+""" Variants of weak-key dictionaries that are based on object identity.
+
+They will ignore the ``__hash__`` and ``__eq__`` implementations on the
+objects. These are intended for various kinds of caches that map instances of
+classes to other things without keeping those instances alive. Note that
+iteration is not guarded, so if one were iterating over these dictionaries and
+one of the weakrefs got cleaned up, this might modify the structure and break
+the iteration. As this is not a common use for such caches, we have not
+bothered to make these dicts robust to that case.
+"""
+
 import collections
 from weakref import ref
 
@@ -11,7 +22,7 @@ def _remover(key_id, id_dict_ref):
 
 
 class WeakIDDict(collections.MutableMapping):
-    """ Make a weak-key-value dictionary that uses the id() of the key for
+    """ A weak-key-value dictionary that uses the id() of the key for
     comparisons.
     """
 
@@ -49,8 +60,7 @@ class WeakIDDict(collections.MutableMapping):
 
 
 class WeakIDKeyDict(WeakIDDict):
-    """ Make a weak-key dictionary that uses the id() of the key for
-    comparisons.
+    """ A weak-key dictionary that uses the id() of the key for comparisons.
 
     This differs from `WeakIDDict` in that it does not try to make a weakref to
     the values.


### PR DESCRIPTION
The Traits listener machinery uses weak-key dicts to track some of the bookkeeping for attaching and unattaching dynamic listeners. The intention of the code assumed that `HasTraits` instances kept the Python 2 default `__hash__` and `__eq__` semantics, which are based on identity, not value. Python 3 has changed those defaults, and there are some places where we do modify `__eq__` to do value comparisons (e.g. `codetools.contexts`).

Here, I introduce a new `WeakIDKeyDict` that mostly works like a `weakref.WeakKeyDictionary`, but the key objects are hashed and compared only by their identity and entirely ignore the `__hash__` and `__eq__` implementations on the keys.

This also replaces a usage of `WeakKeyDictionary` in the adaptation framework, which has similar issues, though that part of the framework is deprecated in any case.