### PR TITLE
Allow use of traits as type annotations in python 3.6+

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -52,6 +52,19 @@ the Traits package, which requires that values assigned be of the standard
 Python type **float**. The value 150.0 specifies the default value of the
 trait.
 
+For versions of Python which support it, this can alternatively be written
+using variable type annotation.
+
+.. index::
+   single: examples; minimal variable annotation
+
+::
+
+    from traits.api import HasTraits, Float
+
+    class Person(HasTraits):
+        weight: Float = 150.0
+
 The value associated with each class-level attribute determines the
 characteristics of the instance attribute identified by the attribute name.
 For example::

--- a/docs/source/traits_user_manual/intro.rst
+++ b/docs/source/traits_user_manual/intro.rst
@@ -113,6 +113,23 @@ package. These features are elaborated in the rest of this guide.
     # (if a supported GUI toolkit is installed)
     moe.configure_traits()
 
+In Python 3.6 and above, where variable annotations are supported, you can
+use that syntax as an alternative for validation and initialization:
+
+.. index:: examples; variable annotation
+
+::
+
+    from traits.api import HasTraits, Int, Str
+    class Parent(HasTraits):
+
+        # VALIDATION: 'age' must be an integer:
+        age: Int
+
+        # INITIALIZATION: last_name' is initialized to '':
+        last_name: Str = ''
+
+
 Background
 ----------
 Python does not require the data type of variables to be declared. As any

--- a/traits/category.py
+++ b/traits/category.py
@@ -59,8 +59,10 @@ class MetaCategory(MetaHasTraits):
             )
 
         # Process any traits-related information in the class dictionary:
+        annotations = class_dict.get('__annotations__', {})
         update_traits_class_dict(
-            class_name, bases, class_dict, is_category=True
+            class_name, bases, class_dict, is_category=False,
+            annotations=annotations
         )
 
         if len(bases) == 2:

--- a/traits/category.py
+++ b/traits/category.py
@@ -61,7 +61,7 @@ class MetaCategory(MetaHasTraits):
         # Process any traits-related information in the class dictionary:
         annotations = class_dict.get('__annotations__', {})
         update_traits_class_dict(
-            class_name, bases, class_dict, is_category=False,
+            class_name, bases, class_dict, is_category=True,
             annotations=annotations
         )
 

--- a/traits/category.py
+++ b/traits/category.py
@@ -60,7 +60,7 @@ class MetaCategory(MetaHasTraits):
 
         # Process any traits-related information in the class dictionary:
         update_traits_class_dict(
-            class_name, bases, class_dict, is_category=True,
+            class_name, bases, class_dict, is_category=True
         )
 
         if len(bases) == 2:

--- a/traits/category.py
+++ b/traits/category.py
@@ -59,10 +59,8 @@ class MetaCategory(MetaHasTraits):
             )
 
         # Process any traits-related information in the class dictionary:
