### PR TITLE
Make sure that all tests are unittest-compatible.

### DIFF
--- a/traits/tests/test_listeners.py
+++ b/traits/tests/test_listeners.py
@@ -83,7 +83,7 @@ class GenerateFailingEvents(HasTraits):
         raise RuntimeError
 
 
-class Test_Listeners(unittest.TestCase):
+class TestListeners(unittest.TestCase):
     def test_listeners(self):
         global events
 

--- a/traits/tests/test_listeners.py
+++ b/traits/tests/test_listeners.py
@@ -84,7 +84,7 @@ class GenerateFailingEvents(HasTraits):
 
 
 class Test_Listeners(unittest.TestCase):
-    def test(self):
+    def test_listeners(self):
         global events
 
         # FIXME: comparing floats

--- a/traits/tests/test_pickle_validated_dict.py
+++ b/traits/tests/test_pickle_validated_dict.py
@@ -26,7 +26,7 @@ class C(HasTraits):
 
 
 class PickleValidatedDictTestCase(unittest.TestCase):
-    def test(self):
+    def test_pickle_validated_dict(self):
 
         # And we must unpickle one
         x = sm.cPickle.dumps(C())

--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -14,6 +14,8 @@
 
 from __future__ import absolute_import, print_function
 
+import unittest
+
 from traits.api import HasTraits, Property
 
 
@@ -56,25 +58,26 @@ def on_anyvalue_changed(value):
     print("on_anyvalue_changed:", value)
 
 
-def test_property_notifications():
-    Test_1().value = "test 1"
-    Test_2().value = "test 2"
-    Test_3().value = "test 3"
+class TestPropertyNotifications(unittest.TestCase):
+    def test_property_notifications(self):
+        Test_1().value = "test 1"
+        Test_2().value = "test 2"
+        Test_3().value = "test 3"
 
-    test_4 = Test()
-    test_4.on_trait_change(on_value_changed, "value")
-    test_4.value = "test 4"
+        test_4 = Test()
+        test_4.on_trait_change(on_value_changed, "value")
+        test_4.value = "test 4"
 
-    test_5 = Test()
-    test_5.on_trait_change(on_anyvalue_changed)
-    test_5.value = "test 5"
+        test_5 = Test()
+        test_5.on_trait_change(on_anyvalue_changed)
+        test_5.value = "test 5"
 
-    test_6 = Test()
-    test_6.on_trait_change(on_value_changed, "value")
-    test_6.on_trait_change(on_anyvalue_changed)
-    test_6.value = "test 6"
+        test_6 = Test()
+        test_6.on_trait_change(on_value_changed, "value")
+        test_6.on_trait_change(on_anyvalue_changed)
+        test_6.value = "test 6"
 
-    test_7 = Test_3()
-    test_7.on_trait_change(on_value_changed, "value")
-    test_7.on_trait_change(on_anyvalue_changed)
-    test_7.value = "test 7"
+        test_7 = Test_3()
+        test_7.on_trait_change(on_value_changed, "value")
+        test_7.on_trait_change(on_anyvalue_changed)
+        test_7.value = "test 7"

--- a/traits/tests/test_trait_list_dict.py
+++ b/traits/tests/test_trait_list_dict.py
@@ -9,6 +9,7 @@ TraitSetObjects.
 from __future__ import absolute_import
 
 import copy
+import unittest
 
 import six.moves as sm
 
@@ -32,113 +33,106 @@ class B(HasTraits):
     dict = Dict(Str, Instance(A))
 
 
-def test_trait_list_object_persists():
-    a = A()
-    list = sm.cPickle.loads(sm.cPickle.dumps(a.alist))
-    assert list.object() is None
-    list.append(10)
-    assert len(a.events) == 0
-    a.alist.append(20)
-    assert len(a.events) == 1
-    list2 = sm.cPickle.loads(sm.cPickle.dumps(list))
-    assert list2.object() is None
+class TestTraitListDictSetPersistence(unittest.TestCase):
+    def test_trait_list_object_persists(self):
+        a = A()
+        list = sm.cPickle.loads(sm.cPickle.dumps(a.alist))
+        self.assertIsNone(list.object())
+        list.append(10)
+        self.assertEqual(len(a.events), 0)
+        a.alist.append(20)
+        self.assertEqual(len(a.events), 1)
+        list2 = sm.cPickle.loads(sm.cPickle.dumps(list))
+        self.assertIsNone(list2.object())
 
