### PR TITLE
Ensure TraitListEvent.index is always an integer

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2949,7 +2949,7 @@ class HasTraits(CHasTraits):
         del locked[name]
 
     def _sync_trait_items_modified(self, object, name, old, event):
-        n0 = event.index
+        n0 = 0 if event.index is None else event.index
         n1 = n0 + len(event.removed)
         name = name[:-6]
         info = self.__sync_trait__

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2949,7 +2949,7 @@ class HasTraits(CHasTraits):
         del locked[name]
 
     def _sync_trait_items_modified(self, object, name, old, event):
-        n0 = 0 if event.index is None else event.index
+        n0 = event.index
         n1 = n0 + len(event.removed)
         name = name[:-6]
         info = self.__sync_trait__

--- a/traits/tests/test_sync_traits.py
+++ b/traits/tests/test_sync_traits.py
@@ -128,6 +128,33 @@ class TestSyncTraits(unittest.TestCase, UnittestTools):
         with self.assertTraitDoesNotChange(a, "l"):
             b.l = [7, 8]
 
+    def test_sync_lists_partial_slice(self):
+        """ Test synchronization of list traits when there is a partial slice.
+
+        Regression test for enthought/traits#540
+        """
+
+        a = A()
+        b = B()
+
+        a.sync_trait("l", b)
+
+        # Change entire list.
+        a.l = [1, 2, 3]
+        self.assertEqual(a.l, b.l)
+        b.l = [4, 5]
+        self.assertEqual(a.l, b.l)
+
+        # Change list items with an empty slice.
+        with self.assertTraitChanges(b, "l_items"):
+            a.l[:] = [7]
+        self.assertEqual(b.l, [7])
+
+        # Change list items with a partial slice.
+        with self.assertTraitChanges(b, "l_items"):
+            a.l[:0] = [6]
+        self.assertEqual(b.l, [6, 7])
+
     def test_sync_delete(self):
         """ Test that deleting a synchronized trait works.
         """

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -1337,8 +1337,10 @@ class test_list_value(test_base2):
         self.assertLastTraitListEventEqual(3, [], [5])
         self.obj.alist[0:2] = [6, 7]
         self.assertLastTraitListEventEqual(0, [2, 3], [6, 7])
+        self.obj.alist[:2] = [4, 5]
+        self.assertLastTraitListEventEqual(0, [6, 7], [4, 5])
         self.obj.alist[0:2:1] = [8, 9]
-        self.assertLastTraitListEventEqual(0, [6, 7], [8, 9])
+        self.assertLastTraitListEventEqual(0, [4, 5], [8, 9])
         old_event = self.last_event
         self.obj.alist[0:2:1] = [8, 9]
         # If no values changed, no new TraitListEvent will be generated.
@@ -1352,6 +1354,14 @@ class test_list_value(test_base2):
         self.obj.alist = [1, 2, 3, 4]
         del self.obj.alist[2:4]
         self.assertLastTraitListEventEqual(2, [3, 4], [])
+        self.obj.alist[:0] = [5, 6, 7, 8]
+        self.assertLastTraitListEventEqual(0, [], [5, 6, 7, 8])
+        del self.obj.alist[:2]
+        self.assertLastTraitListEventEqual(0, [5, 6], [])
+        del self.obj.alist[0:2]
+        self.assertLastTraitListEventEqual(0, [7, 8], [])
+        del self.obj.alist[:]
+        self.assertLastTraitListEventEqual(0, [1, 2], [])
 
     def _record_trait_list_event(self, object, name, old, new):
         self.last_event = new

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -2537,7 +2537,7 @@ class TraitListObject(list):
                     # In this case, we return a TraitListEvent with an
                     # index=key.start and the removed and added lists as they
                     # are.
-                    index = key.start
+                    index = 0 if key.start is None else key.start
                 else:
                     # Otherwise, we have an extended slice which was handled,
                     # badly, by __setitem__ before. In this case, we return the
@@ -2594,7 +2594,7 @@ class TraitListObject(list):
             if step == 1:
                 # FIXME: See corresponding comment in __setitem__() for
                 # explanation.
-                index = key.start
+                index = 0 if key.start is None else key.start
             else:
                 index = key
                 removed = [removed]


### PR DESCRIPTION
Previously, `myobj.mylist[:2] = new_list` would generate a `TraitListEvent` with `index=None`, while `myobj.mylist[0:2] = new_list` would generate a `TraitListEvent` with `index=0`. This PR changes the `TraitListEvent` creation so that the `index` is `0` in both cases.

This is an extension of @tmreay's PR #545 that keeps the existing test but uses a fix closer to the source of the problem.

Fixes #540.