### PR TITLE
Remove TraitRange

### DIFF
--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -15,8 +15,6 @@ Classes
 
 .. autoclass:: TraitHandler
 
-.. autoclass:: TraitRange
-
 .. autoclass:: TraitString
 
 .. autoclass:: TraitCoerceType
@@ -79,5 +77,3 @@ Private Functions
 .. autofunction:: traits.trait_handlers._undefined_get
 
 .. autofunction:: traits.trait_handlers._undefined_set
-
-

--- a/docs/source/traits_user_manual/custom.rst
+++ b/docs/source/traits_user_manual/custom.rst
@@ -537,13 +537,12 @@ An application could use this new trait handler to define traits such as the
 following::
 
     # use_custom_th.py --- Example of using a custom TraitHandler
-    from traits.api import HasTraits, Trait, TraitRange
+    from traits.api import HasTraits, Trait, Range
     from custom_traithandler import TraitOddInteger
 
     class AnOddClass(HasTraits):
         oddball = Trait(1, TraitOddInteger())
-        very_odd = Trait(-1, TraitOddInteger(),
-                             TraitRange(-10, -1))
+        very_odd = Trait(-1, TraitOddInteger(), Range(-10, -1))
 
 The following example demonstrates why the info() method returns a phrase rather
 than a complete sentence::

--- a/docs/source/traits_user_manual/custom.rst
+++ b/docs/source/traits_user_manual/custom.rst
@@ -537,7 +537,7 @@ An application could use this new trait handler to define traits such as the
 following::
 
     # use_custom_th.py --- Example of using a custom TraitHandler
-    from traits.api import HasTraits, Trait, Range
+    from traits.api import HasTraits, Range, Trait
     from custom_traithandler import TraitOddInteger
 
     class AnOddClass(HasTraits):

--- a/examples/tutorials/doc_examples/examples/use_custom_th.py
+++ b/examples/tutorials/doc_examples/examples/use_custom_th.py
@@ -4,11 +4,11 @@
 # use_custom_th.py --- Example of using a custom TraitHandler
 
 # --[Imports]-------------------------------------------------------------------
-from traits.api import HasTraits, Trait, TraitRange
+from traits.api import HasTraits, Range, Trait
 from custom_traithandler import TraitOddInteger
 
 
 # --[Code]----------------------------------------------------------------------
 class AnOddClass(HasTraits):
     oddball = Trait(1, TraitOddInteger())
-    very_odd = Trait(-1, TraitOddInteger(), TraitRange(-10, -1))
+    very_odd = Trait(-1, TraitOddInteger(), Range(-10, -1))

--- a/traits/api.py
+++ b/traits/api.py
@@ -181,7 +181,6 @@ from .trait_handlers import (
     BaseTraitHandler,
     TraitType,
     TraitHandler,
-    TraitRange,
     TraitString,
     TraitCoerceType,
     TraitCastType,

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -31,6 +31,7 @@ from traits.api import (
     Instance,
     Int,
     List,
+    Range,
     Str,
     This,
     Trait,
@@ -38,7 +39,6 @@ from traits.api import (
     TraitList,
     TraitPrefixList,
     TraitPrefixMap,
-    TraitRange,
     Tuple,
     pop_exception_handler,
     push_exception_handler,
@@ -595,7 +595,7 @@ class PrefixMapTest(AnyTraitTest):
 
 
 class IntRangeTrait(HasTraits):
-    value = Trait(3, TraitRange(2, 5))
+    value = Trait(3, Range(2, 5))
 
 
 class IntRangeTest(AnyTraitTest):
@@ -614,7 +614,7 @@ class IntRangeTest(AnyTraitTest):
 
 
 class FloatRangeTrait(HasTraits):
-    value = Trait(3.0, TraitRange(2.0, 5.0))
+    value = Trait(3.0, Range(2.0, 5.0))
 
 
 class FloatRangeTest(AnyTraitTest):
@@ -1029,7 +1029,7 @@ class DelegateTests(unittest.TestCase):
 
 # Make a TraitCompound handler that does not have a fast_validate so we can
 # check for a particular regression.
-slow = Trait(1, TraitRange(1, 3), TraitRange(-3, -1))
+slow = Trait(1, Range(1, 3), Range(-3, -1))
 try:
     del slow.handler.fast_validate
 except AttributeError:
@@ -1037,15 +1037,15 @@ except AttributeError:
 
 
 class complex_value(HasTraits):
-    num1 = Trait(1, TraitRange(1, 5), TraitRange(-5, -1))
+    num1 = Trait(1, Range(1, 5), Range(-5, -1))
     num2 = Trait(
         1,
-        TraitRange(1, 5),
+        Range(1, 5),
         TraitPrefixList("one", "two", "three", "four", "five"),
     )
     num3 = Trait(
         1,
-        TraitRange(1, 5),
+        Range(1, 5),
         TraitPrefixMap({"one": 1, "two": 2, "three": 3, "four": 4, "five": 5}),
     )
     num4 = Trait(1, Trait(1, Tuple, slow), 10)


### PR DESCRIPTION
This PR removes the `TraitRange` subclass of `TraitHandler`. We've recently made a number of fixes to the `Range` and `BaseRange` traits, with the result that those trait types have diverged from `TraitRange`. Since `TraitRange` is essentially unused, it seems better to remove it than to try to propagate those fixes to it.