### PR TITLE
Add gnureadline as a development dependency on macOS and Linux

### DIFF
--- a/edm.yaml
+++ b/edm.yaml
@@ -1,0 +1,7 @@
+# Change this if you are using on-premise brood
+store_url: "https://packages.enthought.com"
+
+repositories:
+  - enthought/free
+  - enthought/lgpl
+  - enthought/gpl

--- a/etstool.py
+++ b/etstool.py
@@ -102,6 +102,11 @@ python2_dependencies = {
     "mock",
 }
 
+# Unix-specific dependencies.
+unix_dependencies = {
+    "gnureadline",
+}
+
 supported_runtimes = ["2.7", "3.5", "3.6"]
 default_runtime = "3.6"
 
@@ -161,6 +166,8 @@ def install(edm, runtime, environment, editable, docs, source):
     dependencies = common_dependencies.copy()
     if runtime.startswith("2."):
         dependencies.update(python2_dependencies)
+    if sys.platform != "win32":
+        dependencies.update(unix_dependencies)
     packages = " ".join(dependencies)
 
     # EDM commands to set up the development environment. The installation

--- a/etstool.py
+++ b/etstool.py
@@ -175,7 +175,7 @@ def install(edm, runtime, environment, editable, docs, source):
     # to explicitly uninstall it before re-installing from source.
     commands = [
         "{edm} environments create {environment} --force --version={runtime}",
-        "{edm} install -y -e {environment} " + packages,
+        "{edm} --config edm.yaml install -y -e {environment} " + packages,
         "{edm} plumbing remove-package -e {environment} traits",
     ]
     if editable:


### PR DESCRIPTION
Debugging without readline is painful, and EDM won't allow `gnureadline` to be installed after the fact, since it considers the development environment to be broken (as a result of uninstalling the traits package even though TraitsUI depends on it). This PR includes `gnureadline` in the development dependencies for platforms other than Windows.