### PR TITLE
Refactor duplicated range checks.

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3375,14 +3375,15 @@ validate_trait_float(trait_object * trait, has_traits_object * obj,
 
 
 /*
-   Determine whether the given value lies in the range specified
-   by range_info.
+   Determine whether `value` lies in the range specified by `range_info`.
 
-   value must be of exact type float.
-   range_info is expected to be a tuple (*, low, high, exclude_mask)
+   * `value` must be of exact type float.
+   * `range_info` is expected to be a tuple (*, low, high, exclude_mask)
+     where `low` and `high` are object of exact type float and exclude_mask
+     is a Python integer.
 
-   Return 1 if value is within range, 0 if not, and -1 (with an exception
-   set) on error.
+   Return 1 if `value` is within range, and 0 if not. If an exception occurs,
+   return -1 and set an error.
 */
 
 static int

--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -29,6 +29,16 @@ class ModelWithRange(HasTraits):
     # Simple floating-point range trait.
     percentage = Range(0.0, 100.0)
 
+    # Traits that exercise the various possiblities for inclusion
+    # or exclusion of the endpoints.
+    open_closed = Range(0.0, 100.0, exclude_low=True)
+
+    closed_open = Range(0.0, 100.0, exclude_high=True)
+
+    open = Range(0.0, 100.0, exclude_low=True, exclude_high=True)
+
+    closed = Range(0.0, 100.0)
+
 
 class ModelWithRangeCompound(HasTraits):
     """
@@ -39,6 +49,16 @@ class ModelWithRangeCompound(HasTraits):
     # exercises a different code path in ctraits.c from the
     # corresponding trait in ModelWithRange.
     percentage = Either(None, Range(0.0, 100.0))
+
+    # Traits that exercise the various possiblities for inclusion
+    # or exclusion of the endpoints.
+    open_closed = Either(None, Range(0.0, 100.0, exclude_low=True))
+
+    closed_open = Either(None, Range(0.0, 100.0, exclude_high=True))
+
+    open = Either(None, Range(0.0, 100.0, exclude_low=True, exclude_high=True))
+
+    closed = Either(None, Range(0.0, 100.0))
 
 
 class InheritsFromFloat(float):
@@ -157,6 +177,33 @@ class CommonRangeTests(object):
     def test_bad_float_like(self):
         with self.assertRaises(ZeroDivisionError):
             self.model.percentage = BadFloatLike()
+
+    def test_endpoints(self):
+        # point within the interior of the range
+        self.model.open = self.model.closed = 50.0
+        self.model.open_closed = self.model.closed_open = 50.0
+        self.assertEqual(self.model.open, 50.0)
+        self.assertEqual(self.model.closed, 50.0)
+        self.assertEqual(self.model.open_closed, 50.0)
+        self.assertEqual(self.model.closed_open, 50.0)
+
+        # low endpoint
+        self.model.closed = self.model.closed_open = 0.0
+        self.assertEqual(self.model.closed, 0.0)
+        self.assertEqual(self.model.closed_open, 0.0)
+        with self.assertRaises(TraitError):
+            self.model.open = 0.0
+        with self.assertRaises(TraitError):
+            self.model.open_closed = 0.0
+
+        # high endpoint
+        self.model.closed = self.model.open_closed = 100.0
+        self.assertEqual(self.model.closed, 100.0)
+        self.assertEqual(self.model.open_closed, 100.0)
+        with self.assertRaises(TraitError):
+            self.model.open = 100.0
+        with self.assertRaises(TraitError):
+            self.model.closed_open = 100.0
 
 
 class TestFloatRange(CommonRangeTests, unittest.TestCase):

--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -39,6 +39,11 @@ class ModelWithRange(HasTraits):
 
     closed = Range(0.0, 100.0)
 
+    # Traits for one-sided intervals
+    steam_temperature = Range(low=100.0)
+
+    ice_temperature = Range(high=0.0)
+
 
 class ModelWithRangeCompound(HasTraits):
     """
@@ -59,6 +64,11 @@ class ModelWithRangeCompound(HasTraits):
     open = Either(None, Range(0.0, 100.0, exclude_low=True, exclude_high=True))
 
     closed = Either(None, Range(0.0, 100.0))
+
+    # Traits for one-sided intervals
+    steam_temperature = Either(None, Range(low=100.0))
+
+    ice_temperature = Either(None, Range(high=0.0))
 
 
 class InheritsFromFloat(float):
@@ -204,6 +214,31 @@ class CommonRangeTests(object):
             self.model.open = 100.0
         with self.assertRaises(TraitError):
             self.model.closed_open = 100.0
+
+    def test_half_infinite(self):
+        ice_temperatures = [-273.15, -273.0, -100.0, -1.0, -0.1, -0.001]
+        water_temperatures = [0.001, 0.1, 1.0, 50.0, 99.0, 99.9, 99.999]
+        steam_temperatures = [100.001, 100.1, 101.0, 1000.0, 1e100]
+
+        for temperature in steam_temperatures:
+            self.model.steam_temperature = temperature
+            self.assertEqual(self.model.steam_temperature, temperature)
+
+        for temperature in ice_temperatures + water_temperatures:
+            self.model.steam_temperature = 1729.0
+            with self.assertRaises(TraitError):
+                self.model.steam_temperature = temperature
+            self.assertEqual(self.model.steam_temperature, 1729.0)
+
+        for temperature in ice_temperatures:
+            self.model.ice_temperature = temperature
+            self.assertEqual(self.model.ice_temperature, temperature)
+
+        for temperature in water_temperatures + steam_temperatures:
+            self.model.ice_temperature = -1729.0
+            with self.assertRaises(TraitError):
+                self.model.ice_temperature = temperature
+            self.assertEqual(self.model.ice_temperature, -1729.0)
 
 
 class TestFloatRange(CommonRangeTests, unittest.TestCase):


### PR DESCRIPTION
This PR refactors the parts of `ctraits.c` having to do with range validation for float-based `Range` traits. It removes most of the duplication in the range-checking code.