### PR TITLE
Clean up Cython tests

### DIFF
--- a/traits/tests/test_cythonized_traits.py
+++ b/traits/tests/test_cythonized_traits.py
@@ -32,12 +32,7 @@ class Test(HasTraits):
 return Test()
 """
 
-        obj = cython.inline(
-            code,
-            force=True,
-            language_level="3",
-        )
-
+        obj = self.execute(code)
         self.assertEqual(obj.name, "Joe")
 
     def test_basic_events(self):
@@ -51,12 +46,7 @@ class Test(HasTraits):
 return Test()
 """
 
-        obj = cython.inline(
-            code,
-            force=True,
-            language_level="3",
-        )
-
+        obj = self.execute(code)
         with self.assertTraitChanges(obj, "name", count=1):
             obj.name = "changing_name"
 
@@ -75,12 +65,7 @@ class Test(HasTraits):
 return Test()
 """
 
-        obj = cython.inline(
-            code,
-            force=True,
-            language_level="3",
-        )
-
+        obj = self.execute(code)
         with self.assertTraitChanges(obj, "value", count=1):
             obj.name = "changing_name"
 
@@ -102,12 +87,7 @@ class Test(HasTraits):
 return Test()
 """
 
-        obj = cython.inline(
-            code,
-            force=True,
-            language_level="3",
-        )
-
+        obj = self.execute(code)
         with self.assertTraitChanges(obj, "value", count=1):
             obj.name = "changing_name"
 
@@ -129,12 +109,7 @@ class Test(HasTraits):
 return Test()
 """
 
-        obj = cython.inline(
-            code,
-            force=True,
-            language_level="3",
-        )
-
+        obj = self.execute(code)
         self.assertEqual(obj.name_len, len(obj.name))
 
         # Assert dependency works
@@ -158,12 +133,7 @@ class Test(HasTraits):
 return Test()
 """
 
-        obj = cython.inline(
-            code,
-            force=True,
-            language_level="3",
-        )
-
+        obj = self.execute(code)
         self.assertEqual(obj.name_len, len(obj.name))
 
         # Assert dependency works
@@ -191,12 +161,7 @@ class Test(HasTraits):
 return Test()
 """
 
-        obj = cython.inline(
-            code,
-            force=True,
-            language_level="3",
-        )
-
+        obj = self.execute(code)
         self.assertEqual(obj.funky_name, obj.name)
 
         # Assert dependency works
@@ -222,53 +187,20 @@ class Test(HasTraits):
 return Test()
 """
 
-        obj = cython.inline(
-            code,
-            force=True,
-            language_level="3",
-        )
-
+        obj = self.execute(code)
         self.assertEqual(obj.funky_name, obj.name)
 
         # Assert dependency works
         obj.name = "Bob"
         self.assertEqual(obj.funky_name, obj.name)
 
-    def test_on_trait_lambda_failure(self):
-
-        # Lambda function are converted like builtins when cythonized which
-        # causes the following code to fail
-
-        code = """
-from traits.api import HasTraits, Str, Int, Property
-
-def Alias(name):
-    return Property(
-        lambda obj: getattr(obj, name),
-        lambda obj, value: setattr(obj, name, value)
-    )
-
-class Test(HasTraits):
-    name = Str
-
-    funky_name = Alias('name')
-
-return Test()
-"""
-
-        try:
-            cython.inline(
-                code,
-                force=True,
-                language_level="3",
-            )
-        except:
-            # We suppose we have an exception. Because of the usage of the
-            # skipIf decorator on the test, we can't use an expectedFailure
-            # decorator as they don't play well together.
-            pass
-        else:
-            self.fail(
-                "Unexpected results. Cython was not managing lambda as regular"
-                " functions. Behaviour changed ..."
-            )
+    def execute(self, code):
+        """
+        Helper function to execute the given code under cython.inline and
+        return the result.
+        """
+        return cython.inline(
+            code,
+            force=True,
+            language_level="3",
+        )

--- a/traits/tests/test_cythonized_traits.py
+++ b/traits/tests/test_cythonized_traits.py
@@ -10,13 +10,28 @@ properly.
 The tests need a Cython version > 0.19 and a compiler.
 
 """
+import sys
 import unittest
 
+import six
+
 from traits.testing.unittest_tools import UnittestTools
-from traits.testing.optional_dependencies import cython, requires_cython
+from traits.testing.optional_dependencies import cython
+
+if cython is None:
+    skip_reason = "Cython is not installed"
+elif sys.platform == "win32" and six.PY2:
+    # Tests are failing for undiagnosed reasons on Windows / Python 2.7.
+    # Ref: enthought/traits#557.
+    skip_reason = (
+        "Compilation issues with Windows / Python 2.7. "
+        "See enthought/traits#557"
+    )
+else:
+    skip_reason = None
 
 
-@requires_cython
+@unittest.skipIf(skip_reason, skip_reason)
 class CythonizedTraitsTestCase(unittest.TestCase, UnittestTools):
     def test_simple_default_methods(self):
 

--- a/traits/tests/test_cythonized_traits.py
+++ b/traits/tests/test_cythonized_traits.py
@@ -135,7 +135,6 @@ return Test()
 
         code = """
 from traits.api import HasTraits, Str, Int, Property
-from traits.api import Unicode
 
 class Test(HasTraits):
     name = Str


### PR DESCRIPTION
Somewhat experimental PR to clean up the Cython tests:

- Cythonize with "language_level=3" to suppress warnings from Cython in the test output. (There's still an unreachable code warning from the compiler; there doesn't appear to be much we can do about that.)
- Factor out common code.
- Don't test whether Cython is usable in order to decide whether to skip tests: assume that if Cython is installed, then it's usable. This removes an import-time side-effect and simplifies the code.
- Remove a test that was designed solely to record an existing failing case; I've turned that into an issue instead (see #554).