### PR TITLE
Fix floating-point Range to accept float-like values

### DIFF
--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -25,6 +25,7 @@ class ModelWithRange(HasTraits):
     """
     Model containing simple Range trait.
     """
+
     # Simple floating-point range trait.
     percentage = Range(0.0, 100.0)
 
@@ -33,6 +34,7 @@ class ModelWithRangeCompound(HasTraits):
     """
     Model containing compound Range trait.
     """
+
     # Range as part of a compound trait. This (currently)
     # exercises a different code path in ctraits.c from percentage.
     percentage = Either(None, Range(0.0, 100.0))

--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -36,7 +36,8 @@ class ModelWithRangeCompound(HasTraits):
     """
 
     # Range as part of a compound trait. This (currently)
-    # exercises a different code path in ctraits.c from percentage.
+    # exercises a different code path in ctraits.c from the
+    # corresponding trait in ModelWithRange.
     percentage = Either(None, Range(0.0, 100.0))
 
 

--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -20,17 +20,21 @@ import unittest
 from traits.api import Either, HasTraits, Range, TraitError
 
 
-class ModelWithRanges(HasTraits):
+class ModelWithRange(HasTraits):
     """
-    Model containing various Range traits for testing purposes.
+    Model containing simple Range trait.
     """
-
     # Simple floating-point range trait.
     percentage = Range(0.0, 100.0)
 
-    # Range as part of a complex trait. This (currently)
+
+class ModelWithRangeCompound(HasTraits):
+    """
+    Model containing compound Range trait.
+    """
+    # Range as part of a compound trait. This (currently)
     # exercises a different code path in ctraits.c from percentage.
-    percentage_or_none = Either(None, Range(0.0, 100.0))
+    percentage = Either(None, Range(0.0, 100.0))
 
 
 class InheritsFromFloat(float):
@@ -62,70 +66,44 @@ class BadFloatLike(object):
         raise ZeroDivisionError("bogus error")
 
 
-class TestFloatRange(unittest.TestCase):
+class CommonRangeTests(object):
     def test_accepts_float(self):
-        model = ModelWithRanges()
-        model.percentage = 35.0
-        self.assertIs(type(model.percentage), float)
-        self.assertEqual(model.percentage, 35.0)
+        self.model.percentage = 35.0
+        self.assertIs(type(self.model.percentage), float)
+        self.assertEqual(self.model.percentage, 35.0)
         with self.assertRaises(TraitError):
-            model.percentage = -0.5
+            self.model.percentage = -0.5
         with self.assertRaises(TraitError):
-            model.percentage = 100.5
+            self.model.percentage = 100.5
 
     def test_accepts_float_subclass(self):
-        model = ModelWithRanges()
-        model.percentage = InheritsFromFloat(44.0)
-        self.assertIs(type(model.percentage), float)
-        self.assertEqual(model.percentage, 44.0)
+        self.model.percentage = InheritsFromFloat(44.0)
+        self.assertIs(type(self.model.percentage), float)
+        self.assertEqual(self.model.percentage, 44.0)
         with self.assertRaises(TraitError):
-            model.percentage = InheritsFromFloat(-0.5)
+            self.model.percentage = InheritsFromFloat(-0.5)
         with self.assertRaises(TraitError):
-            model.percentage = InheritsFromFloat(100.5)
+            self.model.percentage = InheritsFromFloat(100.5)
 
     def test_accepts_float_like(self):
-        model = ModelWithRanges()
-        model.percentage = FloatLike(35.0)
-        self.assertIs(type(model.percentage), float)
-        self.assertEqual(model.percentage, 35.0)
+        self.model.percentage = FloatLike(35.0)
+        self.assertIs(type(self.model.percentage), float)
+        self.assertEqual(self.model.percentage, 35.0)
         with self.assertRaises(TraitError):
-            model.percentage = FloatLike(-0.5)
+            self.model.percentage = FloatLike(-0.5)
         with self.assertRaises(TraitError):
-            model.percentage = FloatLike(100.5)
-
-    def test_range_in_compound_trait_accepts_float(self):
-        model = ModelWithRanges()
-        model.percentage_or_none = 35.0
-        self.assertIs(type(model.percentage_or_none), float)
-        self.assertEqual(model.percentage_or_none, 35.0)
-        with self.assertRaises(TraitError):
-            model.percentage_or_none = -0.5
-        with self.assertRaises(TraitError):
-            model.percentage_or_none = 100.5
-
-    def test_range_in_compound_trait_accepts_float_subclass(self):
-        model = ModelWithRanges()
-        model.percentage_or_none = InheritsFromFloat(67.0)
-        self.assertIs(type(model.percentage_or_none), float)
-        self.assertEqual(model.percentage_or_none, 67.0)
-        with self.assertRaises(TraitError):
-            model.percentage_or_none = InheritsFromFloat(-0.5)
-        with self.assertRaises(TraitError):
-            model.percentage_or_none = InheritsFromFloat(100.5)
-
-    def test_range_in_compound_trait_accepts_float_like(self):
-        model = ModelWithRanges()
-        model.percentage_or_none = FloatLike(67.0)
-        self.assertIs(type(model.percentage_or_none), float)
-        self.assertEqual(model.percentage_or_none, 67.0)
-        with self.assertRaises(TraitError):
-            model.percentage_or_none = FloatLike(-0.5)
-        with self.assertRaises(TraitError):
-            model.percentage_or_none = FloatLike(100.5)
+            self.model.percentage = FloatLike(100.5)
 
     def test_bad_float_like(self):
-        model = ModelWithRanges()
         with self.assertRaises(ZeroDivisionError):
-            model.percentage = BadFloatLike()
-        with self.assertRaises(ZeroDivisionError):
-            model.percentage_or_none = BadFloatLike()
+            self.model.percentage = BadFloatLike()
+
+
+class TestFloatRange(CommonRangeTests, unittest.TestCase):
+    def setUp(self):
+        self.model = ModelWithRange()
+
+
+class TestFloatRangeCompound(CommonRangeTests, unittest.TestCase):
+    def setUp(self):
+        self.model = ModelWithRangeCompound()

--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -1,0 +1,97 @@
+# -----------------------------------------------------------------------------
+#
+#  Copyright (c) 2019, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in /LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+# -----------------------------------------------------------------------------
+"""
+Tests for the Range trait with value type float.
+"""
+
+import unittest
+
+from traits.api import HasTraits, Range, TraitError
+
+
+class ModelWithRanges(HasTraits):
+    """
+    Model containing various Range traits for testing purposes.
+    """
+    percentage = Range(0.0, 100.0)
+
+
+class InheritsFromFloat(float):
+    """
+    Object that's float-like by virtue of inheriting from float.
+    """
+    pass
+
+
+class FloatLike(object):
+    """
+    Object that's float-like by virtue of providing a __float__ method.
+    """
+    def __init__(self, value):
+        self._value = value
+
+    def __float__(self):
+        return self._value
+
+
+class BadFloatLike(object):
+    """
+    Object whose __float__ method raises something other than TypeError.
+    """
+    def __float__(self):
+        raise ZeroDivisionError("bogus error")
+
+
+class TestFloatRange(unittest.TestCase):
+    def test_accepts_float(self):
+        model = ModelWithRanges()
+        model.percentage = 35.0
+        self.assertIs(type(model.percentage), float)
+        self.assertEqual(model.percentage, 35.0)
+        with self.assertRaises(TraitError):
+            model.percentage = -0.5
+        with self.assertRaises(TraitError):
+            model.percentage = 100.5
+
+    def test_accepts_float_subclass(self):
+        model = ModelWithRanges()
+        model.percentage = InheritsFromFloat(44.0)
+        self.assertIs(type(model.percentage), float)
+        self.assertEqual(model.percentage, 44.0)
+
+        # XXX Check error message! Should complain about the range,
+        # not about the type.
+        with self.assertRaises(TraitError):
+            model.percentage = InheritsFromFloat(-0.5)
+        with self.assertRaises(TraitError):
+            model.percentage = InheritsFromFloat(100.5)
+
+    def test_accepts_float_like(self):
+        model = ModelWithRanges()
+        model.percentage = FloatLike(35.0)
+        self.assertIs(type(model.percentage), float)
+        self.assertEqual(model.percentage, 35.0)
+
+        # XXX Check error message! Should complain about the range,
+        # not about the type.
+        with self.assertRaises(TraitError):
+            model.percentage = FloatLike(-0.5)
+        with self.assertRaises(TraitError):
+            model.percentage = FloatLike(100.5)
+
+    def test_bad_float_like(self):
+        model = ModelWithRanges()
+
+        with self.assertRaises(ZeroDivisionError):
+            model.percentage = BadFloatLike()

--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -18,6 +18,7 @@ Tests for the Range trait with value type float.
 import unittest
 
 from traits.api import Either, HasTraits, Range, TraitError
+from traits.testing.optional_dependencies import numpy, requires_numpy
 
 
 class ModelWithRange(HasTraits):
@@ -75,6 +76,62 @@ class CommonRangeTests(object):
             self.model.percentage = -0.5
         with self.assertRaises(TraitError):
             self.model.percentage = 100.5
+
+    def test_accepts_int(self):
+        self.model.percentage = 35
+        self.assertIs(type(self.model.percentage), float)
+        self.assertEqual(self.model.percentage, 35.0)
+        with self.assertRaises(TraitError):
+            self.model.percentage = -1
+        with self.assertRaises(TraitError):
+            self.model.percentage = 101
+
+    def test_accepts_bool(self):
+        self.model.percentage = False
+        self.assertIs(type(self.model.percentage), float)
+        self.assertEqual(self.model.percentage, 0.0)
+
+        self.model.percentage = True
+        self.assertIs(type(self.model.percentage), float)
+        self.assertEqual(self.model.percentage, 1.0)
+
+    def test_rejects_bad_types(self):
+        # A selection of things that don't count as float-like.
+        non_floats = [
+            u"not a number",
+            u"\N{GREEK CAPITAL LETTER SIGMA}",
+            b"not a number",
+            "3.5",
+            "3",
+            3 + 4j,
+            0j,
+            [1.2],
+            (1.2,),
+        ]
+
+        for non_float in non_floats:
+            with self.assertRaises(TraitError):
+                self.model.percentage = non_float
+
+    @requires_numpy
+    def test_accepts_numpy_types(self):
+        numpy_values = [
+            numpy.uint8(25),
+            numpy.uint16(25),
+            numpy.uint32(25),
+            numpy.uint64(25),
+            numpy.int8(25),
+            numpy.int16(25),
+            numpy.int32(25),
+            numpy.int64(25),
+            numpy.float16(25),
+            numpy.float32(25),
+            numpy.float64(25),
+        ]
+        for numpy_value in numpy_values:
+            self.model.percentage = numpy_value
+            self.assertIs(type(self.model.percentage), float)
+            self.assertEqual(self.model.percentage, 25.0)
 
     def test_accepts_float_subclass(self):
         self.model.percentage = InheritsFromFloat(44.0)


### PR DESCRIPTION
This PR changes the floating-point flavour of the `Range` trait to accept the same collection of values that the `Float` trait accepts: namely, instances of `float` (including objects whose type is a strict subclass of `float`), and objects whose type provides a `__float__` method.

This PR is self-contained, but doesn't fix all our range-related woes. There's more post-merge work to do on:

- equivalent changes for integer ranges
- refactoring to remove duplication of the range check code
- equivalent fixes for `BaseRange`
- dealing with float-like or int-like low and high
- equivalent changes for the `Range` trait handler