### PR TITLE
Raise ValueError for invalid args to ctrait.comparison_mode

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -189,7 +189,7 @@ call_notifiers(
 
 /* The maximum value for comparison_mode. Valid values are between 0 and
    the maximum value. */
-#define MAXIMUM_COMPARISON_MODE_VALUE 3
+#define MAXIMUM_COMPARISON_MODE_VALUE 2
 
 /*-----------------------------------------------------------------------------
 |  'CTrait' instance definition:

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4186,8 +4186,8 @@ _trait_comparison_mode ( trait_object * trait, PyObject * args ) {
         case 1:  trait->flags |= TRAIT_OBJECT_ID_TEST;
                  break;
         case 2:  break;
-        default: raise_trait_error(trait, Py_None, Py_None, Py_None)
-                 break;
+        default: bad_trait_error();
+                 return NULL;
     }
 
     Py_INCREF( Py_None );

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4184,7 +4184,10 @@ _trait_comparison_mode ( trait_object * trait, PyObject * args ) {
         case 0:  trait->flags |= TRAIT_NO_VALUE_TEST;
                  break;
         case 1:  trait->flags |= TRAIT_OBJECT_ID_TEST;
-        default: break;
+                 break;
+        case 2:  break;
+        default: raise_trait_error(trait, Py_None, Py_None, Py_None)
+                 break;
     }
 
     Py_INCREF( Py_None );

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -185,6 +185,9 @@ static int call_notifiers ( PyListObject *, PyListObject *,
    validation. */
 #define MAXIMUM_DEFAULT_VALUE_TYPE 9
 
+/* The maximum value for comparison_mode. Valid values are between 0 and
+   the maximum value. */
+#define MAXIMUM_COMPARISON_MODE_VALUE 3
 
 /*-----------------------------------------------------------------------------
 |  'CTrait' instance definition:
@@ -4186,8 +4189,11 @@ _trait_comparison_mode ( trait_object * trait, PyObject * args ) {
         case 1:  trait->flags |= TRAIT_OBJECT_ID_TEST;
                  break;
         case 2:  break;
-        default: bad_trait_error();
-                 return NULL;
+        default: return PyErr_Format(
+            PyExc_ValueError,
+            "The comparison mode must be 0..%d, but %d was specified.",
+            MAXIMUM_COMPARISON_MODE_VALUE,
+            comparison_mode );
     }
 
     Py_INCREF( Py_None );

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -16,6 +16,7 @@ import warnings
 from traits.constants import (
     ComparisonMode, DefaultValue, TraitKind, MAXIMUM_DEFAULT_VALUE_TYPE
 )
+from traits.trait_errors import TraitError
 from traits.traits import CTrait
 
 
@@ -148,3 +149,9 @@ class TestCTrait(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             trait.no_value_test = False
+
+    def test_invalid_comparison_mode(self):
+        trait = CTrait(TraitKind.trait)
+
+        with self.assertRaises(TraitError):
+            trait.comparison_mode(-1)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -155,8 +155,8 @@ class TestCTrait(unittest.TestCase):
 
         # comparison modes other than {0,1,2}
         # are invalid
-        with self.assertRaises(TraitError):
+        with self.assertRaises(ValueError):
             trait.comparison_mode(-1)
 
-        with self.assertRaises(TraitError):
+        with self.assertRaises(ValueError):
             trait.comparison_mode(3)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -153,5 +153,10 @@ class TestCTrait(unittest.TestCase):
     def test_invalid_comparison_mode(self):
         trait = CTrait(TraitKind.trait)
 
+        # comparison modes other than {0,1,2}
+        # are invalid
         with self.assertRaises(TraitError):
             trait.comparison_mode(-1)
+
+        with self.assertRaises(TraitError):
+            trait.comparison_mode(3)


### PR DESCRIPTION
closes #721 


- also added a test to assert a `ValueError` is raised.