### PR TITLE
Fix more use of default magic constants

### DIFF
--- a/traits/tests/test_trait_list_dict.py
+++ b/traits/tests/test_trait_list_dict.py
@@ -20,7 +20,7 @@ from traits.trait_types import Dict, List, Set, Str, Int, Instance
 class A(HasTraits):
     alist = List(Int, list(sm.range(5)))
     adict = Dict(Str, Int, dict(a=1, b=2))
-    aset = Set(Int, list(sm.range(5)))
+    aset = Set(Int, set(sm.range(5)))
 
     events = List()
 
@@ -151,3 +151,33 @@ class TestTraitListDictSetPersistence(unittest.TestCase):
         a = A()
         set_trait = a.traits()["aset"]
         self.assertEqual(set_trait.default_kind, "set")
+
+    def test_trait_list_default(self):
+        a = A()
+        list_trait = a.traits()["alist"]
+        self.assertEqual(list_trait.default, [0, 1, 2, 3, 4])
+
+        # The default property should have returned a copy, so
+        # modifying it doesn't change the actual default.
+        list_trait.default.append(5)
+        self.assertEqual(a.alist, [0, 1, 2, 3, 4])
+
+    def test_trait_dict_default(self):
+        a = A()
+        dict_trait = a.traits()["adict"]
+        self.assertEqual(dict_trait.default, {"a": 1, "b": 2})
+
+        # The default property should have returned a copy, so
+        # modifying it doesn't change the actual default.
+        dict_trait.default.pop("a")
+        self.assertEqual(a.adict, {"a": 1, "b": 2})
+
+    def test_trait_set_default(self):
+        a = A()
+        set_trait = a.traits()["aset"]
+        self.assertEqual(set_trait.default, {0, 1, 2, 3, 4})
+
+        # The default property should have returned a copy, so
+        # modifying it doesn't change the actual default.
+        set_trait.default.remove(2)
+        self.assertEqual(a.aset, {0, 1, 2, 3, 4})

--- a/traits/tests/test_trait_list_dict.py
+++ b/traits/tests/test_trait_list_dict.py
@@ -136,3 +136,18 @@ class TestTraitListDictSetPersistence(unittest.TestCase):
         self.assertEqual(a.aset, set([3, 4]))
         a.aset ^= set([10, 4])
         self.assertEqual(a.aset, set([3, 10]))
+
+    def test_trait_list_default_kind(self):
+        a = A()
+        list_trait = a.traits()["alist"]
+        self.assertEqual(list_trait.default_kind, "list")
+
+    def test_trait_dict_default_kind(self):
+        a = A()
+        dict_trait = a.traits()["adict"]
+        self.assertEqual(dict_trait.default_kind, "dict")
+
+    def test_trait_set_default_kind(self):
+        a = A()
+        set_trait = a.traits()["aset"]
+        self.assertEqual(set_trait.default_kind, "set")

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -54,6 +54,7 @@ from .trait_base import (
     TraitsCache,
     class_of,
     Missing,
+    Self,
 )
 from .trait_errors import TraitError
 
@@ -169,6 +170,28 @@ def _undefined_get(object, name):
 
 def _undefined_set(object, name, value):
     _undefined_get(object, name)
+
+
+def _infer_default_value_type(default_value):
+    """
+    Figure out the appropriate default value type given a default value.
+    """
+    if default_value is Missing:
+        return MISSING_DEFAULT_VALUE
+    elif default_value is Self:
+        return OBJECT_DEFAULT_VALUE
+    elif isinstance(default_value, TraitListObject):
+        return TRAIT_LIST_OBJECT_DEFAULT_VALUE
+    elif isinstance(default_value, TraitDictObject):
+        return TRAIT_DICT_OBJECT_DEFAULT_VALUE
+    elif isinstance(default_value, TraitSetObject):
+        return TRAIT_SET_OBJECT_DEFAULT_VALUE
+    elif isinstance(default_value, list):
+        return LIST_COPY_DEFAULT_VALUE
+    elif isinstance(default_value, dict):
+        return DICT_COPY_DEFAULT_VALUE
+    else:
+        return CONSTANT_DEFAULT_VALUE
 
 
 # -------------------------------------------------------------------------------
@@ -498,19 +521,7 @@ class TraitType(BaseTraitHandler):
         dv = self.default_value
         dvt = self.default_value_type
         if dvt < 0:
