### PR TITLE
Expose module constants in traits.ctraits

### DIFF
--- a/traits/constants.py
+++ b/traits/constants.py
@@ -10,6 +10,19 @@
 
 from enum import IntEnum
 
+from traits.ctraits import (
+    _CONSTANT_DEFAULT_VALUE,
+    _MISSING_DEFAULT_VALUE,
+    _OBJECT_DEFAULT_VALUE,
+    _LIST_COPY_DEFAULT_VALUE,
+    _DICT_COPY_DEFAULT_VALUE,
+    _TRAIT_LIST_COPY_DEFAULT_VALUE,
+    _TRAIT_DICT_COPY_DEFAULT_VALUE,
+    _CALLABLE_AND_ARGS_DEFAULT_VALUE,
+    _CALLABLE_DEFAULT_VALUE,
+    _TRAIT_SET_OBJECT_DEFAULT_VALUE,
+)
+
 
 class TraitKind(IntEnum):
     """ These determine the getters and setters used by the cTrait instance. """
@@ -136,43 +149,43 @@ class DefaultValue(IntEnum):
     unspecified = -1
 
     #: The default_value of the trait is the default value.
-    constant = 0
+    constant = _CONSTANT_DEFAULT_VALUE
 
     #: The default_value of the trait is Missing.
-    missing = 1
+    missing = _MISSING_DEFAULT_VALUE
 
     #: The object containing the trait is the default value.
-    object = 2
+    object = _OBJECT_DEFAULT_VALUE
 
     #: A new copy of the list specified by default_value is the default value.
-    list_copy = 3
+    list_copy = _LIST_COPY_DEFAULT_VALUE
 
     #: A new copy of the dict specified by default_value is the default value.
-    dict_copy = 4
+    dict_copy = _DICT_COPY_DEFAULT_VALUE
 
     #: A new instance of TraitListObject constructed using the default_value list
     #: is the default value.
-    trait_list_object = 5
+    trait_list_object = _TRAIT_LIST_COPY_DEFAULT_VALUE
 
     #: A new instance of TraitDictObject constructed using the default_value dict
     #: is the default value.
-    trait_dict_object = 6
+    trait_dict_object = _TRAIT_DICT_COPY_DEFAULT_VALUE
 
     #: The default_value is a tuple of the form: (*callable*, *args*, *kw*),
     #: where *callable* is a callable, *args* is a tuple, and *kw* is either a
     #: dictionary or None. The default value is the result obtained by invoking
     #: ``callable(\*args, \*\*kw)``.
-    callable_and_args = 7
+    callable_and_args = _CALLABLE_AND_ARGS_DEFAULT_VALUE
 
     #: The default_value is a callable. The default value is the result obtained
     #: by invoking *default_value*(*object*), where *object* is the object
     #: containing the trait. If the trait has a validate() method, the validate()
     #: method is also called to validate the result.
-    callable = 8
+    callable = _CALLABLE_DEFAULT_VALUE
 
     #: A new instance of TraitSetObject constructed using the default_value set
     #: is the default value.
-    trait_set_object = 9
+    trait_set_object = _TRAIT_SET_OBJECT_DEFAULT_VALUE
 
 
 #: Maximum legal value for default_value_type, for use in testing

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -5023,62 +5023,83 @@ PyMODINIT_FUNC PyInit_ctraits(void) {
 
     /* Expose module-level constants used by cTrait and CHasTraits */
     /* CHasTraits flags */
-    PyModule_AddIntConstant(module, "_HASTRAITS_INITED", HASTRAITS_INITED);
-    PyModule_AddIntConstant(
-        module, "_HASTRAITS_NO_NOTIFY", HASTRAITS_NO_NOTIFY);
-    PyModule_AddIntConstant(
-        module, "_HASTRAITS_VETO_NOTIFY", HASTRAITS_VETO_NOTIFY);
+    if ( PyModule_AddIntConstant(module, "_HASTRAITS_INITED", HASTRAITS_INITED) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_HASTRAITS_NO_NOTIFY", HASTRAITS_NO_NOTIFY) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_HASTRAITS_VETO_NOTIFY", HASTRAITS_VETO_NOTIFY) < 0 )
+        return NULL;
 
     /* cTrait flags */
