### PR TITLE
Clean up test output

### DIFF
--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -1,7 +1,5 @@
 """ Tests the 'ETSConfig' configuration object. """
 
-from __future__ import print_function
-
 # Standard library imports.
 import contextlib
 import os
@@ -258,7 +256,7 @@ class ETSConfigTestCase(unittest.TestCase):
 
         with mock_sys_argv(test_args):
             with mock_os_environ(test_environ):
-                print(repr(self.ETSConfig.toolkit))
+                repr(self.ETSConfig.toolkit)
                 with self.ETSConfig.provisional_toolkit("test_direct"):
                     toolkit = self.ETSConfig.toolkit
                     self.assertEqual(toolkit, "test_direct")

--- a/traits/testing/tests/test_unittest_tools.py
+++ b/traits/testing/tests/test_unittest_tools.py
@@ -405,12 +405,15 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
         def old_and_dull_caller():
             old_and_dull()
 
-        # Pollute the registry by pre-calling the function.
-        old_and_dull_caller()
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always", DeprecationWarning)
 
-        # Check that we can still detect the DeprecationWarning.
-        with self.assertDeprecated():
+            # Pollute the registry by pre-calling the function.
             old_and_dull_caller()
+
+            # Check that we can still detect the DeprecationWarning.
+            with self.assertDeprecated():
+                old_and_dull_caller()
 
     def test_assert_not_deprecated_failures(self):
         with self.assertRaises(self.failureException):
@@ -430,10 +433,13 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
         def old_and_dull_caller():
             old_and_dull()
 
-        # Pollute the registry by pre-calling the function.
-        old_and_dull_caller()
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always", DeprecationWarning)
 
-        # Check that we can still detect the DeprecationWarning.
-        with self.assertRaises(self.failureException):
-            with self.assertNotDeprecated():
-                old_and_dull_caller()
+            # Pollute the registry by pre-calling the function.
+            old_and_dull_caller()
+
+            # Check that we can still detect the DeprecationWarning.
+            with self.assertRaises(self.failureException):
+                with self.assertNotDeprecated():
+                    old_and_dull_caller()

--- a/traits/tests/test_category.py
+++ b/traits/tests/test_category.py
@@ -89,7 +89,7 @@ class CategoryTestCase(unittest.TestCase):
         Seems like the declaration of the subclass (BasePlusPlus) should fail.
         """
         try:
-            x = self.base.pp
+            self.base.pp
             self.fail(
                 msg="base.pp should have thrown AttributeError "
                 "as Category subclassing is not supported."
@@ -97,7 +97,7 @@ class CategoryTestCase(unittest.TestCase):
         except AttributeError:
             pass
 
-        basepp = BasePlusPlus()
+        BasePlusPlus()
         return
 
     def test_subclass_instance_category(self):
@@ -130,10 +130,13 @@ class CategoryTestCase(unittest.TestCase):
         class A(HasTraits):
             a = Str()
 
-        class B(Category, A):
-            b = Str()
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always", DeprecationWarning)
 
-        class C(Category, A):
-            c = Str()
+            class B(Category, A):
+                b = Str()
+
+            class C(Category, A):
+                c = Str()
 
         self.assertEqual(Category.__class_traits__, {})


### PR DESCRIPTION
Silence warnings and remove a `print` in a test.