### PR TITLE
Make tests repeatable

### DIFF
--- a/traits/tests/test_anytrait_static_notifiers.py
+++ b/traits/tests/test_anytrait_static_notifiers.py
@@ -5,30 +5,11 @@ from traits import trait_notifiers
 from traits.api import Float, HasTraits, Undefined
 
 
-anycalls_0 = []
-
-
-class AnytraitStaticNotifiers0(HasTraits):
-    ok = Float
-
-    def _anytrait_changed():
-        anycalls_0.append(True)
-
-
 class AnytraitStaticNotifiers0Fail(HasTraits):
     fail = Float
 
     def _anytrait_changed():
         raise Exception("error")
-
-
-class AnytraitStaticNotifiers1(HasTraits):
-    ok = Float
-
-    def _anytrait_changed(self):
-        if not hasattr(self, "anycalls"):
-            self.anycalls = []
-        self.anycalls.append(True)
 
 
 class AnytraitStaticNotifiers1Fail(HasTraits):
@@ -38,15 +19,6 @@ class AnytraitStaticNotifiers1Fail(HasTraits):
         raise Exception("error")
 
 
-class AnytraitStaticNotifiers2(HasTraits):
-    ok = Float
-
-    def _anytrait_changed(self, name):
-        if not hasattr(self, "anycalls"):
-            self.anycalls = []
-        self.anycalls.append(name)
-
-
 class AnytraitStaticNotifiers2Fail(HasTraits):
     fail = Float
 
@@ -54,29 +26,11 @@ class AnytraitStaticNotifiers2Fail(HasTraits):
         raise Exception("error")
 
 
-class AnytraitStaticNotifiers3(HasTraits):
-    ok = Float
-
-    def _anytrait_changed(self, name, new):
-        if not hasattr(self, "anycalls"):
-            self.anycalls = []
-        self.anycalls.append((name, new))
-
-
 class AnytraitStaticNotifiers3Fail(HasTraits):
     fail = Float
 
     def _anytrait_changed(self, name, new):
         raise Exception("error")
-
-
-class AnytraitStaticNotifiers4(HasTraits):
-    ok = Float
-
-    def _anytrait_changed(self, name, old, new):
-        if not hasattr(self, "anycalls"):
-            self.anycalls = []
-        self.anycalls.append((name, old, new))
 
 
 class AnytraitStaticNotifiers4Fail(HasTraits):
@@ -107,12 +61,28 @@ class TestNotifiers(unittest.TestCase):
     #### Tests ################################################################
 
     def test_anytrait_static_notifiers_0(self):
+        anycalls_0 = []
+
+        class AnytraitStaticNotifiers0(HasTraits):
+            ok = Float
+
+            def _anytrait_changed():
+                anycalls_0.append(True)
+
         obj = AnytraitStaticNotifiers0(ok=2)
         obj.ok = 3
 
         self.assertEqual(len(anycalls_0), 2)
 
     def test_anytrait_static_notifiers_1(self):
+        class AnytraitStaticNotifiers1(HasTraits):
+            ok = Float
+
+            def _anytrait_changed(self):
+                if not hasattr(self, "anycalls"):
+                    self.anycalls = []
+                self.anycalls.append(True)
+
         obj = AnytraitStaticNotifiers1(ok=2)
         obj.ok = 3
 
@@ -123,6 +93,14 @@ class TestNotifiers(unittest.TestCase):
         self.assertEqual(len(obj.anycalls), 3)
 
     def test_anytrait_static_notifiers_2(self):
+        class AnytraitStaticNotifiers2(HasTraits):
+            ok = Float
+
+            def _anytrait_changed(self, name):
+                if not hasattr(self, "anycalls"):
+                    self.anycalls = []
+                self.anycalls.append(name)
+
         obj = AnytraitStaticNotifiers2(ok=2)
         obj.ok = 3
 
@@ -130,6 +108,14 @@ class TestNotifiers(unittest.TestCase):
         self.assertEqual(expected, obj.anycalls)
 
     def test_anytrait_static_notifiers_3(self):
