### PR TITLE
Deprecate ListStr, DictStrFloat, ..., false, true convenience trait types

### DIFF
--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -180,9 +180,17 @@ Deprecated trait types
 ----------------------
 
 The following :class:`~.TraitType` instances are deprecated, and may
-be removed in a future version of Traits. Replace these with the
-corresponding compound types (e.g., replace ``ListStr`` with ``List(Str)``
-and ``DictStrAny`` with ``Dict(Str, Any)``).
+be removed in a future version of Traits. In user code, these should be
+replaced with the corresponding compound types (e.g., replace ``ListStr``
+with ``List(Str)`` and ``DictStrAny`` with ``Dict(Str, Any)``).
+
+.. deprecated:: 6.0.0
+
+.. autodata:: false
+
+.. autodata:: true
+
+.. autodata:: undefined
 
 .. autodata:: ListInt
 
@@ -213,10 +221,6 @@ and ``DictStrAny`` with ``Dict(Str, Any)``).
 .. autodata:: DictStrBool
 
 .. autodata:: DictStrList
-
-.. autodata:: false
-
-.. autodata:: true
 
 
 Private Classes

--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -176,6 +176,14 @@ Traits
 
 .. autodata:: Time
 
+Deprecated trait types
+----------------------
+
+The following :class:`~.TraitType` instances are deprecated, and may
+be removed in a future version of Traits. Replace these with the
+corresponding compound types (e.g., replace ``ListStr`` with ``List(Str)``
+and ``DictStrAny`` with ``Dict(Str, Any)``).
+
 .. autodata:: ListInt
 
 .. autodata:: ListFloat
@@ -205,6 +213,11 @@ Traits
 .. autodata:: DictStrBool
 
 .. autodata:: DictStrList
+
+.. autodata:: false
+
+.. autodata:: true
+
 
 Private Classes
 ---------------

--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -176,8 +176,8 @@ Traits
 
 .. autodata:: Time
 
-Deprecated trait types
-----------------------
+Deprecated Traits
+-----------------
 
 The following :class:`~.TraitType` instances are deprecated, and may
 be removed in a future version of Traits. In user code, these should be

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3755,32 +3755,32 @@ ListThis = List(ThisClass)
 
 # -- Dictionary Traits --------------------------------------------------------
 
-#: Only a dictionary of string:Any values can be assigned; only string keys can
-#: be inserted. The default value is {}. This trait type is deprecated. Use
+#: Only a dictionary with strings as keys can be assigned; only string keys
+#: can be inserted. The default value is {}. This trait type is deprecated. Use
 #: ``Dict(Str, Any)`` instead.
 DictStrAny = Dict(str, Any)
 
-#: Only a dictionary of string:string values can be assigned; only string keys
-#: with string values can be inserted. The default value is {}. This trait
+#: Only a dictionary mapping strings to strings can be assigned; only string
+#: keys with string values can be inserted. The default value is {}. This trait
 #: type is deprecated. Use ``Dict(Str, Str)`` instead.
 DictStrStr = Dict(str, str)
 
-#: Only a dictionary of string:integer values can be assigned; only string keys
-#: with integer values can be inserted. The default value is {}. This trait
-#: type is deprecated. Use ``Dict(Str, Int)`` instead.
+#: Only a dictionary mapping strings to integers can be assigned; only string
+#: keys with integer values can be inserted. The default value is {}. This
+#: trait type is deprecated. Use ``Dict(Str, Int)`` instead.
 DictStrInt = Dict(str, int)
 
-#: Only a dictionary of string:float values can be assigned; only string keys
-#: with float values can be inserted. The default value is {}. This trait
+#: Only a dictionary mapping strings to floats can be assigned; only string
+#: keys with float values can be inserted. The default value is {}. This trait
 #: type is deprecated. Use ``Dict(Str, Float)`` instead.
 DictStrFloat = Dict(str, float)
 
-#: Only a dictionary of string:bool values can be assigned; only string keys
-#: with boolean values can be inserted. The default value is {}. This trait
-#: type is deprecated. Use ``Dict(Str, Bool)`` instead.
+#: Only a dictionary mapping strings to booleans can be assigned; only string
+#: keys with boolean values can be inserted. The default value is {}. This
+#: trait type is deprecated. Use ``Dict(Str, Bool)`` instead.
 DictStrBool = Dict(str, bool)
 
