### PR TITLE
Fix and improve clean_filename

### DIFF
--- a/traits/util/tests/test_clean_strings.py
+++ b/traits/util/tests/test_clean_strings.py
@@ -11,7 +11,11 @@
 #  Thanks for using Enthought open source!
 #
 # -----------------------------------------------------------------------------
+from __future__ import unicode_literals
+
 import unittest
+
+import six
 
 from traits.util.clean_strings import clean_filename
 
@@ -59,6 +63,8 @@ class TestCleanStrings(unittest.TestCase):
             self.assertEqual(safe_string, "abcdef")
 
     def test_clean_filename_all_chars(self):
+        if six.PY2:
+            chr = unichr
         test_strings = [
             "".join(chr(n) for n in range(10000)),
             "".join(chr(n) for n in range(10000)) * 2,
@@ -72,6 +78,6 @@ class TestCleanStrings(unittest.TestCase):
         """
         Check that a supposedly safe string is actually safe.
         """
-        self.assertIsInstance(safe_string, str)
+        self.assertIsInstance(safe_string, six.text_type)
         chars_in_string = set(safe_string)
         self.assertLessEqual(chars_in_string, LEGAL_CHARS)

--- a/traits/util/tests/test_clean_strings.py
+++ b/traits/util/tests/test_clean_strings.py
@@ -1,0 +1,77 @@
+# -----------------------------------------------------------------------------
+#
+#  Copyright (c) 2019, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in /LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+# -----------------------------------------------------------------------------
+import unittest
+
+from traits.util.clean_strings import clean_filename
+
+# Safe strings should only contain the following characters.
+LEGAL_CHARS = set("-0123456789_abcdefghijklmnopqrstuvwxyz0123456789")
+
+
+class TestCleanStrings(unittest.TestCase):
+    def test_clean_filename_default(self):
+        test_strings = [
+            "!!!",
+            "",
+            " ",
+            "\t/\n",
+            "^!+",
+        ]
+        for test_string in test_strings:
+            safe_string = clean_filename(test_string, "default-output")
+            self.check_output(safe_string)
+            self.assertEqual(safe_string, "default-output")
+
+    def test_clean_filename_whitespace_handling(self):
+        # Leading and trailing whitespace stripped.
+        self.assertEqual(clean_filename(" abc "), "abc")
+        self.assertEqual(clean_filename(" \t\tabc    \n"), "abc")
+        # Internal whitespace turned into hyphens.
+        self.assertEqual(clean_filename("well name"), "well-name")
+        self.assertEqual(clean_filename("well \n name"), "well-name")
+        self.assertEqual(clean_filename("well - name"), "well-name")
+
+    def test_clean_filename_conversion_to_lowercase(self):
+        test_string = "ABCdefGHI123"
+        safe_string = clean_filename(test_string)
+        self.assertEqual(safe_string, test_string.lower())
+        self.check_output(safe_string)
+
+    def test_clean_filename_accented_chars(self):
+        test_strings = [
+            "\xe4b\xe7d\xe8f",
+            "a\u0308bc\u0327de\u0300f",
+        ]
+        for test_string in test_strings:
+            safe_string = clean_filename(test_string)
+            self.check_output(safe_string)
+            self.assertEqual(safe_string, "abcdef")
+
+    def test_clean_filename_all_chars(self):
+        test_strings = [
+            "".join(chr(n) for n in range(10000)),
+            "".join(chr(n) for n in range(10000)) * 2,
+            "".join(chr(n) for n in reversed(range(10000))),
+        ]
+        for test_string in test_strings:
+            safe_string = clean_filename(test_string)
+            self.check_output(safe_string)
+
+    def check_output(self, safe_string):
+        """
+        Check that a supposedly safe string is actually safe.
+        """
+        self.assertIsInstance(safe_string, str)
+        chars_in_string = set(safe_string)
+        self.assertLessEqual(chars_in_string, LEGAL_CHARS)

--- a/traits/util/tests/test_clean_strings.py
+++ b/traits/util/tests/test_clean_strings.py
@@ -63,12 +63,11 @@ class TestCleanStrings(unittest.TestCase):
             self.assertEqual(safe_string, "abcdef")
 
     def test_clean_filename_all_chars(self):
-        if six.PY2:
-            chr = unichr
+        chr_ = unichr if six.PY2 else chr
         test_strings = [
-            "".join(chr(n) for n in range(10000)),
-            "".join(chr(n) for n in range(10000)) * 2,
-            "".join(chr(n) for n in reversed(range(10000))),
+            "".join(chr_(n) for n in range(10000)),
+            "".join(chr_(n) for n in range(10000)) * 2,
+            "".join(chr_(n) for n in reversed(range(10000))),
         ]
         for test_string in test_strings:
             safe_string = clean_filename(test_string)


### PR DESCRIPTION
This PR replaces the `clean_filename` function with a version that we've been using on other projects, and adds tests.

- Fix: `clean_filename` now returns a `str` instead of a `bytes` instance on Python 3
- Change: the set of permitted characters is further restricted to exclude "." and upper-case characters
- Enhancement: `clean_filename` takes a second argument, to be used as a replacement in case the cleaned string is empty

While subjective, the slugification is somewhat more user-friendly than it was: accented characters are replaced by unaccented ASCII equivalents where those exist, whitespace is replaced with hyphens.
