### PR TITLE
Adjust slice calculation for sync trait items

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2949,7 +2949,7 @@ class HasTraits(CHasTraits):
         del locked[name]
 
     def _sync_trait_items_modified(self, object, name, old, event):
-        n0 = event.index
+        n0 = 0 if event.index is None else event.index
         n1 = n0 + len(event.removed)
         name = name[:-6]
         info = self.__sync_trait__

--- a/traits/tests/test_sync_traits.py
+++ b/traits/tests/test_sync_traits.py
@@ -128,6 +128,33 @@ class TestSyncTraits(unittest.TestCase, UnittestTools):
         with self.assertTraitDoesNotChange(a, "l"):
             b.l = [7, 8]
 
+    def test_sync_lists_partial_slice(self):
+        """ Test synchronization of list traits when there is a partial slice.
+
+        Regression test for enthought/traits#540
+        """
+
+        a = A()
+        b = B()
+
+        a.sync_trait("l", b)
+
+        # Change entire list.
+        a.l = [1, 2, 3]
+        self.assertEqual(a.l, b.l)
+        b.l = [4, 5]
+        self.assertEqual(a.l, b.l)
+
+        # Change list items with an empty slice.
+        with self.assertTraitChanges(b, "l_items"):
+            a.l[:] = [7]
+        self.assertEqual(b.l, [7])
+
+        # Change list items with a partial slice.
+        with self.assertTraitChanges(b, "l_items"):
+            a.l[:0] = [6]
+        self.assertEqual(b.l, [6, 7])
+
     def test_sync_delete(self):
         """ Test that deleting a synchronized trait works.
         """


### PR DESCRIPTION
Mistakenly merged #541 without looking at what repo I was on...

Closes #540 

The logic for computing the slice for a synced list trait when it was a partial slice was a little broke.

Small adjustment to assume if `event.index == None`, the slice starts at the first index, `0`.