### PR TITLE
Sphinx configuration cleanups: no more mocking, fix deprecated option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Traits has the following optional dependencies:
 
 To build the full documentation one needs:
 
-* sphinx > 1.2.3
+* sphinx >= 1.8
 * `enthought-sphinx-theme
   <https://github.com/enthought/enthought-sphinx-theme>`_
   (a version of the documentation can be built without this, but


### PR DESCRIPTION
- Remove use of mocking from the configuration file. The Traits documentation no longer documents anything from Traits UI, so this is unnecessary.
- Fix a deprecated autodoc option, which is removed in Sphinx 3.0
- Require Sphinx >= 1.8. (The replacement autodoc option for the above was introduced with Sphinx 1.8).