### PR TITLE
HasRequiredTraits class

### DIFF
--- a/docs/source/traits_api_reference/has_traits.rst
+++ b/docs/source/traits_api_reference/has_traits.rst
@@ -37,6 +37,8 @@ Classes
 
 .. autoclass:: HasStrictTraits
 
+.. autoclass:: HasRequiredTraits
+
 .. autoclass:: HasPrivateTraits
 
 .. autoclass:: SingletonHasTraits

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -309,7 +309,7 @@ HasRequiredTraits
 '''''''''''''''''
 
 This class builds on the functionality of HasStrictTraits and ensures
-that any object attribute with required=True in its metadata must be passed
+that any object attribute with `required=True` in its metadata must be passed
 as an argument on object initialization.
 
 An example of a class with required traits::
@@ -330,8 +330,8 @@ Non-required traits can also still be provided as usual::
 However, omitting a required trait will raise a TraitError::
 
   >>> new_instance = RequiredTest(non_required_trait=14.0)
-  >>> traits.trait_errors.TraitError: The following required traits were not
-  >>> provided: required_trait.
+  traits.trait_errors.TraitError: The following required traits were not
+  provided: required_trait.
 
 .. index:: HasPrivateTraits class
 

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -308,9 +308,9 @@ structure.
 HasRequiredTraits
 '''''''''''''''''
 
-This class builds on the functionality of HasStrictTraits and ensures
-that any object attribute with `required=True` in its metadata must be passed
-as an argument on object initialization.
+This subclass of :ref:`hasstricttraits` ensures that any object attribute with
+``required=True`` in its metadata must be passed as an argument on object
+initialization.
 
 An example of a class with required traits::
 
@@ -321,17 +321,17 @@ An example of a class with required traits::
 All required traits have to be provided as arguments on creating a new
 instance::
 
-   >>> new_instance = RequiredTest(required_trait=13.0)
+    >>> new_instance = RequiredTest(required_trait=13.0)
 
 Non-required traits can also still be provided as usual::
 
-  >>> new_instance = RequiredTest(required_trait=13.0, non_required_trait=14.0)
+    >>> new_instance = RequiredTest(required_trait=13.0, non_required_trait=14.0)
 
 However, omitting a required trait will raise a TraitError::
 
-  >>> new_instance = RequiredTest(non_required_trait=14.0)
-  traits.trait_errors.TraitError: The following required traits were not
-  provided: required_trait.
+    >>> new_instance = RequiredTest(non_required_trait=14.0)
+    traits.trait_errors.TraitError: The following required traits were not
+    provided: required_trait.
 
 .. index:: HasPrivateTraits class
 

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -301,6 +301,38 @@ exception, as does attempting to set an attribute that is not one of the three
 defined attributes. In essence, TreeNode behaves like a type-checked data
 structure.
 
