### PR TITLE
Refactor of flags and the methods that set them.

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -124,7 +124,7 @@ static int call_notifiers ( PyListObject *, PyListObject *,
 #define TRAIT_MODIFY_DELEGATE 0x00000002
 
 /* Should a simple object identity test be performed (or a rich compare)? */
-#define TRAIT_OBJECT_IDENTITY 0x00000004
+#define TRAIT_OBJECT_ID_TEST 0x00000004
 
 /* Make 'setattr' store the original unvalidated value */
 #define TRAIT_SETATTR_ORIGINAL_VALUE 0x00000008
@@ -2082,7 +2082,7 @@ setattr_trait ( trait_object      * traito,
                 if ( !changed ) {
                     changed = (old_value != value );
                     if ( changed &&
-                         ((traitd->flags & TRAIT_OBJECT_IDENTITY) == 0) ) {
+                         ((traitd->flags & TRAIT_OBJECT_ID_TEST) == 0) ) {
                         changed = PyObject_RichCompareBool( old_value,
                                                             value, Py_NE );
                         if ( changed == -1 ) {
@@ -2164,7 +2164,7 @@ setattr_trait ( trait_object      * traito,
         if ( !changed ) {
             changed = (old_value != value);
             if ( changed &&
-                 ((traitd->flags & TRAIT_OBJECT_IDENTITY) == 0) ) {
+                 ((traitd->flags & TRAIT_OBJECT_ID_TEST) == 0) ) {
                 changed = PyObject_RichCompareBool( old_value, value, Py_NE );
                 if ( changed == -1 ) {
                     PyErr_Clear();
@@ -4074,9 +4074,9 @@ _trait_rich_comparison ( trait_object * trait, PyObject * args ) {
     if ( !PyArg_ParseTuple( args, "p", &compare_type ) )
         return NULL;
 
-    trait->flags &= (~(TRAIT_NO_VALUE_TEST | TRAIT_OBJECT_IDENTITY));
+    trait->flags &= (~(TRAIT_NO_VALUE_TEST | TRAIT_OBJECT_ID_TEST));
     if ( compare_type == 0 )
-        trait->flags |= TRAIT_OBJECT_IDENTITY;
+        trait->flags |= TRAIT_OBJECT_ID_TEST;
 
     Py_INCREF( Py_None );
     return Py_None;
@@ -4094,85 +4094,16 @@ _trait_comparison_mode ( trait_object * trait, PyObject * args ) {
     if ( !PyArg_ParseTuple( args, "i", &comparison_mode ) )
         return NULL;
 
-    trait->flags &= (~(TRAIT_NO_VALUE_TEST | TRAIT_OBJECT_IDENTITY));
+    trait->flags &= (~(TRAIT_NO_VALUE_TEST | TRAIT_OBJECT_ID_TEST));
     switch ( comparison_mode ) {
         case 0:  trait->flags |= TRAIT_NO_VALUE_TEST;
                  break;
-        case 1:  trait->flags |= TRAIT_OBJECT_IDENTITY;
+        case 1:  trait->flags |= TRAIT_OBJECT_ID_TEST;
         default: break;
     }
 
     Py_INCREF( Py_None );
     return Py_None;
-}
-
-
-/*-----------------------------------------------------------------------------
-|  Sets the value of the 'setattr_original_value' flag of a CTrait instance:
-+----------------------------------------------------------------------------*/
-
-static PyObject *
-_trait_setattr_original_value ( trait_object * trait, PyObject * args ) {
-
-    int original_value;
-
-    if ( !PyArg_ParseTuple( args, "p", &original_value ) )
-        return NULL;
-
-    if ( original_value != 0 ) {
-        trait->flags |= TRAIT_SETATTR_ORIGINAL_VALUE;
-    } else {
-        trait->flags &= (~TRAIT_SETATTR_ORIGINAL_VALUE);
-    }
-
-    Py_INCREF( trait );
-    return (PyObject *) trait;
-}
-
-/*-----------------------------------------------------------------------------
-|  Sets the value of the 'post_setattr_original_value' flag of a CTrait
-|  instance (used in the processing of 'post_settattr' calls):
-+----------------------------------------------------------------------------*/
-
-static PyObject *
-_trait_post_setattr_original_value ( trait_object * trait, PyObject * args ) {
-
-    int original_value;
-
-    if ( !PyArg_ParseTuple( args, "p", &original_value ) )
-        return NULL;
-
-    if ( original_value != 0 ) {
-        trait->flags |= TRAIT_POST_SETATTR_ORIGINAL_VALUE;
-    } else {
-        trait->flags &= (~TRAIT_POST_SETATTR_ORIGINAL_VALUE);
-    }
-
-    Py_INCREF( trait );
-    return (PyObject *) trait;
-}
-
-/*-----------------------------------------------------------------------------
-|  Sets the value of the 'is_mapped' flag of a CTrait instance (used in the
-|  processing of the default value of a trait with a 'post_settattr' handler):
-+----------------------------------------------------------------------------*/
-
-static PyObject *
-_trait_is_mapped ( trait_object * trait, PyObject * args ) {
-
-    int is_mapped;
-
-    if ( !PyArg_ParseTuple( args, "p", &is_mapped ) )
-        return NULL;
-
-    if ( is_mapped != 0 ) {
-        trait->flags |= TRAIT_IS_MAPPED;
-    } else {
-        trait->flags &= (~TRAIT_IS_MAPPED);
-    }
-
-    Py_INCREF( trait );
-    return (PyObject *) trait;
 }
 
 /*-----------------------------------------------------------------------------
@@ -4533,13 +4464,13 @@ set_trait_modify_delegate_flag(trait_object * trait, PyObject * value,
 }
 
 /*-----------------------------------------------------------------------------
-|  Returns the current object_identity flag value:
+|  Returns the current object_id_test flag value:
 +----------------------------------------------------------------------------*/
 
 static PyObject *
-get_trait_object_identity_flag(trait_object * trait, void * closure)
+get_trait_object_id_test_flag(trait_object * trait, void * closure)
 {
-    return get_trait_flag(trait, TRAIT_OBJECT_IDENTITY);
+    return get_trait_flag(trait, TRAIT_OBJECT_ID_TEST);
 }
 
 /*-----------------------------------------------------------------------------
@@ -4775,14 +4706,6 @@ static PyMethodDef trait_methods[] = {
                 PyDoc_STR( "rich_comparison(rich_comparison_boolean)" ) },
         { "comparison_mode",  (PyCFunction) _trait_comparison_mode,  METH_VARARGS,
                 PyDoc_STR( "comparison_mode(comparison_mode_enum)" ) },
-        { "setattr_original_value",
-        (PyCFunction) _trait_setattr_original_value,       METH_VARARGS,
-                PyDoc_STR( "setattr_original_value(original_value_boolean)" ) },
-        { "post_setattr_original_value",
-        (PyCFunction) _trait_post_setattr_original_value,  METH_VARARGS,
-                PyDoc_STR( "post_setattr_original_value(original_value_boolean)" ) },
-        { "is_mapped", (PyCFunction) _trait_is_mapped,  METH_VARARGS,
-                PyDoc_STR( "is_mapped(is_mapped_boolean)" ) },
         { "property",      (PyCFunction) _trait_property,      METH_VARARGS,
                 PyDoc_STR( "property([get,set,validate])" ) },
         { "clone",         (PyCFunction) _trait_clone,         METH_VARARGS,
@@ -4801,27 +4724,27 @@ static PyGetSetDef trait_properties[] = {
         { "handler",        (getter) get_trait_handler, (setter) set_trait_handler },
         { "post_setattr",   (getter) get_trait_post_setattr,
                             (setter) set_trait_post_setattr },
-        {"property_flag", (getter) get_trait_property_flag, NULL,
+        {"is_property", (getter) get_trait_property_flag, NULL,
          "Whether the trait is a property trait.", NULL},
-        {"modify_delegate_flag", (getter) get_trait_modify_delegate_flag,
+        {"modify_delegate", (getter) get_trait_modify_delegate_flag,
          (setter) set_trait_modify_delegate_flag,
          "Whether changes to the trait modify the delegate as well", NULL},
-        {"object_identity_flag", (getter) get_trait_object_identity_flag,
+        {"object_id_test", (getter) get_trait_object_id_test_flag,
          NULL, "Whether change comparisons are by object identity.", NULL},
-        {"setattr_original_value_flag",
+        {"setattr_original_value",
          (getter) get_trait_setattr_original_value_flag,
          (setter) set_trait_setattr_original_value_flag,
          "Whether setattr gets the original value set on the trait or the "
          "stored value,", NULL},
-        {"post_setattr_original_value_flag",
+        {"post_setattr_original_value",
          (getter) get_trait_post_setattr_original_value_flag,
          (setter) set_trait_post_setattr_original_value_flag,
          "Whether post_setattr gets the original value set on the trait or "
          "the stored value,", NULL},
-        {"is_mapped_flag", (getter) get_trait_is_mapped_flag,
+        {"is_mapped", (getter) get_trait_is_mapped_flag,
          (setter) set_trait_is_mapped_flag,
          "Whether the trait is a mapped trait.", NULL},
-        {"no_value_test_flag", (getter) get_trait_no_value_test_flag, NULL,
+        {"no_value_test", (getter) get_trait_no_value_test_flag, NULL,
          "Whether trait changes are fired on every assignment, or only when "
          "the value tests as different.", NULL},
         { 0 }

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -79,74 +79,74 @@ class TestCTrait(unittest.TestCase):
         with self.assertRaises(ValueError):
             trait.set_default_value(MAXIMUM_DEFAULT_VALUE_TYPE + 1, None)
 
-    def test_property_flag(self):
+    def test_is_property(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.property_flag)
+        self.assertFalse(trait.is_property)
 
         trait.property(getter, 0, setter, 1, validator, 1)
 
-        self.assertTrue(trait.property_flag)
+        self.assertTrue(trait.is_property)
 
         with self.assertRaises(AttributeError):
-            trait.property_flag = False
+            trait.is_property = False
 
-    def test_modify_delegate_flag(self):
+    def test_modify_delegate(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.modify_delegate_flag)
+        self.assertFalse(trait.modify_delegate)
 
-        trait.modify_delegate_flag = True
+        trait.modify_delegate = True
 
-        self.assertTrue(trait.modify_delegate_flag)
+        self.assertTrue(trait.modify_delegate)
 
-    def test_object_identity_flag(self):
+    def test_object_id_test(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.object_identity_flag)
+        self.assertFalse(trait.object_id_test)
 
         trait.comparison_mode(1)
 
-        self.assertTrue(trait.object_identity_flag)
+        self.assertTrue(trait.object_id_test)
 
         with self.assertRaises(AttributeError):
-            trait.object_identity_flag = False
+            trait.object_id_test = False
 
-    def test_setattr_original_value_flag(self):
+    def test_setattr_original_value(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.setattr_original_value_flag)
+        self.assertFalse(trait.setattr_original_value)
 
-        trait.setattr_original_value_flag = True
+        trait.setattr_original_value = True
 
-        self.assertTrue(trait.setattr_original_value_flag)
+        self.assertTrue(trait.setattr_original_value)
 
-    def test_post_setattr_original_value_flag(self):
+    def test_post_setattr_original_value(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.post_setattr_original_value_flag)
+        self.assertFalse(trait.post_setattr_original_value)
 
-        trait.post_setattr_original_value_flag = True
+        trait.post_setattr_original_value = True
 
-        self.assertTrue(trait.post_setattr_original_value_flag)
+        self.assertTrue(trait.post_setattr_original_value)
 
-    def test_is_mapped_flag(self):
+    def test_is_mapped(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.is_mapped_flag)
+        self.assertFalse(trait.is_mapped)
 
-        trait.is_mapped_flag = True
+        trait.is_mapped = True
 
-        self.assertTrue(trait.is_mapped_flag)
+        self.assertTrue(trait.is_mapped)
 
-    def test_no_value_test_flag(self):
+    def test_no_value_test(self):
         trait = CTrait(0)
 
-        self.assertFalse(trait.no_value_test_flag)
+        self.assertFalse(trait.no_value_test)
 
         trait.comparison_mode(0)
 
-        self.assertTrue(trait.no_value_test_flag)
+        self.assertTrue(trait.no_value_test)
 
         with self.assertRaises(AttributeError):
-            trait.no_value_test_flag = False
+            trait.no_value_test = False

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -662,7 +662,7 @@ class TraitType(BaseTraitHandler):
             post_setattr = getattr(self, "post_setattr", None)
             if post_setattr is not None:
                 trait.post_setattr = post_setattr
-                trait.is_mapped_flag = self.is_mapped
+                trait.is_mapped = self.is_mapped
 
             # Note: The use of 'rich_compare' metadata is deprecated; use
             # 'comparison_mode' metadata instead:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1362,7 +1362,7 @@ class Expression(TraitType):
         # Tell the C code that 'setattr' should store the original, unadapted
         # value passed to it:
         ctrait = super(Expression, self).as_ctrait()
-        ctrait.setattr_original_value_flag = True
+        ctrait.setattr_original_value = True
         return ctrait
 
 
@@ -3020,7 +3020,7 @@ class Supports(Instance):
 
         # Tell the C code that the 'post_setattr' method wants the original,
         # unadapted value passed to 'setattr':
-        ctrait.post_setattr_original_value_flag = True
+        ctrait.post_setattr_original_value = True
         return ctrait
 
 
@@ -3043,7 +3043,7 @@ class AdaptsTo(Supports):
     def modify_ctrait(self, ctrait):
         # Tell the C code that 'setattr' should store the original, unadapted
         # value passed to it:
-        ctrait.setattr_original_value_flag = True
+        ctrait.setattr_original_value = True
         return ctrait
 
 

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -1096,7 +1096,7 @@ class _TraitMaker(object):
             post_setattr = getattr(handler, "post_setattr", None)
             if post_setattr is not None:
                 trait.post_setattr = post_setattr
-                trait.is_mapped_flag = handler.is_mapped
+                trait.is_mapped = handler.is_mapped
 
         # Note: The use of 'rich_compare' metadata is deprecated; use
         # 'comparison_mode' metadata instead:


### PR DESCRIPTION
Renames flag properties to more natural names, removes setter methods
that are now unusued or conflict with property names.

(cherry picked from commit 065f2f26c22f736d05dcd014e00b81f5df3b10c6)

This is a recreation of #672 on top of master; recreating was easier than fixing the merge conflicts.