### PR TITLE
Change extension on changelog, so that GitHub renders it nicely.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,9 +12,9 @@ changes and bug fixes to the code base.
 A few highlights of this release are :
 
 * Removal of 2to3 fixers and the use of six to provide Python 2/3 compatibility
-* Removal of deprecated `traits.protocols` submodule and related utils.
-* New `HasRequiredTraits` class
-* Better IPython tab completion for `HasTraits` subclasses
+* Removal of deprecated ``traits.protocols`` submodule and related utils.
+* New ``HasRequiredTraits`` class
+* Better IPython tab completion for ``HasTraits`` subclasses
 
 Changes summary since 4.6.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -34,9 +34,9 @@ Enhancements
 
 Changes
 
-* Remove deprecated `traits.protocols` submodule and related utils (#435)
+* Remove deprecated ``traits.protocols`` submodule and related utils (#435)
 * Fix invalid string escapes (#429)
-* Apply the `black` code reformatting utility on the Traits codebase (#432)
+* Apply the "black" code reformatting utility on the Traits codebase (#432)
 * Update CI to use edm and etstool module (#420)
 * Clean up ``Float`` and ``BaseFloat`` validation (#393)
 * Merge master into Cython port (#370)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include CHANGES.txt
+include CHANGES.rst
 include LICENSE.txt
 include MANIFEST.in
 include README.rst


### PR DESCRIPTION
Our CHANGES.txt file is mostly reST. This PR:

- changes the extension, so that GitHub renders it nicely, and
- makes some minor reST formatting fixes in recent portions of the changelog.