-            dvt = CONSTANT_DEFAULT_VALUE
-            if isinstance(dv, TraitListObject):
-                dvt = TRAIT_LIST_OBJECT_DEFAULT_VALUE
-            elif isinstance(dv, list):
-                dvt = LIST_COPY_DEFAULT_VALUE
-            elif isinstance(dv, TraitDictObject):
-                dvt = TRAIT_DICT_OBJECT_DEFAULT_VALUE
-            elif isinstance(dv, dict):
-                dvt = DICT_COPY_DEFAULT_VALUE
-            elif isinstance(dv, TraitSetObject):
-                dvt = TRAIT_SET_OBJECT_DEFAULT_VALUE
-
-            self.default_value_type = dvt
+            self.default_value_type = _infer_default_value_type(dv)
 
         return (dvt, dv)
 

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -521,7 +521,8 @@ class TraitType(BaseTraitHandler):
         dv = self.default_value
         dvt = self.default_value_type
         if dvt < 0:
-            self.default_value_type = _infer_default_value_type(dv)
+            dvt = _infer_default_value_type(dv)
+            self.default_value_type = dvt
 
         return (dvt, dv)
 

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -1101,7 +1101,8 @@ class _TraitMaker(object):
 
                 if default_value_type < 0:
                     default_value_type = _infer_default_value_type(
-                        default_value)
+                        default_value
+                    )
 
         self.default_value_type = default_value_type
         self.default_value = default_value

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -101,7 +101,6 @@ from .trait_handlers import (
 )
 
 
-
 # -------------------------------------------------------------------------------
 #  Constants:
 # -------------------------------------------------------------------------------
@@ -358,16 +357,30 @@ class CTrait(cTrait):
     @property
     def default(self):
         kind, value = self.default_value()
-        if kind in (2, 7, 8):
+        if kind in (
+            OBJECT_DEFAULT_VALUE,
+            CALLABLE_AND_ARGS_DEFAULT_VALUE,
+            CALLABLE_DEFAULT_VALUE,
+        ):
             return Undefined
-
-        if kind in (4, 6):
+        elif kind in (
+            DICT_COPY_DEFAULT_VALUE,
+            TRAIT_DICT_OBJECT_DEFAULT_VALUE,
+            TRAIT_SET_OBJECT_DEFAULT_VALUE,
+        ):
             return value.copy()
-
-        if kind in (3, 5):
+        elif kind in (
+            LIST_COPY_DEFAULT_VALUE,
+            TRAIT_LIST_OBJECT_DEFAULT_VALUE,
+        ):
             return value[:]
-
-        return value
+        elif kind in (CONSTANT_DEFAULT_VALUE, MISSING_DEFAULT_VALUE):
+            return value
+        else:
+            # This shouldn't ever happen.
+            raise RuntimeError(
+                "Unexpected default value kind: {!r}".format(kind)
+            )
 
     @property
     def default_kind(self):

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -85,7 +85,19 @@ from .trait_handlers import (
     _undefined_get,
     _undefined_set,
     UNSPECIFIED_DEFAULT_VALUE,
+    CONSTANT_DEFAULT_VALUE,
+    MISSING_DEFAULT_VALUE,
+    OBJECT_DEFAULT_VALUE,
+    LIST_COPY_DEFAULT_VALUE,
+    DICT_COPY_DEFAULT_VALUE,
+    TRAIT_LIST_OBJECT_DEFAULT_VALUE,
+    TRAIT_DICT_OBJECT_DEFAULT_VALUE,
     CALLABLE_AND_ARGS_DEFAULT_VALUE,
+    CALLABLE_DEFAULT_VALUE,
+    TRAIT_SET_OBJECT_DEFAULT_VALUE,
+    TraitListObject,
+    TraitDictObject,
+    TraitSetObject,
 )
 
 
