### PR TITLE
Remove coding cookies

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Traits documentation build configuration file, created by
 # sphinx-quickstart on Tue Jul 22 10:52:03 2008.
 #

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """ Tests for the trait documenter. """
 
 import contextlib

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     A Trait Documenter
     (Subclassed from the autodoc ClassLevelDocumenter)


### PR DESCRIPTION
We no longer need these: file encoding defaults to UTF-8 for Python 3.