### PR TITLE
Remove usage of sys.version_info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Traits CHANGELOG
 ================
 
+DEV
+---
+
+Changes
+
+* Replace usage of ``sys.version_info`` with six.PYX. Note that
+  ``python_version``, derived from ``sys.version_info``, has also been removed
+  from the traits API. (#449)
+
 Release 5.0.0
 -------------
 

--- a/traits/_py2to3.py
+++ b/traits/_py2to3.py
@@ -12,6 +12,9 @@ if six.PY2:
 else:
     LONG_TYPE = int
 
+str_find = str.find
+str_rfind = str.rfind
+
 if six.PY2:
     from types import InstanceType, ClassType
 

--- a/traits/_py2to3.py
+++ b/traits/_py2to3.py
@@ -95,11 +95,3 @@ else:
                 self.close()
                 raise
             return tuple(ret)
-
-
-if six.PY2:
-    def assertCountEqual(self, itemsA, itemsB):
-        self.assertItemsEqual(itemsA, itemsB)
-else:
-    def assertCountEqual(self, itemsA, itemsB):
-        self.assertCountEqual(itemsA, itemsB)

--- a/traits/_py2to3.py
+++ b/traits/_py2to3.py
@@ -12,9 +12,6 @@ if six.PY2:
 else:
     LONG_TYPE = int
 
-str_find = str.find
-str_rfind = str.rfind
-
 if six.PY2:
     from types import InstanceType, ClassType
 

--- a/traits/_py2to3.py
+++ b/traits/_py2to3.py
@@ -12,6 +12,11 @@ if six.PY2:
 else:
     LONG_TYPE = int
 
+# FIXME : These two aliases are being used by released versions of traitsui
+# See PR https://github.com/enthought/traitsui/pull/496 which removes their
+# use from traitsui.
+# Once that PR is merged and a new release of traitsui is available, we can
+# remove these aliases for good.
 str_find = str.find
 str_rfind = str.rfind
 

--- a/traits/_py2to3.py
+++ b/traits/_py2to3.py
@@ -3,7 +3,7 @@
 
 from __future__ import division, absolute_import
 
-import sys
+import contextlib
 
 import six
 
@@ -12,16 +12,10 @@ if six.PY2:
 else:
     LONG_TYPE = int
 
-if sys.version_info[0] < 3:
-    import string
+str_find = str.find
+str_rfind = str.rfind
 
-    str_find = string.find
-    str_rfind = string.rfind
-else:
-    str_find = str.find
-    str_rfind = str.rfind
-
-if sys.version_info[0] < 3:
+if six.PY2:
     from types import InstanceType, ClassType
 
     def is_old_style_instance(obj):
@@ -52,7 +46,7 @@ else:
         return False
 
 
-if sys.version_info[0] < 3:
+if six.PY2:
     from types import InstanceType
 
     def type_w_old_style(obj):
@@ -61,12 +55,10 @@ if sys.version_info[0] < 3:
             # Old-style class.
             the_type = obj.__class__
         return the_type
-
-
 else:
     type_w_old_style = type
 
-if sys.version_info[0] < 3:
+if six.PY2:
     from types import ClassType
 
     ClassTypes = (ClassType, type)
@@ -74,144 +66,12 @@ else:
     ClassTypes = (type,)
 
 
-import contextlib
 
-if sys.version_info[0] < 3:
-
+if six.PY2:
     def nested_context_mgrs(*args):
         return contextlib.nested(*args)
-
-
 else:
-    if sys.version_info[:2] < (3, 3):
-        # ExitStack was introduced in python 3.3. We copy the 3.3 version here
-        # to support python 3.2
-        class ExitStack(object):
-            """Context manager for dynamic management of a stack of exit callbacks
-        
-            For example:
-        
-                with ExitStack() as stack:
-                    files = [stack.enter_context(open(fname)) for fname in filenames]
-                    # All opened files will automatically be closed at the end of
-                    # the with statement, even if attempts to open files later
-                    # in the list raise an exception
-        
-            """
-
-            def __init__(self):
-                from collections import deque
-
-                self._exit_callbacks = deque()
-
-            def pop_all(self):
-                """Preserve the context stack by transferring it to a new instance"""
-                from collections import deque
-
-                new_stack = type(self)()
-                new_stack._exit_callbacks = self._exit_callbacks
-                self._exit_callbacks = deque()
-                return new_stack
-
-            def _push_cm_exit(self, cm, cm_exit):
-                """Helper to correctly register callbacks to __exit__ methods"""
-
-                def _exit_wrapper(*exc_details):
-                    return cm_exit(cm, *exc_details)
-
-                _exit_wrapper.__self__ = cm
-                self.push(_exit_wrapper)
-
-            def push(self, exit):
-                """Registers a callback with the standard __exit__ method signature
-        
-                Can suppress exceptions the same way __exit__ methods can.
-        
-                Also accepts any object with an __exit__ method (registering a call
-                to the method instead of the object itself)
-                """
-                # We use an unbound method rather than a bound method to follow
-                # the standard lookup behaviour for special methods
-                _cb_type = type(exit)
-                try:
-                    exit_method = _cb_type.__exit__
-                except AttributeError:
-                    # Not a context manager, so assume its a callable
-                    self._exit_callbacks.append(exit)
-                else:
-                    self._push_cm_exit(exit, exit_method)
-                return exit  # Allow use as a decorator
-
-            def callback(self, callback, *args, **kwds):
-                """Registers an arbitrary callback and arguments.
-        
-                Cannot suppress exceptions.
-                """
-
-                def _exit_wrapper(exc_type, exc, tb):
-                    callback(*args, **kwds)
-
-                # We changed the signature, so using @wraps is not appropriate, but
-                # setting __wrapped__ may still help with introspection
-                _exit_wrapper.__wrapped__ = callback
-                self.push(_exit_wrapper)
-                return callback  # Allow use as a decorator
-
-            def enter_context(self, cm):
-                """Enters the supplied context manager
-        
-                If successful, also pushes its __exit__ method as a callback and
-                returns the result of the __enter__ method.
-                """
-                # We look up the special methods on the type to match the with statement
-                _cm_type = type(cm)
-                _exit = _cm_type.__exit__
-                result = _cm_type.__enter__(cm)
-                self._push_cm_exit(cm, _exit)
-                return result
-
-            def close(self):
-                """Immediately unwind the context stack"""
-                self.__exit__(None, None, None)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *exc_details):
-                # We manipulate the exception state so it behaves as though
-                # we were actually nesting multiple with statements
-                frame_exc = sys.exc_info()[1]
-
-                def _fix_exception_context(new_exc, old_exc):
-                    while 1:
-                        exc_context = new_exc.__context__
-                        if exc_context in (None, frame_exc):
-                            break
-                        new_exc = exc_context
-                    new_exc.__context__ = old_exc
-
-                # Callbacks are invoked in LIFO order to match the behaviour of
-                # nested context managers
-                suppressed_exc = False
-                while self._exit_callbacks:
-                    cb = self._exit_callbacks.pop()
-                    try:
-                        if cb(*exc_details):
-                            suppressed_exc = True
-                            exc_details = (None, None, None)
-                    except:
-                        new_exc_details = sys.exc_info()
-                        # simulate the stack of exceptions by setting the context
-                        _fix_exception_context(
-                            new_exc_details[1], exc_details[1]
-                        )
-                        if not self._exit_callbacks:
-                            raise
-                        exc_details = new_exc_details
-                return suppressed_exc
-
-    else:
-        ExitStack = contextlib.ExitStack
+    ExitStack = contextlib.ExitStack
 
     class nested_context_mgrs(ExitStack):
         """ Emulation of python 2's :py:class:`contextlib.nested`.
@@ -240,13 +100,9 @@ else:
             return tuple(ret)
 
 
-if sys.version_info[0] < 3:
-
+if six.PY2:
     def assertCountEqual(self, itemsA, itemsB):
         self.assertItemsEqual(itemsA, itemsB)
-
-
 else:
-
     def assertCountEqual(self, itemsA, itemsB):
         self.assertCountEqual(itemsA, itemsB)

--- a/traits/adaptation/adaptation_manager.py
+++ b/traits/adaptation/adaptation_manager.py
@@ -16,7 +16,7 @@
 from heapq import heappop, heappush
 import inspect
 import itertools
-import sys
+import six
 import functools
 
 from traits.adaptation.adaptation_error import AdaptationError
@@ -264,7 +264,7 @@ class AdaptationManager(HasTraits):
             edges = self._get_applicable_offers(current_protocol, path)
 
             # Sort by weight first, then by from_protocol type.
-            if sys.version_info[0] < 3:
+            if six.PY2:
                 edges.sort(cmp=_by_weight_then_from_protocol_specificity)
             else:
                 # functools.cmp_to_key is available from 2.7 and 3.2

--- a/traits/adaptation/adaptation_manager.py
+++ b/traits/adaptation/adaptation_manager.py
@@ -16,8 +16,9 @@
 from heapq import heappop, heappush
 import inspect
 import itertools
-import six
 import functools
+
+import six
 
 from traits.adaptation.adaptation_error import AdaptationError
 from traits.has_traits import HasTraits

--- a/traits/api.py
+++ b/traits/api.py
@@ -23,7 +23,7 @@ Use this module for importing Traits names into your namespace. For example::
 
 from __future__ import absolute_import
 
-from .trait_base import Uninitialized, Undefined, Missing, Self, python_version
+from .trait_base import Uninitialized, Undefined, Missing, Self
 
 from .trait_errors import TraitError, TraitNotificationError, DelegationError
 

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -10,10 +10,7 @@ import sys
 import tempfile
 import time
 
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 # Enthought library imports.
 from traits.etsconfig.etsconfig import ETSConfig, ETSToolkitError

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, division, print_function
 import copy as copy_module
 import weakref
 import re
-import sys
 
 from types import FunctionType, MethodType
 
@@ -129,7 +128,7 @@ WrapperTypes = (
     StaticTraitChangeNotifyWrapper,
 )
 
-if sys.version_info[0] >= 3:
+if six.PY3:
     # in python 3, unbound methods do not exist anymore, they're just functions
     BoundMethodTypes = (MethodType,)
     UnboundMethodTypes = (FunctionType,)

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -128,13 +128,14 @@ WrapperTypes = (
     StaticTraitChangeNotifyWrapper,
 )
 
-if six.PY3:
+if six.PY2:
+    BoundMethodTypes = (MethodType,)
+    UnboundMethodTypes = (MethodType,)
+else:
     # in python 3, unbound methods do not exist anymore, they're just functions
     BoundMethodTypes = (MethodType,)
     UnboundMethodTypes = (FunctionType,)
-else:
-    BoundMethodTypes = (MethodType,)
-    UnboundMethodTypes = (MethodType,)
+
 
 FunctionTypes = (FunctionType,)
 

--- a/traits/testing/tests/test_unittest_tools.py
+++ b/traits/testing/tests/test_unittest_tools.py
@@ -15,7 +15,6 @@ import warnings
 import six
 import six.moves as sm
 
-from traits import _py2to3
 from traits.api import (
     Bool,
     Event,
@@ -307,7 +306,7 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
         for t in threads:
             t.join()
 
-        _py2to3.assertCountEqual(
+        six.assertCountEqual(
             self,
             event_collector.events,
             list(sm.range(events_per_thread)) * thread_count,

--- a/traits/tests/test_class_traits.py
+++ b/traits/tests/test_class_traits.py
@@ -7,7 +7,8 @@ from __future__ import absolute_import
 
 import unittest
 
-from traits import _py2to3
+import six
+
 from traits.api import HasTraits, Int, List, Str
 
 
@@ -33,22 +34,22 @@ class C(B):
 class TestClassTraits(unittest.TestCase):
     def test_all_class_traits(self):
         expected = ["x", "name", "trait_added", "trait_modified"]
-        _py2to3.assertCountEqual(self, A.class_traits(), expected)
+        six.assertCountEqual(self, A.class_traits(), expected)
 
         # Check that derived classes report the correct traits.
-        _py2to3.assertCountEqual(self, B.class_traits(), expected)
+        six.assertCountEqual(self, B.class_traits(), expected)
 
         expected.extend(("lst", "y"))
-        _py2to3.assertCountEqual(self, C.class_traits(), expected)
+        six.assertCountEqual(self, C.class_traits(), expected)
 
     def test_class_traits_with_metadata(self):
 
         # Retrieve all traits that have the `marked` metadata
         # attribute set to True.
         traits = C.class_traits(marked=True)
-        _py2to3.assertCountEqual(self, list(traits.keys()), ("y", "name"))
+        six.assertCountEqual(self, list(traits.keys()), ("y", "name"))
 
         # Retrieve all traits that have a `marked` metadata attribute,
         # regardless of its value.
         marked_traits = C.class_traits(marked=lambda attr: attr is not None)
-        _py2to3.assertCountEqual(self, marked_traits, ("y", "name", "lst"))
+        six.assertCountEqual(self, marked_traits, ("y", "name", "lst"))

--- a/traits/tests/test_dynamic_notifiers.py
+++ b/traits/tests/test_dynamic_notifiers.py
@@ -2,7 +2,8 @@
 import gc
 import unittest
 
-from traits import _py2to3
+import six
+
 from traits import trait_notifiers
 from traits.api import Event, Float, HasTraits, List, on_trait_change
 
@@ -204,7 +205,7 @@ class TestDynamicNotifiers(unittest.TestCase):
         obj = DynamicNotifiers()
         obj.fail = 1
 
-        _py2to3.assertCountEqual(self, [0, 1, 2, 3, 4], obj.exceptions_from)
+        six.assertCountEqual(self, [0, 1, 2, 3, 4], obj.exceptions_from)
         self.assertEqual([(obj, "fail", 0, 1)] * 5, self.exceptions)
 
     def test_dynamic_notifiers_functions(self):
@@ -266,7 +267,7 @@ class TestDynamicNotifiers(unittest.TestCase):
 
         obj.fail = 1
 
-        _py2to3.assertCountEqual(self, [0, 1, 2, 3, 4], obj.exceptions_from)
+        six.assertCountEqual(self, [0, 1, 2, 3, 4], obj.exceptions_from)
         # 10 failures: 5 are from the internal dynamic listeners, see
         # test_dynamic_notifiers_methods_failing
         self.assertEqual([(obj, "fail", 0, 1)] * 10, self.exceptions)

--- a/traits/tests/test_extended_notifiers.py
+++ b/traits/tests/test_extended_notifiers.py
@@ -8,7 +8,8 @@ listeners to `a:b` when `a` changes.
 """
 import unittest
 
