### PR TITLE
Remove print statements from test suite

### DIFF
--- a/traits/tests/test_container_events.py
+++ b/traits/tests/test_container_events.py
@@ -54,17 +54,12 @@ class Callback:
         self.changed = changed
         self.removed = removed
         self.called = False
-        return
 
     def __call__(self, event):
-        if event.added != self.added:
-            print("\n\n******Error\nevent.added:", event.added)
-        else:
-            self.obj.assertEqual(event.added, self.added)
+        self.obj.assertEqual(event.added, self.added)
         self.obj.assertEqual(event.changed, self.changed)
         self.obj.assertEqual(event.removed, self.removed)
         self.called = True
-        return
 
 
 class DictEventTestCase(unittest.TestCase):

--- a/traits/tests/test_str_handler.py
+++ b/traits/tests/test_str_handler.py
@@ -33,7 +33,6 @@ def validator(object, name, value):
 # Validation via Handler
 class MyHandler(TraitHandler):
     def validate(self, object, name, value):
-        # print 'myvalidate "%s" %s' % (value, type(value))
         try:
             value = strx(value)
             if value.find("fail") < 0:

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -96,41 +96,27 @@ class test_base2(unittest.TestCase):
         mapped_values=None,
     ):
         obj = self.obj
-        try:
-            # Make sure the default value is correct:
-            msg = "default value"
-            value = default_value
-            self.assertEqual(getattr(obj, name), value)
 
-            # Iterate over all legal values being tested:
-            if actual_values is None:
-                actual_values = good_values
-            msg = "legal values"
-            i = 0
-            for value in good_values:
-                setattr(obj, name, value)
-                self.assertEqual(getattr(obj, name), actual_values[i])
-                if mapped_values is not None:
-                    self.assertEqual(
-                        getattr(obj, name + "_"), mapped_values[i]
-                    )
-                i += 1
+        # Make sure the default value is correct:
+        value = default_value
+        self.assertEqual(getattr(obj, name), value)
 
-            # Iterate over all illegal values being tested:
-            msg = "illegal values"
-            for value in bad_values:
-                self.assertRaises(TraitError, setattr, obj, name, value)
-        except:
-            print(
-                "Failed while testing %s for value: %s(%s) in %s"
-                % (
-                    msg,
-                    value,
-                    value.__class__.__name__,
-                    self.__class__.__name__,
+        # Iterate over all legal values being tested:
+        if actual_values is None:
+            actual_values = good_values
+        i = 0
+        for value in good_values:
+            setattr(obj, name, value)
+            self.assertEqual(getattr(obj, name), actual_values[i])
+            if mapped_values is not None:
+                self.assertEqual(
+                    getattr(obj, name + "_"), mapped_values[i]
                 )
-            )
-            raise
+            i += 1
+
+        # Iterate over all illegal values being tested:
+        for value in bad_values:
+            self.assertRaises(TraitError, setattr, obj, name, value)
 
 
 class AnyTrait(HasTraits):


### PR DESCRIPTION
This PR removes some unnecessary `print`s from the test suite. There are still `print`s in `test_property_notifications.py`, which needs a closer look (see #751).