### PR TITLE
Add cTrait.set_default_value

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2991,7 +2991,7 @@ _trait_set_default_value ( trait_object * trait, PyObject * args ) {
 /*-----------------------------------------------------------------------------
 |  Get or set the 'default_value_type' and 'default_value' fields
 |  of a CTrait instance. Use of this function for setting the default
-|  value information is deprecated; use set_default_value for that instead.
+|  value information is deprecated; use set_default_value instead.
 +----------------------------------------------------------------------------*/
 
 static PyObject *
@@ -3007,14 +3007,10 @@ _trait_default_value ( trait_object * trait, PyObject * args ) {
         }
     }
 
-    /* The default_value method used to support setting the default value
-       information, as well as getting it. We continue to support this for
-       backwards compatibility, but issue a deprecation warning. */
-
     PyErr_Clear();
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
             "Use of the default_value method with arguments is deprecated. "
-            "To set defaults, use the set_default_value method instead.", 1) != 0) {
+            "To set defaults, use set_default_value instead.", 1) != 0) {
         return NULL;
     }
     return _trait_set_default_value(trait, args);
@@ -5017,15 +5013,42 @@ set_trait_post_setattr ( trait_object * trait, PyObject * value,
 |  'CTrait' instance methods:
 +----------------------------------------------------------------------------*/
 
+PyDoc_STRVAR(default_value_doc,
+"default_value()\n"
+"\n"
+"Return tuple giving default value information for this trait.\n"
+"\n"
+"Returns\n"
+"-------\n"
+"default_value_type : int\n"
+"    An integer representing the kind of the default value\n"
+"default_value : value\n"
+"    A value or callable providing the default\n"
+);
+
+PyDoc_STRVAR(set_default_value_doc,
+"set_default_value(default_value_type, default_value)\n"
+"\n"
+"Set the default value information for this trait.\n"
+"\n"
+"Parameters\n"
+"----------\n"
+"default_value_type : int\n"
+"    An integer representing the kind of the default value\n"
+"default_value : value\n"
+"    A value or callable providing the default\n"
+);
+
+
 static PyMethodDef trait_methods[] = {
         { "__getstate__", (PyCFunction) _trait_getstate,       METH_VARARGS,
                 PyDoc_STR( "__getstate__()" ) },
         { "__setstate__", (PyCFunction) _trait_setstate,       METH_VARARGS,
                 PyDoc_STR( "__setstate__(state)" ) },
         { "default_value", (PyCFunction) _trait_default_value, METH_VARARGS,
-                PyDoc_STR( "default_value()" ) },
+                default_value_doc },
         { "set_default_value", (PyCFunction) _trait_set_default_value, METH_VARARGS,
-                PyDoc_STR( "set_default_value(default_value_type, default_value)")},
+                set_default_value_doc },
         { "default_value_for", (PyCFunction) _trait_default_value_for, METH_VARARGS,
                 PyDoc_STR( "default_value_for(object,name)" ) },
         { "set_validate",  (PyCFunction) _trait_set_validate,  METH_VARARGS,

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2966,23 +2966,21 @@ _trait_set_default_value ( trait_object * trait, PyObject * args ) {
     if ( !PyArg_ParseTuple( args, "iO", &value_type, &value ) )
         return NULL;
 
-    PyErr_Clear();
     if ( (value_type < 0) || (value_type > MAXIMUM_DEFAULT_VALUE_TYPE) ) {
         PyErr_Format(
             PyExc_ValueError,
             "The default value type must be 0..%d, but %d was specified.",
             MAXIMUM_DEFAULT_VALUE_TYPE,
             value_type );
-
         return NULL;
     }
 
     trait->default_value_type = value_type;
-    Py_INCREF( value );
 
     /* The DECREF on the old value can call arbitrary code, so take care not to
        DECREF until the trait is in a consistent state. (Newer CPython versions
        have a Py_XSETREF macro to do this safely.) */
+    Py_INCREF( value );
     old_value = trait->default_value;
     trait->default_value = value;
     Py_XDECREF( old_value );

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -207,6 +207,10 @@ static int call_notifiers ( PyListObject *, PyListObject *,
    is the default value */
 #define TRAIT_SET_OBJECT_DEFAULT_VALUE 9
 
+/* Maximum legal value for default_value_type, for use in testing and
+   validation. */
+#define MAXIMUM_DEFAULT_VALUE_TYPE 9
+
 
 /*-----------------------------------------------------------------------------
 |  'CTrait' instance definition:
@@ -2963,10 +2967,12 @@ _trait_set_default_value ( trait_object * trait, PyObject * args ) {
         return NULL;
 
     PyErr_Clear();
-    if ( (value_type < 0) || (value_type > 9) ) {
-        PyErr_Format( PyExc_ValueError,
-                "The default value type must be 0..9, but %d was specified.",
-                value_type );
+    if ( (value_type < 0) || (value_type > MAXIMUM_DEFAULT_VALUE_TYPE) ) {
+        PyErr_Format(
+            PyExc_ValueError,
+            "The default value type must be 0..%d, but %d was specified.",
+            MAXIMUM_DEFAULT_VALUE_TYPE,
+            value_type );
 
         return NULL;
     }

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -647,7 +647,8 @@ def update_traits_class_dict(class_name, bases, class_dict):
                     class_traits[name] = value = ictrait(default_value)
                     # Make sure that the trait now has the default value
                     # has the correct initializer.
-                    value.default_value(MISSING_DEFAULT_VALUE, value.default)
+                    value.set_default_value(
+                        MISSING_DEFAULT_VALUE, value.default)
                     del class_dict[name]
                     handler = value.handler
                     if (handler is not None) and handler.is_mapped:
@@ -778,7 +779,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
                 _add_notifiers(trait._notifiers(1), handlers)
 
             if default is not None:
-                trait.default_value(CALLABLE_DEFAULT_VALUE, default)
+                trait.set_default_value(CALLABLE_DEFAULT_VALUE, default)
 
         # Handle the case of properties whose value depends upon the value
         # of other traits:

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -18,6 +18,7 @@ from traits.traits import CTrait
 from traits.trait_handlers import (
     CONSTANT_DEFAULT_VALUE,
     LIST_COPY_DEFAULT_VALUE,
+    MAXIMUM_DEFAULT_VALUE_TYPE,
 )
 
 
@@ -54,3 +55,12 @@ class TestCTrait(unittest.TestCase):
         )
         _, _, this_module = __name__.rpartition(".")
         self.assertIn(this_module, warn_msg.filename)
+
+    def test_bad_default_value_type(self):
+        trait = CTrait(0)
+
+        with self.assertRaises(ValueError):
+            trait.set_default_value(-1, None)
+
+        with self.assertRaises(ValueError):
+            trait.set_default_value(MAXIMUM_DEFAULT_VALUE_TYPE + 1, None)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -40,7 +40,7 @@ class TestCTrait(unittest.TestCase):
             trait.default_value(), (LIST_COPY_DEFAULT_VALUE, [1, 2, 3])
         )
 
-    def test_default_value_for_set(self):
+    def test_default_value_for_set_is_deprecated(self):
         trait = CTrait(0)
         with warnings.catch_warnings(record=True) as warn_msgs:
             warnings.simplefilter("always", DeprecationWarning)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -13,7 +13,6 @@
 import unittest
 import warnings
 
-
 from traits.traits import CTrait
 from traits.trait_handlers import (
     CONSTANT_DEFAULT_VALUE,

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -1,0 +1,56 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in enthought/LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+# ------------------------------------------------------------------------------
+
+
+import unittest
+import warnings
+
+
+from traits.traits import CTrait
+from traits.trait_handlers import (
+    CONSTANT_DEFAULT_VALUE,
+    LIST_COPY_DEFAULT_VALUE,
+)
+
+
+class TestCTrait(unittest.TestCase):
+    """ Tests for the CTrait class. """
+
+    def test_initial_default_value(self):
+        trait = CTrait(0)
+        self.assertEqual(
+            trait.default_value(), (CONSTANT_DEFAULT_VALUE, None),
+        )
+
+    def test_set_and_get_default_value(self):
+        trait = CTrait(0)
+        trait.set_default_value(CONSTANT_DEFAULT_VALUE, 2.3)
+        self.assertEqual(trait.default_value(), (CONSTANT_DEFAULT_VALUE, 2.3))
+
+        trait.set_default_value(LIST_COPY_DEFAULT_VALUE, [1, 2, 3])
+        self.assertEqual(
+            trait.default_value(), (LIST_COPY_DEFAULT_VALUE, [1, 2, 3])
+        )
+
+    def test_default_value_for_set(self):
+        trait = CTrait(0)
+        with warnings.catch_warnings(record=True) as warn_msgs:
+            warnings.simplefilter("always", DeprecationWarning)
+            trait.default_value(CONSTANT_DEFAULT_VALUE, 3.7)
+
+        self.assertEqual(len(warn_msgs), 1)
+        warn_msg = warn_msgs[0]
+        self.assertIn(
+            "default_value method with arguments is deprecated",
+            str(warn_msg.message),
+        )
+        _, _, this_module = __name__.rpartition(".")
+        self.assertIn(this_module, warn_msg.filename)

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -681,7 +681,7 @@ class TraitType(BaseTraitHandler):
 
             metadata.setdefault("type", "trait")
 
-        trait.default_value(*self.get_default_value())
+        trait.set_default_value(*self.get_default_value())
 
         trait.value_allowed(metadata.get("trait_value", False) is True)
 

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -116,6 +116,10 @@ CALLABLE_DEFAULT_VALUE = 8
 #: is the default value.
 TRAIT_SET_OBJECT_DEFAULT_VALUE = 9
 
+#: Maximum legal value for default_value_type, for use in testing
+#: and validation.
+MAXIMUM_DEFAULT_VALUE_TYPE = 9
+
 
 # Mapping from trait metadata 'type' to CTrait 'type':
 trait_types = {"python": 1, "event": 2}

--- a/traits/trait_value.py
+++ b/traits/trait_value.py
@@ -30,7 +30,13 @@ from .traits import CTrait
 from .has_traits import HasTraits, HasPrivateTraits
 from .trait_errors import TraitError
 from .trait_types import Tuple, Dict, Any, Str, Instance, Event, Callable
-from .trait_handlers import TraitType, _read_only, _write_only, _arg_count
+from .trait_handlers import (
+    _arg_count,
+    _read_only,
+    _write_only,
+    CALLABLE_AND_ARGS_DEFAULT_VALUE,
+    TraitType,
+)
 
 # -------------------------------------------------------------------------------
 #  'BaseTraitValue' class:
@@ -165,7 +171,10 @@ class TraitValue(BaseTraitValue):
             if original_trait.__dict__ is not None:
                 trait.__dict__ = original_trait.__dict__.copy()
 
-            trait.default_value(7, (self.default, self.args, self.kw))
+            trait.set_default_value(
+                CALLABLE_AND_ARGS_DEFAULT_VALUE,
+                (self.default, self.args, self.kw),
+            )
 
         elif self.type is not None:
             type = self.type

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -1154,7 +1154,7 @@ class _TraitMaker(object):
             if clone.__dict__ is not None:
                 trait.__dict__ = clone.__dict__.copy()
 
-        trait.default_value(self.default_value_type, self.default_value)
+        trait.set_default_value(self.default_value_type, self.default_value)
 
         handler = self.handler
         if handler is not None:


### PR DESCRIPTION
Currently, the `cTrait.default_value` method does double duty: it's used both to set and to get the default value information for a Trait.

This PR refactors to add a separate method `cTrait.set_default_value` for setting, and deprecates the use of the `default_value` method for setting the default value.

