### PR TITLE
Click.option-s should have help text

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -77,9 +77,10 @@ import glob
 import os
 import subprocess
 import sys
-from shutil import rmtree, copy as copyfile
-from tempfile import mkdtemp
 from contextlib import contextmanager
+from shutil import copy as copyfile
+from shutil import rmtree
+from tempfile import mkdtemp
 
 import click
 
@@ -130,7 +131,7 @@ runtime_option = click.option(
 
 @cli.command()
 @runtime_option
-@click.option('--environment', default=None)
+@click.option('--environment', default=None, help='Name of the EDM environment to install')
 @click.option('--docs/--no-docs', default=True)
 @click.option('--source/--no-source', default=False)
 def install(runtime, environment, docs, source):
@@ -180,7 +181,7 @@ def install(runtime, environment, docs, source):
 
 @cli.command()
 @runtime_option
-@click.option('--environment', default=None)
+@click.option('--environment', default=None, help='Name of EDM environment to test.')
 def test(runtime, environment):
     """ Run the test suite in a given environment.
 
@@ -211,7 +212,7 @@ def test(runtime, environment):
 
 @cli.command()
 @runtime_option
-@click.option('--environment', default=None)
+@click.option('--environment', default=None, help='Name of EDM environment to build docs for.')
 def docs(runtime, environment):
     """ Build the html documentation.
 
@@ -227,7 +228,7 @@ def docs(runtime, environment):
 
 @cli.command()
 @runtime_option
-@click.option('--environment', default=None)
+@click.option('--environment', default=None, help='Name of EDM environment to remove.')
 def cleanup(runtime, environment):
     """ Remove a development environment.
 
@@ -259,7 +260,7 @@ def test_clean(runtime):
 
 @cli.command()
 @runtime_option
-@click.option('--environment', default=None)
+@click.option('--environment', default=None, help='Name of EDM environment to update.')
 def update(runtime, environment):
     """ Update/Reinstall package into environment.
 

--- a/etstool.py
+++ b/etstool.py
@@ -77,10 +77,9 @@ import glob
 import os
 import subprocess
 import sys
-from contextlib import contextmanager
-from shutil import copy as copyfile
-from shutil import rmtree
+from shutil import copy as copyfile, rmtree
 from tempfile import mkdtemp
+from contextlib import contextmanager
 
 import click
 

--- a/etstool.py
+++ b/etstool.py
@@ -77,7 +77,7 @@ import glob
 import os
 import subprocess
 import sys
-from shutil import copy as copyfile, rmtree
+from shutil import rmtree, copy as copyfile
 from tempfile import mkdtemp
 from contextlib import contextmanager
 


### PR DESCRIPTION
## What?
Add `help` text to click.option

## Why?
Click.option should ideally have a `help` text defined to be useful.
