### PR TITLE
Fix inadvertent modification of the Category base class.

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1347,6 +1347,13 @@ class HasTraits(CHasTraits):
         # Update the class and each of the existing subclasses:
         for subclass in [cls] + cls.trait_subclasses(True):
 
+            # The list of subclasses may include other Category
+            # subclasses. Those don't have the full complement of
+            # special dictionary attributes (ClassTraits and friends),
+            # so we shouldn't update them.
+            if BaseTraits not in subclass.__dict__:
+                continue
+
             # Merge the 'base_traits':
             subclass_traits = getattr(subclass, BaseTraits)
             for name, value in base_traits.items():

--- a/traits/tests/test_category.py
+++ b/traits/tests/test_category.py
@@ -104,3 +104,20 @@ class CategoryTestCase(unittest.TestCase):
         except SystemError:
             pass
         return
+
+    def test_subclasses_dont_modify_category_base_class(self):
+        # Regression test for enthought/traits#507
+        from traits.api import Category, HasTraits, Str
+
+        self.assertFalse(Category.__class_traits__)
+
+        class A(HasTraits):
+            a = Str()
+
+        class B(Category, A):
+            b = Str()
+
+        class C(Category, A):
+            c = Str()
+
+        self.assertFalse(Category.__class_traits__)

--- a/traits/tests/test_category.py
+++ b/traits/tests/test_category.py
@@ -106,9 +106,7 @@ class CategoryTestCase(unittest.TestCase):
         return
 
     def test_subclasses_dont_modify_category_base_class(self):
-        # Regression test for enthought/traits#507
-        from traits.api import Category, HasTraits, Str
-
+        # Regression test for enthought/traits#507.
         self.assertEqual(Category.__class_traits__, {})
 
         class A(HasTraits):

--- a/traits/tests/test_category.py
+++ b/traits/tests/test_category.py
@@ -109,7 +109,7 @@ class CategoryTestCase(unittest.TestCase):
         # Regression test for enthought/traits#507
         from traits.api import Category, HasTraits, Str
 
-        self.assertFalse(Category.__class_traits__)
+        self.assertEqual(Category.__class_traits__, {})
 
         class A(HasTraits):
             a = Str()
@@ -120,4 +120,4 @@ class CategoryTestCase(unittest.TestCase):
         class C(Category, A):
             c = Str()
 
-        self.assertFalse(Category.__class_traits__)
+        self.assertEqual(Category.__class_traits__, {})


### PR DESCRIPTION
A second Category extension of a HasTraits subclass caused `Category` itself to be modified. This PR fixes that issue and provides a regression test.

Fixes #507.