### PR TITLE
CLN: Annotate validators with corresponding cases.

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4123,24 +4123,34 @@ done:
 +----------------------------------------------------------------------------*/
 
 static trait_validate validate_handlers[] = {
-    validate_trait_type,        validate_trait_instance,
+    validate_trait_type,         /* case 0: Type check */
+    validate_trait_instance,     /* case 1: Instance check */
+    validate_trait_self_type,    /* case 2: Self type check */
 #if PY_MAJOR_VERSION < 3
-    validate_trait_self_type,   validate_trait_int,
+    validate_trait_int,          /* case 3: Integer range check */
 #else
-    validate_trait_self_type,   NULL,
+    NULL,                        /* case 3: Integer range check */
 #endif // #if PY_MAJOR_VERSION < 3
-    validate_trait_float_range, validate_trait_enum,
-    validate_trait_map,         validate_trait_complex,
-    NULL,                       validate_trait_tuple,
-    validate_trait_prefix_map,  validate_trait_coerce_type,
-    validate_trait_cast_type,   validate_trait_function,
-    validate_trait_python,
+    validate_trait_float_range,  /* case 4: Floating-point range check */
+    validate_trait_enum,         /* case 5: Enumerated item check */
+    validate_trait_map,          /* case 6: Mapped item check */
+    validate_trait_complex,      /* case 7: TraitComplex item check */
+    NULL,                        /* case 8: 'Slow' validate check */
+    validate_trait_tuple,        /* case 9: TupleOf item check */
+    validate_trait_prefix_map,   /* case 10: Prefix map item check */
+    validate_trait_coerce_type,  /* case 11: Coercable type check */
+    validate_trait_cast_type,    /* case 12: Castable type check */
+    validate_trait_function,     /* case 13: Function validator check */
+    validate_trait_python,       /* case 14: Python-based validator check */
 /*  The following entries are used by the __getstate__ method... */
-    setattr_validate0,           setattr_validate1,
-    setattr_validate2,           setattr_validate3,
+    setattr_validate0,
+    setattr_validate1,
+    setattr_validate2,
+    setattr_validate3,
 /*  ...End of __getstate__ method entries */
-    validate_trait_adapt,        validate_trait_integer,
-    validate_trait_float,
+    validate_trait_adapt,        /* case 19: PyProtocols 'adapt' check */
+    validate_trait_integer,      /* case 20: Integer check */
+    validate_trait_float,        /* case 21: Float check */
 };
 
 static PyObject *


### PR DESCRIPTION
Minor cleanup in the ctraits.c code: clarify which case each of the entries in the `validate_handlers` table corresponds to.
