### PR TITLE
Remove redefinition of NullHandler

### DIFF
--- a/traits/__init__.py
+++ b/traits/__init__.py
@@ -15,6 +15,6 @@ except ImportError:
 # Add a NullHandler so 'traits' loggers don't complain when they get used.
 import logging
 
-logging.getLogger("traits").addHandler(logging.NullHandler())
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 del logging

--- a/traits/__init__.py
+++ b/traits/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2008-2019 by Enthought, Inc.
+# All rights reserved.
+
 from __future__ import absolute_import
 
 try:
@@ -12,19 +15,6 @@ except ImportError:
 # Add a NullHandler so 'traits' loggers don't complain when they get used.
 import logging
 
+logging.getLogger("traits").addHandler(logging.NullHandler())
 
-class NullHandler(logging.Handler):
-    def handle(self, record):
-        pass
-
-    def emit(self, record):
-        pass
-
-    def createLock(self):
-        self.lock = None
-
-
-logger = logging.getLogger(__name__)
-logger.addHandler(NullHandler())
-
-del logging, logger, NullHandler
+del logging


### PR DESCRIPTION
Some cleanups to the top-level `__init__.py`:

- `NullHandler` is in the standard library since Python 2.7, and we don't support Python 2.6. Remove the redefinition and use the std. lib. version
- Add copyright header.