+        class AnytraitStaticNotifiers3(HasTraits):
+            ok = Float
+
+            def _anytrait_changed(self, name, new):
+                if not hasattr(self, "anycalls"):
+                    self.anycalls = []
+                self.anycalls.append((name, new))
+
         obj = AnytraitStaticNotifiers3(ok=2)
         obj.ok = 3
 
@@ -137,6 +123,14 @@ class TestNotifiers(unittest.TestCase):
         self.assertEqual(expected, obj.anycalls)
 
     def test_anytrait_static_notifiers_4(self):
+        class AnytraitStaticNotifiers4(HasTraits):
+            ok = Float
+
+            def _anytrait_changed(self, name, old, new):
+                if not hasattr(self, "anycalls"):
+                    self.anycalls = []
+                self.anycalls.append((name, old, new))
+
         obj = AnytraitStaticNotifiers4(ok=2)
         obj.ok = 3
 

--- a/traits/tests/test_dynamic_notifiers.py
+++ b/traits/tests/test_dynamic_notifiers.py
@@ -96,73 +96,6 @@ class UnhashableDynamicNotifiers(DynamicNotifiers):
         raise NotImplementedError()
 
 
-# 'ok' function listeners
-
-calls_0 = []
-
-
-def function_listener_0():
-    calls_0.append(True)
-
-
-calls_1 = []
-
-
-def function_listener_1(new):
-    calls_1.append(new)
-
-
-calls_2 = []
-
-
-def function_listener_2(name, new):
-    calls_2.append((name, new))
-
-
-calls_3 = []
-
-
-def function_listener_3(obj, name, new):
-    calls_3.append((obj, name, new))
-
-
-calls_4 = []
-
-
-def function_listener_4(obj, name, old, new):
-    calls_4.append((obj, name, old, new))
-
-
-# 'fail' function listeners
-
-exceptions_from = []
-
-
-def failing_function_listener_0():
-    exceptions_from.append(0)
-    raise Exception("error")
-
-
-def failing_function_listener_1(new):
-    exceptions_from.append(1)
-    raise Exception("error")
-
-
-def failing_function_listener_2(name, new):
-    exceptions_from.append(2)
-    raise Exception("error")
-
-
-def failing_function_listener_3(obj, name, new):
-    exceptions_from.append(3)
-    raise Exception("error")
-
-
-def failing_function_listener_4(obj, name, old, new):
-    exceptions_from.append(4)
-    raise Exception("error")
-
-
 class TestDynamicNotifiers(unittest.TestCase):
 
     #### 'TestCase' protocol ##################################################
@@ -207,6 +140,31 @@ class TestDynamicNotifiers(unittest.TestCase):
         self.assertEqual([(obj, "fail", 0, 1)] * 5, self.exceptions)
 
     def test_dynamic_notifiers_functions(self):
+        calls_0 = []
+
+        def function_listener_0():
+            calls_0.append(())
+
+        calls_1 = []
+
+        def function_listener_1(new):
+            calls_1.append((new,))
+
+        calls_2 = []
+
+        def function_listener_2(name, new):
+            calls_2.append((name, new))
+
+        calls_3 = []
+
+        def function_listener_3(obj, name, new):
+            calls_3.append((obj, name, new))
+
+        calls_4 = []
+
+        def function_listener_4(obj, name, old, new):
+            calls_4.append((obj, name, old, new))
+
         obj = DynamicNotifiers()
 
         obj.on_trait_change(function_listener_0, "ok")
@@ -218,16 +176,19 @@ class TestDynamicNotifiers(unittest.TestCase):
         obj.ok = 2
         obj.ok = 3
 
-        expected_1 = [2, 3]
+        expected_0 = [(), ()]
+        self.assertEqual(expected_0, calls_0)
+
+        expected_1 = [(2.0,), (3.0,)]
         self.assertEqual(expected_1, calls_1)
 
