### PR TITLE
Add missing changelog entries for #466 and #467.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Enhancements
 
 * Make UUID trait initializable. (#459)
 * Change default ``FileEditor`` behavior for a ``File`` trait based on
-  whether ``exists=True`` is specified for that trait. (#451)
+  whether ``exists=True`` is specified for that trait. (#451, #467)
 
 Changes
 
@@ -37,6 +37,8 @@ Miscellaneous
 * Code cleanups: remove "EOF" markers from code. Remove ``__main__`` blocks
   for unit tests. Remove imports of ``unittest`` from ``unittest_tools``.
   (#448, #446)
+* Update Travis CI and Appveyor configurations to run tests against
+  all PR branches, not just PRs against master. (#466)
 
 
 Release 5.0.0


### PR DESCRIPTION
#467 was merged to the release branch without a changelog entry (but can be folded into the entry for #451, since there hasn't been a release since #451); #466 should have been included in the earlier changelog update #465.