### PR TITLE
Bump Traits version for the 5.2.0 release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import setuptools
 MAJOR = 5
 MINOR = 2
 MICRO = 0
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
Prepare for the 5.2.0 release. The changelog is ready; all we need to do is bump the version.