-        expected_2 = [("ok", 2), ("ok", 3)]
+        expected_2 = [("ok", 2.0), ("ok", 3.0)]
         self.assertEqual(expected_2, calls_2)
 
-        expected_3 = [(obj, "ok", 2), (obj, "ok", 3)]
+        expected_3 = [(obj, "ok", 2.0), (obj, "ok", 3.0)]
         self.assertEqual(expected_3, calls_3)
 
-        expected_4 = [(obj, "ok", 0, 2), (obj, "ok", 2, 3)]
+        expected_4 = [(obj, "ok", 0.0, 2.0), (obj, "ok", 2.0, 3.0)]
         self.assertEqual(expected_4, calls_4)
 
     def test_priority_notifiers_first(self):
@@ -257,6 +218,28 @@ class TestDynamicNotifiers(unittest.TestCase):
     def test_dynamic_notifiers_functions_failing(self):
         obj = DynamicNotifiers()
 
+        exceptions_from = []
+
+        def failing_function_listener_0():
+            exceptions_from.append(0)
+            raise Exception("error")
+
+        def failing_function_listener_1(new):
+            exceptions_from.append(1)
+            raise Exception("error")
+
+        def failing_function_listener_2(name, new):
+            exceptions_from.append(2)
+            raise Exception("error")
+
+        def failing_function_listener_3(obj, name, new):
+            exceptions_from.append(3)
+            raise Exception("error")
+
+        def failing_function_listener_4(obj, name, old, new):
+            exceptions_from.append(4)
+            raise Exception("error")
+
         obj.on_trait_change(failing_function_listener_0, "fail")
         obj.on_trait_change(failing_function_listener_1, "fail")
         obj.on_trait_change(failing_function_listener_2, "fail")
@@ -265,6 +248,7 @@ class TestDynamicNotifiers(unittest.TestCase):
 
         obj.fail = 1
 
+        self.assertEqual([0, 1, 2, 3, 4], exceptions_from)
         self.assertCountEqual([0, 1, 2, 3, 4], obj.exceptions_from)
         # 10 failures: 5 are from the internal dynamic listeners, see
         # test_dynamic_notifiers_methods_failing
@@ -276,8 +260,11 @@ class TestDynamicNotifiers(unittest.TestCase):
 
         import weakref
 
+        def listener():
+            pass
+
         obj = DynamicNotifiers()
-        obj.on_trait_change(function_listener_0, "ok")
+        obj.on_trait_change(listener, "ok")
 
         # Create a weak reference to `obj` with a callback that flags when the
         # object is finalized.
@@ -293,6 +280,7 @@ class TestDynamicNotifiers(unittest.TestCase):
         del obj
 
         self.assertEqual(obj_collected, [True])
+        self.assertIsNone(obj_weakref())
 
     def test_unhashable_object_can_be_garbage_collected(self):
         # Make sure that an unhashable trait object can be garbage collected
@@ -300,8 +288,11 @@ class TestDynamicNotifiers(unittest.TestCase):
 
         import weakref
 
+        def listener():
+            pass
+
         obj = UnhashableDynamicNotifiers()
-        obj.on_trait_change(function_listener_0, "a_list:ok")
+        obj.on_trait_change(listener, "a_list:ok")
         # Changing a List trait is the easiest way to trigger a check into the
         # weak key dict.
         obj.a_list.append(UnhashableDynamicNotifiers())
@@ -320,6 +311,7 @@ class TestDynamicNotifiers(unittest.TestCase):
         del obj
 
         self.assertEqual(obj_collected, [True])
+        self.assertIsNone(obj_weakref())
 
     def test_creating_notifiers_dont_create_cyclic_garbage(self):
         gc.collect()

--- a/traits/tests/test_extended_notifiers.py
+++ b/traits/tests/test_extended_notifiers.py
@@ -201,6 +201,12 @@ class TestExtendedNotifiers(unittest.TestCase):
         self.assertEqual([(obj, "fail", 0, 1)] * 5, self.exceptions)
 
     def test_extended_notifiers_functions(self):