-from traits import _py2to3
+import six
+
 from traits import trait_notifiers
 from traits.api import Float, HasTraits, List
 
@@ -198,7 +199,7 @@ class TestExtendedNotifiers(unittest.TestCase):
         obj = ExtendedNotifiers()
         obj.fail = 1
 
-        _py2to3.assertCountEqual(self, [0, 1, 2, 3, 4], obj.exceptions_from)
+        six.assertCountEqual(self, [0, 1, 2, 3, 4], obj.exceptions_from)
         self.assertEqual([(obj, "fail", 0, 1)] * 5, self.exceptions)
 
     def test_extended_notifiers_functions(self):
@@ -246,7 +247,7 @@ class TestExtendedNotifiers(unittest.TestCase):
 
         obj.fail = 1
 
-        _py2to3.assertCountEqual(self, [0, 1, 2, 3, 4], obj.exceptions_from)
+        six.assertCountEqual(self, [0, 1, 2, 3, 4], obj.exceptions_from)
         # 10 failures: 5 are from the internal extended listeners, see
         # test_extended_notifiers_methods_failing
         self.assertEqual([(obj, "fail", 0, 1)] * 10, self.exceptions)

--- a/traits/tests/test_float.py
+++ b/traits/tests/test_float.py
@@ -15,7 +15,6 @@
 Tests for the Float trait type.
 
 """
-import sys
 import unittest
 
 try:
@@ -124,7 +123,7 @@ class CommonFloatTests(object):
         a.float_or_text = u"not a float"
         self.assertEqual(a.float_or_text, u"not a float")
 
-    @unittest.skipUnless(sys.version_info < (3,), "Not applicable to Python 3")
+    @unittest.skipUnless(six.PY2, "Not applicable to Python 3")
     def test_accepts_small_long(self):
         a = self.test_class()
         a.value = LONG_TYPE(2)
@@ -135,7 +134,7 @@ class CommonFloatTests(object):
         self.assertIs(type(a.value_or_none), float)
         self.assertEqual(a.value_or_none, 2.0)
 
-    @unittest.skipUnless(sys.version_info < (3,), "Not applicable to Python 3")
+    @unittest.skipUnless(six.PY2, "Not applicable to Python 3")
     def test_accepts_large_long(self):
         a = self.test_class()
 

--- a/traits/tests/test_list.py
+++ b/traits/tests/test_list.py
@@ -8,9 +8,9 @@
 
 from __future__ import absolute_import
 
-import sys
 import unittest
 
+import six
 import six.moves as sm
 
 from traits.api import CList, HasTraits, Instance, Int, List, Str, TraitError
@@ -302,7 +302,7 @@ class ListTestCase(unittest.TestCase):
         except ImportError:
             pass
         else:
-            if sys.version_info[0] < 3:
+            if six.PY2:
                 f.ints = array([1, 2, 3])
                 self.assertEqual(f.ints, [1, 2, 3])
             else:
@@ -355,14 +355,14 @@ class ListTestCase(unittest.TestCase):
         f.l.sort(key=lambda x: -ord(x), reverse=True)
         self.assertEqual(f.l, ["a", "b", "c", "d"])
 
-    @unittest.skipIf(sys.version_info[0] >= 3, "Not for Python 3")
+    @unittest.skipIf(six.PY3, "Not for Python 3")
     def test_sort_cmp(self):
         f = Foo()
         f.l = ["a", "c", "b", "d"]
         f.l.sort(cmp=lambda x, y: ord(x) - ord(y))
         self.assertEqual(f.l, ["a", "b", "c", "d"])
 
-    @unittest.skipIf(sys.version_info[0] < 3, "Not for Python 2")
+    @unittest.skipIf(six.PY2, "Not for Python 2")
     def test_sort_cmp_error(self):
         f = Foo()
         f.l = ["a", "c", "b", "d"]

--- a/traits/tests/test_list.py
+++ b/traits/tests/test_list.py
@@ -355,7 +355,7 @@ class ListTestCase(unittest.TestCase):
         f.l.sort(key=lambda x: -ord(x), reverse=True)
         self.assertEqual(f.l, ["a", "b", "c", "d"])
 
-    @unittest.skipIf(six.PY3, "Not for Python 3")
+    @unittest.skipUnless(six.PY2, "Not for Python 3")
     def test_sort_cmp(self):
         f = Foo()
         f.l = ["a", "c", "b", "d"]

--- a/traits/tests/test_property_delete.py
+++ b/traits/tests/test_property_delete.py
@@ -6,7 +6,8 @@ property trait (regression tests for Github issue #67).
 
 import unittest
 
-from traits import _py2to3
+import six
+
 from traits.api import Any, HasTraits, Int, Property, TraitError
 
 
@@ -28,4 +29,4 @@ class TestPropertyDelete(unittest.TestCase):
     def test_property_reset_traits(self):
         e = E()
         unresetable = e.reset_traits()
-        _py2to3.assertCountEqual(self, unresetable, ["a", "b"])
+        six.assertCountEqual(self, unresetable, ["a", "b"])

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -588,7 +588,7 @@ class BytesTest(StringTest):
         (b"",),
         None,
         True,
-    ] + (version_dependent if six.PY3 else [])
+    ] + ([] if six.PY2 else version_dependent)
 
     def coerce(self, value):
         return bytes(value)
@@ -638,7 +638,7 @@ class CoercibleBytesTest(StringTest):
         {10: "foo"},
         True,
     ] + (version_dependent if six.PY2 else [])
-    _bad_values = version_dependent if six.PY3 else []
+    _bad_values = [] if six.PY2 else version_dependent
 
     def coerce(self, value):
         return bytes(value)

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -15,7 +15,6 @@
 #  Imports
 from __future__ import absolute_import, print_function
 
-import sys
 import unittest
 
 import six
@@ -291,7 +290,7 @@ class CoercibleLongTest(AnyTraitTest):
         u"10",
         u"-10",
     ]
-    if sys.version_info[0] < 3:
+    if six.PY2:
         _good_values.extend(["10L", "-10L", u"10L", u"-10L"])
     _bad_values = [
         "10.1",
@@ -431,7 +430,7 @@ class FloatTest(AnyTraitTest):
         u"-10.1",
     ]
 
-    if sys.version_info[0] < 3:
+    if six.PY2:
         _good_values.extend([LONG_TYPE(-10), LONG_TYPE(10)])
 
     def coerce(self, value):
@@ -573,7 +572,7 @@ class BytesTest(StringTest):
 
     _default_value = b"bytes"
     _good_values = [b"", b"10", b"-10"] + (
-        version_dependent if sys.version_info[0] == 2 else []
+        version_dependent if six.PY2 else []
     )
     _bad_values = [
         10,
@@ -589,7 +588,7 @@ class BytesTest(StringTest):
         (b"",),
         None,
         True,
-    ] + (version_dependent if sys.version_info[0] == 3 else [])
+    ] + (version_dependent if six.PY3 else [])
 
     def coerce(self, value):
         return bytes(value)
@@ -638,8 +637,8 @@ class CoercibleBytesTest(StringTest):
         set([10]),
         {10: "foo"},
         True,
-    ] + (version_dependent if sys.version_info[0] == 2 else [])
-    _bad_values = version_dependent if sys.version_info[0] == 3 else []
+    ] + (version_dependent if six.PY2 else [])
+    _bad_values = version_dependent if six.PY3 else []
 
     def coerce(self, value):
         return bytes(value)

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -41,10 +41,6 @@ from .etsconfig.api import ETSConfig
 # backwards compatibility: trait_base used to provide a patched enumerate
 enumerate = enumerate
 
-# Set the Python version being used:
-vi = sys.version_info
-python_version = vi[0] + (float(vi[1]) / 10.0)
-
 # -------------------------------------------------------------------------------
 #  Constants:
 # -------------------------------------------------------------------------------

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -2572,7 +2572,7 @@ class TraitListObject(list):
             excp.set_prefix("Each element of the")
             raise excp
 
-    if sys.version_info[0] < 3:
+    if six.PY2:
 
         def __setslice__(self, i, j, values):
             self.__setitem__(slice(i, j), values)
@@ -2614,7 +2614,7 @@ class TraitListObject(list):
                 self.name_items, TraitListEvent(index, removed)
             )
 
-    if sys.version_info[0] < 3:
+    if six.PY2:
 
         def __delslice__(self, i, j):
             self.__delitem__(slice(i, j))
@@ -2776,7 +2776,7 @@ class TraitListObject(list):
         else:
             self.len_error(len(self) - 1)
 
-    if sys.version_info[0] < 3:
+    if six.PY2:
 
         def sort(self, cmp=None, key=None, reverse=False):
             removed = self[:]

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -45,7 +45,6 @@ from .trait_base import (
     ClassTypes,
     Undefined,
     TraitsCache,
-    python_version,
 )
 
 from .trait_handlers import (

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -30,6 +30,7 @@ import re
 import sys
 from os.path import isfile, isdir
 from types import FunctionType, MethodType, ModuleType
+import uuid
 
 import six
 
@@ -1210,7 +1211,7 @@ class Method(TraitType):
     info_text = "a method"
 
 
-if sys.version_info[0] < 3:
+if six.PY2:
     from types import ClassType
 
     class Class(TraitType):
@@ -3655,44 +3656,40 @@ class Symbol(TraitType):
             )
 
 
-if python_version >= 2.5:
+# ---------------------------------------------------------------------------
+#  'UUID' trait:
+# ---------------------------------------------------------------------------
 
-    import uuid
+class UUID(TraitType):
+    """ Defines a trait whose value is a globally unique UUID (type 4).
+    """
 
-    # ---------------------------------------------------------------------------
-    #  'UUID' trait:
-    # ---------------------------------------------------------------------------
+    #: A description of the type of value this trait accepts:
+    info_text = "a read-only UUID"
 
-    class UUID(TraitType):
-        """ Defines a trait whose value is a globally unique UUID (type 4).
+    def __init__(self, **metadata):
+        """ Returns a UUID trait.
         """
