### PR TITLE
Revert enthought/traits#373: instance traits are no longer pickleable

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1517,9 +1517,6 @@ class HasTraits(CHasTraits):
                 ]
             )
         )
-        # Add all instance traits
-        inst_traits = self._instance_traits()
-        result["__instance_traits__"] = inst_traits
 
         # If this object implements ISerializable, make sure that all
         # contained HasTraits objects in its persisted state also implement
@@ -1563,10 +1560,7 @@ class HasTraits(CHasTraits):
         else:
             # Otherwise, apply the Traits 3.0 restore logic:
             self._init_trait_listeners()
-            inst_traits = state.pop("__instance_traits__", {})
             self.trait_set(trait_change_notify=trait_change_notify, **state)
-            for attr in inst_traits:
-                self.add_trait(attr, inst_traits[attr])
             self._post_init_trait_listeners()
             self.traits_init()
 
@@ -1935,9 +1929,6 @@ class HasTraits(CHasTraits):
         new = self.__new__(self.__class__)
         memo[id(self)] = new
         new._init_trait_listeners()
-        inst_traits = self._instance_traits()
-        for attr in inst_traits:
-            new.add_trait(attr, inst_traits[attr])
         new.copy_traits(self, traits, memo, copy, **metadata)
         new._post_init_trait_listeners()
         new.traits_init()

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -20,6 +20,7 @@ from traits.has_traits import (
     Property,
     on_trait_change,
 )
+from traits.trait_errors import TraitError
 from traits.trait_types import Bool, DelegatesTo, Either, Instance, Int, List
 
 

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -20,7 +20,6 @@ from traits.has_traits import (
     Property,
     on_trait_change,
 )
-from traits.trait_errors import TraitError
 from traits.trait_types import Bool, DelegatesTo, Either, Instance, Int, List
 
 
@@ -219,33 +218,6 @@ class TestRegression(unittest.TestCase):
 
         # All the counts should be the same.
         self.assertEqual(counts[warmup:-1], counts[warmup + 1 :])
-
-    def test_hastraits_deepcopy(self):
-        # Regression test for enthought/traits#2 and enthought/traits#16
-        from copy import deepcopy
-
-        a = HasTraits()
-        a.add_trait("foo", Int)
-        a.foo = 1
-        with self.assertRaises(TraitError):
-            a.foo = "a"
-        copied_a = deepcopy(a)
-        with self.assertRaises(TraitError):
-            copied_a.foo = "a"
-
-    def test_hastraits_pickle(self):
-        # Regression test for enthought/traits#2 and enthought/traits#16
-        from pickle import dumps, loads
-
-        a = HasTraits()
-        a.add_trait("foo", Int)
-        a.foo = 1
-        with self.assertRaises(TraitError):
-            a.foo = "a"
-        pickled_a = dumps(a)
-        unpickled_a = loads(pickled_a)
-        with self.assertRaises(TraitError):
-            unpickled_a.foo = "a"
 
     @unittest.skipUnless(numpy_available, "test requires NumPy")
     def test_exception_from_numpy_comparison_ignored(self):


### PR DESCRIPTION
#373 made instance traits (not `Instance` traits![*]) pickleable. While the aim was a good one, the change introduced a variety of unintended consequences and breakages, so I'm reverting it here. We may be able to do it again properly one day.

The main issues are:

1. Pickling instance traits requires that the corresponding `TraitType` objects are pickleable (whereas for class-level traits, we only need to pickle the trait values). Many `TraitType` objects currently _aren't_ pickleable, especially in Python 2. That could certainly be fixed: see #457 for some work in that direction, but there's much more to do.

2. Even in the absence of use of `add_trait` (which is relatively rare in most Traits projects), the `_instance_traits` dictionary has entries added to it whenever a listener is attached to a class trait on a `HasTraits` object: the instance trait acts as the place to register listeners that are specific to that instance. This meant that #373 resulted in attempts to pickle various (as it turns out unpickleable) class-level traits, breaking existing code. This again, could be fixed, at the cost of some work and some restructuring.

Point 2 is what causes the unexpected breakage of previously working code.

I'll re-open the various issues that were closed by #373.

[*] Not "Instance" traits! This issue is about traits added directly to an object (e.g., with `HasTraits.add_trait`), as opposed to traits declared at class level.

Closes #452