### PR TITLE
Clearer calls to _notifiers methods

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -762,7 +762,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
                 class_traits[name] = trait = _clone_trait(trait)
 
             if len(handlers) > 0:
-                _add_notifiers(trait._notifiers(1), handlers)
+                _add_notifiers(trait._notifiers(True), handlers)
 
             if default is not None:
                 trait.set_default_value(CALLABLE_DEFAULT_VALUE, default)
@@ -1175,7 +1175,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         # If there are and handlers, add them to the trait's notifier's list:
         if len(handlers) > 0:
             trait = _clone_trait(trait)
-            _add_notifiers(trait._notifiers(1), handlers)
+            _add_notifiers(trait._notifiers(True), handlers)
 
         # Finally, add the new trait to the class trait dictionary:
         class_traits[name] = trait
@@ -2305,12 +2305,12 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         if remove:
             if name == "anytrait":
-                notifiers = self._notifiers(0)
+                notifiers = self._notifiers(False)
             else:
                 trait = self._trait(name, 1)
                 if trait is None:
                     return
-                notifiers = trait._notifiers(0)
+                notifiers = trait._notifiers(False)
 
             if notifiers is not None:
                 for i, notifier in enumerate(notifiers):
@@ -2322,9 +2322,9 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             return
 
         if name == "anytrait":
-            notifiers = self._notifiers(1)
+            notifiers = self._notifiers(True)
         else:
-            notifiers = self._trait(name, 2)._notifiers(1)
+            notifiers = self._trait(name, 2)._notifiers(True)
 
         for notifier in notifiers:
             if notifier.equals(handler):
@@ -2834,9 +2834,9 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         # If there already was a trait with the same name:
         if old_trait is not None:
             # Copy the old traits notifiers into the new trait:
-            old_notifiers = old_trait._notifiers(0)
+            old_notifiers = old_trait._notifiers(False)
             if old_notifiers is not None:
-                trait._notifiers(1).extend(old_notifiers)
+                trait._notifiers(True).extend(old_notifiers)
         else:
             # Otherwise, see if there are any static notifiers that should be
             # applied to the trait:
@@ -2857,7 +2857,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
             # If there are any static notifiers, attach them to the trait:
             if len(handlers) > 0:
-                _add_notifiers(trait._notifiers(1), handlers)
+                _add_notifiers(trait._notifiers(True), handlers)
 
         # If this was a new trait, fire the 'trait_added' event:
         if old_trait is None:
@@ -3217,7 +3217,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 # list:
                 if len(handlers) > 0:
                     trait = _clone_trait(trait)
-                    _add_notifiers(trait._notifiers(1), handlers)
+                    _add_notifiers(trait._notifiers(True), handlers)
 
                 return trait
 

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -174,11 +174,11 @@ class TestRegression(unittest.TestCase):
         """
         dummy = Dummy()
         ctrait = dummy._trait("x", 2)
-        self.assertEqual(len(ctrait._notifiers(1)), 0)
+        self.assertEqual(len(ctrait._notifiers(True)), 0)
         presenter = Presenter(obj=dummy)
-        self.assertEqual(len(ctrait._notifiers(1)), 1)
+        self.assertEqual(len(ctrait._notifiers(True)), 1)
         del presenter
-        self.assertEqual(len(ctrait._notifiers(1)), 0)
+        self.assertEqual(len(ctrait._notifiers(True)), 0)
 
     def test_init_list_depends(self):
         """ Using two lists with bracket notation in extended name notation

--- a/traits/trait_value.py
+++ b/traits/trait_value.py
@@ -51,7 +51,7 @@ class BaseTraitValue(HasPrivateTraits):
     def as_ctrait(self, original_trait):
         """ Returns the low-level C-based trait for this TraitValue.
         """
-        notifiers = original_trait._notifiers(0)
+        notifiers = original_trait._notifiers(False)
 
         if self._ctrait is not None:
             if (notifiers is None) or (len(notifiers) == 0):
@@ -67,7 +67,7 @@ class BaseTraitValue(HasPrivateTraits):
             and (notifiers is not None)
             and (len(notifiers) > 0)
         ):
-            trait._notifiers(1).extend(notifiers)
+            trait._notifiers(True).extend(notifiers)
 
         return trait
 


### PR DESCRIPTION
This is a semi-automated drive-by fix.

The `_notifiers` methods of `CHasTraits` and `CTrait` expect one argument that tells the method whether to create a list of notifiers if one doesn't already exist.  Most calls to this use 1 and 0, but it would be clearer if they used `True` and `False` instead.

This PR applies that change.