+        super(UUID, self).__init__(None, **metadata)
 
-        #: A description of the type of value this trait accepts:
-        info_text = "a read-only UUID"
+    def validate(self, object, name, value):
+        """ Raises an error, since no values can be assigned to the trait.
+        """
+        raise TraitError(
+            "The '%s' trait of %s instance is a read-only "
+            "UUID." % (name, class_of(object))
+        )
 
-        def __init__(self, **metadata):
-            """ Returns a UUID trait.
-            """
-            super(UUID, self).__init__(None, **metadata)
+    def get_default_value(self):
+        return (
+            CALLABLE_AND_ARGS_DEFAULT_VALUE,
+            (self._create_uuid, (), None),
+        )
 
-        def validate(self, object, name, value):
-            """ Raises an error, since no values can be assigned to the trait.
-            """
-            raise TraitError(
-                "The '%s' trait of %s instance is a read-only "
-                "UUID." % (name, class_of(object))
-            )
+    # -- Private Methods ---------------------------------------------------
 
-        def get_default_value(self):
-            return (
-                CALLABLE_AND_ARGS_DEFAULT_VALUE,
-                (self._create_uuid, (), None),
-            )
-
-        # -- Private Methods ---------------------------------------------------
-
-        def _create_uuid(self):
-            return uuid.uuid4()
+    def _create_uuid(self):
+        return uuid.uuid4()
 
 
 # -------------------------------------------------------------------------------
@@ -3823,7 +3820,7 @@ ListFunction = List(FunctionType)
 #: List of method values; default value is [].
 ListMethod = List(MethodType)
 
-if sys.version_info[0] < 3:
+if six.PY2:
     from types import ClassType, InstanceType
 
     #: List of class values; default value is [].

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -576,7 +576,7 @@ PythonTypes = (
     NoneType,
 )
 
-if sys.version_info[0] < 3:
+if six.PY2:
     from types import InstanceType, ClassType
 
     PythonTypes = (


### PR DESCRIPTION
~NOTE : There is still one place where `sys.version_info`~
~I don't see any uses of `python_version`
but I'm not sure if we want to/can remove it completely.~

Replace it's usage with six.PY2/six.PY3 instead
and remove outdated pieces of code which added workarounds for
python < 2.7 and < 3.4

With this PR, #364 can be closed, as 2to3 have been replaced and 
sys.version_info usage has been removed.