### PR TITLE
Replace uses of __import__ with import_module

### DIFF
--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -31,6 +31,7 @@ consistent.
 #  Imports:
 # -------------------------------------------------------------------------------
 
+from importlib import import_module
 import re
 import sys
 from types import FunctionType, MethodType
@@ -1084,21 +1085,19 @@ class TraitInstance(ThisClass):
             trait = handler.item_trait
         trait.set_validate(self.fast_validate)
 
-    def find_class(self, aClass):
+    def find_class(self, klass):
         module = self.module
-        col = aClass.rfind(".")
+        col = klass.rfind(".")
         if col >= 0:
-            module = aClass[:col]
-            aClass = aClass[col + 1 :]
+            module = klass[:col]
+            klass = klass[col + 1 :]
 
-        theClass = getattr(sys.modules.get(module), aClass, None)
+        theClass = getattr(sys.modules.get(module), klass, None)
         if (theClass is None) and (col >= 0):
             try:
-                mod = __import__(module, globals=globals(), level=1)
-                for component in module.split(".")[1:]:
-                    mod = getattr(mod, component)
-                theClass = getattr(mod, aClass, None)
-            except:
+                mod = import_module(module)
+                theClass = getattr(mod, klass, None)
+            except Exception:
                 pass
 
         return theClass

--- a/traits/util/import_symbol.py
+++ b/traits/util/import_symbol.py
@@ -1,5 +1,9 @@
 """ A function to import symbols. """
 
+from importlib import import_module
+
+from traits.trait_base import xgetattr
+
 
 def import_symbol(symbol_path):
     """ Import the symbol defined by the specified symbol path.
@@ -21,15 +25,15 @@ def import_symbol(symbol_path):
     if ":" in symbol_path:
         module_name, symbol_name = symbol_path.split(":")
 
-        module = __import__(module_name, {}, {}, [symbol_name], 0)
-        symbol = eval(symbol_name, module.__dict__)
+        module = import_module(module_name)
+        symbol = xgetattr(module, symbol_name)
 
     else:
         components = symbol_path.split(".")
         module_name = ".".join(components[:-1])
         symbol_name = components[-1]
 
-        module = __import__(module_name, {}, {}, [symbol_name], 0)
+        module = import_module(module_name)
         symbol = getattr(module, symbol_name)
 
     return symbol

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -79,8 +79,7 @@ class TraitDocumenter(ClassLevelDocumenter):
 
         """
         try:
-            import_module(self.modname)
-            current = self.module = sys.modules[self.modname]
+            current = self.module = import_module(self.modname)
             for part in self.objpath[:-1]:
                 current = self.get_attr(current, part)
             name = self.objpath[-1]

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -6,6 +6,7 @@
     :copyright: Copyright 2012 by Enthought, Inc
 
 """
+from importlib import import_module
 import inspect
 import io
 import sys
@@ -78,7 +79,7 @@ class TraitDocumenter(ClassLevelDocumenter):
 
         """
         try:
-            __import__(self.modname)
+            import_module(self.modname)
             current = self.module = sys.modules[self.modname]
             for part in self.objpath[:-1]:
                 current = self.get_attr(current, part)


### PR DESCRIPTION
We are leaving the `exec`-based dynamic import alone `TraitClass` in favour of removing completely in #710 

Using import_module removes the need to use `getattr` to step down through the packages.