@@ -96,15 +108,16 @@ from .trait_handlers import (
 
 # Mapping from 'ctrait' default value types to a string representation:
 KindMap = {
-    0: "value",
-    1: "value",
-    2: "self",
-    3: "list",
-    4: "dict",
-    5: "list",
-    6: "dict",
-    7: "factory",
-    8: "method",
+    CONSTANT_DEFAULT_VALUE: "value",
+    MISSING_DEFAULT_VALUE: "value",
+    OBJECT_DEFAULT_VALUE: "self",
+    LIST_COPY_DEFAULT_VALUE: "list",
+    DICT_COPY_DEFAULT_VALUE: "dict",
+    TRAIT_LIST_OBJECT_DEFAULT_VALUE: "list",
+    TRAIT_DICT_OBJECT_DEFAULT_VALUE: "dict",
+    CALLABLE_AND_ARGS_DEFAULT_VALUE: "factory",
+    CALLABLE_DEFAULT_VALUE: "method",
+    TRAIT_SET_OBJECT_DEFAULT_VALUE: "set",
 }
 
 # -------------------------------------------------------------------------------
@@ -598,9 +611,6 @@ DefaultValues = {
     bool: False,
 }
 
-DefaultValueSpecial = [Missing, Self]
-DefaultValueTypes = [list, dict]
-
 # -------------------------------------------------------------------------------
 #  Function used to unpickle new-style objects:
 # -------------------------------------------------------------------------------
@@ -618,13 +628,25 @@ def __newobj__(cls, *args):
 
 
 def _default_value_type(default_value):
-    try:
-        return DefaultValueSpecial.index(default_value) + 1
-    except:
-        try:
-            return DefaultValueTypes.index(type(default_value)) + 3
-        except:
-            return 0
+    """
+    Figure out the appropriate default value type given a default value.
+    """
+    if default_value is Missing:
+        return MISSING_DEFAULT_VALUE
+    elif default_value is Self:
+        return OBJECT_DEFAULT_VALUE
+    elif isinstance(default_value, TraitListObject):
+        return TRAIT_LIST_OBJECT_DEFAULT_VALUE
+    elif isinstance(default_value, TraitDictObject):
+        return TRAIT_DICT_OBJECT_DEFAULT_VALUE
+    elif isinstance(default_value, TraitSetObject):
+        return TRAIT_SET_OBJECT_DEFAULT_VALUE
+    elif isinstance(default_value, list):
+        return LIST_COPY_DEFAULT_VALUE
+    elif isinstance(default_value, dict):
+        return DICT_COPY_DEFAULT_VALUE
+    else:
+        return CONSTANT_DEFAULT_VALUE
 
 
 # -------------------------------------------------------------------------------

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -84,6 +84,7 @@ from .trait_handlers import (
     _write_only,
     _undefined_get,
     _undefined_set,
+    _infer_default_value_type,
     UNSPECIFIED_DEFAULT_VALUE,
     CONSTANT_DEFAULT_VALUE,
     MISSING_DEFAULT_VALUE,
@@ -632,33 +633,6 @@ def __newobj__(cls, *args):
 
 
 # -------------------------------------------------------------------------------
-#  Returns the type of default value specified:
-# -------------------------------------------------------------------------------
-
-
-def _default_value_type(default_value):
-    """
-    Figure out the appropriate default value type given a default value.
-    """
-    if default_value is Missing:
-        return MISSING_DEFAULT_VALUE
-    elif default_value is Self:
-        return OBJECT_DEFAULT_VALUE
-    elif isinstance(default_value, TraitListObject):
-        return TRAIT_LIST_OBJECT_DEFAULT_VALUE
-    elif isinstance(default_value, TraitDictObject):
-        return TRAIT_DICT_OBJECT_DEFAULT_VALUE
-    elif isinstance(default_value, TraitSetObject):
-        return TRAIT_SET_OBJECT_DEFAULT_VALUE
-    elif isinstance(default_value, list):
-        return LIST_COPY_DEFAULT_VALUE
-    elif isinstance(default_value, dict):
-        return DICT_COPY_DEFAULT_VALUE
-    else:
-        return CONSTANT_DEFAULT_VALUE
-
-
-# -------------------------------------------------------------------------------
 #  'TraitFactory' class:
 # -------------------------------------------------------------------------------
 
@@ -1126,7 +1100,8 @@ class _TraitMaker(object):
                             pass
 
                 if default_value_type < 0:
-                    default_value_type = _default_value_type(default_value)
+                    default_value_type = _infer_default_value_type(
+                        default_value)
 
         self.default_value_type = default_value_type
         self.default_value = default_value


### PR DESCRIPTION
This PR:

- fixes more uses of magic integers representing `default_value_type` constants
- adds a missing entry for `TRAIT_SET_OBJECT_DEFAULT_VALUE` to the `KindMap`
- rewrites the `_default_value_type` function to avoid magic, and to add checks for `TraitListObject`, `TraitDictObject` and `TraitSetObject`. Note that the `_default_value_type` code now very closely resembles corresponding code in `trait_handlers.py`.
- refactors to use the same default_value_type inference function in both `traits.py` and `trait_handlers.py`.