### PR TITLE
Clean up BaseInstance and Instance validation

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -44,7 +44,7 @@ static PyObject * TraitListObject;     /* TraitListObject class */
 static PyObject * TraitSetObject;      /* TraitSetObject class */
 static PyObject * TraitDictObject;     /* TraitDictObject class */
 static PyObject * TraitValue;          /* TraitValue class */
-static PyObject * adapt;               /* PyProtocols 'adapt' function */
+static PyObject * adapt;               /* 'adapt' function */
 static PyObject * is_callable;         /* Marker for 'callable' value */
 static PyTypeObject * ctrait_type;     /* Python-level CTrait type reference */
 
@@ -3917,7 +3917,7 @@ validate_trait_complex ( trait_object * trait, has_traits_object * obj,
 
             /* case 15..18: Property 'setattr' validate checks: */
 
-            case 19:  /* PyProtocols 'adapt' check: */
+            case 19:  /* Adaptable object check: */
                 if ( value == Py_None ) {
                     long allow_none;
 #if PY_MAJOR_VERSION < 3
@@ -4054,7 +4054,7 @@ static trait_validate validate_handlers[] = {
     setattr_validate2,
     setattr_validate3,
 /*  ...End of __getstate__ method entries */
-    validate_trait_adapt,        /* case 19: PyProtocols 'adapt' check */
+    validate_trait_adapt,        /* case 19: Adaptable object check */
     validate_trait_integer,      /* case 20: Integer check */
     validate_trait_float,        /* case 21: Float check */
 };
@@ -4190,7 +4190,7 @@ _trait_set_validate ( trait_object * trait, PyObject * args ) {
 
                 /* case 14: Python-based validator check: */
                 /* case 15..18: Property 'setattr' validate checks: */
-                case 19:  /* PyProtocols 'adapt' check: */
+                case 19:  /* Adaptable object check: */
                     /* Note: We don't check the 'class' argument (item[1])
                        because some old-style code creates classes that are not
                        strictly classes or types (e.g. VTK), and yet they work
@@ -5133,7 +5133,7 @@ _ctraits_value_class ( PyObject * self, PyObject * args ) {
 }
 
 /*-----------------------------------------------------------------------------
-|  Sets the global 'adapt' reference to the PyProtocols 'adapt' function:
+|  Sets the global 'adapt' reference to the 'adapt' function:
 +----------------------------------------------------------------------------*/
 
 static PyObject *
@@ -5178,7 +5178,7 @@ static PyMethodDef ctraits_methods[] = {
         { "_value_class", (PyCFunction) _ctraits_value_class,   METH_VARARGS,
                 PyDoc_STR( "_value_class(TraitValue)" ) },
         { "_adapt", (PyCFunction) _ctraits_adapt, METH_VARARGS,
-                PyDoc_STR( "_adapt(PyProtocols._speedups.adapt)" ) },
+                PyDoc_STR( "_adapt(adaptation_function)" ) },
         { "_ctrait",       (PyCFunction) _ctraits_ctrait,       METH_VARARGS,
                 PyDoc_STR( "_ctrait(CTrait_class)" ) },
         { NULL, NULL },

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3920,17 +3920,20 @@ validate_trait_complex ( trait_object * trait, has_traits_object * obj,
 
             case 19:  /* PyProtocols 'adapt' check: */
                 if ( value == Py_None ) {
+                    long allow_none;
 #if PY_MAJOR_VERSION < 3
-                    if ( PyInt_AS_LONG( PyTuple_GET_ITEM( type_info, 3 ) ) )
+                    allow_none = PyInt_AS_LONG( PyTuple_GET_ITEM( type_info, 3 ) ) );
 #else
-                    mode = PyLong_AsLong( PyTuple_GET_ITEM( type_info, 2 ) );
-                    if( mode==-1 && PyErr_Occurred())
+                    allow_none = PyLong_AsLong( PyTuple_GET_ITEM( type_info, 2 ) );
+                    if( allow_none==-1 && PyErr_Occurred())
                         return NULL;
-                    if( mode )
 #endif // #if PY_MAJOR_VERSION < 3
+                    if( allow_none ) {
                         goto done;
+                    }
                     break;
                 }
+
                 type = PyTuple_GET_ITEM( type_info, 1 );
 #if PY_MAJOR_VERSION < 3
                 mode = PyInt_AS_LONG( PyTuple_GET_ITEM( type_info, 2 ) );
@@ -3939,51 +3942,37 @@ validate_trait_complex ( trait_object * trait, has_traits_object * obj,
                 if( mode==-1 && PyErr_Occurred())
                     return NULL;
 #endif // #if PY_MAJOR_VERSION < 3
-                if ( mode == 2 ) {
-                    args = PyTuple_New( 3 );
-                    if ( args == NULL )
-                        return NULL;
 
-                    PyTuple_SET_ITEM( args, 2, Py_None );
-                    Py_INCREF( Py_None );
+                if ( mode == 2 ) {
+                    args = PyTuple_Pack(3, value, type, Py_None);
                 } else {
-                    args = PyTuple_New( 2 );
-                    if ( args == NULL )
-                        return NULL;
+                    args = PyTuple_Pack(2, value, type);
+                }
+                if (args == NULL) {
+                    return NULL;
                 }
 
-                PyTuple_SET_ITEM( args, 0, value );
-                PyTuple_SET_ITEM( args, 1, type );
-                Py_INCREF( value );
-                Py_INCREF( type );
                 result = PyObject_Call( adapt, args, NULL );
+                Py_DECREF( args );
                 if ( result != NULL ) {
                     if ( result != Py_None ) {
-                        if ( (mode == 0) && (result != value) ) {
-                            Py_DECREF( result );
-                            goto check_implements;
+                        if ( (mode > 0) || (result == value) ) {
+                            return result;
                         }
-                        Py_DECREF( args );
-                        return result;
+                        Py_DECREF( result );
+                        goto check_implements;
                     }
 
                     Py_DECREF( result );
-                    result = PyObject_Call( validate_implements, args, NULL );
-#if PY_MAJOR_VERSION < 3
-                    rc = PyInt_AS_LONG( result );
-#else
-                    rc = PyLong_AsLong( result );
+
+                    rc = PyObject_IsInstance(value, type);
                     if( rc==-1 && PyErr_Occurred()){
-                        PyErr_Clear();
-                        Py_DECREF( args );
-                        Py_DECREF( result );
-                        break;
+                        return NULL;
                     }
-#endif // #if PY_MAJOR_VERSION < 3
-                    Py_DECREF( args );
-                    Py_DECREF( result );
-                    if ( rc )
+                    if ( rc ) {
                         goto done;
+                    }
+
                     result = default_value_for( trait, obj, name );
                     if ( result != NULL )
                         return result;
@@ -3993,20 +3982,10 @@ validate_trait_complex ( trait_object * trait, has_traits_object * obj,
                 }
                 PyErr_Clear();
 check_implements:
-                result = PyObject_Call( validate_implements, args, NULL );
-#if PY_MAJOR_VERSION < 3
-                rc = PyInt_AS_LONG( result );
-#else
-                rc = PyLong_AsLong( result );
+                rc = PyObject_IsInstance(value, type);
                 if( rc==-1 && PyErr_Occurred()){
-                    PyErr_Clear();
-                    Py_DECREF( args );
-                    Py_DECREF( result );
-                    break;
+                    return NULL;
                 }
-#endif // #if PY_MAJOR_VERSION < 3
-                Py_DECREF( args );
-                Py_DECREF( result );
                 if ( rc )
                     goto done;
                 break;

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -45,7 +45,6 @@ static PyObject * TraitSetObject;      /* TraitSetObject class */
 static PyObject * TraitDictObject;     /* TraitDictObject class */
 static PyObject * TraitValue;          /* TraitValue class */
 static PyObject * adapt;               /* PyProtocols 'adapt' function */
-static PyObject * validate_implements; /* 'validate implementation' function */
 static PyObject * is_callable;         /* Marker for 'callable' value */
 static PyTypeObject * ctrait_type;     /* Python-level CTrait type reference */
 
@@ -5150,23 +5149,6 @@ _ctraits_adapt ( PyObject * self, PyObject * args ) {
 }
 
 /*-----------------------------------------------------------------------------
-|  Sets the global 'validate_implements' reference to the Python level
-|  function:
-+----------------------------------------------------------------------------*/
-
-static PyObject *
-_ctraits_validate_implements ( PyObject * self, PyObject * args ) {
-
-    if ( !PyArg_ParseTuple( args, "O", &validate_implements ) )
-        return NULL;
-
-    Py_INCREF( validate_implements );
-
-    Py_INCREF( Py_None );
-    return Py_None;
-}
-
-/*-----------------------------------------------------------------------------
 |  Sets the global 'ctrait_type' class reference:
 +----------------------------------------------------------------------------*/
 
@@ -5197,8 +5179,6 @@ static PyMethodDef ctraits_methods[] = {
                 PyDoc_STR( "_value_class(TraitValue)" ) },
         { "_adapt", (PyCFunction) _ctraits_adapt, METH_VARARGS,
                 PyDoc_STR( "_adapt(PyProtocols._speedups.adapt)" ) },
-        { "_validate_implements", (PyCFunction) _ctraits_validate_implements,
-        METH_VARARGS, PyDoc_STR( "_validate_implements(validate_implements)" )},
         { "_ctrait",       (PyCFunction) _ctraits_ctrait,       METH_VARARGS,
                 PyDoc_STR( "_ctrait(CTrait_class)" ) },
         { NULL, NULL },

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3668,6 +3668,9 @@ validate_trait_adapt ( trait_object * trait, has_traits_object * obj,
     } else {
         args = PyTuple_Pack(2, value, type);
     }
+    if (args == NULL) {
+        return NULL;
+    }
 
     result = PyObject_Call( adapt, args, NULL );
     Py_DECREF( args );

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3640,7 +3640,7 @@ validate_trait_adapt ( trait_object * trait, has_traits_object * obj,
     if ( value == Py_None ) {
         long allow_none;
 #if PY_MAJOR_VERSION < 3
-        allow_none = PyInt_AS_LONG( PyTuple_GET_ITEM( type_info, 3 ) ) );
+        allow_none = PyInt_AS_LONG( PyTuple_GET_ITEM( type_info, 3 ) );
 #else
         allow_none = PyLong_AsLong( PyTuple_GET_ITEM( type_info, 3 ) );
         if( allow_none==-1 && PyErr_Occurred())
@@ -3921,7 +3921,7 @@ validate_trait_complex ( trait_object * trait, has_traits_object * obj,
                 if ( value == Py_None ) {
                     long allow_none;
 #if PY_MAJOR_VERSION < 3
-                    allow_none = PyInt_AS_LONG( PyTuple_GET_ITEM( type_info, 3 ) ) );
+                    allow_none = PyInt_AS_LONG( PyTuple_GET_ITEM( type_info, 3 ) );
 #else
                     allow_none = PyLong_AsLong( PyTuple_GET_ITEM( type_info, 2 ) );
                     if( allow_none==-1 && PyErr_Occurred())

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2807,13 +2807,6 @@ def validate_implements(value, klass, unused=None):
     return isinstance(value, klass)
 
 
-#: Tell the C-base code about the 'validate_implements' function (used by the
-#: 'fast_validate' code for Instance types):
-from . import ctraits
-
-ctraits._validate_implements(validate_implements)
-
-
 class BaseInstance(BaseClass):
     """ Defines a trait whose value must be an instance of a specified class,
         or one of its subclasses.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3076,12 +3076,12 @@ class Instance(BaseInstance):
     def init_fast_validate(self):
         """ Sets up the C-level fast validator. """
 
-        from .has_traits import isinterface
-
-        if (self.adapt == 0) and (not isinterface(self.klass)):
+        if self.adapt == 0:
             fast_validate = [1, self.klass]
             if self._allow_none:
                 fast_validate = [1, None, self.klass]
+            else:
+                fast_validate = [1, self.klass]
 
             if self.klass in TypeTypes:
                 fast_validate[0] = 0

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2800,13 +2800,6 @@ class BaseClass(TraitType):
         self.error(object, name, value)
 
 
-def validate_implements(value, klass, unused=None):
-    """ Checks to see if a specified value implements the instance class
-        interface (if it is an interface).
-    """
-    return isinstance(value, klass)
-
-
 class BaseInstance(BaseClass):
     """ Defines a trait whose value must be an instance of a specified class,
         or one of its subclasses.
@@ -2945,20 +2938,20 @@ class BaseInstance(BaseClass):
                 if value is adapt(value, self.klass):
                     return value
             except:
-                if validate_implements(value, self.klass):
+                if isinstance(value, self.klass):
                     return value
 
         elif self.adapt == 1:
             try:
                 return adapt(value, self.klass)
             except:
-                if validate_implements(value, self.klass):
+                if isinstance(value, self.klass):
                     return value
 
         else:
             result = adapt(value, self.klass, None)
             if result is None:
-                if validate_implements(value, self.klass):
+                if isinstance(value, self.klass):
                     return value
 
                 result = self.default_value


### PR DESCRIPTION
This is a follow-up to #630. Now that `validate_implements` merely does an `isinstance` check, we don't need to call it from the C code any more.

This PR replaces uses of `validate_implements` in both `ctraits.c` and `trait_types.py` with the corresponding `isinstance` check, and does some minor cleanup on that portion of `ctraits.c` in passing. It then removes `validate_implements` along with the private hook that makes that function available to `ctraits.c`.