### PR TITLE
Move and document ComparisonMode member aliases

### DIFF
--- a/docs/source/traits_api_reference/constants.rst
+++ b/docs/source/traits_api_reference/constants.rst
@@ -14,3 +14,9 @@ Classes
 .. autodata:: ComparisonMode
 
 .. autodata:: DefaultValue
+
+.. autodata:: NO_COMPARE
+
+.. autodata:: OBJECT_IDENTITY_COMPARE
+
+.. autodata:: RICH_COMPARE

--- a/docs/source/traits_api_reference/constants.rst
+++ b/docs/source/traits_api_reference/constants.rst
@@ -11,9 +11,9 @@ Classes
 
 .. autodata:: ValidateTrait
 
-.. autodata:: ComparisonMode
-
 .. autodata:: DefaultValue
+
+.. autodata:: ComparisonMode
 
 .. autodata:: NO_COMPARE
 

--- a/traits/api.py
+++ b/traits/api.py
@@ -21,7 +21,12 @@ Use this module for importing Traits names into your namespace. For example::
     from traits.api import HasTraits
 """
 
-from .constants import ComparisonMode
+from .constants import (
+    ComparisonMode,
+    NO_COMPARE,
+    OBJECT_IDENTITY_COMPARE,
+    RICH_COMPARE,
+)
 
 from .trait_base import Uninitialized, Undefined, Missing, Self
 
@@ -228,8 +233,3 @@ try:
         AbstractViewElement.register(ViewElement)
 except ImportError:
     pass
-
-# Backward compatibility for comparison mode constants.
-NO_COMPARE = ComparisonMode.no_compare
-OBJECT_IDENTITY_COMPARE = ComparisonMode.object_id_compare
-RICH_COMPARE = ComparisonMode.equality_compare

--- a/traits/constants.py
+++ b/traits/constants.py
@@ -110,13 +110,15 @@ class ComparisonMode(IntEnum):
     Indicates when trait change notifications should be generated based upon
     the result of comparing the old and new values of a trait assignment:
 
-    0 (no_compare)
+    Enumeration members:
+
+    no_compare
         The values are not compared and a trait change notification is
         generated on each assignment.
-    1 (object_id_compare)
+    object_id_compare
         A trait change notification is generated if the old and new values are
         not the same object.
-    2 (equality_compare)
+    equality_compare
         A trait change notification is generated if the old and new values are
         not the same object, and not equal using Python's standard equality
         testing. This is the default.

--- a/traits/constants.py
+++ b/traits/constants.py
@@ -110,12 +110,15 @@ class ComparisonMode(IntEnum):
     Indicates when trait change notifications should be generated based upon
     the result of comparing the old and new values of a trait assignment:
 
-    * 0 (no_compare): The values are not compared and a trait change
-        notification is generated on each assignment.
-    * 1 (object_id_compare): A trait change notification is
-        generated if the old and new values are not the same object.
-    * 2 (equality_compare): A trait change notification is generated if the
-        old and new values are not equal using Python's standard equality
+    0 (no_compare)
+        The values are not compared and a trait change notification is
+        generated on each assignment.
+    1 (object_id_compare)
+        A trait change notification is generated if the old and new values are
+        not the same object.
+    2 (equality_compare)
+        A trait change notification is generated if the old and new values are
+        not the same object, and not equal using Python's standard equality
         testing. This is the default.
     """
 
@@ -127,6 +130,18 @@ class ComparisonMode(IntEnum):
 
     #: Compare values by equality.
     equality_compare = 2
+
+
+# Backward compatibility for comparison mode constants.
+
+#: Deprecated alias for ``ComparisonMode.no_compare``.
+NO_COMPARE = ComparisonMode.no_compare
+
+#: Deprecated alias for ``ComparisonMode.object_id_compare``.
+OBJECT_IDENTITY_COMPARE = ComparisonMode.object_id_compare
+
+#: Deprecated alias for ``ComparisonMode.equality_compare``.
+RICH_COMPARE = ComparisonMode.equality_compare
 
 
 class DefaultValue(IntEnum):

--- a/traits/tests/test_constants.py
+++ b/traits/tests/test_constants.py
@@ -1,0 +1,26 @@
+
+#  Copyright (c) 2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+
+import unittest
+
+from traits.api import ComparisonMode
+
+
+class TestConstants(unittest.TestCase):
+    def test_deprecated_comparison_constants(self):
+        # Check availability of comparison constants.
+        from traits.api import (
+            NO_COMPARE, OBJECT_IDENTITY_COMPARE, RICH_COMPARE)
+        self.assertIs(NO_COMPARE, ComparisonMode.no_compare)
+        self.assertIs(
+            OBJECT_IDENTITY_COMPARE, ComparisonMode.object_id_compare)
+        self.assertIs(
+            RICH_COMPARE, ComparisonMode.equality_compare)


### PR DESCRIPTION
This PR:

- moves the `NO_COMPARE` aliases from `api.py` to `constants.py`, and imports them in `api.py`
- documents those aliases (including documenting that they're deprecated)
- adds tests for the aliases
- fixes formatting issues in the existing `ComparisonMode` documentation

Closes #695.