-    PyModule_AddIntConstant(module, "_TRAIT_PROPERTY", TRAIT_PROPERTY);
-    PyModule_AddIntConstant(
-        module, "_TRAIT_MODIFY_DELEGATE", TRAIT_MODIFY_DELEGATE);
-    PyModule_AddIntConstant(
-        module, "_TRAIT_OBJECT_IDENTITY", TRAIT_OBJECT_IDENTITY);
-    PyModule_AddIntConstant(
-        module,
-        "_TRAIT_SETATTR_ORIGINAL_VALUE",
-        TRAIT_SETATTR_ORIGINAL_VALUE);
-    PyModule_AddIntConstant(
-        module,
-        "_TRAIT_POST_SETATTR_ORIGINAL_VALUE",
-        TRAIT_POST_SETATTR_ORIGINAL_VALUE);
-    PyModule_AddIntConstant(
-        module, "_TRAIT_IS_MAPPED", TRAIT_IS_MAPPED);
-    PyModule_AddIntConstant(
-        module, "_TRAIT_NO_VALUE_TEST", TRAIT_NO_VALUE_TEST);
+    if ( PyModule_AddIntConstant(module, "_TRAIT_PROPERTY", TRAIT_PROPERTY) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_TRAIT_MODIFY_DELEGATE", TRAIT_MODIFY_DELEGATE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_TRAIT_OBJECT_IDENTITY", TRAIT_OBJECT_IDENTITY) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module,
+            "_TRAIT_SETATTR_ORIGINAL_VALUE",
+            TRAIT_SETATTR_ORIGINAL_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module,
+            "_TRAIT_POST_SETATTR_ORIGINAL_VALUE",
+            TRAIT_POST_SETATTR_ORIGINAL_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_TRAIT_IS_MAPPED", TRAIT_IS_MAPPED) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_TRAIT_NO_VALUE_TEST", TRAIT_NO_VALUE_TEST) < 0 )
+        return NULL;
 
     /* Default value type constants */
