### PR TITLE
Remove definitions of unnecessary macros

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -77,21 +77,6 @@ static PyTypeObject * ctrait_type;     /* Python-level CTrait type reference */
     ((((tnotifiers) != NULL) && (PyList_GET_SIZE((tnotifiers))>0)) || \
      (((onotifiers) != NULL) && (PyList_GET_SIZE((onotifiers))>0)))
 
-/* Python version dependent macros: */
-#if ( (PY_MAJOR_VERSION == 2) && (PY_MINOR_VERSION < 3) )
-#define PyMODINIT_FUNC void
-#define PyDoc_VAR(name) static char name[]
-#define PyDoc_STRVAR(name,str) PyDoc_VAR(name) = PyDoc_STR(str)
-#ifdef WITH_DOC_STRINGS
-#define PyDoc_STR(str) str
-#else
-#define PyDoc_STR(str) ""
-#endif
-#endif
-#if (PY_VERSION_HEX < 0x02050000)
-typedef int Py_ssize_t;
-#endif
-
 /*-----------------------------------------------------------------------------
 |  Forward declarations:
 +----------------------------------------------------------------------------*/

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -56,29 +56,6 @@ static PyTypeObject * ctrait_type;     /* Python-level CTrait type reference */
 |  Macro definitions:
 +----------------------------------------------------------------------------*/
 
-/* The following macro is automatically defined in Python 2.4 and later: */
-#ifndef Py_VISIT
-#define Py_VISIT(op) \
-do { \
-    if (op) { \
-        int vret = visit((PyObject *)(op), arg);        \
-        if (vret) return vret; \
-    } \
-} while (0)
-#endif
-
-/* The following macro is automatically defined in Python 2.4 and later: */
-#ifndef Py_CLEAR
-#define Py_CLEAR(op) \
-do { \
-    if (op) { \
-        PyObject *tmp = (PyObject *)(op); \
-        (op) = NULL;     \
-        Py_DECREF(tmp); \
-    } \
-} while (0)
-#endif
-
 #define DEFERRED_ADDRESS(ADDR) NULL
 #define PyTrait_CheckExact(op) ((op)->ob_type == ctrait_type)
 


### PR DESCRIPTION
The `Py_CLEAR` and `Py_VISIT` macros are avialable in Python 2.4  and later.

The `Py_CLEAR` macro in Python 2.7 is - https://github.com/python/cpython/blob/e6499033032d5b647e43a3b49da0c1c64b151743/Include/object.h#L780-L821 - which is the same as the macro definition in our codebase.

But the macro definition is different in Python 3.6 -  https://github.com/python/cpython/blob/0716056c49e9505041e30386dad9b2e788f67aaf/Include/object.h#L798-L839 .

The `Py_VISIT` macro in Python 2.7 is - https://github.com/python/cpython/blob/e6499033032d5b647e43a3b49da0c1c64b151743/Include/objimpl.h#L334-L346 - which is the same as the macro definition in our codebase and the macro definition is the same on Python 2.7 and Python 3.6