### PR TITLE
Replace TypeType with type

### DIFF
--- a/docs/source/traits_api_reference/trait_base.rst
+++ b/docs/source/traits_api_reference/trait_base.rst
@@ -47,6 +47,3 @@ Functions
 .. autofunction:: not_event
 
 .. autofunction:: is_str
-
-
-

--- a/docs/source/traits_api_reference/trait_base.rst
+++ b/docs/source/traits_api_reference/trait_base.rst
@@ -47,3 +47,6 @@ Functions
 .. autofunction:: not_event
 
 .. autofunction:: is_str
+
+
+

--- a/docs/source/traits_user_manual/custom.rst
+++ b/docs/source/traits_user_manual/custom.rst
@@ -277,7 +277,7 @@ Python types:
 * MethodType
 * ClassType
 * InstanceType
-* TypeType
+* type
 * NoneType
 
 Specifying one of these types means that the trait value must be of the

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -42,8 +42,6 @@ import six.moves as sm
 
 from types import FunctionType, MethodType
 
-TypeType = type
-
 from weakref import ref
 
 from .trait_base import (
@@ -938,7 +936,7 @@ class TraitCoerceType(TraitHandler):
         example, the string 'cat' is automatically mapped to ``str`` (i.e.,
         types.StringType).
         """
-        if not isinstance(aType, TypeType):
+        if not isinstance(aType, type):
             aType = type(aType)
         self.aType = aType
         try:
@@ -1051,7 +1049,7 @@ class TraitCastType(TraitCoerceType):
         automatically mapped to ``str`` (i.e., types.StringType).
 
         """
-        if not isinstance(aType, TypeType):
+        if not isinstance(aType, type):
             aType = type(aType)
         self.aType = aType
         self.fast_validate = (12, aType)


### PR DESCRIPTION
`TypeType` was originally defined in Python 2's `types` module, but was removed in Python 3 because it's an exact synonym for `type`.