### PR TITLE
Fix a Sphinx deprecation warning in tests.

### DIFF
--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -142,7 +142,10 @@ class TestTraitDocumenter(unittest.TestCase):
             app = SphinxTestApp(srcdir=path(tmpdir))
             app.builder.env.app = app
             app.builder.env.temp_data["docname"] = "dummy"
-            yield DocumenterBridge(app.env, LoggingReporter(''), Options(), 1)
+            state = mock.Mock()
+            state.document.settings.tab_width = 8
+            yield DocumenterBridge(
+                app.env, LoggingReporter(''), Options(), 1, state)
 
     @contextlib.contextmanager
     def tmpdir(self):

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -142,10 +142,19 @@ class TestTraitDocumenter(unittest.TestCase):
             app = SphinxTestApp(srcdir=path(tmpdir))
             app.builder.env.app = app
             app.builder.env.temp_data["docname"] = "dummy"
-            state = mock.Mock()
-            state.document.settings.tab_width = 8
+
+            # Backwards compatibility hack: for now, we need to be compatible
+            # with both Sphinx < 2.1 (whose DocumenterBridge doesn't take
+            # a state argument) and Sphinx >= 2.3 (which warns if the state
+            # isn't passed). Eventually we should be able to drop support
+            # for Sphinx < 2.1.
+            kwds = {}
+            if sphinx.version_info >= (2, 1):
+                state = mock.Mock()
+                state.document.settings.tab_width = 8
+                kwds["state"] = state
             yield DocumenterBridge(
-                app.env, LoggingReporter(''), Options(), 1, state)
+                app.env, LoggingReporter(''), Options(), 1, **kwds)
 
     @contextlib.contextmanager
     def tmpdir(self):


### PR DESCRIPTION
This PR fixes a warning about behaviour change of `DocumenterBridge`, which is used explicitly in the `trait_documenter` tests.

Closes #690.