### PR TITLE
BUG: Fix name-mangling of __methods in _Classes

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -182,7 +182,9 @@ def _get_def(class_name, class_dict, bases, method):
     """ Gets the definition of a specified method (if any).
     """
     if method[0:2] == "__":
-        method = "_%s%s" % (class_name, method)
+        # When name-mangling to handle the __ case (for _private traits),
+        # leading underscores in the class name are stripped out.
+        method = "_%s%s" % (class_name.lstrip('_'), method)
 
     result = class_dict.get(method)
     if (

--- a/traits/tests/test_static_notifiers.py
+++ b/traits/tests/test_static_notifiers.py
@@ -6,7 +6,7 @@
 import unittest
 
 from traits import trait_notifiers
-from traits.api import Float, HasTraits
+from traits.api import Float, HasTraits, List
 
 
 calls_0 = []
@@ -80,6 +80,14 @@ class StaticNotifiers4(HasTraits):
         raise Exception("error")
 
 
+class _LeadingUnderscore(HasTraits):
+    _ok = Float()
+    calls = List()
+
+    def __ok_changed(self, name, old, new):
+        self.calls.append((name, old, new))
+
+
 class TestNotifiers(unittest.TestCase):
     """ Tests for the static notifiers, and the "anytrait" static notifiers.
     """
@@ -131,3 +139,10 @@ class TestNotifiers(unittest.TestCase):
 
         obj.fail = 1
         self.assertEqual(self.exceptions, [(obj, "fail", 0, 1)])
+
+    def test_leading_underscore(self):
+        """ Test the name-mangling for the double-underscored change handlers.
+        """
+        obj = _LeadingUnderscore(_ok=2.0)
+        obj._ok = 3.0
+        self.assertEqual(obj.calls, [("_ok", 0.0, 2.0), ("_ok", 2.0, 3.0)])


### PR DESCRIPTION
Traits was manually performing the double-underscore name-mangling without taking into account a corner-case.