### PR TITLE
CLN : Remove the try/except around the abc import

### DIFF
--- a/traits/api.py
+++ b/traits/api.py
@@ -153,6 +153,9 @@ from .trait_types import (
 from .trait_types import UUID, ValidatedTuple
 
 from .has_traits import (
+    ABCHasStrictTraits,
+    ABCHasTraits,
+    ABCMetaHasTraits,
     HasTraits,
     HasStrictTraits,
     HasPrivateTraits,
@@ -171,11 +174,6 @@ from .has_traits import (
     provides,
     isinterface,
 )
-
-try:
-    from .has_traits import ABCHasTraits, ABCHasStrictTraits, ABCMetaHasTraits
-except ImportError:
-    pass
 
 from .trait_handlers import (
     BaseTraitHandler,

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -27,6 +27,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import abc
 import copy as copy_module
 import os
 import re
@@ -3577,42 +3578,36 @@ class HasPrivateTraits(HasTraits):
 
 
 # ------------------------------------------------------------------------------
-# ABC classes with traits: (where available)
+# ABC classes with traits:
 # ------------------------------------------------------------------------------
-try:
-
-    import abc
-
-    class ABCMetaHasTraits(abc.ABCMeta, MetaHasTraits):
-        """ A MetaHasTraits subclass which also inherits from
-        abc.ABCMeta.
-
-        .. note:: The ABCMeta class is cooperative and behaves nicely
-            with MetaHasTraits, provided it is inherited first.
-        """
-
-        pass
-
-    @six.add_metaclass(ABCMetaHasTraits)
-    class ABCHasTraits(HasTraits):
-        """ A HasTraits subclass which enables the features of Abstract
-        Base Classes (ABC). See the 'abc' module in the standard library
-        for more information.
-
-        """
-
-    class ABCHasStrictTraits(ABCHasTraits):
-        """ A HasTraits subclass which behaves like HasStrictTraits but
-        also enables the features of Abstract Base Classes (ABC). See the
-        'abc' module in the standard library for more information.
-
-        """
-
-        _ = Disallow
 
 
-except ImportError:
+class ABCMetaHasTraits(abc.ABCMeta, MetaHasTraits):
+    """ A MetaHasTraits subclass which also inherits from
+    abc.ABCMeta.
+
+    .. note:: The ABCMeta class is cooperative and behaves nicely
+        with MetaHasTraits, provided it is inherited first.
+    """
+
     pass
+
+@six.add_metaclass(ABCMetaHasTraits)
+class ABCHasTraits(HasTraits):
+    """ A HasTraits subclass which enables the features of Abstract
+    Base Classes (ABC). See the 'abc' module in the standard library
+    for more information.
+
+    """
+
+class ABCHasStrictTraits(ABCHasTraits):
+    """ A HasTraits subclass which behaves like HasStrictTraits but
+    also enables the features of Abstract Base Classes (ABC). See the
+    'abc' module in the standard library for more information.
+
+    """
+
+    _ = Disallow
 
 # -------------------------------------------------------------------------------
 #  Singleton classes with traits:


### PR DESCRIPTION
The abc module is available on both Python 2.7 and 3.6, which are supported by the traits package at the moment.

The code was originally added in https://github.com/enthought/traits/pull/15 , in Mar 2012, at which point Python 2.6 and 2.7 made the abc module available via the standard library. I'm not sure if the codebase had support for those versions of Python at that point in time, which is why the imports needed to be conditional.

Note that the PR added a test which also included conditional imports but that test module has been updated to remove the conditional imports (ref https://github.com/enthought/traits/pull/121/)