-    PyModule_AddIntConstant(
-        module, "_CONSTANT_DEFAULT_VALUE", CONSTANT_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module, "_MISSING_DEFAULT_VALUE", MISSING_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module, "_OBJECT_DEFAULT_VALUE", OBJECT_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module, "_LIST_COPY_DEFAULT_VALUE", LIST_COPY_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module, "_DICT_COPY_DEFAULT_VALUE", DICT_COPY_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module,
-        "_TRAIT_LIST_OBJECT_DEFAULT_VALUE",
-        TRAIT_LIST_OBJECT_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module,
-        "_TRAIT_DICT_OBJECT_DEFAULT_VALUE",
-        TRAIT_DICT_OBJECT_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module,
-        "_CALLABLE_AND_ARGS_DEFAULT_VALUE",
-        CALLABLE_AND_ARGS_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module, "_CALLABLE_DEFAULT_VALUE", CALLABLE_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module,
-        "_TRAIT_SET_OBJECT_DEFAULT_VALUE",
-        TRAIT_SET_OBJECT_DEFAULT_VALUE);
-    PyModule_AddIntConstant(
-        module, "_MAXIMUM_DEFAULT_VALUE_TYPE", MAXIMUM_DEFAULT_VALUE_TYPE);
+    if ( PyModule_AddIntConstant(
+            module, "_CONSTANT_DEFAULT_VALUE", CONSTANT_DEFAULT_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_MISSING_DEFAULT_VALUE", MISSING_DEFAULT_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_OBJECT_DEFAULT_VALUE", OBJECT_DEFAULT_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_LIST_COPY_DEFAULT_VALUE", LIST_COPY_DEFAULT_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_DICT_COPY_DEFAULT_VALUE", DICT_COPY_DEFAULT_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module,
+            "_TRAIT_LIST_OBJECT_DEFAULT_VALUE",
+            TRAIT_LIST_OBJECT_DEFAULT_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module,
+            "_TRAIT_DICT_OBJECT_DEFAULT_VALUE",
+            TRAIT_DICT_OBJECT_DEFAULT_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module,
+            "_CALLABLE_AND_ARGS_DEFAULT_VALUE",
+            CALLABLE_AND_ARGS_DEFAULT_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_CALLABLE_DEFAULT_VALUE", CALLABLE_DEFAULT_VALUE) < 0 )
+            return NULL;
+    if ( PyModule_AddIntConstant(
+            module,
+            "_TRAIT_SET_OBJECT_DEFAULT_VALUE",
+            TRAIT_SET_OBJECT_DEFAULT_VALUE) < 0 )
+        return NULL;
+    if ( PyModule_AddIntConstant(
+            module, "_MAXIMUM_DEFAULT_VALUE_TYPE", MAXIMUM_DEFAULT_VALUE_TYPE) < 0 )
+        return NULL;
 
     /* Predefine a Python string == "__class_traits__": */
     class_traits = PyUnicode_FromString( "__class_traits__" );

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4908,43 +4908,6 @@ PyMODINIT_FUNC PyInit_ctraits(void) {
                          (PyObject *) &trait_type ) < 0 )
        return NULL;
 
-    /* Expose module-level constants used by cTrait and CHasTraits */
-    /* CHasTraits flags */
-    if ( PyModule_AddIntConstant(module, "_HASTRAITS_INITED", HASTRAITS_INITED) < 0 )
-        return NULL;
-    if ( PyModule_AddIntConstant(
-            module, "_HASTRAITS_NO_NOTIFY", HASTRAITS_NO_NOTIFY) < 0 )
-        return NULL;
-    if ( PyModule_AddIntConstant(
-            module, "_HASTRAITS_VETO_NOTIFY", HASTRAITS_VETO_NOTIFY) < 0 )
-        return NULL;
-
-    /* cTrait flags */
-    if ( PyModule_AddIntConstant(module, "_TRAIT_PROPERTY", TRAIT_PROPERTY) < 0 )
-        return NULL;
-    if ( PyModule_AddIntConstant(
-            module, "_TRAIT_MODIFY_DELEGATE", TRAIT_MODIFY_DELEGATE) < 0 )
-        return NULL;
-    if ( PyModule_AddIntConstant(
-            module, "_TRAIT_OBJECT_IDENTITY", TRAIT_OBJECT_IDENTITY) < 0 )
-        return NULL;
-    if ( PyModule_AddIntConstant(
-            module,
-            "_TRAIT_SETATTR_ORIGINAL_VALUE",
-            TRAIT_SETATTR_ORIGINAL_VALUE) < 0 )
-        return NULL;
-    if ( PyModule_AddIntConstant(
-            module,
-            "_TRAIT_POST_SETATTR_ORIGINAL_VALUE",
-            TRAIT_POST_SETATTR_ORIGINAL_VALUE) < 0 )
-        return NULL;
-    if ( PyModule_AddIntConstant(
-            module, "_TRAIT_IS_MAPPED", TRAIT_IS_MAPPED) < 0 )
-        return NULL;
-    if ( PyModule_AddIntConstant(
-            module, "_TRAIT_NO_VALUE_TEST", TRAIT_NO_VALUE_TEST) < 0 )
-        return NULL;
-
     /* Default value type constants */
     if ( PyModule_AddIntConstant(
             module, "_CONSTANT_DEFAULT_VALUE", CONSTANT_DEFAULT_VALUE) < 0 )

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -5021,6 +5021,65 @@ PyMODINIT_FUNC PyInit_ctraits(void) {
                          (PyObject *) &trait_type ) < 0 )
        return NULL;
 
