### PR TITLE
Release traits v5

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Traits CHANGELOG
 Release 5.0.0
 -------------
 
-Released : 29 January 2019
+Released : 30 January 2019
 
 This major release accumulates more than an year's worth of improvements,
 changes and bug fixes to the code base.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -241,7 +241,7 @@ if BUILD_DOCSET:
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "Traits 4 User Manual"
+html_title = "Traits 5 User Manual"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None
@@ -306,7 +306,7 @@ latex_documents = [
     (
         "index",
         "Traits.tex",
-        "Traits 4 User Manual",
+        "Traits 5 User Manual",
         "Enthought, Inc.",
         "manual",
     )
@@ -340,7 +340,7 @@ texinfo_documents = [
     (
         "index",
         "traits",
-        "Traits 4 User Manual",
+        "Traits 5 User Manual",
         "Enthought, Inc.",
         "Traits",
         "Explicitly typed attributes for Python.",

--- a/docs/source/traits_user_manual/front.rst
+++ b/docs/source/traits_user_manual/front.rst
@@ -1,5 +1,5 @@
 ====================
-Traits 4 User Manual
+Traits 5 User Manual
 ====================
 
 :Authors: David C. Morrill, Janet M. Swisher

--- a/docs/source/traits_user_manual/index.rst
+++ b/docs/source/traits_user_manual/index.rst
@@ -1,4 +1,4 @@
-Traits 4 User Manual
+Traits 5 User Manual
 ====================
 
 .. toctree::

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ import sys
 from setuptools import setup, Extension, find_packages
 
 MAJOR = 5
-MINOR = 0
-MICRO = 1
+MINOR = 1
+MICRO = 0
 
 IS_RELEASED = False
 

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ from setuptools import setup, Extension, find_packages
 
 MAJOR = 5
 MINOR = 0
-MICRO = 0
+MICRO = 1
 
-IS_RELEASED = True
+IS_RELEASED = False
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ import sys
 
 from setuptools import setup, Extension, find_packages
 
-MAJOR = 4
-MINOR = 7
+MAJOR = 5
+MINOR = 0
 MICRO = 0
 
-IS_RELEASED = False
+IS_RELEASED = True
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Note that the commit - https://github.com/enthought/traits/pull/438/commits/73ba9fcb0b5967ad88c3358fe12de91f80642d39 will be tagged with the 5.0.0 release.

- [x] Update docs to reflect version 5
- [x] update  setup scripts to reflect the version change
- [ ] bump version back to dev