### PR TITLE
Update to EDM 2.0.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 env:
   global:
-    - INSTALL_EDM_VERSION=1.10.0
+    - INSTALL_EDM_VERSION=2.0.0
       PYTHONUNBUFFERED="1"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,7 @@ environment:
 
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "1.9.2"
-    # We're having trouble setting up EDM 1.10.0.
-    # See PR #420 for details.
+    INSTALL_EDM_VERSION: "2.0.0"
 
   matrix:
 
@@ -18,7 +16,7 @@ cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt
 
 init:
-  - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
+  - ps: $Env:path = "C:/Enthought/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ cache:
   - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt
 
 init:
-  - ps: $Env:path = "C:/Enthought/Enthought/edm;" + $Env:path
+  - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
 
 install:

--- a/install-edm-linux.sh
+++ b/install-edm-linux.sh
@@ -4,11 +4,11 @@ set -e
 
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
-    local EDM_PACKAGE="edm_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
-        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh5_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
     fi
 
     bash "$EDM_INSTALLER_PATH" -b -p "${HOME}/edm"

--- a/install-edm-osx.sh
+++ b/install-edm-osx.sh
@@ -4,7 +4,7 @@ set -e
 
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
-    local EDM_PACKAGE="edm_${INSTALL_EDM_VERSION}.pkg"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}.pkg"
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then

--- a/install-edm-windows.cmd
+++ b/install-edm-windows.cmd
@@ -9,12 +9,12 @@ FOR /F "tokens=1,2,3 delims=." %%a in ("%INSTALL_EDM_VERSION%") do (
 )
 
 SET EDM_MAJOR_MINOR=%MAJOR%.%MINOR%
-SET EDM_PACKAGE=edm_%INSTALL_EDM_VERSION%_x86_64.msi
+SET EDM_PACKAGE=edm_cli_%INSTALL_EDM_VERSION%_x86_64.msi
 SET EDM_INSTALLER_PATH=%HOMEDRIVE%%HOMEPATH%\.cache\%EDM_PACKAGE%
 SET COMMAND="(new-object net.webclient).DownloadFile('https://package-data.enthought.com/edm/win_x86_64/%EDM_MAJOR_MINOR%/%EDM_PACKAGE%', '%EDM_INSTALLER_PATH%')"
 
 IF NOT EXIST %EDM_INSTALLER_PATH% CALL powershell.exe -Command %COMMAND% || GOTO error
-CALL msiexec /qn /a %EDM_INSTALLER_PATH% TARGETDIR=c:\ || GOTO error
+CALL msiexec /qn /a %EDM_INSTALLER_PATH% TARGETDIR=c:\Enthought\edm || GOTO error
 
 ENDLOCAL
 @ECHO.DONE

--- a/install-edm-windows.cmd
+++ b/install-edm-windows.cmd
@@ -14,7 +14,7 @@ SET EDM_INSTALLER_PATH=%HOMEDRIVE%%HOMEPATH%\.cache\%EDM_PACKAGE%
 SET COMMAND="(new-object net.webclient).DownloadFile('https://package-data.enthought.com/edm/win_x86_64/%EDM_MAJOR_MINOR%/%EDM_PACKAGE%', '%EDM_INSTALLER_PATH%')"
 
 IF NOT EXIST %EDM_INSTALLER_PATH% CALL powershell.exe -Command %COMMAND% || GOTO error
-CALL msiexec /qn /a %EDM_INSTALLER_PATH% TARGETDIR=c:\Enthought\edm || GOTO error
+CALL msiexec /qn /i %EDM_INSTALLER_PATH% EDMAPPDIR=C:\Enthought\edm || GOTO error
 
 ENDLOCAL
 @ECHO.DONE


### PR DESCRIPTION
Update Travis CI and Appveyor to use EDM 2.0.0.

This should fix the issues we're seeing with CI on Python 3.6 (see CI runs for #559).

```
OkonomiyakiError: Unsupported PKG-INFO metadata format: u'2.1'
```