### PR TITLE
Fix coercion fast validation to do an exact type check instead of an instance check

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3593,8 +3593,8 @@ validate_trait_cast_type ( trait_object * trait, has_traits_object * obj,
     PyObject * result;
 
     PyObject * type_info = trait->py_validate;
-    PyObject * type      = PyTuple_GET_ITEM( type_info, 1 );
-    if ( PyObject_TypeCheck( value, (PyTypeObject *) type ) ) {
+    PyObject * type = PyTuple_GET_ITEM( type_info, 1 );
+    if (Py_TYPE(value) == (PyTypeObject *)type) {
         Py_INCREF( value );
         return value;
     }
@@ -3917,8 +3917,9 @@ validate_trait_complex ( trait_object * trait, has_traits_object * obj,
 
             case 12:  /* Castable type check */
                 type = PyTuple_GET_ITEM( type_info, 1 );
-                if ( PyObject_TypeCheck( value, (PyTypeObject *) type ) )
+                if (Py_TYPE(value) == (PyTypeObject *)type) {
                     goto done;
+                }
 
                 if ( (result = type_converter( type, value )) != NULL )
                     return result;

--- a/traits/tests/test_integer.py
+++ b/traits/tests/test_integer.py
@@ -20,12 +20,14 @@ import decimal
 import sys
 import unittest
 
-from traits.api import HasTraits, Int, TraitError
+from traits.api import HasTraits, Int, CInt, TraitError
 from traits.testing.optional_dependencies import numpy, requires_numpy
 
 
 class A(HasTraits):
     integral = Int
+
+    convertible = CInt
 
 
 class IntegerLike(object):
@@ -109,3 +111,10 @@ class TestInt(unittest.TestCase):
             a.integral = numpy.float32(4.0)
         with self.assertRaises(TraitError):
             a.integral = numpy.float64(4.0)
+
+    def test_cint_conversion_of_subclasses(self):
+        # Regression test for enthought/traits#646
+        a = A()
+        a.convertible = True
+        self.assertIs(type(a.convertible), int)
+        self.assertEqual(a.convertible, 1)

--- a/traits/tests/test_integer.py
+++ b/traits/tests/test_integer.py
@@ -20,7 +20,7 @@ import decimal
 import sys
 import unittest
 
-from traits.api import HasTraits, Int, CInt, TraitError
+from traits.api import Either, HasTraits, Int, CInt, TraitError
 from traits.testing.optional_dependencies import numpy, requires_numpy
 
 
@@ -28,6 +28,8 @@ class A(HasTraits):
     integral = Int
 
     convertible = CInt
+
+    convertible_or_none = Either(None, CInt)
 
 
 class IntegerLike(object):
@@ -115,6 +117,11 @@ class TestInt(unittest.TestCase):
     def test_cint_conversion_of_subclasses(self):
         # Regression test for enthought/traits#646
         a = A()
+
         a.convertible = True
         self.assertIs(type(a.convertible), int)
         self.assertEqual(a.convertible, 1)
+
+        a.convertible_or_none = True
+        self.assertIs(type(a.convertible_or_none), int)
+        self.assertEqual(a.convertible_or_none, 1)


### PR DESCRIPTION
This PR changes the "type 12" fast validation to do an exact type check instead of an isinstance check in its fast path, before falling back to the usual slow path. This ensures that instances of subclasses of the target type are properly converted to the target type.

Fixes #646 