### PR TITLE
Make sure traitsui.api is available when traitsui is.

### DIFF
--- a/traits/testing/optional_dependencies.py
+++ b/traits/testing/optional_dependencies.py
@@ -53,6 +53,10 @@ requires_sphinx = unittest.skipIf(sphinx is None, "Sphinx not available")
 
 traitsui = optional_import("traitsui")
 requires_traitsui = unittest.skipIf(traitsui is None, "TraitsUI not available")
+# Import traitsui.api so that client code can use traits.api directly without
+# an extra import.
+if traitsui is not None:
+    import traitsui.api
 
 requires_python2 = unittest.skipUnless(six.PY2, "Applicable only to Python 2")
 conflicts_with_python2 = unittest.skipIf(six.PY2, "Does not apply to Python 2")

--- a/traits/tests/test_configure_traits.py
+++ b/traits/tests/test_configure_traits.py
@@ -15,7 +15,7 @@ import unittest
 import six
 
 from traits.api import HasTraits, Int
-from traits.testing.optional_dependencies import requires_traitsui
+from traits.testing.optional_dependencies import requires_traitsui, traitsui
 
 
 class Model(HasTraits):
@@ -25,8 +25,6 @@ class Model(HasTraits):
 @requires_traitsui
 class TestConfigureTraits(unittest.TestCase):
     def setUp(self):
-        import traitsui.api
-
         self.toolkit = traitsui.api.toolkit()
         self.tmpdir = tempfile.mkdtemp()
 


### PR DESCRIPTION
This PR allows testers who require `traitsui` to do:
```
from traits.testing.optional_dependencies import requires_traitsui, traitsui
```
and then use `traitsui.api.<thing>` in a test without the need for further imports.

Motivated by #614 