+.. index:: HasRequiredTraits class
+
+.. _hasrequiredtraits:
+
+HasRequiredTraits
+'''''''''''''''''
+
+This class builds on the functionality of HasStrictTraits and ensures
+that any object attribute with required=True in its metadata must be passed
+as an argument on object initialization.
+
+An example of a class with required traits::
+
+    class RequiredTest(HasRequiredTraits):
+        required_trait = Any(required=True)
+        non_required_trait = Any()
+
+All required traits have to be provided as arguments on creating a new
+instance::
+
+   >>> new_instance = RequiredTest(required_trait=13.0)
+
+Non-required traits can also still be provided as usual::
+
+  >>> new_instance = RequiredTest(required_trait=13.0, non_required_trait=14.0)
+
+However, omitting a required trait will raise a TraitError::
+
+  >>> new_instance = RequiredTest(non_required_trait=14.0)
+  >>> traits.trait_errors.TraitError: The following required traits were not
+  >>> provided: required_trait.
+
 .. index:: HasPrivateTraits class
 
 .. _hasprivatetraits:

--- a/traits/api.py
+++ b/traits/api.py
@@ -65,10 +65,10 @@ from .trait_types import (BaseInt, BaseLong, BaseFloat, BaseComplex, BaseStr,
 from .trait_types import UUID, ValidatedTuple
 
 from .has_traits import (HasTraits, HasStrictTraits, HasPrivateTraits,
-        Interface, SingletonHasTraits, SingletonHasStrictTraits,
-        SingletonHasPrivateTraits, MetaHasTraits, Vetoable, VetoableEvent,
-        implements, traits_super, on_trait_change, cached_property,
-        property_depends_on, provides, isinterface)
+        HasRequiredTraits, Interface, SingletonHasTraits,
+        SingletonHasStrictTraits, SingletonHasPrivateTraits, MetaHasTraits,
+        Vetoable, VetoableEvent, implements, traits_super, on_trait_change,
+        cached_property, property_depends_on, provides, isinterface)
 
 try:
     from .has_traits import ABCHasTraits, ABCHasStrictTraits, ABCMetaHasTraits

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3461,8 +3461,8 @@ class HasStrictTraits ( HasTraits ):
 
 class HasRequiredTraits(HasStrictTraits):
     """ This class builds on the functionality of HasStrictTraits and ensures
-     that any object attribute with `required=True` in its metadata must be
-     passed as an argument on object initialization.
+    that any object attribute with `required=True` in its metadata must be
+    passed as an argument on object initialization.
 
     This can be useful in cases where an object has traits which are required
     for it to function correctly.
@@ -3470,20 +3470,23 @@ class HasRequiredTraits(HasStrictTraits):
     Raises
     ------
     TraitError
-        If a required trait is not passed as an argument
+        If a required trait is not passed as an argument.
 
-    Examples
-    --------
+    Usage
+    -----
     A class with required traits:
-    >>> class RequiredTest(HasRequiredTraits):
-    >>>     required_trait = Any(required=True)
-    >>>     non_required_trait = Any()
 
-    Making an instance of a HasRequiredTraits class:
+    >>> class RequiredTest(HasRequiredTraits):
+    ...     required_trait = Any(required=True)
+    ...     non_required_trait = Any()
+
+    Creating an instance of a HasRequiredTraits subclass:
+
     >>> test_instance = RequiredTest(required_trait=13, non_required_trait=11)
     >>> test_instance2 = RequiredTest(required_trait=13)
 
     Forgetting to specify a required trait:
+
     >>> test_instance = RequiredTest(non_required_trait=11)
     traits.trait_errors.TraitError: The following required traits were not
     provided: required_trait.

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3461,7 +3461,7 @@ class HasStrictTraits ( HasTraits ):
 
 class HasRequiredTraits(HasStrictTraits):
     """ This class builds on the functionality of HasStrictTraits and ensures
-     that any object attribute with required=True in its metadata must be
+     that any object attribute with `required=True` in its metadata must be
      passed as an argument on object initialization.
 
     This can be useful in cases where an object has traits which are required

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3461,8 +3461,8 @@ class HasStrictTraits ( HasTraits ):
 
 class HasRequiredTraits(HasStrictTraits):
     """ This class builds on the functionality of HasStrictTraits and ensures
-     that any object attribute with required=True (metadata) must be passed
-     as an argument on object initialization.
+     that any object attribute with required=True in its metadata must be
+     passed as an argument on object initialization.
 
     This can be useful in cases where an object has traits which are required
     for it to function correctly.
@@ -3486,20 +3486,19 @@ class HasRequiredTraits(HasStrictTraits):
     Forgetting to specify a required trait:
     >>> test_instance = RequiredTest(non_required_trait=11)
     traits.trait_errors.TraitError: The following required traits were not
-    passed as a keyword argument: required_trait.
+    provided: required_trait.
     """
 
     def __init__(self, **traits):
-        missing_required_traits = []
-        for name in self.trait_names(required=True):
-            if name not in traits:
-                missing_required_traits.append(name)
+
+        missing_required_traits = [
+            name for name in self.trait_names(required=True)
+            if name not in traits
+        ]
         if missing_required_traits:
             raise TraitError(
-                "The following required traits were not passed as a "
-                "keyword argument: {names}.".format(
-                    names=', '.join(sorted(missing_required_traits))
-                )
+                "The following required traits were not provided: "
+                "{}.".format(', '.join(sorted(missing_required_traits)))
             )
 
         super(HasRequiredTraits, self).__init__(**traits)

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3456,6 +3456,55 @@ class HasStrictTraits ( HasTraits ):
     _ = Disallow   # Disallow access to any traits not explicitly defined
 
 #-------------------------------------------------------------------------------
+#  'HasRequiredTraits' class:
+#-------------------------------------------------------------------------------
+
+class HasRequiredTraits(HasStrictTraits):
+    """ This class builds on the functionality of HasStrictTraits and ensures
+     that any object attribute with required=True (metadata) must be passed
+     as an argument on object initialization.
+
+    This can be useful in cases where an object has traits which are required
+    for it to function correctly.
+
+    Raises
+    ------
+    TraitError
+        If a required trait is not passed as an argument
+
+    Examples
+    --------
+    A class with required traits:
+    >>> class RequiredTest(HasRequiredTraits):
+    >>>     required_trait = Any(required=True)
+    >>>     non_required_trait = Any()
+
+    Making an instance of a HasRequiredTraits class:
+    >>> test_instance = RequiredTest(required_trait=13, non_required_trait=11)
+    >>> test_instance2 = RequiredTest(required_trait=13)
+
+    Forgetting to specify a required trait:
+    >>> test_instance = RequiredTest(non_required_trait=11)
+    traits.trait_errors.TraitError: The following required traits were not
+    passed as a keyword argument: required_trait.
+    """
+
+    def __init__(self, **traits):
+        missing_required_traits = []
+        for name in self.trait_names(required=True):
+            if name not in traits:
+                missing_required_traits.append(name)
+        if missing_required_traits:
+            raise TraitError(
+                "The following required traits were not passed as a "
+                "keyword argument: {names}.".format(
+                    names=', '.join(missing_required_traits)
+                )
+            )
+
+        super(HasRequiredTraits, self).__init__(**traits)
+
+#-------------------------------------------------------------------------------
 #  'HasPrivateTraits' class:
 #-------------------------------------------------------------------------------
 

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3498,7 +3498,7 @@ class HasRequiredTraits(HasStrictTraits):
             raise TraitError(
                 "The following required traits were not passed as a "
                 "keyword argument: {names}.".format(
-                    names=', '.join(missing_required_traits)
+                    names=', '.join(sorted(missing_required_traits))
                 )
             )
 

--- a/traits/tests/test_has_required_traits.py
+++ b/traits/tests/test_has_required_traits.py
@@ -1,0 +1,38 @@
+import unittest
+from traits.api import Int, Float, String, HasRequiredTraits, TraitError
+
+class TestHasRequiredTraits(unittest.TestCase):
+
+    def test_trait_value_assignment(self):
+        test_instance = RequiredTest(i_trait=4, f_trait=2.2, s_trait="test")
+        self.assertEqual(test_instance.i_trait, 4)
+        self.assertEqual(test_instance.f_trait, 2.2)
+        self.assertEqual(test_instance.s_trait, "test")
+        self.assertEqual(test_instance.non_req_trait, 4.4)
+
+
+    def test_missing_required_trait(self):
+        with self.assertRaises(TraitError) as exc:
+            test_instance = RequiredTest(i_trait=3)
+        self.assertEqual(
+            exc.exception.args[0], "The following required traits were not "
+            "passed as a keyword argument: f_trait, s_trait."
+        )
+
+    def test_overwrite_required(self):
+        test_instance = RequiredTest(
+            i_trait=6, f_trait=3.3, s_trait="hi"
+        )
+        self.assertEqual(test_instance.i_trait, 6)
+        self.assertEqual(test_instance.f_trait, 3.3)
+        self.assertEqual(test_instance.s_trait, "hi")
+        self.assertEqual(test_instance.non_req_trait, 4.4)
+        test_instance.i_trait = 7
+        self.assertEqual(test_instance.i_trait, 7)
+
+
+class RequiredTest(HasRequiredTraits):
+    i_trait = Int(required=True)
+    f_trait = Float(required=True)
+    s_trait = String(required=True)
+    non_req_trait = Float(4.4, required=False)

--- a/traits/tests/test_has_required_traits.py
+++ b/traits/tests/test_has_required_traits.py
@@ -4,11 +4,13 @@ from traits.api import Int, Float, String, HasRequiredTraits, TraitError
 class TestHasRequiredTraits(unittest.TestCase):
 
     def test_trait_value_assignment(self):
-        test_instance = RequiredTest(i_trait=4, f_trait=2.2, s_trait="test")
+        test_instance = RequiredTest(
+            i_trait=4, f_trait=2.2, s_trait="test")
         self.assertEqual(test_instance.i_trait, 4)
         self.assertEqual(test_instance.f_trait, 2.2)
         self.assertEqual(test_instance.s_trait, "test")
         self.assertEqual(test_instance.non_req_trait, 4.4)
+        self.assertEqual(test_instance.normal_trait, 42.0)
 
 
     def test_missing_required_trait(self):
@@ -16,19 +18,8 @@ class TestHasRequiredTraits(unittest.TestCase):
             test_instance = RequiredTest(i_trait=3)
         self.assertEqual(
             exc.exception.args[0], "The following required traits were not "
-            "passed as a keyword argument: f_trait, s_trait."
+            "provided: f_trait, s_trait."
         )
-
-    def test_overwrite_required(self):
-        test_instance = RequiredTest(
-            i_trait=6, f_trait=3.3, s_trait="hi"
-        )
-        self.assertEqual(test_instance.i_trait, 6)
-        self.assertEqual(test_instance.f_trait, 3.3)
-        self.assertEqual(test_instance.s_trait, "hi")
-        self.assertEqual(test_instance.non_req_trait, 4.4)
-        test_instance.i_trait = 7
-        self.assertEqual(test_instance.i_trait, 7)
 
 
 class RequiredTest(HasRequiredTraits):
@@ -36,3 +27,4 @@ class RequiredTest(HasRequiredTraits):
     f_trait = Float(required=True)
     s_trait = String(required=True)
     non_req_trait = Float(4.4, required=False)
+    normal_trait = Float(42.0)


### PR DESCRIPTION
From the docstring: This class builds on the functionality of HasStrictTraits and ensures that any object attribute with the metadata required=True must be passed as an argument on object initialization.

This came up as there were situations where a class had a few 'key' traits and the others were derived from them. It made sense to try and provide a more formal implementation of this pattern!

Things that I'm not sure about:
- What else to test for
- Whether using TraitError is appropriate (It doesn't really use any of the extra functionality TraitError provides)

