### PR TITLE
Fix deprecated collections.MutableMapping import 

### DIFF
--- a/traits/util/weakiddict.py
+++ b/traits/util/weakiddict.py
@@ -10,6 +10,9 @@ bothered to make these dicts robust to that case.
 """
 
 try:
+    # Collections Abstract Base Classes was moved to the collections.abc 
+    # module in python 3.3
+    # This try expect block can be removed when python 2 support is dropped.
     from collections.abc import MutableMapping
 except ImportError:
     from collections import MutableMapping

--- a/traits/util/weakiddict.py
+++ b/traits/util/weakiddict.py
@@ -9,7 +9,11 @@ the iteration. As this is not a common use for such caches, we have not
 bothered to make these dicts robust to that case.
 """
 
-import collections
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+
 from weakref import ref
 
 
@@ -22,7 +26,7 @@ def _remover(key_id, id_dict_ref):
     return callback
 
 
-class WeakIDDict(collections.MutableMapping):
+class WeakIDDict(MutableMapping):
     """ A weak-key-value dictionary that uses the id() of the key for
     comparisons.
     """


### PR DESCRIPTION
This is deprecated since python 3.3, see https://docs.python.org/3.7/library/collections.html and will be remove in python 3.8.

It also removes the following warning:
```
  /opt/miniconda3/lib/python3.7/site-packages/traits/util/weakiddict.py:25: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    class WeakIDDict(collections.MutableMapping):
```
