### PR TITLE
Remove TraitCallable

### DIFF
--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -43,8 +43,6 @@ Classes
 
 .. autoclass:: TraitTuple
 
-.. autoclass:: TraitCallable
-
 .. autoclass:: TraitList
 
 .. autoclass:: TraitDict

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -1832,25 +1832,6 @@ class TraitTuple(TraitHandler):
 
 
 # -------------------------------------------------------------------------------
-#  'TraitCallable' class:
-# -------------------------------------------------------------------------------
-
-
-class TraitCallable(TraitHandler):
-    """Ensures that the value of a trait attribute is a callable Python object
-    (usually a function or method).
-    """
-
-    def validate(self, object, name, value):
-        if (value is None) or callable(value):
-            return value
-        self.error(object, name, value)
-
-    def info(self):
-        return "a callable value"
-
-
-# -------------------------------------------------------------------------------
 #  'TraitList' class:
 # -------------------------------------------------------------------------------
 


### PR DESCRIPTION
`TraitCallable` is untested, and unused within ETS and within ETS-using projects that I have access to the source for. Let's remove it for 6.0.