### PR TITLE
Fix exception message and type for Unicode HasStrictTraits attribute name.

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -551,7 +551,8 @@ set_readonly_error ( has_traits_object * obj, PyObject * name ) {
 static int
 set_disallow_error ( has_traits_object * obj, PyObject * name ) {
 
-    if ( !Py2to3_SimpleString_Check( name ) ) {
+    PyObject *nname = Py2to3_NormaliseAttrName(name);
+    if (nname == NULL) {
         return invalid_attribute_error( name );
     }
 
@@ -559,9 +560,10 @@ set_disallow_error ( has_traits_object * obj, PyObject * name ) {
         TraitError,
         "Cannot set the undefined '%.400" Py2to3_PYERR_SIMPLE_STRING_FMTCHR "'"
             " attribute of a '%.50s' object.",
-        Py2to3_PYERR_PREPARE_SIMPLE_STRING( name ),
+        Py2to3_PYERR_PREPARE_SIMPLE_STRING( nname ),
         Py_TYPE(obj)->tp_name
     );
+    Py2to3_FinishNormaliseAttrName(name, nname);
     return -1;
 }
 

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -12,7 +12,8 @@ else:
     numpy_available = True
     from traits.trait_numeric import Array
 
-from traits.has_traits import HasTraits, Property, on_trait_change
+from traits.has_traits import (
+    HasStrictTraits, HasTraits, Property, on_trait_change)
 from traits.trait_errors import TraitError
 from traits.trait_types import Bool, DelegatesTo, Either, Instance, Int, List
 from traits.testing.unittest_tools import unittest
@@ -258,6 +259,25 @@ class TestRegression(unittest.TestCase):
         self.assertFalse(model.changed)
         dummy.x = 11
         self.assertTrue(model.changed)
+
+    def test_set_disallowed_exception(self):
+        class StrictDummy(HasStrictTraits):
+            foo = Int
+
+        # Regression test for enthought/traits#415
+        with self.assertRaises(TraitError):
+            StrictDummy(forbidden=53)
+
+        with self.assertRaises(TraitError):
+            StrictDummy(**{'forbidden': 53})
+
+        # This is the case that used to fail on Python 2.
+        with self.assertRaises(TraitError):
+            StrictDummy(**{u'forbidden': 53})
+
+        a = StrictDummy()
+        with self.assertRaises(TraitError):
+            setattr(a, u'forbidden', 53)
 
 
 if __name__ == '__main__':

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -2,6 +2,7 @@
 import gc
 import sys
 
+import six
 import six.moves as sm
 
 try:

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -261,15 +261,17 @@ class TestRegression(unittest.TestCase):
         self.assertTrue(model.changed)
 
     def test_set_disallowed_exception(self):
+        # Regression test for enthought/traits#415
+
         class StrictDummy(HasStrictTraits):
             foo = Int
 
-        # Regression test for enthought/traits#415
         with self.assertRaises(TraitError):
             StrictDummy(forbidden=53)
 
-        with self.assertRaises(TraitError):
-            StrictDummy(**{'forbidden': 53})
+        if six.PY2:
+            with self.assertRaises(TraitError):
+                StrictDummy(**{b'forbidden': 53})
 
         # This is the case that used to fail on Python 2.
         with self.assertRaises(TraitError):


### PR DESCRIPTION
This PR fixes an odd error message and wrong exception type `TypeError` that should have been `TraitError` when attempting to assign a disallowed name in a `HasStrictTraits` subclass (for example).

Looking at the code, there are likely other instances of this pattern that need to be fixed, but that's not a reason not to fix this one (which has been encountered independently by several people).

Fixes #399 (and #415).