### PR TITLE
Create an ABC for ViewElements

### DIFF
--- a/traits/api.py
+++ b/traits/api.py
@@ -156,6 +156,7 @@ from .has_traits import (
     ABCHasStrictTraits,
     ABCHasTraits,
     ABCMetaHasTraits,
+    AbstractViewElement,
     HasTraits,
     HasStrictTraits,
     HasPrivateTraits,
@@ -224,15 +225,14 @@ from .adaptation.adaptation_manager import (
 from .trait_numeric import Array, ArrayOrNone, CArray
 
 try:
-    from . import has_traits as has_traits
-
     # -------------------------------------------------------------------------------
     #  Patch the main traits module with the correct definition for the
     #  ViewElement class:
     # -------------------------------------------------------------------------------
 
-    from traitsui import view_element
+    from traitsui.view_element import ViewElement
 
-    has_traits.ViewElement = view_element.ViewElement
+    if not isinstance(ViewElement, AbstractViewElement):
+        AbstractViewElement.register(ViewElement)
 except ImportError:
     pass

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -99,16 +99,15 @@ from .util.deprecated import deprecated
 CHECK_INTERFACES = 0
 
 # -------------------------------------------------------------------------------
-#  Deferred definitions:
-#
-#  The following classes have a 'chicken and the egg' definition problem. They
-#  require Traits to work, because they subclass Traits, but the Traits
-#  meta-class programming support uses them, so Traits can't be subclassed
-#  until they are defined.
+#  This ABC is a placeholder for the TraitsUI ViewElement class, which should
+#  inherit from or register as implementing the API.  This has to be done here
+#  so that the metaclass machinery has something to check against when filtering
+#  out TraitsUI elements that are declared as part of a HasTraits class.
 # -------------------------------------------------------------------------------
 
 
-class ViewElement(object):
+@six.add_metaclass(abc.ABCMeta)
+class AbstractViewElement(object):
     pass
 
 
@@ -623,7 +622,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
             class_traits[name] = generic_trait
 
         # Handle any view elements found in the class:
-        elif isinstance(value, ViewElement):
+        elif isinstance(value, AbstractViewElement):
 
             view_elements[name] = value
 
@@ -1899,7 +1898,7 @@ class HasTraits(CHasTraits):
         """ Gets or sets a ViewElement associated with an object's class.
         """
         # If a view element was passed instead of a name or None, return it:
-        if isinstance(name, ViewElement):
+        if isinstance(name, AbstractViewElement):
             return name
 
         # Get the ViewElements object associated with the class:
@@ -1932,7 +1931,7 @@ class HasTraits(CHasTraits):
         name = default_name()
 
         # If the default is a View, return it:
-        if isinstance(name, ViewElement):
+        if isinstance(name, AbstractViewElement):
             return name
 
         # Otherwise, get all View objects associated with the object's class:
@@ -1946,7 +1945,7 @@ class HasTraits(CHasTraits):
             method = getattr(handler, name, None)
             if callable(method):
                 result = method()
-                if isinstance(result, ViewElement):
+                if isinstance(result, AbstractViewElement):
                     return result
 
         # If there is only one View, return it:


### PR DESCRIPTION
This is the second part of solving #610  

This creates and ABC `AbstractViewElement` class and then registers `traitsui.view_element.ViewElement` as implementing the API when `traits.api` is imported.  This is an improvement over the current situation, as we can now get rid of the TraitsUI dependency in `traits.api` by:

1. Making `ViewElement` inherit from/register as `AbstractViewElement` when defining it in TraitsUI.
2. After sufficient time, when we can reasonably expect users to have updated their TraitsUI versions or explicitly require a version of TraitsUI that includes (1), we can remove the import.