### PR TITLE
Remove branch which handled python < and >= version 2.5

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2905,11 +2905,7 @@ _trait_cast ( trait_object * trait, PyObject * args ) {
             break;
         default:
             PyErr_Format( PyExc_TypeError,
-#if PY_VERSION_HEX >= 0x02050000
                 "Trait cast takes 1, 2 or 3 arguments (%zd given).",
-#else
-                "Trait cast takes 1, 2 or 3 arguments (%u given).",
-#endif
                 PyTuple_GET_SIZE( args ) );
             return NULL;
     }


### PR DESCRIPTION
Python version 2.5 is no longer supported.

For reference, here are the docs for `PyErr_format` - https://docs.python.org/3.6/c-api/exceptions.html#c.PyErr_Format - where the format characters are defined in - https://docs.python.org/2.7/c-api/string.html#c.PyString_FromFormat and https://docs.python.org/3.6/c-api/unicode.html#c.PyUnicode_FromFormat