### PR TITLE
Fix: remove EDM-installed traits before installing from source.

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -144,10 +144,14 @@ def install(runtime, environment, docs, source):
     if runtime.startswith("2."):
         dependencies.update(python2_dependencies)
     packages = ' '.join(dependencies)
-    # edm commands to setup the development environment
+
+    # EDM commands to setup the development environment. The installation
+    # of TraitsUI from EDM installs Traits as a dependency, so we need
+    # to explicitly uninstall it before re-installing from source.
     commands = [
         "edm environments create {environment} --force --version={runtime}",
         "edm install -y -e {environment} " + packages,
+        "edm plumbing remove-package -e {environment} traits",
         "edm run -e {environment} -- python -m pip install --no-deps .",
     ]
     click.echo("Creating environment '{environment}'".format(**parameters))


### PR DESCRIPTION
`python etstool.py install` installs Traits from EDM (as a dependency of Traits UI), but doesn't uninstall it before `pip install`ing Traits from source. The result is that `site-packages/traits` ends up holding the contents of both the released and the new version of Traits. (It's a bit worrying/surprising to me that the `pip install` doesn't warn, or fail entirely.) The problem became visible when manually testing #515: we were ending up with both a `version.py` _and_ a `_version.py` file in the installed environment.

This PR fixes that.