### PR TITLE
Turn warnings into errors in documentation build

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -264,15 +264,22 @@ def test(edm, runtime, verbose, environment):
     default=None,
     help="Name of EDM environment to build docs for.",
 )
-def docs(edm, runtime, environment):
+@click.option(
+    "--error-on-warn/--no-error-on-warn",
+    default=True,
+    help="Turn warnings into errors?  [default: --error-on-warn] "
+)
+def docs(edm, runtime, environment, error_on_warn):
     """ Build the html documentation.
 
     """
     parameters = get_parameters(edm, runtime, environment)
-    commands = [
+    build_docs = (
         "{edm} run -e {environment} -- sphinx-build -b html "
-        "-d build/doctrees source build/html",
-    ]
+        + ("-W " if error_on_warn else "")
+        + "-d build/doctrees source build/html"
+    )
+    commands = [build_docs]
     with do_in_existingdir(os.path.join(os.getcwd(), "docs")):
         execute(commands, parameters)
 

--- a/etstool.py
+++ b/etstool.py
@@ -267,7 +267,7 @@ def test(edm, runtime, verbose, environment):
 @click.option(
     "--error-on-warn/--no-error-on-warn",
     default=True,
-    help="Turn warnings into errors?  [default: --error-on-warn] "
+    help="Turn warnings into errors?  [default: --error-on-warn] ",
 )
 def docs(edm, runtime, environment, error_on_warn):
     """ Build the html documentation.


### PR DESCRIPTION
This PR:

- adds a new `--error-on-warn` option to the `python etstool.py docs` command
- makes `--error-on-warn` the default.

This means that the CI will fail for future PRs that cause new documentation warnings. If that proves excessive (there are false positives that we can't easily work around), we might change the default here, or run the documentation build in a separate job that can be ignored for PR approval purposes.

Closes #743.