-        annotations = class_dict.get('__annotations__', {})
         update_traits_class_dict(
             class_name, bases, class_dict, is_category=True,
-            annotations=annotations
         )
 
         if len(bases) == 2:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -568,10 +568,12 @@ def update_traits_class_dict(class_name, bases, class_dict, is_category,
 
     # Reprocess any annotations.
     for name, annotation in annotations.items():
-        if name in class_dict:
-            default_value = class_dict[name]
-            annotation = annotation(default_value=default_value)
-        class_dict[name] = annotation
+        annotation = _check_trait(annotation)
+        if isinstance(annotation, CTrait):
+            if name in class_dict:
+                default_value = class_dict[name]
+                annotation = annotation(default_value=default_value)
+            class_dict[name] = annotation
 
     # Move all trait definitions from the class dictionary to the
     # appropriate trait class dictionaries:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -567,6 +567,12 @@ def update_traits_class_dict(class_name, bases, class_dict, is_category):
         annotation = _check_trait(annotation)
         if isinstance(annotation, CTrait):
             if name in class_dict:
+                if annotation.type in CantHaveDefaultValue:
+                    raise TraitError(
+                        "Cannot specify a default value "
+                        "for the %s trait '%s'."
+                        % (annotation.type, name)
+                    )
                 default_value = class_dict[name]
                 annotation = annotation(default_value=default_value)
             class_dict[name] = annotation

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -487,8 +487,7 @@ class MetaHasTraits(type):
     def __new__(cls, class_name, bases, class_dict):
         annotations = class_dict.get('__annotations__', {})
         update_traits_class_dict(
-            class_name, bases, class_dict, is_category=False,
-            annotations=annotations
+            class_name, bases, class_dict, is_category=False
         )
 
         # Finish building the class using the updated class dictionary:
@@ -523,8 +522,7 @@ class MetaHasTraits(type):
     remove_listener = classmethod(remove_listener)
 
 
-def update_traits_class_dict(class_name, bases, class_dict, is_category,
-                             annotations={}):
+def update_traits_class_dict(class_name, bases, class_dict, is_category):
     """ Processes all of the traits related data in the class dictionary.
 
     This is called during the construction of a new HasTraits class. The first
@@ -542,8 +540,6 @@ def update_traits_class_dict(class_name, bases, class_dict, is_category,
         A dictionary of class members.
     is_category : bool
         Whether this is a Category subclass.
-    annotations : dict
-        Any trait types using type annotation syntax.
 
     """
     # Create the various class dictionaries, lists and objects needed to
@@ -567,6 +563,7 @@ def update_traits_class_dict(class_name, bases, class_dict, is_category,
     ]
 
     # Reprocess any annotations.
+    annotations = class_dict.get('__annotations__', {})
     for name, annotation in annotations.items():
         annotation = _check_trait(annotation)
         if isinstance(annotation, CTrait):

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -485,7 +485,6 @@ class MetaHasTraits(type):
     _listeners = {}
 
     def __new__(cls, class_name, bases, class_dict):
-        annotations = class_dict.get('__annotations__', {})
         update_traits_class_dict(
             class_name, bases, class_dict, is_category=False
         )

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -11,7 +11,8 @@ from traits.has_traits import (
     HasTraits,
 )
 from traits.traits import ForwardProperty, generic_trait
-from traits.trait_types import Float, Int
+from traits.trait_errors import TraitError
+from traits.trait_types import Event, Float, Int
 
 
 def _dummy_getter(self):
@@ -276,3 +277,16 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         self.assertEqual(class_dict["attr"], "something")
         self.assertNotIn("my_int", class_dict)
         self.assertEqual(class_dict[BaseTraits]["my_int"].default_value()[1], 5)
+
+    def test_annotation_no_default_trait_with_value(self):
+        # Given
+        class_name = "MyClass"
+        bases = (object,)
+        class_dict = {"my_event": 5}
+        is_category = False
+        annotations = {"my_event": Event}
+        class_dict['__annotations__'] = annotations
+
+        # When
+        with self.assertRaises(TraitError):
+            update_traits_class_dict(class_name, bases, class_dict, is_category)

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -34,10 +34,10 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         class_dict = {"attr": "something"}
         is_category = False
         annotations = {"annotation": "some_value"}
+        class_dict['__annotations__'] = annotations
 
         # When
-        update_traits_class_dict(class_name, bases, class_dict, is_category,
-                                 annotations)
+        update_traits_class_dict(class_name, bases, class_dict, is_category)
 
         # Then; Check that the original Python-level class attributes are still
         # present in the class dictionary.
@@ -61,10 +61,10 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         }
         is_category = False
         annotations = {}
+        class_dict['__annotations__'] = annotations
 
         # When
-        update_traits_class_dict(class_name, bases, class_dict, is_category,
-                                 annotations)
+        update_traits_class_dict(class_name, bases, class_dict, is_category)
 
         # Then
         self.assertEqual(class_dict[ListenerTraits], {})
