### PR TITLE
Change Instance(ISomeInterface) to use isinstance

### DIFF
--- a/traits/tests/test_interfaces.py
+++ b/traits/tests/test_interfaces.py
@@ -95,7 +95,7 @@ class SampleAverage(HasTraits):
 
 class UndeclaredAverageProvider(HasTraits):
     """
-    Class that conforms to the IList interface, but doesn't declare
+    Class that conforms to the IAverage interface, but doesn't declare
     that it does so.
     """
     def get_average(self):

--- a/traits/tests/test_interfaces.py
+++ b/traits/tests/test_interfaces.py
@@ -93,6 +93,15 @@ class SampleAverage(HasTraits):
         return average / len(value)
 
 
+class UndeclaredAverageProvider(HasTraits):
+    """
+    Class that conforms to the IList interface, but doesn't declare
+    that it does so.
+    """
+    def get_average(self):
+        return 5.6
+
+
 class SampleBad(HasTraits):
     pass
 
@@ -307,3 +316,9 @@ class InterfacesTest(unittest.TestCase):
     def test_decorated_class_name_and_docstring(self):
         self.assertEqual(SampleList.__name__, "SampleList")
         self.assertEqual(SampleList.__doc__, "SampleList docstring.")
+
+    def test_instance_requires_provides(self):
+        ta = TraitsHolder()
+        provider = UndeclaredAverageProvider()
+        with self.assertRaises(TraitError):
+            ta.a_no = provider

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2810,11 +2810,7 @@ def validate_implements(value, klass, unused=None):
     """ Checks to see if a specified value implements the instance class
         interface (if it is an interface).
     """
-
-    from .has_traits import isinterface
-    from .interface_checker import check_implements
-
-    return isinterface(klass) and check_implements(value.__class__, klass)
+    return isinstance(value, klass)
 
 
 #: Tell the C-base code about the 'validate_implements' function (used by the


### PR DESCRIPTION
Currently if `ISomeInterface` inherits from `Interface` (or more properly, is an instance of `MetaInterface`) and a value `value` is assigned to a trait of the form:
```
    foo = Instance(ISomeInterface)
```
then the Traits interface checker kicks in and checks that `type(value)` conforms to the interface `ISomeInterface`.

This PR removes that check and replaces it with a simple `isinstance(value, ISomeInterface)`. With the reworked interfaces machinery, this should almost always be the right way to check for conformance to an interface.

Note: for ease of review and discussion, I've isolated the behaviour change in this PR. There's a lot more non-behaviour-changing cleanup that can be done once this goes in.