### PR TITLE
Make ListInt, DictStrInt, etc. less surprising.

### DIFF
--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3713,22 +3713,22 @@ undefined = Any(Undefined)
 # -- List Traits ----------------------------------------------------------------
 
 #: List of integer values; default value is [].
-ListInt = List(int)
+ListInt = List(Int)
 
 #: List of float values; default value is [].
-ListFloat = List(float)
+ListFloat = List(Float)
 
 #: List of string values; default value is [].
-ListStr = List(str)
+ListStr = List(Str)
 
 #: List of Unicode string values; default value is [].
-ListUnicode = List(six.text_type)
+ListUnicode = List(Unicode)
 
 #: List of complex values; default value is [].
-ListComplex = List(complex)
+ListComplex = List(Complex)
 
 #: List of Boolean values; default value is [].
-ListBool = List(bool)
+ListBool = List(Bool)
 
 #: List of function values; default value is [].
 ListFunction = List(FunctionType)
@@ -3743,24 +3743,24 @@ ListThis = List(ThisClass)
 
 #: Only a dictionary of string:Any values can be assigned; only string keys can
 #: be inserted. The default value is {}.
-DictStrAny = Dict(str, Any)
+DictStrAny = Dict(Str, Any)
 
 #: Only a dictionary of string:string values can be assigned; only string keys
 #: with string values can be inserted. The default value is {}.
-DictStrStr = Dict(str, str)
+DictStrStr = Dict(Str, Str)
 
 #: Only a dictionary of string:integer values can be assigned; only string keys
 #: with integer values can be inserted. The default value is {}.
-DictStrInt = Dict(str, int)
+DictStrInt = Dict(Str, Int)
 
 #: Only a dictionary of string:float values can be assigned; only string keys
 #: with float values can be inserted. The default value is {}.
-DictStrFloat = Dict(str, float)
+DictStrFloat = Dict(Str, Float)
 
 #: Only a dictionary of string:bool values can be assigned; only string keys
 #: with boolean values can be inserted. The default value is {}.
-DictStrBool = Dict(str, bool)
+DictStrBool = Dict(Str, Bool)
 
 #: Only a dictionary of string:list values can be assigned; only string keys
 #: with list values can be assigned. The default value is {}.
-DictStrList = Dict(str, list)
+DictStrList = Dict(Str, List)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -54,7 +54,6 @@ from .trait_handlers import (
     TraitSetEvent,
     TraitDictObject,
     TraitDictEvent,
-    ThisClass,
     items_event,
     RangeTypes,
     HandleWeakRef,
@@ -3737,7 +3736,7 @@ ListFunction = List(Instance(FunctionType, allow_none=False))
 ListMethod = List(Instance(MethodType, allow_none=False))
 
 #: List of container type values; default value is [].
-ListThis = List(ThisClass)
+ListThis = List(This(allow_none=False))
 
 # -- Dictionary Traits ----------------------------------------------------------
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3731,10 +3731,10 @@ ListComplex = List(Complex)
 ListBool = List(Bool)
 
 #: List of function values; default value is [].
-ListFunction = List(FunctionType)
+ListFunction = List(Instance(FunctionType, allow_none=False))
 
 #: List of method values; default value is [].
-ListMethod = List(MethodType)
+ListMethod = List(Instance(MethodType, allow_none=False))
 
 #: List of container type values; default value is [].
 ListThis = List(ThisClass)


### PR DESCRIPTION
Traits defines and exports some compound trait types like `ListFloat` and `DictStrInt`. Currently, these do not wrap the `Float`, `Str`, `Int` trait types that you'd expect them to, meaning that (for example) `ListFloat` is not equivalent to `List(Float)`, and has some surprises (see below).

This PR replaces these trait types with their obvious TraitType-based equivalents, and fixes those surprises.

```
>>> from traits.api import *
>>> class A(HasTraits):
...     foo = ListInt
...     bar = ListFloat
... 
>>> a = A()
>>> a.foo = [True, False]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 2452, in validate
    return TraitListObject(self, object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 2258, in __init__
    raise excp
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 2250, in __init__
    value = [validate(object, name, val) for val in value]
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 2250, in <listcomp>
    value = [validate(object, name, val) for val in value]
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 974, in validate
    self.error(object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 256, in error
    object, name, self.full_info(object, name, value), value
traits.trait_errors.TraitError: Each element of the 'foo' trait of an A instance must be a value of class 'int', but a value of True <class 'bool'> was specified.
>>> import numpy as np
>>> a.bar = list(np.arange(5.0))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 2452, in validate
    return TraitListObject(self, object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 2258, in __init__
    raise excp
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 2250, in __init__
    value = [validate(object, name, val) for val in value]
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 2250, in <listcomp>
    value = [validate(object, name, val) for val in value]
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 974, in validate
    self.error(object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_handlers.py", line 256, in error
    object, name, self.full_info(object, name, value), value
traits.trait_errors.TraitError: Each element of the 'bar' trait of an A instance must be a value of class 'float', but a value of 0.0 <class 'numpy.float64'> was specified.
```