+    /* Expose module-level constants used by cTrait and CHasTraits */
+    /* CHasTraits flags */
+    PyModule_AddIntConstant(module, "_HASTRAITS_INITED", HASTRAITS_INITED);
+    PyModule_AddIntConstant(
+        module, "_HASTRAITS_NO_NOTIFY", HASTRAITS_NO_NOTIFY);
+    PyModule_AddIntConstant(
+        module, "_HASTRAITS_VETO_NOTIFY", HASTRAITS_VETO_NOTIFY);
+
+    /* cTrait flags */
+    PyModule_AddIntConstant(module, "_TRAIT_PROPERTY", TRAIT_PROPERTY);
+    PyModule_AddIntConstant(
+        module, "_TRAIT_MODIFY_DELEGATE", TRAIT_MODIFY_DELEGATE);
+    PyModule_AddIntConstant(
+        module, "_TRAIT_OBJECT_IDENTITY", TRAIT_OBJECT_IDENTITY);
+    PyModule_AddIntConstant(
+        module,
+        "_TRAIT_SETATTR_ORIGINAL_VALUE",
+        TRAIT_SETATTR_ORIGINAL_VALUE);
+    PyModule_AddIntConstant(
+        module,
+        "_TRAIT_POST_SETATTR_ORIGINAL_VALUE",
+        TRAIT_POST_SETATTR_ORIGINAL_VALUE);
+    PyModule_AddIntConstant(
+        module, "_TRAIT_IS_MAPPED", TRAIT_IS_MAPPED);
+    PyModule_AddIntConstant(
+        module, "_TRAIT_NO_VALUE_TEST", TRAIT_NO_VALUE_TEST);
+
+    /* Default value type constants */
+    PyModule_AddIntConstant(
+        module, "_CONSTANT_DEFAULT_VALUE", CONSTANT_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module, "_MISSING_DEFAULT_VALUE", MISSING_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module, "_OBJECT_DEFAULT_VALUE", OBJECT_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module, "_LIST_COPY_DEFAULT_VALUE", LIST_COPY_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module, "_DICT_COPY_DEFAULT_VALUE", DICT_COPY_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module,
+        "_TRAIT_LIST_OBJECT_DEFAULT_VALUE",
+        TRAIT_LIST_OBJECT_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module,
+        "_TRAIT_DICT_OBJECT_DEFAULT_VALUE",
+        TRAIT_DICT_OBJECT_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module,
+        "_CALLABLE_AND_ARGS_DEFAULT_VALUE",
+        CALLABLE_AND_ARGS_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module, "_CALLABLE_DEFAULT_VALUE", CALLABLE_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module,
+        "_TRAIT_SET_OBJECT_DEFAULT_VALUE",
+        TRAIT_SET_OBJECT_DEFAULT_VALUE);
+    PyModule_AddIntConstant(
+        module, "_MAXIMUM_DEFAULT_VALUE_TYPE", MAXIMUM_DEFAULT_VALUE_TYPE);
+
     /* Predefine a Python string == "__class_traits__": */
     class_traits = PyUnicode_FromString( "__class_traits__" );
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4984,9 +4984,6 @@ PyMODINIT_FUNC PyInit_ctraits(void) {
             "_TRAIT_SET_OBJECT_DEFAULT_VALUE",
             TRAIT_SET_OBJECT_DEFAULT_VALUE) < 0 )
         return NULL;
-    if ( PyModule_AddIntConstant(
-            module, "_MAXIMUM_DEFAULT_VALUE_TYPE", MAXIMUM_DEFAULT_VALUE_TYPE) < 0 )
-        return NULL;
 
     /* Predefine a Python string == "__class_traits__": */
     class_traits = PyUnicode_FromString( "__class_traits__" );

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -13,7 +13,6 @@
 import unittest
 import warnings
 
-import traits.ctraits
 from traits.constants import (
     ComparisonMode, DefaultValue, TraitKind, MAXIMUM_DEFAULT_VALUE_TYPE
 )
@@ -148,4 +147,4 @@ class TestCTrait(unittest.TestCase):
         self.assertTrue(trait.no_value_test)
 
         with self.assertRaises(AttributeError):
-            trait.no_value_test_flag = False
+            trait.no_value_test = False

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -13,6 +13,7 @@
 import unittest
 import warnings
 
