### PR TITLE
Test fix: skip test that requires Traits UI if Traits UI is not available.

### DIFF
--- a/traits/tests/test_file.py
+++ b/traits/tests/test_file.py
@@ -3,6 +3,12 @@ import unittest
 
 import six
 
+try:
+    import traitsui
+    HAS_TRAITSUI = True
+except ImportError:
+    HAS_TRAITSUI = False
+
 from traits.api import File, HasTraits, TraitError
 
 
@@ -51,6 +57,8 @@ class FileTestCase(unittest.TestCase):
 
 
 class TestCreateEditor(unittest.TestCase):
+
+    @unittest.skipUnless(HAS_TRAITSUI, "This test needs traitsui")
     def test_exists_controls_editor_dialog_style(self):
         x = File(exists=True)
         editor = x.create_editor()


### PR DESCRIPTION
This adds a `skipUnless` to a test that requires Traits UI, to ensure that that test doesn't fail if Traits UI is not installed.