### PR TITLE
Remove abuses of Missing

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -73,7 +73,6 @@ from .trait_handlers import (
 )
 
 from .trait_base import (
-    Missing,
     SequenceTypes,
     TraitsCache,
     Undefined,
@@ -1388,9 +1387,11 @@ class HasTraits(CHasTraits):
         elif n == 0:
             names = self.trait_names(**metadata)
 
+        # Sentinel for missing attributes.
+        missing = object()
         for name in names:
-            value = getattr(self, name, Missing)
-            if value is not Missing:
+            value = getattr(self, name, missing)
+            if value is not missing:
                 result[name] = value
 
         return result

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -530,7 +530,7 @@ class TraitType(BaseTraitHandler):
 
         return (dvt, dv)
 
-    def clone(self, default_value=Missing, **metadata):
+    def clone(self, default_value=NoDefaultSpecified, **metadata):
         """ Clones the contents of this object into a new instance of the same
             class, and then modifies the cloned copy using the specified
             *default_value* and *metadata*. Returns the cloned object as the
@@ -556,7 +556,7 @@ class TraitType(BaseTraitHandler):
 
         new._metadata.update(metadata)
 
-        if default_value is not Missing:
+        if default_value is not NoDefaultSpecified:
             new.default_value = default_value
             if self.validate is not None:
                 try:


### PR DESCRIPTION
This simple PR extracts just two of the changes in #604. This fixes two places where the codebase uses `Missing` as a handy singleton, unrelated to the actual purpose of `Missing`.