+import traits.ctraits
 from traits.traits import CTrait
 from traits.trait_handlers import (
     CONSTANT_DEFAULT_VALUE,
@@ -150,3 +151,35 @@ class TestCTrait(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             trait.no_value_test_flag = False
+
+    def test_module_constants_exist(self):
+        ctraits_module_constants = [
+            # CHasTraits flags
+            "_HASTRAITS_INITED",
+            "_HASTRAITS_NO_NOTIFY",
+            "_HASTRAITS_VETO_NOTIFY",
+            # cTrait flags
+            "_TRAIT_PROPERTY",
+            "_TRAIT_MODIFY_DELEGATE",
+            "_TRAIT_MODIFY_DELEGATE",
+            "_TRAIT_OBJECT_IDENTITY",
+            "_TRAIT_SETATTR_ORIGINAL_VALUE",
+            "_TRAIT_POST_SETATTR_ORIGINAL_VALUE",
+            "_TRAIT_IS_MAPPED",
+            "_TRAIT_NO_VALUE_TEST",
+            # Default value type constants
+            "_CONSTANT_DEFAULT_VALUE",
+            "_MISSING_DEFAULT_VALUE",
+            "_OBJECT_DEFAULT_VALUE",
+            "_LIST_COPY_DEFAULT_VALUE",
+            "_DICT_COPY_DEFAULT_VALUE",
+            "_TRAIT_LIST_OBJECT_DEFAULT_VALUE",
+            "_TRAIT_DICT_OBJECT_DEFAULT_VALUE",
+            "_CALLABLE_AND_ARGS_DEFAULT_VALUE",
+            "_CALLABLE_DEFAULT_VALUE",
+            "_TRAIT_SET_OBJECT_DEFAULT_VALUE",
+            "_MAXIMUM_DEFAULT_VALUE_TYPE",
+        ]
+        for var in ctraits_module_constants:
+            cnst = getattr(traits.ctraits, var)
+            self.assertIsInstance(cnst, int)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -180,6 +180,6 @@ class TestCTrait(unittest.TestCase):
             "_TRAIT_SET_OBJECT_DEFAULT_VALUE",
             "_MAXIMUM_DEFAULT_VALUE_TYPE",
         ]
-        for var in ctraits_module_constants:
-            cnst = getattr(traits.ctraits, var)
-            self.assertIsInstance(cnst, int)
+        for constant_name in ctraits_module_constants:
+            constant_value = getattr(traits.ctraits, constant_name)
+            self.assertIsInstance(constant_value, int)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -148,40 +148,4 @@ class TestCTrait(unittest.TestCase):
         self.assertTrue(trait.no_value_test)
 
         with self.assertRaises(AttributeError):
-<<<<<<< HEAD
             trait.no_value_test_flag = False
-
-    def test_module_constants_exist(self):
-        ctraits_module_constants = [
-            # CHasTraits flags
-            "_HASTRAITS_INITED",
-            "_HASTRAITS_NO_NOTIFY",
-            "_HASTRAITS_VETO_NOTIFY",
-            # cTrait flags
-            "_TRAIT_PROPERTY",
-            "_TRAIT_MODIFY_DELEGATE",
-            "_TRAIT_MODIFY_DELEGATE",
-            "_TRAIT_OBJECT_IDENTITY",
-            "_TRAIT_SETATTR_ORIGINAL_VALUE",
-            "_TRAIT_POST_SETATTR_ORIGINAL_VALUE",
-            "_TRAIT_IS_MAPPED",
-            "_TRAIT_NO_VALUE_TEST",
-            # Default value type constants
-            "_CONSTANT_DEFAULT_VALUE",
-            "_MISSING_DEFAULT_VALUE",
-            "_OBJECT_DEFAULT_VALUE",
-            "_LIST_COPY_DEFAULT_VALUE",
-            "_DICT_COPY_DEFAULT_VALUE",
-            "_TRAIT_LIST_OBJECT_DEFAULT_VALUE",
-            "_TRAIT_DICT_OBJECT_DEFAULT_VALUE",
-            "_CALLABLE_AND_ARGS_DEFAULT_VALUE",
-            "_CALLABLE_DEFAULT_VALUE",
-            "_TRAIT_SET_OBJECT_DEFAULT_VALUE",
-            "_MAXIMUM_DEFAULT_VALUE_TYPE",
-        ]
-        for constant_name in ctraits_module_constants:
-            constant_value = getattr(traits.ctraits, constant_name)
-            self.assertIsInstance(constant_value, int)
-=======
-            trait.no_value_test = False
->>>>>>> c703654ba8e1546c651669be38514f4f85184a34


### PR DESCRIPTION
fixes #686 

This PR exposes all of the module-level constants used in the `traits.ctraits` module. Exposing these constants will remove the need to duplicate the constants elsewhere in the traits codebase (This will be done in a separate PR).

Note that there are a new number of constants that need to be defined and exposed in `traits.ctraits` - which will also be done in a separate PR.