### PR TITLE
Fix missing import in the adaptation benchmark script.

### DIFF
--- a/traits/adaptation/tests/benchmark.py
+++ b/traits/adaptation/tests/benchmark.py
@@ -10,6 +10,8 @@ import abc
 from pprint import pprint
 import time
 
+import six
+
 from traits.adaptation.adaptation_manager import AdaptationManager
 from traits.api import Adapter, HasTraits, Interface, provides
 


### PR DESCRIPTION
The adaptation benchmark script was non-functional on Python 3. This PR fixes it.