### PR TITLE
Build update: don't finish fast.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,6 @@ environment:
     - RUNTIME: '3.5'
     - RUNTIME: '3.6'
 
-matrix:
-  fast_finish: true
-
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt
   - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt


### PR DESCRIPTION
The "finish fast" setting is unhelpful: we sometimes still want to know whether things work on Python 3.5 / 3.6 even if the 2.7 job has failed.