### PR TITLE
Fix: propagate exceptions from slow_validate

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3915,11 +3915,12 @@ validate_trait_complex ( trait_object * trait, has_traits_object * obj,
             case 8:  /* Perform 'slow' validate check: */
                 result = PyObject_CallMethod( PyTuple_GET_ITEM( type_info, 1 ),
                                   "slow_validate", "(OOO)", obj, name, value );
-                if ( result != NULL )
-                    return result;
 
-                PyErr_Clear();
-                break;
+                if (result == NULL && PyErr_ExceptionMatches(TraitError)) {
+                    PyErr_Clear();
+                    break;
+                }
+                return result;
 
             case 9:  /* Tuple item check: */
                 result = validate_trait_tuple_check(

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -16,7 +16,6 @@ from traits.testing.optional_dependencies import numpy, requires_numpy
 from traits.trait_errors import TraitError
 from traits.trait_handlers import TraitType
 from traits.trait_types import Bool, DelegatesTo, Either, Instance, Int, List
-from traits.traits import Trait
 
 if numpy is not None:
     from traits.trait_numeric import Array
@@ -279,7 +278,7 @@ class TestRegression(unittest.TestCase):
         class A(HasTraits):
             foo = RaisingValidator()
 
-            bar = Trait(Int(), RaisingValidator())
+            bar = Either(None, RaisingValidator())
 
         a = A()
         with self.assertRaises(ZeroDivisionError):


### PR DESCRIPTION
If an exception other than `TraitError` occurs in a `slow_validate` call, it should be propagated rather than swallowed. This is the usual behaviour, but it doesn't happen for code that goes through the `validate_trait_complex` code path. This PR fixes that.

The particular case that motivated this PR: given a Trait definition:

```
class A(HasTraits):
    foo = Either(None, Range(0, 100))
```

if the range validation check fails due to a bad `__index__` method on the target object, for example, we would expect to see the exception from that method. Instead, it's currently swallowed.