### PR TITLE
Compute ViewElements lazily

### DIFF
--- a/traits/api.py
+++ b/traits/api.py
@@ -230,7 +230,7 @@ try:
 
     # -------------------------------------------------------------------------------
     #  Patch the main traits module with the correct definition for the
-    #  ViewElement and ViewSubElement class:
+    #  ViewElement class:
     # -------------------------------------------------------------------------------
 
     from traitsui import view_element

--- a/traits/api.py
+++ b/traits/api.py
@@ -228,24 +228,13 @@ from .trait_numeric import Array, ArrayOrNone, CArray
 try:
     from . import has_traits as has_traits
 
-    # ---------------------------------------------------------------------------
-    #  Patch the main traits module with the correct definition for the
-    #  ViewElements class:
-    #  NOTE: We do this in a try..except block because traits.ui depends on
-    #  the pyface module (part of the TraitsGUI package) which may not
-    #  necessarily be installed. Not having TraitsGUI means that the 'ui'
-    #  features of traits will not work.
-    # ---------------------------------------------------------------------------
-
-    from traitsui import view_elements
-
-    has_traits.ViewElements = view_elements.ViewElements
-
     # -------------------------------------------------------------------------------
     #  Patch the main traits module with the correct definition for the
     #  ViewElement and ViewSubElement class:
     # -------------------------------------------------------------------------------
 
-    has_traits.ViewElement = view_elements.ViewElement
+    from traitsui import view_element
+
+    has_traits.ViewElement = view_element.ViewElement
 except ImportError:
     pass

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -111,10 +111,6 @@ class ViewElement(object):
     pass
 
 
-def ViewElements():
-    return None
-
-
 # -------------------------------------------------------------------------------
 #  Constants:
 # -------------------------------------------------------------------------------
@@ -537,7 +533,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
     prefix_traits = {}
     listeners = {}
     prefix_list = []
