### PR TITLE
Fix BaseRange to accept the same values as Range

### DIFF
--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -47,7 +47,7 @@ class ModelWithRange(HasTraits):
 
 class ModelWithBaseRange(HasTraits):
     """
-    Model containing simple Range trait.
+    Model containing simple BaseRange trait.
     """
 
     # Simple floating-point range trait.
@@ -93,6 +93,32 @@ class ModelWithRangeCompound(HasTraits):
     steam_temperature = Either(None, Range(low=100.0))
 
     ice_temperature = Either(None, Range(high=0.0))
+
+
+class ModelWithBaseRangeCompound(HasTraits):
+    """
+    Model containing compound BaseRange trait.
+    """
+
+    # Range as part of a compound trait. This (currently)
+    # exercises a different code path in ctraits.c from the
+    # corresponding trait in ModelWithRange.
+    percentage = Either(None, BaseRange(0.0, 100.0))
+
+    # Traits that exercise the various possiblities for inclusion
+    # or exclusion of the endpoints.
+    open_closed = Either(None, BaseRange(0.0, 100.0, exclude_low=True))
+
+    closed_open = Either(None, BaseRange(0.0, 100.0, exclude_high=True))
+
+    open = Either(None, BaseRange(0.0, 100.0, exclude_low=True, exclude_high=True))
+
+    closed = Either(None, BaseRange(0.0, 100.0))
+
+    # Traits for one-sided intervals
+    steam_temperature = Either(None, BaseRange(low=100.0))
+
+    ice_temperature = Either(None, BaseRange(high=0.0))
 
 
 class InheritsFromFloat(float):
@@ -278,3 +304,8 @@ class TestFloatBaseRange(CommonRangeTests, unittest.TestCase):
 class TestFloatRangeCompound(CommonRangeTests, unittest.TestCase):
     def setUp(self):
         self.model = ModelWithRangeCompound()
+
+
+class TestFloatBaseRangeCompound(CommonRangeTests, unittest.TestCase):
+    def setUp(self):
+        self.model = ModelWithBaseRangeCompound()

--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -17,7 +17,7 @@ Tests for the Range trait with value type float.
 
 import unittest
 
-from traits.api import Either, HasTraits, Range, TraitError
+from traits.api import BaseRange, Either, HasTraits, Range, TraitError
 from traits.testing.optional_dependencies import numpy, requires_numpy
 
 
@@ -43,6 +43,30 @@ class ModelWithRange(HasTraits):
     steam_temperature = Range(low=100.0)
 
     ice_temperature = Range(high=0.0)
+
+
+class ModelWithBaseRange(HasTraits):
+    """
+    Model containing simple Range trait.
+    """
+
+    # Simple floating-point range trait.
+    percentage = BaseRange(0.0, 100.0)
+
+    # Traits that exercise the various possiblities for inclusion
+    # or exclusion of the endpoints.
+    open_closed = BaseRange(0.0, 100.0, exclude_low=True)
+
+    closed_open = BaseRange(0.0, 100.0, exclude_high=True)
+
+    open = BaseRange(0.0, 100.0, exclude_low=True, exclude_high=True)
+
+    closed = BaseRange(0.0, 100.0)
+
+    # Traits for one-sided intervals
+    steam_temperature = BaseRange(low=100.0)
+
+    ice_temperature = BaseRange(high=0.0)
 
 
 class ModelWithRangeCompound(HasTraits):
@@ -244,6 +268,11 @@ class CommonRangeTests(object):
 class TestFloatRange(CommonRangeTests, unittest.TestCase):
     def setUp(self):
         self.model = ModelWithRange()
+
+
+class TestFloatBaseRange(CommonRangeTests, unittest.TestCase):
+    def setUp(self):
+        self.model = ModelWithBaseRange()
 
 
 class TestFloatRangeCompound(CommonRangeTests, unittest.TestCase):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1835,25 +1835,28 @@ class BaseRange(TraitType):
     def float_validate(self, object, name, value):
         """ Validate that the value is a float value in the specified range.
         """
+        # Keep original value for use in error reporting.
+        original_value = value
         try:
-            if (
-                isinstance(value, RangeTypes)
-                and (
-                    (self._low is None)
-                    or (self._exclude_low and (self._low < value))
-                    or ((not self._exclude_low) and (self._low <= value))
-                )
-                and (
-                    (self._high is None)
-                    or (self._exclude_high and (self._high > value))
-                    or ((not self._exclude_high) and (self._high >= value))
-                )
-            ):
-                return float(value)
-        except:
-            pass
+            value = _validate_float(value)
+        except TypeError:
+            self.error(object, name, original_value)
 
-        self.error(object, name, value)
+        if (
+            (
+                (self._low is None)
+                or (self._exclude_low and (self._low < value))
+                or ((not self._exclude_low) and (self._low <= value))
+            )
+            and (
+                (self._high is None)
+                or (self._exclude_high and (self._high > value))
+                or ((not self._exclude_high) and (self._high >= value))
+            )
+        ):
+            return value
+
+        self.error(object, name, original_value)
 
     def int_validate(self, object, name, value):
         """ Validate that the value is an int value in the specified range.


### PR DESCRIPTION
This PR fixes `BaseRange` for floating-point ranges so that it accepts the same values as `Range` does.

There's an expected test failure (for a test involving `BadFloatLike`), which should be fixed by #581.