### PR TITLE
Use unittest to run tests in continuous integration

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -232,7 +232,8 @@ def test(edm, runtime, environment):
     environ["PYTHONUNBUFFERED"] = "1"
 
     commands = [
-        "{edm} run -e {environment} -- coverage run -p -m unittest discover -v traits"
+        "{edm} run -e {environment} -- "
+        "coverage run -p -m unittest discover -v traits"
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traits

--- a/etstool.py
+++ b/etstool.py
@@ -88,7 +88,6 @@ common_dependencies = {
     "coverage",
     "cython",
     "enthought_sphinx_theme",
-    "nose",
     "numpy",
     "pyqt",
     "Sphinx",
@@ -233,8 +232,7 @@ def test(edm, runtime, environment):
     environ["PYTHONUNBUFFERED"] = "1"
 
     commands = [
-        "{edm} run -e {environment} -- coverage run -p -m nose.core -v traits "
-        "--nologcapture"
+        "{edm} run -e {environment} -- coverage run -p -m unittest discover -v traits"
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traits

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-envlist = py{26,27,33,34,35}
-
-[testenv]
-deps = -rtravis-ci-requirements.txt
-
-changedir = .tox
-commands = python -m nose.core -v traits

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -93,8 +93,7 @@ class test_base2(unittest.TestCase):
         list[index1:index2:step] = value
 
     # This avoids using a method name that contains 'test' so that this is not
-    # called by the tester directly, as nose looks for all tests, regardless of
-    # the handler at the bottom of this file.
+    # called by the tester directly.
     def check_values(
         self,
         name,


### PR DESCRIPTION
This PR switches the test runner used by etstool.py from `nosetests` to `unittest discover`. It also removes some other spurious or outdated occurrences of `nose` from the codebase and removes a non-working `tox.ini`.