### PR TITLE
Use SVG badges in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,12 @@ traits: explicitly typed attributes for Python
 
 http://docs.enthought.com/traits
 
-.. image:: https://api.travis-ci.org/enthought/traits.png?branch=master
+.. image:: https://travis-ci.org/enthought/traits.svg?branch=master
    :target: https://travis-ci.org/enthought/traits
    :alt: Build status
 
-.. image:: https://coveralls.io/repos/enthought/traits/badge.png
-   :target: https://coveralls.io/r/enthought/traits
+.. image:: https://coveralls.io/repos/github/enthought/traits/badge.svg?branch=master
+   :target: https://coveralls.io/github/enthought/traits
    :alt: Coverage status
 
 The Traits project is at the center of all Enthought Tool Suite development


### PR DESCRIPTION
The badges on the [PyPI page](https://pypi.org/project/traits/5.2.0/) look fuzzy to my eyes; this PR fixes them to use .svg images instead of .png images. SVG is supported by all mainstream browsers these days, and the failure mode if it isn't should not be catastrophic.

Screenshot from PyPI:

<img width="332" alt="Screenshot 2019-11-19 at 11 35 24" src="https://user-images.githubusercontent.com/662003/69143386-c1d23980-0ac0-11ea-9e36-ee36527b93e7.png">

For comparison, here's Envisage:

<img width="314" alt="Screenshot 2019-11-19 at 11 35 48" src="https://user-images.githubusercontent.com/662003/69143401-c8f94780-0ac0-11ea-9d87-afa62bc54ed7.png">
