### PR TITLE
Fix flake8 warnings from api imports

### DIFF
--- a/traits/adaptation/api.py
+++ b/traits/adaptation/api.py
@@ -1,8 +1,8 @@
-from .adapter import Adapter, PurePythonAdapter
+from .adapter import Adapter, PurePythonAdapter  # noqa: F401
 
-from .adaptation_error import AdaptationError
+from .adaptation_error import AdaptationError  # noqa: F401
 
-from .adaptation_manager import (
+from .adaptation_manager import (  # noqa: F401
     adapt,
     AdaptationManager,
     get_global_adaptation_manager,
@@ -15,4 +15,4 @@ from .adaptation_manager import (
     supports_protocol,
 )
 
-from .adaptation_offer import AdaptationOffer
+from .adaptation_offer import AdaptationOffer  # noqa: F401

--- a/traits/api.py
+++ b/traits/api.py
@@ -21,26 +21,30 @@ Use this module for importing Traits names into your namespace. For example::
     from traits.api import HasTraits
 """
 
-from .constants import (
+from .constants import (  # noqa: F401
     ComparisonMode,
     NO_COMPARE,
     OBJECT_IDENTITY_COMPARE,
     RICH_COMPARE,
 )
 
-from .trait_base import Uninitialized, Undefined, Missing, Self
+from .trait_base import Uninitialized, Undefined, Missing, Self  # noqa: F401
 
-from .trait_errors import TraitError, TraitNotificationError, DelegationError
+from .trait_errors import (  # noqa: F401
+    TraitError,
+    TraitNotificationError,
+    DelegationError,
+)
 
-from .trait_notifiers import (
+from .trait_notifiers import (  # noqa: F401
     push_exception_handler,
     pop_exception_handler,
     TraitChangeNotifyWrapper,
 )
 
-from .ctrait import CTrait
-from .trait_factory import TraitFactory
-from .traits import (
+from .ctrait import CTrait  # noqa: F401
+from .trait_factory import TraitFactory  # noqa: F401
+from .traits import (  # noqa: F401
     Trait,
     Property,
     Default,
@@ -49,7 +53,7 @@ from .traits import (
     Font,
 )
 
-from .trait_types import (
+from .trait_types import (  # noqa: F401
     Any,
     Int,
     Float,
@@ -111,7 +115,7 @@ from .trait_types import (
 
 # Deprecated TraitType subclasses and instances.
 
-from .trait_types import (
+from .trait_types import (  # noqa: F401
     BaseUnicode,
     Unicode,
     BaseCUnicode,
@@ -140,7 +144,7 @@ from .trait_types import (
     DictStrList,
 )
 
-from .trait_types import (
+from .trait_types import (  # noqa: F401
     BaseInt,
     BaseFloat,
     BaseComplex,
@@ -160,9 +164,9 @@ from .trait_types import (
     BaseInstance,
 )
 
-from .trait_types import UUID, ValidatedTuple
+from .trait_types import UUID, ValidatedTuple  # noqa: F401
 
-from .has_traits import (
+from .has_traits import (  # noqa: F401
     ABCHasStrictTraits,
     ABCHasTraits,
     ABCMetaHasTraits,
@@ -186,10 +190,10 @@ from .has_traits import (
     isinterface,
 )
 
-from .base_trait_handler import BaseTraitHandler
-from .trait_handler import TraitHandler
-from .trait_type import TraitType
-from .trait_handlers import (
+from .base_trait_handler import BaseTraitHandler  # noqa: F401
+from .trait_handler import TraitHandler  # noqa: F401
+from .trait_type import TraitType  # noqa: F401
+from .trait_handlers import (  # noqa: F401
     TraitCoerceType,
     TraitCastType,
     TraitInstance,
@@ -206,20 +210,20 @@ from .trait_handlers import (
 )
 
 
-from .trait_dict_object import TraitDictEvent, TraitDictObject
-from .trait_list_object import TraitListEvent, TraitListObject
-from .trait_set_object import TraitSetEvent, TraitSetObject
+from .trait_dict_object import TraitDictEvent, TraitDictObject  # noqa: F401
+from .trait_list_object import TraitListEvent, TraitListObject  # noqa: F401
+from .trait_set_object import TraitSetEvent, TraitSetObject  # noqa: F401
 
 
-from .adaptation.adapter import Adapter
-from .adaptation.adaptation_error import AdaptationError
-from .adaptation.adaptation_manager import (
+from .adaptation.adapter import Adapter  # noqa: F401
+from .adaptation.adaptation_error import AdaptationError  # noqa: F401
+from .adaptation.adaptation_manager import (  # noqa: F401
     adapt,
     register_factory,
     register_provides,
 )
 
-from .trait_numeric import Array, ArrayOrNone, CArray
+from .trait_numeric import Array, ArrayOrNone, CArray  # noqa: F401
 
 try:
     # -------------------------------------------------------------------------------

--- a/traits/etsconfig/api.py
+++ b/traits/etsconfig/api.py
@@ -1,1 +1,1 @@
-from .etsconfig import ETSConfig, ETSToolkitError
+from .etsconfig import ETSConfig, ETSToolkitError  # noqa: F401

--- a/traits/testing/api.py
+++ b/traits/testing/api.py
@@ -1,3 +1,3 @@
-from .doctest_tools import doctest_for_module
-from .nose_tools import deprecated, performance, skip
-from .unittest_tools import UnittestTools
+from .doctest_tools import doctest_for_module  # noqa: F401
+from .nose_tools import deprecated, performance, skip  # noqa: F401
+from .unittest_tools import UnittestTools  # noqa: F401

--- a/traits/util/api.py
+++ b/traits/util/api.py
@@ -1,5 +1,3 @@
-__all__ = ["deprecated", "import_symbol", "record_events"]
-
-from .deprecated import deprecated
-from .event_tracer import record_events
-from .import_symbol import import_symbol
+from .deprecated import deprecated  # noqa: F401
+from .event_tracer import record_events  # noqa: F401
+from .import_symbol import import_symbol  # noqa: F401


### PR DESCRIPTION
This is part of work towards making the Traits codebase a little bit more clean, and eventually introducing flake8 checks to keep it that way.

This PR fixes false flake8 positives about unused imports from the `api.py` modules. (The other way of fixing this is to introduce and use `__all__` everywhere, but that results in a *lot* of duplication, especially in the top-level `api.py`).

For consistency, I've removed the `__all__` from `traits.utils.api`.