### PR TITLE
Missing is missing!

### DIFF
--- a/docs/source/traits_api_reference/trait_base.rst
+++ b/docs/source/traits_api_reference/trait_base.rst
@@ -11,8 +11,6 @@ Classes
 
 .. autodata:: Undefined
 
-.. autodata:: Missing
-
 .. autodata:: Self
 
 Functions

--- a/traits/api.py
+++ b/traits/api.py
@@ -23,7 +23,7 @@ Use this module for importing Traits names into your namespace. For example::
 
 from __future__ import absolute_import
 
-from .trait_base import Uninitialized, Undefined, Missing, Self
+from .trait_base import Uninitialized, Undefined, Self
 
 from .trait_errors import TraitError, TraitNotificationError, DelegationError
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -171,9 +171,6 @@ static int call_notifiers ( PyListObject *, PyListObject *,
 /* The default_value of the trait is the default value */
 #define CONSTANT_DEFAULT_VALUE 0
 
-/* The default_value of the trait is Missing */
-#define MISSING_DEFAULT_VALUE 1
-
 /* The object containing the trait is the default value */
 #define OBJECT_DEFAULT_VALUE 2
 
@@ -1592,7 +1589,6 @@ default_value_for ( trait_object      * trait,
 
     switch ( trait->default_value_type ) {
         case CONSTANT_DEFAULT_VALUE:
-        case MISSING_DEFAULT_VALUE:
             result = trait->default_value;
             if (result == NULL) {
                 result = Py_None;

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -66,9 +66,9 @@ from .trait_notifiers import (
 
 from .trait_handlers import (
     TraitType,
-    MISSING_DEFAULT_VALUE,
     TRAIT_LIST_OBJECT_DEFAULT_VALUE,
     CALLABLE_DEFAULT_VALUE,
+    CONSTANT_DEFAULT_VALUE,
 )
 
 from .trait_base import (
@@ -663,7 +663,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
                     class_traits[name] = value = ictrait(default_value)
                     # Make sure that the trait now has the default value
                     # has the correct initializer.
-                    value.default_value(MISSING_DEFAULT_VALUE, value.default)
+                    value.default_value(CONSTANT_DEFAULT_VALUE, value.default)
                     del class_dict[name]
                     handler = value.handler
                     if (handler is not None) and handler.is_mapped:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -72,7 +72,6 @@ from .trait_handlers import (
 )
 
 from .trait_base import (
-    Missing,
     SequenceTypes,
     TraitsCache,
     Undefined,
@@ -1410,8 +1409,11 @@ class HasTraits(CHasTraits):
             names = self.trait_names(**metadata)
 
         for name in names:
-            value = getattr(self, name, Missing)
-            if value is not Missing:
+            try:
+                value = getattr(self, name)
+            except AttributeError:
+                pass
+            else:
                 result[name] = value
 
         return result

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -150,22 +150,6 @@ from . import ctraits
 
 ctraits._undefined(Undefined, Uninitialized)
 
-# -------------------------------------------------------------------------------
-#  Singleton 'Missing' object (used as missing method argument marker):
-# -------------------------------------------------------------------------------
-
-
-class Missing(object):
-    """ Singleton 'Missing' object (used as missing method argument marker).
-    """
-
-    def __repr__(self):
-        return "<missing>"
-
-
-#: Singleton object that indicates that a method argument is missing from a
-#: type-checked method signature.
-Missing = Missing()
 
 # -------------------------------------------------------------------------------
 #  Singleton 'Self' object (used as object reference to current 'object'):

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -89,8 +89,6 @@ CallableTypes = (FunctionType, MethodType)
 UNSPECIFIED_DEFAULT_VALUE = -1
 #: The default_value of the trait is the default value.
 CONSTANT_DEFAULT_VALUE = 0
-#: The default_value of the trait is Missing.
-MISSING_DEFAULT_VALUE = 1
 #: The object containing the trait is the default value.
 OBJECT_DEFAULT_VALUE = 2
 #: A new copy of the list specified by default_value is the default value.

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -55,7 +55,6 @@ from .trait_base import (
     CoercableTypes,
     TraitsCache,
     class_of,
-    Missing,
 )
 from .trait_errors import TraitError
 
@@ -514,7 +513,7 @@ class TraitType(BaseTraitHandler):
 
         return (dvt, dv)
 
-    def clone(self, default_value=Missing, **metadata):
+    def clone(self, default_value=NoDefaultSpecified, **metadata):
         """ Clones the contents of this object into a new instance of the same
             class, and then modifies the cloned copy using the specified
             *default_value* and *metadata*. Returns the cloned object as the
@@ -540,7 +539,7 @@ class TraitType(BaseTraitHandler):
 
         new._metadata.update(metadata)
 
-        if default_value is not Missing:
+        if default_value is not NoDefaultSpecified:
             new.default_value = default_value
             if self.validate is not None:
                 try:

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -62,7 +62,6 @@ from .trait_base import (
     SequenceTypes,
     Self,
     Undefined,
-    Missing,
     TypeTypes,
     add_article,
 )
@@ -598,7 +597,7 @@ DefaultValues = {
     bool: False,
 }
 
-DefaultValueSpecial = [Missing, Self]
+DefaultValueSpecial = [Self]
 DefaultValueTypes = [list, dict]
 
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
This PR removes the `Missing` constant, which was originally intended for use in the `method` magic non-decorator decorator (removed in #112).