-#: Only a dictionary of string:list values can be assigned; only string keys
-#: with list values can be assigned. The default value is {}. This trait type
+#: Only a dictionary mapping strings to lists can be assigned; only string keys
+#: with list values can be inserted. The default value is {}. This trait type
 #: is deprecated. Use ``Dict(Str, List)`` instead.
 DictStrList = Dict(str, list)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3696,9 +3696,9 @@ Date = BaseInstance(datetime.date, editor=date_editor)
 Time = BaseInstance(datetime.time, editor=time_editor)
 
 
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  Create predefined, reusable trait instances:
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 #: Synonym for Bool; default value is ``False``. This trait type is
 #: deprecated. Use ``Bool(False)`` or ``Bool()`` instead.
@@ -3713,45 +3713,47 @@ true = Bool(True)
 #: ``Any(Undefined)`` instead.
 undefined = Any(Undefined)
 
-# -- List Traits ----------------------------------------------------------------
+# -- List Traits --------------------------------------------------------------
 
 #: List of integer values; default value is ``[]``. This trait type is
 #: deprecated. Use ``List(Int)`` instead.
 ListInt = List(int)
 
-#: List of float values; default value is []. This trait type is deprecated.
-#: Use ``List(Float)`` instead.
+#: List of float values; default value is ``[]``. This trait type is
+#: deprecated. Use ``List(Float)`` instead.
 ListFloat = List(float)
 
-#: List of string values; default value is []. This trait type is deprecated.
-#: Use ``List(Str)`` instead.
+#: List of string values; default value is ``[]``. This trait type is
+#: deprecated. Use ``List(Str)`` instead.
 ListStr = List(str)
 
-#: List of Unicode string values; default value is []. This trait type is
+#: List of Unicode string values; default value is ``[]``. This trait type is
 #: deprecated. Use ``List(Unicode)`` instead.
 ListUnicode = List(six.text_type)
 
-#: List of complex values; default value is []. This trait type is deprecated.
-#: Use ``List(Complex)`` instead.
+#: List of complex values; default value is ``[]``. This trait type is
+#: deprecated. Use ``List(Complex)`` instead.
 ListComplex = List(complex)
 
-#: List of Boolean values; default value is []. This trait type is deprecated.
-#: Use ``List(Bool)`` instead.
+#: List of Boolean values; default value is ``[]``. This trait type is
+#: deprecated. Use ``List(Bool)`` instead.
 ListBool = List(bool)
 
-#: List of function values; default value is []. This trait type is deprecated.
-#: Use ``List(Instance(types.FunctionType, allow_none=False))`` instead.
+#: List of function values; default value is ``[]``. This trait type is
+#: deprecated. Use ``List(Instance(types.FunctionType, allow_none=False))``
+#: instead.
 ListFunction = List(FunctionType)
 
-#: List of method values; default value is []. This trait type is deprecated.
-#: Use ``List(Instance(types.MethodType, allow_none=False))`` instead.
+#: List of method values; default value is ``[]``. This trait type is
+#: deprecated. Use ``List(Instance(types.MethodType, allow_none=False))``
+#: instead.
 ListMethod = List(MethodType)
 
-#: List of container type values; default value is []. This trait type is
+#: List of container type values; default value is ``[]``. This trait type is
 #: deprecated. Use ``List(This(allow_none=False))`` instead.
 ListThis = List(ThisClass)
 
-# -- Dictionary Traits ----------------------------------------------------------
+# -- Dictionary Traits --------------------------------------------------------
 
 #: Only a dictionary of string:Any values can be assigned; only string keys can
 #: be inserted. The default value is {}. This trait type is deprecated. Use

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3700,67 +3700,85 @@ Time = BaseInstance(datetime.time, editor=time_editor)
 #  Create predefined, reusable trait instances:
 # -------------------------------------------------------------------------------
 
-# Synonym for Bool; default value is False.
+#: Synonym for Bool; default value is ``False```. This trait type is
+#: deprecated. Use ``Bool(False)`` or ``Bool()`` instead.
 false = Bool
 
-# Boolean values only; default value is True.
+#:  Boolean values only; default value is ``True```. This trait type is
+#: deprecated. Use ``Bool(True)`` instead.
 true = Bool(True)
 
-# Allows any value to be assigned; no type-checking is performed.
-# Default value is Undefined.
+#: Allows any value to be assigned; no type-checking is performed.
+#: Default value is ``Undefined```. This trait type is deprecated. Use
+#: ``Any(Undefined)`` instead.
 undefined = Any(Undefined)
 
 # -- List Traits ----------------------------------------------------------------
 
-#: List of integer values; default value is [].
+#: List of integer values; default value is ``[]``. This trait type is
+#: deprecated. Use ``List(Int)`` instead.
 ListInt = List(int)
 
-#: List of float values; default value is [].
+#: List of float values; default value is []. This trait type is deprecated.
+#: Use ``List(Float)`` instead.
 ListFloat = List(float)
 
-#: List of string values; default value is [].
+#: List of string values; default value is []. This trait type is deprecated.
+#: Use ``List(Str)`` instead.
 ListStr = List(str)
 
