### PR TITLE
Support installation from source archives

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,31 @@ def git_version():
     )
     return version, git_revision
 
+def archive_version():
+    """
+    Construct version information for an archive.
+
+    Returns
+    -------
+    version : unicode
+        Package version.
+    git_revision : unicode
+        The full commit hash for the current Git revision.
+
+    Raises
+    ------
+    ValueError
+        If this does not appear to be an archive.
+    """
+    if "$" in ARCHIVE_COMMIT_HASH:
+        raise ValueError("This does not appear to be an archive.")
+
+    version_template = RELEASED_VERSION if IS_RELEASED else UNRELEASED_VERSION
+    version = version_template.format(
+        major=MAJOR, minor=MINOR, micro=MICRO, dev="-unknown"
+    )
+    return version, ARCHIVE_COMMIT_HASH
+
 
 def resolve_version():
     """
@@ -182,6 +207,12 @@ def resolve_version():
         # it to the version file, overwriting any existing information.
         version = git_version()
         print(u"Computed package version: {}".format(version))
+        print(u"Writing version to version file {}.".format(VERSION_FILE))
+        write_version_file(*version)
+    elif "$" not in ARCHIVE_COMMIT_HASH:
+        # This is a source archive.
+        version = archive_version()
+        print(u"Archive package version: {}".format(version))
         print(u"Writing version to version file {}.".format(VERSION_FILE))
         write_version_file(*version)
     elif os.path.isfile(VERSION_FILE):


### PR DESCRIPTION
Previously, if a user tried installing traits from a source archive, the setup script would raise an error as it wont find a version file and it wont find a git source tree.

This PR adds support for local installation from source archives. It use the version information and archive info from setup.py (see PR #526 ) when generating version file for a source archive e.g. a git download archive

Note that the version number for an installation from source for an unreleased version will be of the form "a.b.c.dev-unknown" as the setup machinery will not be able to infer the rev list count to calculate the approriate dev number. Note that the git revision is still preserved to help debug any issues with such installations.

Note that these changes are borrowed from similar work in envisage.