### PR TITLE
DOC: Don't autogenerate documentation for ViewElement

### DIFF
--- a/docs/source/traits_api_reference/has_traits.rst
+++ b/docs/source/traits_api_reference/has_traits.rst
@@ -7,8 +7,6 @@
 Classes
 -------
 
-.. autoclass:: ViewElement
-
 .. autoclass:: MetaHasTraits
 
 .. autoclass:: MetaInterface


### PR DESCRIPTION
`ViewElement` comes from TraitsUI, not Traits. It should be documented there. (It looks as though that's not currently the case; I'll open a separate issue in TraitsUI.)

This autodoc entry was causing some of the TraitsUI source to be included in the Traits documentation.

Fixes #492.