### PR TITLE
Fix Travis CI configuration for Xenial rollout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: generic
+dist: xenial
+services:
+  - xvfb
 
 env:
   global:
@@ -16,7 +19,6 @@ matrix:
       env: RUNTIME=3.5
     - os: osx
       env: RUNTIME=3.6
-  fast_finish: true
 
 cache:
   directories:
@@ -24,8 +26,6 @@ cache:
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"
-  - export DISPLAY=:99.0
-  - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start; fi
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
@@ -39,7 +39,3 @@ after_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov
   - edm run -- codecov
-
-notifications:
-  email:
-    - travis-ci@enthought.com


### PR DESCRIPTION
Update the way the framebuffer is started to be compatible with Ubuntu Xenial.

Also tweaks a couple of other Travis CI settings along the way:
- don't fail fast
- don't send notifications to an email address that no-one listens to

cf: enthought/envisage#159