### PR TITLE
Cleanup of flag setting methods

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -580,29 +580,35 @@ set_value ( PyObject ** field, PyObject * value ) {
     return 0;
 }
 
-static PyObject *
-get_trait_flag ( trait_object * trait, int mask ) {
-    PyObject * result;
+/*-----------------------------------------------------------------------------
+|  Gets the value of a flag on a cTrait object specified by a mask.
++----------------------------------------------------------------------------*/
 
-    if ( (trait->flags & mask) == 0 ) {
-        result = Py_False;
+static PyObject *
+get_trait_flag(trait_object * trait, int mask)
+{
+    if ((trait->flags & mask) == 0) {
+        Py_RETURN_FALSE;
     }
     else {
-        result = Py_True;
+        Py_RETURN_TRUE;
     }
-
-    Py_INCREF( result );
-    return result;
 }
 
+/*-----------------------------------------------------------------------------
+|  Sets the value of a flag on a cTrait object specified by a mask.
++----------------------------------------------------------------------------*/
+
 static int
-set_trait_flag ( trait_object * trait, int mask, PyObject * value ) {
+set_trait_flag(trait_object * trait, int mask, PyObject * value)
+{
     int flag = PyObject_IsTrue(value);
-    if ( flag == -1 ) {
+
+    if (flag == -1) {
         return -1;
     }
 
-    if ( flag ) {
+    if (flag) {
         trait->flags |= mask;
     }
     else {
@@ -611,7 +617,6 @@ set_trait_flag ( trait_object * trait, int mask, PyObject * value ) {
 
     return 0;
 }
-
 
 /*-----------------------------------------------------------------------------
 |  Returns the result of calling a specified 'class' object with 1 argument:
@@ -4557,8 +4562,9 @@ set_trait_post_setattr ( trait_object * trait, PyObject * value,
 +----------------------------------------------------------------------------*/
 
 static PyObject *
-get_trait_property_flag ( trait_object * trait, void * closure ) {
-    return get_trait_flag( trait, TRAIT_PROPERTY );
+get_trait_property_flag(trait_object * trait, void * closure)
+{
+    return get_trait_flag(trait, TRAIT_PROPERTY);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4566,8 +4572,9 @@ get_trait_property_flag ( trait_object * trait, void * closure ) {
 +----------------------------------------------------------------------------*/
 
 static PyObject *
-get_trait_modify_delegate_flag ( trait_object * trait, void * closure ) {
-    return get_trait_flag( trait, TRAIT_MODIFY_DELEGATE );
+get_trait_modify_delegate_flag(trait_object * trait, void * closure )
+{
+    return get_trait_flag(trait, TRAIT_MODIFY_DELEGATE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4575,8 +4582,10 @@ get_trait_modify_delegate_flag ( trait_object * trait, void * closure ) {
 +----------------------------------------------------------------------------*/
 
 static int
-set_trait_modify_delegate_flag ( trait_object * trait, PyObject * value, void * closure ) {
-    return set_trait_flag( trait, TRAIT_MODIFY_DELEGATE, value );
+set_trait_modify_delegate_flag(trait_object * trait, PyObject * value,
+                               void * closure)
+{
+    return set_trait_flag(trait, TRAIT_MODIFY_DELEGATE, value);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4584,8 +4593,9 @@ set_trait_modify_delegate_flag ( trait_object * trait, PyObject * value, void * 
 +----------------------------------------------------------------------------*/
 
 static PyObject *
-get_trait_object_identity_flag ( trait_object * trait, void * closure ) {
-    return get_trait_flag( trait, TRAIT_OBJECT_IDENTITY );
+get_trait_object_identity_flag(trait_object * trait, void * closure)
+{
+    return get_trait_flag(trait, TRAIT_OBJECT_IDENTITY);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4593,8 +4603,9 @@ get_trait_object_identity_flag ( trait_object * trait, void * closure ) {
 +----------------------------------------------------------------------------*/
 
 static PyObject *
-get_trait_setattr_original_value_flag ( trait_object * trait, void * closure ) {
-    return get_trait_flag( trait, TRAIT_SETATTR_ORIGINAL_VALUE );
+get_trait_setattr_original_value_flag(trait_object * trait, void * closure)
+{
+    return get_trait_flag(trait, TRAIT_SETATTR_ORIGINAL_VALUE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4602,8 +4613,10 @@ get_trait_setattr_original_value_flag ( trait_object * trait, void * closure ) {
 +----------------------------------------------------------------------------*/
 
 static int
-set_trait_setattr_original_value_flag ( trait_object * trait, PyObject * value, void * closure ) {
-    return set_trait_flag( trait, TRAIT_SETATTR_ORIGINAL_VALUE, value );
+set_trait_setattr_original_value_flag(trait_object * trait, PyObject * value,
+                                      void * closure)
+{
+    return set_trait_flag(trait, TRAIT_SETATTR_ORIGINAL_VALUE, value);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4611,8 +4624,10 @@ set_trait_setattr_original_value_flag ( trait_object * trait, PyObject * value, 
 +----------------------------------------------------------------------------*/
 
 static PyObject *
-get_trait_post_setattr_original_value_flag ( trait_object * trait, void * closure ) {
-    return get_trait_flag( trait, TRAIT_POST_SETATTR_ORIGINAL_VALUE );
+get_trait_post_setattr_original_value_flag(trait_object * trait,
+                                           void * closure)
+{
+    return get_trait_flag(trait, TRAIT_POST_SETATTR_ORIGINAL_VALUE);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4620,8 +4635,11 @@ get_trait_post_setattr_original_value_flag ( trait_object * trait, void * closur
 +----------------------------------------------------------------------------*/
 
 static int
-set_trait_post_setattr_original_value_flag ( trait_object * trait, PyObject * value, void * closure ) {
-    return set_trait_flag( trait, TRAIT_POST_SETATTR_ORIGINAL_VALUE, value );
+set_trait_post_setattr_original_value_flag(trait_object * trait,
+                                           PyObject * value,
+                                           void * closure)
+{
+    return set_trait_flag(trait, TRAIT_POST_SETATTR_ORIGINAL_VALUE, value);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4629,8 +4647,9 @@ set_trait_post_setattr_original_value_flag ( trait_object * trait, PyObject * va
 +----------------------------------------------------------------------------*/
 
 static PyObject *
-get_trait_is_mapped_flag ( trait_object * trait, void * closure ) {
-    return get_trait_flag( trait, TRAIT_IS_MAPPED );
+get_trait_is_mapped_flag(trait_object * trait, void * closure)
+{
+    return get_trait_flag(trait, TRAIT_IS_MAPPED);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4638,8 +4657,10 @@ get_trait_is_mapped_flag ( trait_object * trait, void * closure ) {
 +----------------------------------------------------------------------------*/
 
 static int
-set_trait_is_mapped_flag ( trait_object * trait, PyObject * value, void * closure ) {
-    return set_trait_flag( trait, TRAIT_IS_MAPPED, value );
+set_trait_is_mapped_flag(trait_object * trait, PyObject * value,
+                         void * closure)
+{
+    return set_trait_flag(trait, TRAIT_IS_MAPPED, value);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4647,8 +4668,9 @@ set_trait_is_mapped_flag ( trait_object * trait, PyObject * value, void * closur
 +----------------------------------------------------------------------------*/
 
 static PyObject *
-get_trait_no_value_test_flag ( trait_object * trait, void * closure ) {
-    return get_trait_flag( trait, TRAIT_NO_VALUE_TEST );
+get_trait_no_value_test_flag(trait_object * trait, void * closure)
+{
+    return get_trait_flag(trait, TRAIT_NO_VALUE_TEST);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4753,21 +4775,29 @@ static PyGetSetDef trait_properties[] = {
         { "handler",        (getter) get_trait_handler, (setter) set_trait_handler },
         { "post_setattr",   (getter) get_trait_post_setattr,
                             (setter) set_trait_post_setattr },
-        { "property_flag",  (getter) get_trait_property_flag, NULL },
-        { "modify_delegate_flag", (getter) get_trait_modify_delegate_flag,
-                            (setter) set_trait_modify_delegate_flag },
-        { "object_identity_flag",
-                            (getter) get_trait_object_identity_flag, NULL },
-        { "setattr_original_value_flag",
-                            (getter) get_trait_setattr_original_value_flag,
-                            (setter) set_trait_setattr_original_value_flag },
-        { "post_setattr_original_value_flag",
-                            (getter) get_trait_post_setattr_original_value_flag,
-                            (setter) set_trait_post_setattr_original_value_flag },
-        { "is_mapped_flag", (getter) get_trait_is_mapped_flag,
-                            (setter) set_trait_is_mapped_flag },
-        { "no_value_test_flag",
-                            (getter) get_trait_no_value_test_flag, NULL },
+        {"property_flag", (getter) get_trait_property_flag, NULL,
+         "Whether the trait is a property trait.", NULL},
+        {"modify_delegate_flag", (getter) get_trait_modify_delegate_flag,
+         (setter) set_trait_modify_delegate_flag,
+         "Whether changes to the trait modify the delegate as well", NULL},
+        {"object_identity_flag", (getter) get_trait_object_identity_flag,
+         NULL, "Whether change comparisons are by object identity.", NULL},
+        {"setattr_original_value_flag",
+         (getter) get_trait_setattr_original_value_flag,
+         (setter) set_trait_setattr_original_value_flag,
+         "Whether setattr gets the original value set on the trait or the "
+         "stored value,", NULL},
+        {"post_setattr_original_value_flag",
+         (getter) get_trait_post_setattr_original_value_flag,
+         (setter) set_trait_post_setattr_original_value_flag,
+         "Whether post_setattr gets the original value set on the trait or "
+         "the stored value,", NULL},
+        {"is_mapped_flag", (getter) get_trait_is_mapped_flag,
+         (setter) set_trait_is_mapped_flag,
+         "Whether the trait is a mapped trait.", NULL},
+        {"no_value_test_flag", (getter) get_trait_no_value_test_flag, NULL,
+         "Whether trait changes are fired on every assignment, or only when "
+         "the value tests as different.", NULL},
         { 0 }
 };
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -580,6 +580,39 @@ set_value ( PyObject ** field, PyObject * value ) {
     return 0;
 }
 
+static PyObject *
+get_trait_flag ( trait_object * trait, int mask ) {
+    PyObject * result;
+
+    if ( (trait->flags & mask) == 0 ) {
+        result = Py_False;
+    }
+    else {
+        result = Py_True;
+    }
+
+    Py_INCREF( result );
+    return result;
+}
+
+static int
+set_trait_flag ( trait_object * trait, int mask, PyObject * value ) {
+    int flag = PyObject_IsTrue(value);
+    if ( flag == -1 ) {
+        return -1;
+    }
+
+    if ( flag ) {
+        trait->flags |= mask;
+    }
+    else {
+        trait->flags &= (~mask);
+    }
+
+    return 0;
+}
+
+
 /*-----------------------------------------------------------------------------
 |  Returns the result of calling a specified 'class' object with 1 argument:
 +----------------------------------------------------------------------------*/
@@ -4520,6 +4553,105 @@ set_trait_post_setattr ( trait_object * trait, PyObject * value,
 }
 
 /*-----------------------------------------------------------------------------
+|  Returns the current property flag value:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+get_trait_property_flag ( trait_object * trait, void * closure ) {
+    return get_trait_flag( trait, TRAIT_PROPERTY );
+}
+
+/*-----------------------------------------------------------------------------
+|  Returns the current modify_delegate flag value:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+get_trait_modify_delegate_flag ( trait_object * trait, void * closure ) {
+    return get_trait_flag( trait, TRAIT_MODIFY_DELEGATE );
+}
+
+/*-----------------------------------------------------------------------------
+|  Sets the current modify_delegate flag value:
++----------------------------------------------------------------------------*/
+
+static int
+set_trait_modify_delegate_flag ( trait_object * trait, PyObject * value, void * closure ) {
+    return set_trait_flag( trait, TRAIT_MODIFY_DELEGATE, value );
+}
+
+/*-----------------------------------------------------------------------------
+|  Returns the current object_identity flag value:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+get_trait_object_identity_flag ( trait_object * trait, void * closure ) {
+    return get_trait_flag( trait, TRAIT_OBJECT_IDENTITY );
+}
+
+/*-----------------------------------------------------------------------------
+|  Returns the current setattr_original_value flag value:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+get_trait_setattr_original_value_flag ( trait_object * trait, void * closure ) {
+    return get_trait_flag( trait, TRAIT_SETATTR_ORIGINAL_VALUE );
+}
+
+/*-----------------------------------------------------------------------------
+|  Sets the current setattr_original_value flag value:
++----------------------------------------------------------------------------*/
+
+static int
+set_trait_setattr_original_value_flag ( trait_object * trait, PyObject * value, void * closure ) {
+    return set_trait_flag( trait, TRAIT_SETATTR_ORIGINAL_VALUE, value );
+}
+
+/*-----------------------------------------------------------------------------
+|  Returns the current post_setattr_original_value flag value:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+get_trait_post_setattr_original_value_flag ( trait_object * trait, void * closure ) {
+    return get_trait_flag( trait, TRAIT_POST_SETATTR_ORIGINAL_VALUE );
+}
+
+/*-----------------------------------------------------------------------------
+|  Sets the current post_setattr_original_value flag value:
++----------------------------------------------------------------------------*/
+
+static int
+set_trait_post_setattr_original_value_flag ( trait_object * trait, PyObject * value, void * closure ) {
+    return set_trait_flag( trait, TRAIT_POST_SETATTR_ORIGINAL_VALUE, value );
+}
+
+/*-----------------------------------------------------------------------------
+|  Returns the current is_mapped flag value:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+get_trait_is_mapped_flag ( trait_object * trait, void * closure ) {
+    return get_trait_flag( trait, TRAIT_IS_MAPPED );
+}
+
+/*-----------------------------------------------------------------------------
+|  Sets the current is_mapped flag value:
++----------------------------------------------------------------------------*/
+
+static int
+set_trait_is_mapped_flag ( trait_object * trait, PyObject * value, void * closure ) {
+    return set_trait_flag( trait, TRAIT_IS_MAPPED, value );
+}
+
+/*-----------------------------------------------------------------------------
+|  Returns the current no_value_test flag value:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+get_trait_no_value_test_flag ( trait_object * trait, void * closure ) {
+    return get_trait_flag( trait, TRAIT_NO_VALUE_TEST );
+}
+
+/*-----------------------------------------------------------------------------
 |  'CTrait' instance methods:
 +----------------------------------------------------------------------------*/
 
@@ -4617,10 +4749,25 @@ static PyMethodDef trait_methods[] = {
 +----------------------------------------------------------------------------*/
 
 static PyGetSetDef trait_properties[] = {
-        { "__dict__",     (getter) get_trait_dict,    (setter) set_trait_dict },
-        { "handler",      (getter) get_trait_handler, (setter) set_trait_handler },
-        { "post_setattr", (getter) get_trait_post_setattr,
-                      (setter) set_trait_post_setattr },
+        { "__dict__",       (getter) get_trait_dict,    (setter) set_trait_dict },
+        { "handler",        (getter) get_trait_handler, (setter) set_trait_handler },
+        { "post_setattr",   (getter) get_trait_post_setattr,
+                            (setter) set_trait_post_setattr },
+        { "property_flag",  (getter) get_trait_property_flag, NULL },
+        { "modify_delegate_flag", (getter) get_trait_modify_delegate_flag,
+                            (setter) set_trait_modify_delegate_flag },
+        { "object_identity_flag",
+                            (getter) get_trait_object_identity_flag, NULL },
+        { "setattr_original_value_flag",
+                            (getter) get_trait_setattr_original_value_flag,
+                            (setter) set_trait_setattr_original_value_flag },
+        { "post_setattr_original_value_flag",
+                            (getter) get_trait_post_setattr_original_value_flag,
+                            (setter) set_trait_post_setattr_original_value_flag },
+        { "is_mapped_flag", (getter) get_trait_is_mapped_flag,
+                            (setter) set_trait_is_mapped_flag },
+        { "no_value_test_flag",
+                            (getter) get_trait_no_value_test_flag, NULL },
         { 0 }
 };
 

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -21,6 +21,21 @@ from traits.trait_handlers import (
 )
 
 
+def getter():
+    """ Trivial getter. """
+    return True
+
+
+def setter(value):
+    """ Trivial setter. """
+    pass
+
+
+def validator(value):
+    """ Trivial validator. """
+    return value
+
+
 class TestCTrait(unittest.TestCase):
     """ Tests for the CTrait class. """
 
@@ -63,3 +78,75 @@ class TestCTrait(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             trait.set_default_value(MAXIMUM_DEFAULT_VALUE_TYPE + 1, None)
+
+    def test_property_flag(self):
+        trait = CTrait(0)
+
+        self.assertFalse(trait.property_flag)
+
+        trait.property(getter, 0, setter, 1, validator, 1)
+
+        self.assertTrue(trait.property_flag)
+
+        with self.assertRaises(AttributeError):
+            trait.property_flag = False
+
+    def test_modify_delegate_flag(self):
+        trait = CTrait(0)
+
+        self.assertFalse(trait.modify_delegate_flag)
+
+        trait.modify_delegate_flag = True
+
+        self.assertTrue(trait.modify_delegate_flag)
+
+    def test_object_identity_flag(self):
+        trait = CTrait(0)
+
+        self.assertFalse(trait.object_identity_flag)
+
+        trait.comparison_mode(1)
+
+        self.assertTrue(trait.object_identity_flag)
+
+        with self.assertRaises(AttributeError):
+            trait.object_identity_flag = False
+
+    def test_setattr_original_value_flag(self):
+        trait = CTrait(0)
+
+        self.assertFalse(trait.setattr_original_value_flag)
+
+        trait.setattr_original_value_flag = True
+
+        self.assertTrue(trait.setattr_original_value_flag)
+
+    def test_post_setattr_original_value_flag(self):
+        trait = CTrait(0)
+
+        self.assertFalse(trait.post_setattr_original_value_flag)
+
+        trait.post_setattr_original_value_flag = True
+
+        self.assertTrue(trait.post_setattr_original_value_flag)
+
+    def test_is_mapped_flag(self):
+        trait = CTrait(0)
+
+        self.assertFalse(trait.is_mapped_flag)
+
+        trait.is_mapped_flag = True
+
+        self.assertTrue(trait.is_mapped_flag)
+
+    def test_no_value_test_flag(self):
+        trait = CTrait(0)
+
+        self.assertFalse(trait.no_value_test_flag)
+
+        trait.comparison_mode(0)
+
+        self.assertTrue(trait.no_value_test_flag)
+
+        with self.assertRaises(AttributeError):
+            trait.no_value_test_flag = False

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -79,74 +79,74 @@ class TestCTrait(unittest.TestCase):
         with self.assertRaises(ValueError):
             trait.set_default_value(MAXIMUM_DEFAULT_VALUE_TYPE + 1, None)
 
-    def test_property_flag(self):
+    def test_is_property(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.property_flag)
+        self.assertFalse(trait.is_property)
 
         trait.property(getter, 0, setter, 1, validator, 1)
 
-        self.assertTrue(trait.property_flag)
+        self.assertTrue(trait.is_property)
 
         with self.assertRaises(AttributeError):
-            trait.property_flag = False
+            trait.is_property = False
 
-    def test_modify_delegate_flag(self):
+    def test_modify_delegate(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.modify_delegate_flag)
+        self.assertFalse(trait.modify_delegate)
 
-        trait.modify_delegate_flag = True
+        trait.modify_delegate = True
 
-        self.assertTrue(trait.modify_delegate_flag)
+        self.assertTrue(trait.modify_delegate)
 
-    def test_object_identity_flag(self):
+    def test_object_id_test(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.object_identity_flag)
+        self.assertFalse(trait.object_id_test)
 
         trait.comparison_mode(1)
 
-        self.assertTrue(trait.object_identity_flag)
+        self.assertTrue(trait.object_id_test)
 
         with self.assertRaises(AttributeError):
-            trait.object_identity_flag = False
+            trait.object_id_test = False
 
-    def test_setattr_original_value_flag(self):
+    def test_setattr_original_value(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.setattr_original_value_flag)
+        self.assertFalse(trait.setattr_original_value)
 
-        trait.setattr_original_value_flag = True
+        trait.setattr_original_value = True
 
-        self.assertTrue(trait.setattr_original_value_flag)
+        self.assertTrue(trait.setattr_original_value)
 
-    def test_post_setattr_original_value_flag(self):
+    def test_post_setattr_original_value(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.post_setattr_original_value_flag)
+        self.assertFalse(trait.post_setattr_original_value)
 
-        trait.post_setattr_original_value_flag = True
+        trait.post_setattr_original_value = True
 
-        self.assertTrue(trait.post_setattr_original_value_flag)
+        self.assertTrue(trait.post_setattr_original_value)
 
-    def test_is_mapped_flag(self):
+    def test_is_mapped(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.is_mapped_flag)
+        self.assertFalse(trait.is_mapped)
 
-        trait.is_mapped_flag = True
+        trait.is_mapped = True
 
-        self.assertTrue(trait.is_mapped_flag)
+        self.assertTrue(trait.is_mapped)
 
-    def test_no_value_test_flag(self):
+    def test_no_value_test(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.no_value_test_flag)
+        self.assertFalse(trait.no_value_test)
 
         trait.comparison_mode(0)
 
-        self.assertTrue(trait.no_value_test_flag)
+        self.assertTrue(trait.no_value_test)
 
         with self.assertRaises(AttributeError):
-            trait.no_value_test_flag = False
+            trait.no_value_test = False

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -662,7 +662,7 @@ class TraitType(BaseTraitHandler):
             post_setattr = getattr(self, "post_setattr", None)
             if post_setattr is not None:
                 trait.post_setattr = post_setattr
-                trait.is_mapped(self.is_mapped)
+                trait.is_mapped_flag = self.is_mapped
 
             # Note: The use of 'rich_compare' metadata is deprecated; use
             # 'comparison_mode' metadata instead:

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -662,7 +662,7 @@ class TraitType(BaseTraitHandler):
             post_setattr = getattr(self, "post_setattr", None)
             if post_setattr is not None:
                 trait.post_setattr = post_setattr
-                trait.is_mapped_flag = self.is_mapped
+                trait.is_mapped = self.is_mapped
 
             # Note: The use of 'rich_compare' metadata is deprecated; use
             # 'comparison_mode' metadata instead:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1361,7 +1361,9 @@ class Expression(TraitType):
         """
         # Tell the C code that 'setattr' should store the original, unadapted
         # value passed to it:
-        return super(Expression, self).as_ctrait().setattr_original_value(True)
+        ctrait = super(Expression, self).as_ctrait()
+        ctrait.setattr_original_value_flag = True
+        return ctrait
 
 
 # -------------------------------------------------------------------------------
@@ -3018,7 +3020,8 @@ class Supports(Instance):
 
         # Tell the C code that the 'post_setattr' method wants the original,
         # unadapted value passed to 'setattr':
-        return ctrait.post_setattr_original_value(True)
+        ctrait.post_setattr_original_value_flag = True
+        return ctrait
 
 
 # Alias defined for backward compatibility with Traits 4.3.0
@@ -3040,7 +3043,8 @@ class AdaptsTo(Supports):
     def modify_ctrait(self, ctrait):
         # Tell the C code that 'setattr' should store the original, unadapted
         # value passed to it:
-        return ctrait.setattr_original_value(True)
+        ctrait.setattr_original_value_flag = True
+        return ctrait
 
 
 # -------------------------------------------------------------------------------

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1362,7 +1362,7 @@ class Expression(TraitType):
         # Tell the C code that 'setattr' should store the original, unadapted
         # value passed to it:
         ctrait = super(Expression, self).as_ctrait()
-        ctrait.setattr_original_value_flag = True
+        ctrait.setattr_original_value = True
         return ctrait
 
 
@@ -3020,7 +3020,7 @@ class Supports(Instance):
 
         # Tell the C code that the 'post_setattr' method wants the original,
         # unadapted value passed to 'setattr':
-        ctrait.post_setattr_original_value_flag = True
+        ctrait.post_setattr_original_value = True
         return ctrait
 
 
@@ -3043,7 +3043,7 @@ class AdaptsTo(Supports):
     def modify_ctrait(self, ctrait):
         # Tell the C code that 'setattr' should store the original, unadapted
         # value passed to it:
-        ctrait.setattr_original_value_flag = True
+        ctrait.setattr_original_value = True
         return ctrait
 
 

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -1104,7 +1104,7 @@ class _TraitMaker(object):
             post_setattr = getattr(handler, "post_setattr", None)
             if post_setattr is not None:
                 trait.post_setattr = post_setattr
-                trait.is_mapped_flag = handler.is_mapped
+                trait.is_mapped = handler.is_mapped
 
         # Note: The use of 'rich_compare' metadata is deprecated; use
         # 'comparison_mode' metadata instead:

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -1104,7 +1104,7 @@ class _TraitMaker(object):
             post_setattr = getattr(handler, "post_setattr", None)
             if post_setattr is not None:
                 trait.post_setattr = post_setattr
-                trait.is_mapped(handler.is_mapped)
+                trait.is_mapped_flag = handler.is_mapped
 
         # Note: The use of 'rich_compare' metadata is deprecated; use
         # 'comparison_mode' metadata instead:


### PR DESCRIPTION
This builds on #666 by removing the old methods `is_mapped`, `setattr_original_value` and `post_setattr_original_value` and replacing them with the corresponding properties from #666 

It also re-names some the other flag properties to remove the `_flag` suffix and renames `object_identity` to `object_id_test` (and also the corresponding flag constant).

Tests and associated code are also cleaned up.

This is nominally backward incompatible, but the only code using the affected methods appears to be in Traits.  If there were other code that is using these methods, breakage would be immediate (trying to call a bool value) and the fix trivial.

Requires #666 to be merged first.