### PR TITLE
Test packages from source using cron jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
   - edm install -y wheel click coverage
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME} || exit
+  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]], then edm run -- python etstool.py install --runtime=${RUNTIME} --source || exit; fi
 script:
   - edm run -- python etstool.py test --runtime=${RUNTIME} || exit
   - edm run -- python etstool.py docs --runtime=${RUNTIME} || exit

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - edm install -y wheel click coverage
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME} || exit
-  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]], then edm run -- python etstool.py install --runtime=${RUNTIME} --source || exit; fi
+  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then edm run -- python etstool.py install --runtime=${RUNTIME} --source || exit; fi
 script:
   - edm run -- python etstool.py test --runtime=${RUNTIME} || exit
   - edm run -- python etstool.py docs --runtime=${RUNTIME} || exit


### PR DESCRIPTION
- update travis config to handle cron jobs, using the `TRAVIS_EVENT_TYPE` environment variable. See https://docs.travis-ci.com/user/cron-jobs/ for more info.
- update the `install` command to install packages from source, specifically github, when a specific flag is passed to the command `--source`.

Together, we will not be able to test the traits package regularly using the master branches of dependencies e.g. `traitsui`.

Note that the cron job itself will need to be added manually from the settings pane of the travis project page.