### PR TITLE
ENH: Control dialog_style based on the Trait attribute.

### DIFF
--- a/traits/tests/test_file.py
+++ b/traits/tests/test_file.py
@@ -48,3 +48,14 @@ class FileTestCase(unittest.TestCase):
         example_model = FastExampleModel(file_name=__file__)
         example_model.path = "."
         example_model.path = u"."
+
+
+class TestCreateEditor(unittest.TestCase):
+    def test_exists_controls_editor_dialog_style(self):
+        x = File(exists=True)
+        editor = x.create_editor()
+        self.assertEqual(editor.dialog_style, "open")
+
+        x = File(exists=False)
+        editor = x.create_editor()
+        self.assertEqual(editor.dialog_style, "save")

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1651,6 +1651,7 @@ class BaseFile(BaseStr):
             filter=self.filter or [],
             auto_set=self.auto_set,
             entries=self.entries,
+            dialog_style="open" if self.exists else "save"
         )
         return editor
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1651,7 +1651,7 @@ class BaseFile(BaseStr):
             filter=self.filter or [],
             auto_set=self.auto_set,
             entries=self.entries,
-            dialog_style="open" if self.exists else "save"
+            dialog_style="open" if self.exists else "save",
         )
         return editor
 


### PR DESCRIPTION
Currently, the `exists` attribute of the Trait doesn't have any impact on the `FileEditor`. Without this fix, the editor we get for the following code:
```
from traits.api import HasTraits, File

class A(HasTraits):
    f = File(exists=False)
```
is still the `open` version:
![screen shot 2019-02-08 at 2 36 00 pm](https://user-images.githubusercontent.com/593945/52504729-e9e65100-2bae-11e9-8581-c028f0b066ab.png)

With this fix, we get the expected dialog:
![screen shot 2019-02-08 at 2 35 15 pm](https://user-images.githubusercontent.com/593945/52504717-e2bf4300-2bae-11e9-9159-7008c01c4dd1.png)
