### PR TITLE
Make git commit hash available to archives.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# For archives, substitute the commit hash in the setup.py file.
+/setup.py export-subst

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ MICRO = 0
 IS_RELEASED = False
 
 # If this file is part of a Git export (for example created with "git archive",
-# or downloaded from GitHub), then ARCHIVE_COMMIT gives the commit that
-# was exported.
-ARCHIVE_COMMIT = "$Format:%H$"
+# or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the
+# commit that was exported.
+ARCHIVE_COMMIT_HASH = "$Format:%H$"
 
 # Templates for version strings.
 RELEASED_VERSION = u"{major}.{minor}.{micro}"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,11 @@ MINOR = 2
 MICRO = 0
 IS_RELEASED = False
 
+# If this file is part of a Git export (for example created with "git archive",
+# or downloaded from GitHub), then ARCHIVE_COMMIT gives the commit that
+# was exported.
+ARCHIVE_COMMIT = "$Format:%H$"
+
 # Templates for version strings.
 RELEASED_VERSION = u"{major}.{minor}.{micro}"
 UNRELEASED_VERSION = u"{major}.{minor}.{micro}.dev{dev}"


### PR DESCRIPTION
This PR adds the necessary Git magic to make it possible to retrieve the commit that an archive was generated from. This could help support building directly from a GitHub download.

Related: #515, enthought/envisage#190.