### PR TITLE
Remove HasTraits.trait_monitor

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -900,10 +900,6 @@ has_traits_init ( PyObject * obj, PyObject * args, PyObject * kwds ) {
 
     PyObject * key;
     PyObject * value;
-    PyObject * klass;
-    PyObject * handler;
-    PyObject * handler_args;
-    int n;
     int has_listeners;
     Py_ssize_t i = 0;
 
@@ -5296,8 +5292,6 @@ static PyMethodDef ctraits_methods[] = {
 +----------------------------------------------------------------------------*/
 
 Py2to3_MOD_INIT(ctraits) {
-    PyObject * tmp;
-
     /* Create the 'ctraits' module: */
     PyObject * module;
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -48,7 +48,6 @@ static PyObject * TraitValue;          /* TraitValue class */
 static PyObject * adapt;               /* PyProtocols 'adapt' function */
 static PyObject * validate_implements; /* 'validate implementation' function */
 static PyObject * is_callable;         /* Marker for 'callable' value */
-static PyObject * _HasTraits_monitors; /* Object creation monitors. */
 static PyObject * _trait_notification_handler; /* User supplied trait */
                 /* notification handler (intended for use by debugging tools) */
 static PyTypeObject * ctrait_type;     /* Python-level CTrait type reference */
@@ -940,24 +939,6 @@ has_traits_init ( PyObject * obj, PyObject * args, PyObject * kwds ) {
             return -1;
 
         Py_DECREF( value );
-    }
-
-    /* Notify any interested monitors that a new object has been created: */
-    for ( i = 0, n = PyList_GET_SIZE( _HasTraits_monitors ); i < n; i++ ) {
-        value = PyList_GET_ITEM( _HasTraits_monitors, i );
-        assert( PyTuple_Check( value ) );
-        assert( PyTuple_GET_SIZE( value ) == 2 );
-
-        klass   = PyTuple_GET_ITEM( value, 0 );
-        handler = PyTuple_GET_ITEM( value, 1 );
-
-        if ( PyObject_IsInstance( obj, klass ) > 0 ) {
-            handler_args = PyTuple_New( 1 );
-            PyTuple_SetItem( handler_args, 0, obj );
-            Py_INCREF( obj );
-            PyObject_Call( handler, handler_args, NULL );
-            Py_DECREF( handler_args );
-        }
     }
 
     /* Call the 'traits_init' method to finish up initialization: */
@@ -5352,16 +5333,6 @@ Py2to3_MOD_INIT(ctraits) {
     if ( PyModule_AddObject( module, "cTrait",
                          (PyObject *) &trait_type ) < 0 )
        return Py2to3_MOD_ERROR_VAL;
-
-    /* Create the 'HasTraitsMonitor' list: */
-    tmp = PyList_New( 0 );
-    Py_INCREF( tmp );
-    if ( PyModule_AddObject( module, "_HasTraits_monitors",
-                             (PyObject*) tmp) < 0 ) {
-       return Py2to3_MOD_ERROR_VAL;
-    }
-
-    _HasTraits_monitors = tmp;
 
     /* Predefine a Python string == "__class_traits__": */
     class_traits = Py2to3_SimpleString_FromString( "__class_traits__" );

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -39,7 +39,7 @@ from . import __version__ as TraitsVersion
 
 from .adaptation.adaptation_error import AdaptationError
 
-from .ctraits import CHasTraits, _HasTraits_monitors
+from .ctraits import CHasTraits
 
 from .traits import (
     CTrait,
@@ -881,32 +881,6 @@ def migrate_property(name, property, property_info, class_dict):
 
 
 # -------------------------------------------------------------------------------
-#  Manages the list of trait instance monitors:
-# -------------------------------------------------------------------------------
-
-
-def _trait_monitor_index(cls, handler):
-    global _HasTraits_monitors
-
-    type_handler = type(handler)
-    for i, _cls, _handler in enumerate(_HasTraits_monitors):
-        if type_handler is type(_handler):
-            if (
-                (type_handler is MethodType)
-                or "cython_function_or_method" in str(type_handler)
-            ) and (handler.__self__ is not None):
-                if (handler.__name__ == _handler.__name__) and (
-                    handler.__self__ is _handler.__self__
-                ):
-                    return i
-
-            elif handler == _handler:
-                return i
-
-    return -1
-
-
-# -------------------------------------------------------------------------------
 #  'HasTraits' decorators:
 # -------------------------------------------------------------------------------
 
@@ -1168,41 +1142,6 @@ class HasTraits(CHasTraits):
             self._init_trait_delegate_listener(
                 name, "delegate", get_delegate_pattern(name, trait)
             )
-
-    # ---------------------------------------------------------------------------
-    #  Adds/Removes a trait instance creation monitor:
-    # ---------------------------------------------------------------------------
-
-    @classmethod
-    def trait_monitor(cls, handler, remove=False):
-        """Adds or removes the specified *handler* from the list of active
-        monitors.
-
-        Parameters
-        ----------
-        handler : function
-            The function to add or remove as a monitor.
-        remove : bool
-            Flag indicating whether to remove (True) or add the specified
-            handler as a monitor for this class.
-
-        Description
-        -----------
-        If *remove* is omitted or False, the specified handler is added to
-        the list of active monitors; if *remove* is True, the handler is
-        removed from the active monitor list.
-
-        """
-        global _HasTraits_monitors
-
-        index = _trait_monitor_index(cls, handler)
-        if remove:
-            if index >= 0:
-                del _HasTraits_monitors[index]
-            return
-
-        if index < 0:
-            _HasTraits_monitors.append((cls, handler))
 
     # ---------------------------------------------------------------------------
     #  Add a new class trait (i.e. applies to all instances and subclasses):


### PR DESCRIPTION
This PR removes the `HasTraits.trait_monitor` method: the current implementation is broken, undocumented, untested, and (as far as I can tell) unused elsewhere. As such, it's not worth the maintenance burden.

Closes #569 