+    def test_trait_dict_object_persists(self):
+        a = A()
+        dict = sm.cPickle.loads(sm.cPickle.dumps(a.adict))
+        self.assertIsNone(dict.object())
+        dict["key"] = 10
+        self.assertEqual(len(a.events), 0)
+        a.adict["key"] = 10
+        self.assertEqual(len(a.events), 1)
+        dict2 = sm.cPickle.loads(sm.cPickle.dumps(dict))
+        self.assertIsNone(dict2.object())
 
-def test_trait_dict_object_persists():
-    a = A()
-    dict = sm.cPickle.loads(sm.cPickle.dumps(a.adict))
-    assert dict.object() is None
-    dict["key"] = 10
-    assert len(a.events) == 0
-    a.adict["key"] = 10
-    assert len(a.events) == 1
-    dict2 = sm.cPickle.loads(sm.cPickle.dumps(dict))
-    assert dict2.object() is None
+    def test_trait_set_object_persists(self):
+        a = A()
+        set = sm.cPickle.loads(sm.cPickle.dumps(a.aset))
+        self.assertIsNone(set.object())
+        set.add(10)
+        self.assertEqual(len(a.events), 0)
+        a.aset.add(20)
+        self.assertEqual(len(a.events), 1)
+        set2 = sm.cPickle.loads(sm.cPickle.dumps(set))
+        self.assertIsNone(set2.object())
 
+    def test_trait_list_object_copies(self):
+        a = A()
+        list = copy.deepcopy(a.alist)
+        self.assertIsNone(list.object())
+        list.append(10)
+        self.assertEqual(len(a.events), 0)
+        a.alist.append(20)
+        self.assertEqual(len(a.events), 1)
+        list2 = copy.deepcopy(list)
+        list2.append(30)
+        self.assertIsNone(list2.object())
 
-def test_trait_set_object_persists():
-    a = A()
-    set = sm.cPickle.loads(sm.cPickle.dumps(a.aset))
-    assert set.object() is None
-    set.add(10)
-    assert len(a.events) == 0
-    a.aset.add(20)
-    assert len(a.events) == 1
-    set2 = sm.cPickle.loads(sm.cPickle.dumps(set))
-    assert set2.object() is None
+    def test_trait_dict_object_copies(self):
+        a = A()
+        dict = copy.deepcopy(a.adict)
+        self.assertIsNone(dict.object())
+        dict["key"] = 10
+        self.assertEqual(len(a.events), 0)
+        a.adict["key"] = 10
+        self.assertEqual(len(a.events), 1)
+        dict2 = copy.deepcopy(dict)
+        dict2["key2"] = 20
+        self.assertIsNone(dict2.object())
 
+    def test_trait_set_object_copies(self):
+        a = A()
+        set1 = copy.deepcopy(a.aset)
+        self.assertIsNone(set1.object())
+        set1.add(10)
+        self.assertEqual(len(a.events), 0)
+        a.aset.add(20)
+        self.assertEqual(len(a.events), 1)
+        set2 = copy.deepcopy(set1)
+        set2.add(30)
+        self.assertIsNone(set2.object())
+        set3 = a.aset.copy()
+        self.assertIs(type(set3), set)
+        # Should not raise an AttributeError:
+        set3.remove(20)
 
-def test_trait_list_object_copies():
-    a = A()
-    list = copy.deepcopy(a.alist)
-    assert list.object() is None
-    list.append(10)
-    assert len(a.events) == 0
-    a.alist.append(20)
-    assert len(a.events) == 1
-    list2 = copy.deepcopy(list)
-    list2.append(30)
-    assert list2.object() is None
+    def test_pickle_whole(self):
+        a = A()
+        sm.cPickle.loads(sm.cPickle.dumps(a))
+        b = B(dict=dict(a=a))
+        sm.cPickle.loads(sm.cPickle.dumps(b))
 