-#: List of Unicode string values; default value is [].
+#: List of Unicode string values; default value is []. This trait type is
+#: deprecated. Use ``List(Unicode)`` instead.
 ListUnicode = List(six.text_type)
 
-#: List of complex values; default value is [].
+#: List of complex values; default value is []. This trait type is deprecated.
+#: Use ``List(Complex)`` instead.
 ListComplex = List(complex)
 
-#: List of Boolean values; default value is [].
+#: List of Boolean values; default value is []. This trait type is deprecated.
+#: Use ``List(Bool)`` instead.
 ListBool = List(bool)
 
-#: List of function values; default value is [].
+#: List of function values; default value is []. This trait type is deprecated.
+#: Use ``List(Instance(types.FunctionType, allow_none=False))`` instead.
 ListFunction = List(FunctionType)
 
-#: List of method values; default value is [].
+#: List of method values; default value is []. This trait type is deprecated.
+#: Use ``List(Instance(types.MethodType, allow_none=False))`` instead.
 ListMethod = List(MethodType)
 
-#: List of container type values; default value is [].
+#: List of container type values; default value is []. This trait type is
+#: deprecated. Use ``List(This(allow_none=False))`` instead.
 ListThis = List(ThisClass)
 
 # -- Dictionary Traits ----------------------------------------------------------
 
 #: Only a dictionary of string:Any values can be assigned; only string keys can
-#: be inserted. The default value is {}.
+#: be inserted. The default value is {}. This trait type is deprecated. Use
+#: ``Dict(Str, Any)`` instead.
 DictStrAny = Dict(str, Any)
 
 #: Only a dictionary of string:string values can be assigned; only string keys
-#: with string values can be inserted. The default value is {}.
+#: with string values can be inserted. The default value is {}. This trait
+#: type is deprecated. Use ``Dict(Str, Str)`` instead.
 DictStrStr = Dict(str, str)
 
 #: Only a dictionary of string:integer values can be assigned; only string keys
-#: with integer values can be inserted. The default value is {}.
+#: with integer values can be inserted. The default value is {}. This trait
+#: type is deprecated. Use ``Dict(Str, Int)`` instead.
 DictStrInt = Dict(str, int)
 
 #: Only a dictionary of string:float values can be assigned; only string keys
-#: with float values can be inserted. The default value is {}.
+#: with float values can be inserted. The default value is {}. This trait
+#: type is deprecated. Use ``Dict(Str, Float)`` instead.
 DictStrFloat = Dict(str, float)
 
 #: Only a dictionary of string:bool values can be assigned; only string keys
-#: with boolean values can be inserted. The default value is {}.
+#: with boolean values can be inserted. The default value is {}. This trait
+#: type is deprecated. Use ``Dict(Str, Bool)`` instead.
 DictStrBool = Dict(str, bool)
 
 #: Only a dictionary of string:list values can be assigned; only string keys
-#: with list values can be assigned. The default value is {}.
+#: with list values can be assigned. The default value is {}. This trait type
+#: is deprecated. Use ``Dict(Str, List)`` instead.
 DictStrList = Dict(str, list)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3700,16 +3700,16 @@ Time = BaseInstance(datetime.time, editor=time_editor)
 #  Create predefined, reusable trait instances:
 # -------------------------------------------------------------------------------
 
-#: Synonym for Bool; default value is ``False```. This trait type is
+#: Synonym for Bool; default value is ``False``. This trait type is
 #: deprecated. Use ``Bool(False)`` or ``Bool()`` instead.
 false = Bool
 
-#:  Boolean values only; default value is ``True```. This trait type is
+#:  Boolean values only; default value is ``True``. This trait type is
 #: deprecated. Use ``Bool(True)`` instead.
 true = Bool(True)
 
 #: Allows any value to be assigned; no type-checking is performed.
-#: Default value is ``Undefined```. This trait type is deprecated. Use
+#: Default value is ``Undefined``. This trait type is deprecated. Use
 #: ``Any(Undefined)`` instead.
 undefined = Any(Undefined)
 


### PR DESCRIPTION
This PR soft-deprecates the various convenience trait types (`ListStr` and friends), marking them as deprecated in the documentation but not issuing any `DeprecationWarning`.

Rationale for the deprecation:

- In many cases these traits have surprising behaviour, because they're based on the old `TraitCoerceType` machinery rather than the new `TraitType` machinery. For example, `List(Float)` will accept NumPy floats, but `ListFloat` will not.
- The traits are unnecessary, and extra work to maintain (see the failed PR #622 for an example)
- These are trivial to replace with the right things. (For example, `ListStr` with `List(Str)`.)