### PR TITLE
Fix TraitHandler.clone with new default value

### DIFF
--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -119,9 +119,6 @@ TRAIT_SET_OBJECT_DEFAULT_VALUE = 9
 # Mapping from trait metadata 'type' to CTrait 'type':
 trait_types = {"python": 1, "event": 2}
 
-#
-
-
 # -------------------------------------------------------------------------------
 #  Forward references:
 # -------------------------------------------------------------------------------

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -119,6 +119,9 @@ TRAIT_SET_OBJECT_DEFAULT_VALUE = 9
 # Mapping from trait metadata 'type' to CTrait 'type':
 trait_types = {"python": 1, "event": 2}
 
+#
+
+
 # -------------------------------------------------------------------------------
 #  Forward references:
 # -------------------------------------------------------------------------------
@@ -542,6 +545,10 @@ class TraitType(BaseTraitHandler):
 
         if default_value is not Missing:
             new.default_value = default_value
+            # Use UNSPECIFIED_DEFAULT_VALUE to trigger the usual processing
+            # of the default value when this handler is converted to a CTrait.
+            new.default_value_type = UNSPECIFIED_DEFAULT_VALUE
+
             if self.validate is not None:
                 try:
                     new.default_value = self.validate(


### PR DESCRIPTION
The `clone` method of a `TraitHandler` does the wrong thing for a trait with a callable default, giving inconsistent `default_value` and `default_value_type` for that trait. This PR fixes that.

Here's an example of current behaviour on master, that's fixed by this PR:
```
>>> from traits.api import *
>>> import datetime
>>> class Base(HasTraits):
...     x = Instance(datetime.datetime, factory=datetime.datetime.utcnow)
... 
>>> class Child(Base):
...     x = datetime.datetime(1970, 1, 1)
... 
>>> child = Child()
>>> child.x  # Expect datetime.datetime(1970, 1, 1)
<undefined>
```