+        calls_0.clear()
+        calls_1.clear()
+        calls_2.clear()
+        calls_3.clear()
+        calls_4.clear()
+
         obj = ExtendedNotifiers()
 
         obj._on_trait_change(function_listener_0, "ok", dispatch="extended")
@@ -211,6 +217,9 @@ class TestExtendedNotifiers(unittest.TestCase):
 
         obj.ok = 2
         obj.ok = 3
+
+        expected_0 = [True, True]
+        self.assertEqual(expected_0, calls_0)
 
         expected_1 = [2, 3]
         self.assertEqual(expected_1, calls_1)
@@ -226,6 +235,8 @@ class TestExtendedNotifiers(unittest.TestCase):
 
     def test_extended_notifiers_functions_failing(self):
         obj = ExtendedNotifiers()
+
+        exceptions_from.clear()
 
         obj._on_trait_change(
             failing_function_listener_0, "fail", dispatch="extended"

--- a/traits/tests/test_static_notifiers.py
+++ b/traits/tests/test_static_notifiers.py
@@ -103,6 +103,8 @@ class TestNotifiers(unittest.TestCase):
         self.exceptions.append((obj, name, old, new))
 
     def test_static_notifiers_0(self):
+        calls_0.clear()
+
         obj = StaticNotifiers0(ok=2)
         obj.ok = 3
         self.assertEqual(len(calls_0), 2)

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -137,7 +137,8 @@ class AnyTrait(HasTraits):
 
 class AnyTraitTest(BaseTest, unittest.TestCase):
 
-    obj = AnyTrait()
+    def setUp(self):
+        self.obj = AnyTrait()
 
     _default_value = None
     _good_values = [10.0, b"ten", "ten", [10], {"ten": 10}, (10,), None, 1j]
@@ -155,7 +156,8 @@ class IntTrait(HasTraits):
 
 class CoercibleIntTest(AnyTraitTest):
 
-    obj = CoercibleIntTrait()
+    def setUp(self):
+        self.obj = CoercibleIntTrait()
 
     _default_value = 99
     _good_values = [
@@ -195,7 +197,8 @@ class CoercibleIntTest(AnyTraitTest):
 
 class IntTest(AnyTraitTest):
 
-    obj = IntTrait()
+    def setUp(self):
+        self.obj = IntTrait()
 
     _default_value = 99
     _good_values = [10, -10]
@@ -255,7 +258,8 @@ class FloatTrait(HasTraits):
 
 
 class CoercibleFloatTest(AnyTraitTest):
-    obj = CoercibleFloatTrait()
+    def setUp(self):
+        self.obj = CoercibleFloatTrait()
 
     _default_value = 99.0
     _good_values = [
@@ -291,7 +295,8 @@ class CoercibleFloatTest(AnyTraitTest):
 
 
 class FloatTest(AnyTraitTest):
-    obj = FloatTrait()
+    def setUp(self):
+        self.obj = FloatTrait()
 
     _default_value = 99.0
     _good_values = [10, -10, 10.1, -10.1]
@@ -329,8 +334,8 @@ class ImaginaryValueTrait(HasTraits):
 
 
 class ImaginaryValueTest(AnyTraitTest):
-
-    obj = ImaginaryValueTrait()
+    def setUp(self):
+        self.obj = ImaginaryValueTrait()
 
     _default_value = 99.0 - 99.0j
     _good_values = [
@@ -364,7 +369,8 @@ class StringTrait(HasTraits):
 
 class StringTest(AnyTraitTest):
 
-    obj = StringTrait()
+    def setUp(self):
+        self.obj = StringTrait()
 
     _default_value = "string"
     _good_values = [
@@ -398,7 +404,8 @@ class BytesTrait(HasTraits):
 
 class BytesTest(StringTest):
 
-    obj = BytesTrait()
+    def setUp(self):
+        self.obj = BytesTrait()
 
     _default_value = b"bytes"
     _good_values = [b"", b"10", b"-10"]
@@ -427,7 +434,8 @@ class CoercibleBytesTrait(HasTraits):
 
 class CoercibleBytesTest(StringTest):
 
-    obj = CoercibleBytesTrait()
+    def setUp(self):
+        self.obj = CoercibleBytesTrait()
 
     _default_value = b"bytes"
     _good_values = [
@@ -471,7 +479,8 @@ class EnumTrait(HasTraits):
 
 class EnumTest(AnyTraitTest):
 
-    obj = EnumTrait()
+    def setUp(self):
+        self.obj = EnumTrait()
 
     _default_value = 1
     _good_values = [1, "one", 2, "two", 3, "three", 4.4, "four.four"]
@@ -483,7 +492,8 @@ class MappedTrait(HasTraits):
 
 
 class MappedTest(AnyTraitTest):
-    obj = MappedTrait()
+    def setUp(self):
+        self.obj = MappedTrait()
 
     _default_value = "one"
     _good_values = ["one", "two", "three"]
@@ -496,7 +506,8 @@ class PrefixListTrait(HasTraits):
 
 
 class PrefixListTest(AnyTraitTest):
-    obj = PrefixListTrait()
+    def setUp(self):
+        self.obj = PrefixListTrait()
 
     _default_value = "one"
     _good_values = [
@@ -521,7 +532,8 @@ class PrefixMapTrait(HasTraits):
 
 
 class PrefixMapTest(AnyTraitTest):
-    obj = PrefixMapTrait()
+    def setUp(self):
+        self.obj = PrefixMapTrait()
 
     _default_value = "one"
     _good_values = [
@@ -569,7 +581,8 @@ class OldInstanceTrait(HasTraits):
 
 
 class OldInstanceTest(AnyTraitTest):
-    obj = OldInstanceTrait()
+    def setUp(self):
+        self.obj = OldInstanceTrait()
 
     _default_value = otrait_test1
     _good_values = [
@@ -619,7 +632,8 @@ class NewInstanceTrait(HasTraits):
 
 
 class NewInstanceTest(AnyTraitTest):
-    obj = NewInstanceTrait()
+    def setUp(self):
+        self.obj = NewInstanceTrait()
 
     _default_value = ntrait_test1
     _good_values = [
@@ -708,7 +722,8 @@ class OddIntegerTrait(HasTraits):
 
 
 class OddIntegerTest(AnyTraitTest):
-    obj = OddIntegerTrait()
+    def setUp(self):
+        self.obj = OddIntegerTrait()
 
     _default_value = 99
     _good_values = [
@@ -760,13 +775,8 @@ class NotifierTraits(HasTraits):
 
 
 class NotifierTests(unittest.TestCase):
-    obj = NotifierTraits()
-
-    def __init__(self, value):
-        unittest.TestCase.__init__(self, value)
-
     def setUp(self):
-        obj = self.obj
+        obj = self.obj = NotifierTraits()
         obj.value1 = 0
         obj.value2 = 0
         obj.value1_count = 0
@@ -956,7 +966,8 @@ class complex_value(HasTraits):
 
 
 class test_complex_value(test_base2):
-    obj = complex_value()
+    def setUp(self):
+        self.obj = complex_value()
 
     def test_num1(self):
         self.check_values(
@@ -1002,10 +1013,8 @@ class list_value(HasTraits):
 
 class test_list_value(test_base2):
 
-    obj = list_value()
-
     def setUp(self):
-        test_base2.setUp(self)
+        self.obj = list_value()
         self.last_event = None
 
     def tearDown(self):


### PR DESCRIPTION
Checking for reference leaks involves running test modules repeatedly and looking at the way that the total reference count changes. Unfortunately, some of our tests fail when run repeatedly. This PR fixes most of those tests to avoid mutating global state, or at least to reset the state so that the test doesn't fail when run a second time.

Related: #725.