### PR TITLE
Add a CHasTraits._class_traits() method

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1309,6 +1309,20 @@ _has_traits_instance_traits ( has_traits_object * obj, PyObject *Py_UNUSED(ignor
 }
 
 /*-----------------------------------------------------------------------------
+|  Returns the class trait dictionary:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+_has_traits_class_traits(has_traits_object *obj, PyObject *Py_UNUSED(ignored))
+{
+    PyObject *ctrait_dict;
+
+    ctrait_dict = (PyObject *)obj->ctrait_dict;
+    Py_INCREF(ctrait_dict);
+    return ctrait_dict;
+}
+
+/*-----------------------------------------------------------------------------
 |  Returns (and optionally creates) the anytrait 'notifiers' list:
 +----------------------------------------------------------------------------*/
 
@@ -1397,6 +1411,9 @@ static PyMethodDef has_traits_methods[] = {
         { "_instance_traits", (PyCFunction) _has_traits_instance_traits,
       METH_NOARGS,
       PyDoc_STR( "_instance_traits() -> dict" ) },
+        { "_class_traits", (PyCFunction) _has_traits_class_traits,
+      METH_NOARGS,
+      PyDoc_STR( "_class_traits() -> dict" ) },
         { "_notifiers",       (PyCFunction) _has_traits_notifiers, METH_VARARGS,
       PyDoc_STR( "_notifiers(force_create) -> list" ) },
         { NULL, NULL },

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -10,7 +10,7 @@ from traits.has_traits import (
     InstanceTraits,
     HasTraits,
 )
-from traits.traits import ForwardProperty, generic_trait
+from traits.traits import CTrait, ForwardProperty, generic_trait
 from traits.trait_types import Float, Int
 
 
@@ -194,3 +194,33 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
             class_dict[BaseTraits]["my_trait"],
             class_dict[ClassTraits]["my_trait"],
         )
+
+    def test__class_traits(self):
+        # Exercise the _class_traits() private introspection method.
+        class Base(HasTraits):
+            pin = Int
+
+        a = Base()
+        a_class_traits = a._class_traits()
+        self.assertIsInstance(a_class_traits, dict)
+        self.assertIn("pin", a_class_traits)
+        self.assertIsInstance(a_class_traits["pin"], CTrait)
+
+        b = Base()
+        self.assertIs(b._class_traits(), a_class_traits)
+
+    def test__instance_traits(self):
+        # Exercise the _instance_traits() private introspection method.
+        class Base(HasTraits):
+            pin = Int
+
+        a = Base()
+        a_instance_traits = a._instance_traits()
+        self.assertIsInstance(a_instance_traits, dict)
+
+        # A second call should return the same dictionary.
+        self.assertIs(a._instance_traits(), a_instance_traits)
+
+        # A different instance should have its own instance traits dict.
+        b = Base()
+        self.assertIsNot(b._instance_traits(), a_instance_traits)


### PR DESCRIPTION
This PR adds a `_class_traits` method to `CHasTraits` for introspection purposes. There's currently no other reliable and obvious way to get the `_class_traits` dictionary that a `CHasTraits` instance is actually using at any particular moment; in particular, the returned dictionary may or may not match the result of `my_has_traits_object.class_traits()`.