### PR TITLE
Expose HASTRAITS_NO_NOTIFY and HASTRAITS_VETO_NOTIFY flags

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1250,6 +1250,22 @@ _has_traits_change_notify ( has_traits_object * obj, PyObject * args ) {
 }
 
 /*-----------------------------------------------------------------------------
+| Reports whether trait change notifications are enabled when this object is
+| assigned to a trait:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+_has_traits_notifications_vetoed(has_traits_object *obj, PyObject *Py_UNUSED(ignored))
+{
+    if (obj->flags & HASTRAITS_VETO_NOTIFY) {
+        Py_RETURN_TRUE;
+    }
+    else {
+        Py_RETURN_FALSE;
+    }
+}
+
+/*-----------------------------------------------------------------------------
 |  Enables/Disables trait change notifications when this object is assigned to
 |  a trait:
 +----------------------------------------------------------------------------*/
@@ -1416,7 +1432,23 @@ PyDoc_STRVAR(_trait_notifications_enabled_doc,
 "Returns\n"
 "-------\n"
 "enabled : bool\n"
-"    True if notifications are current enabled for this object, else False.\n"
+"    True if notifications are currently enabled for this object, else False.\n"
+);
+
+PyDoc_STRVAR(_trait_notifications_vetoed_doc,
+"_trait_notifications_vetoed()\n"
+"\n"
+"Report whether trait notifications are vetoed for this object.\n"
+"\n"
+"If trait notifications are vetoed for an object, assignment of that object\n"
+"to a trait will not generate a notification.\n"
+"This setting can be enabled or disabled using the ``_trait_veto_notify``\n"
+"method. By default, notifications are not vetoed.\n"
+"\n"
+"Returns\n"
+"-------\n"
+"vetoed : bool\n"
+"    True if notifications are currently vetoed for this object, else False.\n"
 );
 
 static PyMethodDef has_traits_methods[] = {
@@ -1437,6 +1469,12 @@ static PyMethodDef has_traits_methods[] = {
         { "_trait_veto_notify", (PyCFunction) _has_traits_veto_notify,
       METH_VARARGS,
       PyDoc_STR( "_trait_veto_notify(boolean)" ) },
+        {
+            "_trait_notifications_vetoed",
+            (PyCFunction) _has_traits_notifications_vetoed,
+            METH_NOARGS,
+            _trait_notifications_vetoed_doc,
+        },
         { "traits_init", (PyCFunction) _has_traits_init,
       METH_NOARGS,
       PyDoc_STR( "traits_init()" ) },

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1210,6 +1210,22 @@ add_trait:
 }
 
 /*-----------------------------------------------------------------------------
+| Reports whether trait change notifications are enabled for this object:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+_has_traits_notifications_enabled(has_traits_object *obj, PyObject *Py_UNUSED(ignored))
+{
+    if (obj->flags & HASTRAITS_NO_NOTIFY) {
+        Py_RETURN_FALSE;
+    }
+    else {
+        Py_RETURN_TRUE;
+    }
+}
+
+
+/*-----------------------------------------------------------------------------
 |  Enables/Disables trait change notification for the object:
 +----------------------------------------------------------------------------*/
 
@@ -1389,6 +1405,20 @@ set_has_traits_dict ( has_traits_object * obj, PyObject * value,
 |  'CHasTraits' instance methods:
 +----------------------------------------------------------------------------*/
 
+PyDoc_STRVAR(_trait_notifications_enabled_doc,
+"_trait_notifications_enabled()\n"
+"\n"
+"Report whether trait notifications are enabled for this object.\n"
+"\n"
+"Notifications can be enabled or disabled using the ``_trait_change_notify``\n"
+"method. By default, notifications are enabled.\n"
+"\n"
+"Returns\n"
+"-------\n"
+"enabled : bool\n"
+"    True if notifications are current enabled for this object, else False.\n"
+);
+
 static PyMethodDef has_traits_methods[] = {
         { "trait_property_changed", (PyCFunction) _has_traits_property_changed,
       METH_VARARGS,
@@ -1398,6 +1428,12 @@ static PyMethodDef has_traits_methods[] = {
         { "_trait_change_notify", (PyCFunction) _has_traits_change_notify,
       METH_VARARGS,
       PyDoc_STR( "_trait_change_notify(boolean)" ) },
+        {
+            "_trait_notifications_enabled",
+            (PyCFunction) _has_traits_notifications_enabled,
+            METH_NOARGS,
+            _trait_notifications_enabled_doc,
+        },
         { "_trait_veto_notify", (PyCFunction) _has_traits_veto_notify,
       METH_VARARGS,
       PyDoc_STR( "_trait_veto_notify(boolean)" ) },

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -195,6 +195,8 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
             class_dict[ClassTraits]["my_trait"],
         )
 
+
+class TestHasTraits(unittest.TestCase):
     def test__class_traits(self):
         # Exercise the _class_traits() private introspection method.
         class Base(HasTraits):
@@ -224,3 +226,36 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         # A different instance should have its own instance traits dict.
         b = Base()
         self.assertIsNot(b._instance_traits(), a_instance_traits)
+
+    def test__trait_notifications_enabled(self):
+        class Base(HasTraits):
+            foo = Int(0)
+
+            foo_notify_count = Int(0)
+
+            def _foo_changed(self):
+                self.foo_notify_count += 1
+
+        a = Base()
+
+        # Default state is that notifications are enabled.
+        self.assertTrue(a._trait_notifications_enabled())
+
+        # Changing foo increments the count.
+        old_count = a.foo_notify_count
+        a.foo += 1
+        self.assertEqual(a.foo_notify_count, old_count + 1)
+
+        # After disabling notifications, count is not increased.
+        a._trait_change_notify(False)
+        self.assertFalse(a._trait_notifications_enabled())
+        old_count = a.foo_notify_count
+        a.foo += 1
+        self.assertEqual(a.foo_notify_count, old_count)
+
+        # After re-enabling notifications, count is increased.
+        a._trait_change_notify(True)
+        self.assertTrue(a._trait_notifications_enabled())
+        old_count = a.foo_notify_count
+        a.foo += 1
+        self.assertEqual(a.foo_notify_count, old_count + 1)


### PR DESCRIPTION
This PR adds new private methods on `CHasTraits` to allow introspection of the `HASTRAITS_NO_NOTIFY` and `HASTRAITS_VETO_NOTIFY` flags. In current master, those flags can be set, but cannot be directly read.

- `CHasTraits._trait_notifications_enabled` reports whether notifications are currently enabled for this object.
- `CHasTraits._trait_notifications_vetoed` reports whether notifications are currently vetoed for this object.

Closes #703