### PR TITLE
Enthought Sphinx Theme for Docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,3 +62,7 @@ To build the full documentation one needs:
 
 * sphinx > 1.2.3
 * mock (optional if traitsui is not available)
+* `enthought-sphinx-theme
+  <https://github.com/enthought/enthought-sphinx-theme>`_
+  (a version of the documentation can be built without this, but
+  some formatting may be incorrect)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -205,9 +205,20 @@ except ImportError as exc:
                 https://github.com/enthought/enthought-sphinx-theme'''
     warnings.warn(RuntimeWarning(msg.format(exc)))
 
-    # Use old defaults
+    # Use old defaults if enthought-sphinx-theme not available
+
+    # The name of an image file (within the static path) to place at the top
+    # of the sidebar.
     html_logo = "e-logo-rev.png"
+
+    # The name of an image file (within the static path) to use as favicon of
+    # the docs.  This file should be a Windows icon file (.ico) being 16x16
+    # or 32x32 pixels large.
     html_favicon = "et.ico"
+
+    # The style sheet to use for HTML and HTML Help pages. A file of that name
+    # must exist either in Sphinx' static/ path, or in one of the custom paths
+    # given in html_static_path.
     html_style = 'default.css'
 
 # When using docset browsers like Dash and Zeal the side bar is redundant.
@@ -216,26 +227,12 @@ if BUILD_DOCSET:
         'nosidebar': 'true'
     }
 
-# The style sheet to use for HTML and HTML Help pages. A file of that name
-# must exist either in Sphinx' static/ path, or in one of the custom paths
-# given in html_static_path.
-#html_style = 'default.css'
-
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 html_title = "Traits 4 User Manual"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
-
-# The name of an image file (within the static path) to place at the top of
-# the sidebar.
-#html_logo = "e-logo-rev.png"
-
-# The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-#html_favicon = "et.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,7 +91,7 @@ def mock_modules():
 
         @classmethod
         def __getattr__(self, name):
-            if name in ('__file__', '__path__'):
+            if name in ('__file__', '__path__', '_mock_methods'):
                 # sphinx does not like getting a Mock object in this case.
                 return '/dev/null'
             else:
@@ -191,6 +191,25 @@ autodoc_member_order = 'bysource'
 # Options for HTML output
 # -----------------------
 
+# Use enthought-sphinx-theme if available
+try:
+    import enthought_sphinx_theme
+
+    html_theme_path = [enthought_sphinx_theme.theme_path]
+    html_theme = 'enthought'
+except ImportError as exc:
+    import warnings
+    msg = '''Can't find Enthought Sphinx Theme, using default.
+                Exception was: {}
+                Enthought Sphinx Theme can be downloaded from
+                https://github.com/enthought/enthought-sphinx-theme'''
+    warnings.warn(RuntimeWarning(msg.format(exc)))
+
+    # Use old defaults
+    html_logo = "e-logo-rev.png"
+    html_favicon = "et.ico"
+    html_style = 'default.css'
+
 # When using docset browsers like Dash and Zeal the side bar is redundant.
 if BUILD_DOCSET:
     html_theme_options = {
@@ -200,7 +219,7 @@ if BUILD_DOCSET:
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
-html_style = 'default.css'
+#html_style = 'default.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -211,12 +230,12 @@ html_title = "Traits 4 User Manual"
 
 # The name of an image file (within the static path) to place at the top of
 # the sidebar.
-html_logo = "e-logo-rev.png"
+#html_logo = "e-logo-rev.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = "et.ico"
+#html_favicon = "et.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
This mirrors the documentation setup for TraitsUI, where we try to use the [enthought-sphinx-theme](https://github.com/enthought/enthought-sphinx-theme) and fall back to the older defaults if this is not available. Though this presumably should only happen for someone building the docs locally, since anyone building them to upload to the website should probably just download the enthought theme!

This also fixes a bug where the docs would not build without a version of traitsui. This was due to the `DocMock` class calling `getattr(self, _mock_methods)` recursively on initialisation. 

There are some new warnings due to Traits having classes exclusive to python 2 - however sphinx effectively ends up just skipping these rather than it causing any problems (as far as I can tell anyway!). These warnings are also present if the docs are built with traitsui present on python 3.