@@ -91,10 +91,10 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         class_dict = {"attr": "something", "my_int": Int}
         is_category = False
         annotations = {}
+        class_dict['__annotations__'] = annotations
 
         # When
-        update_traits_class_dict(class_name, bases, class_dict, is_category,
-                                 annotations)
+        update_traits_class_dict(class_name, bases, class_dict, is_category)
 
         # Then
         self.assertEqual(class_dict[ListenerTraits], {})
@@ -120,10 +120,10 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         class_dict = {"attr": "something", "my_int_": Int}  # prefix trait
         is_category = False
         annotations = {}
+        class_dict['__annotations__'] = annotations
 
         # When
-        update_traits_class_dict(class_name, bases, class_dict, is_category,
-                                 annotations)
+        update_traits_class_dict(class_name, bases, class_dict, is_category)
 
         # Then
         for kind in (BaseTraits, ClassTraits, ListenerTraits, InstanceTraits):
@@ -147,10 +147,10 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         class_dict = {"attr": "something", "my_listener": listener}
         is_category = False
         annotations = {}
+        class_dict['__annotations__'] = annotations
 
         # When
-        update_traits_class_dict(class_name, bases, class_dict, is_category,
-                                 annotations)
+        update_traits_class_dict(class_name, bases, class_dict, is_category)
 
         # Then
         self.assertEqual(class_dict[BaseTraits], {})
@@ -180,10 +180,10 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         }
         is_category = False
         annotations = {}
+        class_dict['__annotations__'] = annotations
 
         # When
-        update_traits_class_dict(class_name, bases, class_dict, is_category,
-                                 annotations)
+        update_traits_class_dict(class_name, bases, class_dict, is_category)
 
         # Then
         self.assertEqual(class_dict[BaseTraits], {})
@@ -201,10 +201,10 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         class_dict = {"attr": "something", "my_trait": Float()}
         is_category = False
         annotations = {}
+        class_dict['__annotations__'] = annotations
 
         # When
-        update_traits_class_dict(class_name, bases, class_dict, is_category,
-                                 annotations)
+        update_traits_class_dict(class_name, bases, class_dict, is_category)
 
         # Then
         self.assertEqual(class_dict[InstanceTraits], {})
@@ -224,10 +224,10 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         class_dict = {"attr": "something"}
         is_category = False
         annotations = {"my_int": Int}
+        class_dict['__annotations__'] = annotations
 
         # When
-        update_traits_class_dict(class_name, bases, class_dict, is_category,
-                                 annotations)
+        update_traits_class_dict(class_name, bases, class_dict, is_category)
 
         # Then
         self.assertEqual(class_dict[ListenerTraits], {})
@@ -254,10 +254,10 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         class_dict = {"attr": "something", "my_int": 5}
         is_category = False
         annotations = {"my_int": Int}
+        class_dict['__annotations__'] = annotations
 
         # When
-        update_traits_class_dict(class_name, bases, class_dict, is_category,
-                                 annotations)
+        update_traits_class_dict(class_name, bases, class_dict, is_category)
 
         # Then
         self.assertEqual(class_dict[ListenerTraits], {})


### PR DESCRIPTION
In other words, be able to do:
```
from traits.api import HasTraits, Int, List

class Foo(HasTraits):
    bar: Int
    baz: List(Int) = [1, 1, 2, 3, 5]
    wom: Int(metadata_works=True) = 100
```
and have it work as expected.  Because you know that you wanted to do this as soon as PEP 526 was published...

The implementation simply goes through the `__annotations__` looking for annotation values that look like traits, adds the corresponding value (if any) as a default for the trait, and adds them to the class dict before the class dict is processed.

In other words this essentially does a re-write of `x: <trait> = <default>` to `x = <trait>(default_value=<default>)`.

So implementation is simple, but it is possible that there are odd corner cases out there and so a second brain thinking this through would be useful.

This PR makes no attempt to interact with the `typing` module in any way.

Includes tests.