-    view_elements = ViewElements()
+    view_elements = {}
 
     # Create a list of just those base classes that derive from HasTraits:
     hastraits_bases = [
@@ -630,17 +626,12 @@ def update_traits_class_dict(class_name, bases, class_dict):
 
             # Add the view element to the class's 'ViewElements' if it is
             # not already defined (duplicate definitions are errors):
-            if name in view_elements.content:
+            if name in view_elements:
                 raise TraitError(
                     "Duplicate definition for view element '%s'" % name
                 )
 
-            view_elements.content[name] = value
-
-            # Replace all substitutable view sub elements with 'Include'
-            # objects, and add the substituted items to the
-            # 'ViewElements':
-            value.replace_include(view_elements)
+            view_elements[name] = value
 
             # Remove the view element from the class definition:
             del class_dict[name]
@@ -711,12 +702,6 @@ def update_traits_class_dict(class_name, bases, class_dict):
             if name not in prefix_list:
                 prefix_list.append(name)
                 prefix_traits[name] = base_prefix_traits[name]
-
-        # If the base class has a 'ViewElements' object defined, add it to
-        # the 'parents' list of this class's 'ViewElements':
-        parent_view_elements = base_dict.get(ViewTraits)
-        if parent_view_elements is not None:
-            view_elements.parents.append(parent_view_elements)
 
     # Make sure there is a definition for 'undefined' traits:
     if prefix_traits.get("") is None:
@@ -2082,7 +2067,7 @@ class HasTraits(CHasTraits):
             if parent_view_elements is not None:
                 view_elements.parents.append(parent_view_elements)
 
-        cls.__dict__[ViewTraits] = view_elements
+        setattr(cls, ViewTraits, view_elements)
         return view_elements
 
     # ---------------------------------------------------------------------------

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -624,13 +624,6 @@ def update_traits_class_dict(class_name, bases, class_dict):
         # Handle any view elements found in the class:
         elif isinstance(value, ViewElement):
 
-            # Add the view element to the class's 'ViewElements' if it is
-            # not already defined (duplicate definitions are errors):
-            if name in view_elements:
-                raise TraitError(
-                    "Duplicate definition for view element '%s'" % name
-                )
-
             view_elements[name] = value
 
             # Remove the view element from the class definition:
@@ -2052,7 +2045,14 @@ class HasTraits(CHasTraits):
         view_elements = ViewElements()
         elements_dict = cls.__dict__[ViewTraits]
 
-        for name, element in elements_dict:
+        for name, element in elements_dict.items():
+            # Add the view element to the class's 'ViewElements' if it is
+            # not already defined (duplicate definitions are errors):
+            if name in view_elements.content:
+                raise TraitError(
+                    "Duplicate definition for view element '%s'" % name
+                )
+
             view_elements.content[name] = element
 
             # Replace all substitutable view sub elements with 'Include'

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2040,7 +2040,7 @@ class HasTraits(CHasTraits):
 
         hastraits_bases = [
             base for base in cls.__bases__
-            if base.__dict__.get(ClassTraits) is not None
+            if ClassTraits in base.__dict__
         ]
         view_elements = ViewElements()
         elements_dict = cls.__dict__[ViewTraits]

--- a/traits/tests/test_view_elements.py
+++ b/traits/tests/test_view_elements.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2019 by Enthought, Inc.
+# All rights reserved.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import six
+
+from traits.api import HasTraits, Int, TraitError
+from traits.testing.optional_dependencies import requires_traitsui
+
+
+@requires_traitsui
+class TestViewElements(unittest.TestCase):
+    def setUp(self):
+        import traitsui.api
+
+        self.toolkit = traitsui.api.toolkit()
+
+    def tearDown(self):
+        del self.toolkit
+
+    def test_view_definition(self):
+        from traitsui.api import View
+
+        view = View('count')
+
+        class Model(HasTraits):
+            count = Int
+            my_view = view
+
+        view_elements = Model.class_trait_view_elements()
+
+        self.assertEqual(view_elements.content, {'my_view': view})
+
+    def test_included_names(self):
+        from traitsui.api import Group, Item, View
+
+        item = Item('count', id='item_with_id')
+        group = Group(item)
+        view = View(Item('count'))
+
+        class Model(HasTraits):
+            count = Int
+            my_group = Group(item)
+            my_view = view
+
+        view_elements = Model.class_trait_view_elements()
+
+        self.assertEqual(
+            set(view_elements.content),
+            {'my_view', 'my_group', 'item_with_id'}
+        )
+
+    def test_duplicate_names(self):
+        from traitsui.api import Group, Item, View
+
+        class Model(HasTraits):
+            count = Int
+            includable = Group(Item('count', id='name_conflict'))
+            name_conflict = View(Item('count'))
+
+        with self.assertRaises(TraitError):
+            Model.class_trait_view_elements()

--- a/traits/tests/test_view_elements.py
+++ b/traits/tests/test_view_elements.py
@@ -1,12 +1,7 @@
 # Copyright (c) 2019 by Enthought, Inc.
 # All rights reserved.
 
-import os
-import shutil
-import tempfile
 import unittest
-
-import six
 
 from traits.api import HasTraits, Int, TraitError
 from traits.testing.optional_dependencies import requires_traitsui
@@ -35,6 +30,49 @@ class TestViewElements(unittest.TestCase):
 
         self.assertEqual(view_elements.content, {'my_view': view})
 
+    def test_view_definition_twice(self):
+        from traitsui.api import View
+
+        view = View('count')
+
+        class Model(HasTraits):
+            count = Int
+            my_view = view
+
+        view_elements = Model.class_trait_view_elements()
+        view_elements2 = Model.class_trait_view_elements()
+
+        self.assertEqual(view_elements.content, {'my_view': view})
+        self.assertIs(view_elements, view_elements2)
+
+    def test_instance_view_definition(self):
+        from traitsui.api import View
+
+        view = View('count')
+
+        class Model(HasTraits):
+            count = Int
+            my_view = view
+
+        m = Model()
+        view_elements = m.trait_view_elements()
+
+        self.assertEqual(view_elements.content, {'my_view': view})
+
+    def test_trait_views(self):
+        from traitsui.api import View
+
+        view = View('count')
+
+        class Model(HasTraits):
+            count = Int
+            my_view = view
+
+        m = Model()
+        views = m.trait_views()
+
+        self.assertEqual(views, ['my_view'])
+
     def test_included_names(self):
         from traitsui.api import Group, Item, View
 
@@ -44,14 +82,14 @@ class TestViewElements(unittest.TestCase):
 
         class Model(HasTraits):
             count = Int
-            my_group = Group(item)
+            my_group = group
             my_view = view
 
         view_elements = Model.class_trait_view_elements()
 
         self.assertEqual(
-            set(view_elements.content),
-            {'my_view', 'my_group', 'item_with_id'}
+            view_elements.content,
+            {'my_view': view, 'my_group': group, 'item_with_id': item}
         )
 
     def test_duplicate_names(self):

--- a/traits/tests/test_view_elements.py
+++ b/traits/tests/test_view_elements.py
@@ -45,6 +45,22 @@ class TestViewElements(unittest.TestCase):
         self.assertEqual(view_elements.content, {'my_view': view})
         self.assertIs(view_elements, view_elements2)
 
+    def test_view_elements_parents(self):
+        from traitsui.api import View
+
+        class Model(HasTraits):
+            count = Int
+            my_view = View('count')
+
+        class ModelSubclass(Model):
+            total = Int
+            my_view = View('count', 'total')
+
+        view_elements = ModelSubclass.class_trait_view_elements()
+        parent_view_elements = Model.class_trait_view_elements()
+
+        self.assertEqual(view_elements.parents[0], parent_view_elements)
+
     def test_instance_view_definition(self):
         from traitsui.api import View
 


### PR DESCRIPTION
This is a refactor of the way that `ViewElements` are constructed, making it lazy.  The changed code now:

1. collects all `ViewElement` instances as part of `update_traits_class_dict` and extract them into a simple dictionary in `cls.__view_traits__`, no longer doing `Include` injection or base class analysis.
2. when we need to do something with the ViewElements, if `cls.__view_traits__` is a dict, then we do the initialization and replace the dictionary with the `ViewElement` instance.

Assumptions are that the only places that use `cls.__view_traits__` directly are `HasTraits.trait_views` and `HasTraits.clas_trait_view_elements` and so we only need to perform initialization here.

This is working towards #610.