+    def test_trait_set_object_operations(self):
+        # Regression test for update methods not coercing in the same way as
+        # standard set objects (github issue #288)
+        a = A()
+        a.aset.update({10: "a"})
+        self.assertEqual(a.aset, set([0, 1, 2, 3, 4, 10]))
+        a.aset.intersection_update({3: "b", 4: "b", 10: "a", 11: "b"})
+        self.assertEqual(a.aset, set([3, 4, 10]))
+        a.aset.difference_update({10: "a", 11: "b"})
+        self.assertEqual(a.aset, set([3, 4]))
+        a.aset.symmetric_difference_update({10: "a", 4: "b"})
+        self.assertEqual(a.aset, set([3, 10]))
 
-def test_trait_dict_object_copies():
-    a = A()
-    dict = copy.deepcopy(a.adict)
-    assert dict.object() is None
-    dict["key"] = 10
-    assert len(a.events) == 0
-    a.adict["key"] = 10
-    assert len(a.events) == 1
-    dict2 = copy.deepcopy(dict)
-    dict2["key2"] = 20
-    assert dict2.object() is None
-
-
-def test_trait_set_object_copies():
-    a = A()
-    set1 = copy.deepcopy(a.aset)
-    assert set1.object() is None
-    set1.add(10)
-    assert len(a.events) == 0
-    a.aset.add(20)
-    assert len(a.events) == 1
-    set2 = copy.deepcopy(set1)
-    set2.add(30)
-    assert set2.object() is None
-    set3 = a.aset.copy()
-    assert type(set3) is set
-    # Should not raise an AttributeError:
-    set3.remove(20)
-
-
-def test_pickle_whole():
-    a = A()
-    sm.cPickle.loads(sm.cPickle.dumps(a))
-    b = B(dict=dict(a=a))
-    sm.cPickle.loads(sm.cPickle.dumps(b))
-
-
-def test_trait_set_object_operations():
-    # Regression test for update methods not coercing in the same way as
-    # standard set objects (github issue #288)
-    a = A()
-    a.aset.update({10: "a"})
-    assert a.aset == set([0, 1, 2, 3, 4, 10])
-    a.aset.intersection_update({3: "b", 4: "b", 10: "a", 11: "b"})
-    assert a.aset == set([3, 4, 10])
-    a.aset.difference_update({10: "a", 11: "b"})
-    assert a.aset == set([3, 4])
-    a.aset.symmetric_difference_update({10: "a", 4: "b"})
-    assert a.aset == set([3, 10])
-
-
-def test_trait_set_object_inplace():
-    a = A()
-    a.aset |= set([10])
-    assert a.aset == set([0, 1, 2, 3, 4, 10])
-    a.aset &= set([3, 4, 10, 11])
-    assert a.aset == set([3, 4, 10])
-    a.aset -= set([10, 11])
-    assert a.aset == set([3, 4])
-    a.aset ^= set([10, 4])
-    assert a.aset == set([3, 10])
+    def test_trait_set_object_inplace(self):
+        a = A()
+        a.aset |= set([10])
+        self.assertEqual(a.aset, set([0, 1, 2, 3, 4, 10]))
+        a.aset &= set([3, 4, 10, 11])
+        self.assertEqual(a.aset, set([3, 4, 10]))
+        a.aset -= set([10, 11])
+        self.assertEqual(a.aset, set([3, 4]))
+        a.aset ^= set([10, 4])
+        self.assertEqual(a.aset, set([3, 10]))

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -111,7 +111,7 @@ class TestTraitDocumenter(unittest.TestCase):
 
     def test_abbreviated_annotations(self):
         # Regression test for enthought/traits#493.
-        with self.create_test_directive() as directive:
+        with self.create_directive() as directive:
             documenter = TraitDocumenter(
                 directive, __name__ + ".MyTestClass.bar")
             documenter.generate(all_members=True)
@@ -129,7 +129,7 @@ class TestTraitDocumenter(unittest.TestCase):
         self.assertNotIn("\n", item)
 
     @contextlib.contextmanager
-    def create_test_directive(self):
+    def create_directive(self):
         """
         Helper function to create a a "directive" suitable
         for instantiating the TraitDocumenter with, along with resources


### PR DESCRIPTION
This PR is preparation for changing the continuous integration to use unittest instead of nose.

We had only a handful of nose-style tests (i.e., tests not based on `TestCase`); this PR changes those to use unit test, and makes some minor renames to avoid some not-tests being picked up by nosetests.

With these changes, I see exactly 569 tests on master, with both `nosetests` and `unittest discover`.

And yes, some of these tests are horrible and in need of more work. But not in this PR.