### PR TITLE
Move AdaptedTo to list of deprecated traits

### DIFF
--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -176,6 +176,8 @@ and may be removed in a future version of Traits.
 
 .. deprecated:: 6.0.0
 
+.. autodata:: AdaptedTo
+
 .. autodata:: BaseUnicode
 
 .. autodata:: Unicode

--- a/examples/tutorials/traits_4.0/interfaces/adaptation.py
+++ b/examples/tutorials/traits_4.0/interfaces/adaptation.py
@@ -159,12 +159,12 @@ Now for the good part... how do you use adapters?
 And the answer is... you don't. At least not explicitly.
 
 In traits, adapters are created automatically whenever you assign an object to
-an *interface* **AdaptsTo** or **AdaptedTo** trait and the object being
+an *interface* **AdaptsTo** or **Supports** trait and the object being
 assigned does not implement the required interface. In this case, if an
 adapter class exists that can adapt the specified object to the required
 interface, an instance of the adapter class will be created for the object,
 and the resulting adapter object is what ends up being assigned to the trait,
-along with the original object. When using the **AdaptedTo** trait, the
+along with the original object. When using the **Supports** trait, the
 adapter is assigned as the value of the trait, and the original object is
 assigned as its *mapped* value. For the **AdaptsTo** trait, the original
 object is assigned as the trait value, and the adapter is assigned as its
@@ -203,10 +203,10 @@ Refer to the **Output** tab for the actual result of running this example.
 Controlling Adaptation
 ----------------------
 
-The **AdaptedTo** and **AdaptsTo** traits are actually subclasses of the
+The **Supports** and **AdaptsTo** traits are actually subclasses of the
 **Instance** trait. Normally, adaptation occurs automatically when values are
-assigned to an **AdaptedTo** or **AdaptsTo** trait. However, any of the
-**Instance**, **AdaptedTo** and **AdaptsTo** traits allow you to control how
+assigned to an **Supports** or **AdaptsTo** trait. However, any of the
+**Instance**, **Supports** and **AdaptsTo** traits allow you to control how
 adaptation is performed by means of the *adapt* metadata, which can have one of
 the following values:
 
@@ -215,18 +215,18 @@ no
 
 yes
     Adaptation is allowed. If adaptation fails, an exception is raised (This is
-    the default for both the **AdaptedTo** and **AdaptsTo** traits).
+    the default for both the **Supports** and **AdaptsTo** traits).
 
 default
     Adapation is allowed. If adaptation fails, the default value for the trait
     is assigned instead.
 
-As an example of modifying the adaptation behavior of an **AdaptedTo** trait,
+As an example of modifying the adaptation behavior of an **Supports** trait,
 we could rewrite the example **Apartment** class as follows::
 
     class Apartment(HasTraits):
 
-        renter = AdaptedTo(IName, adapt = 'no')
+        renter = Supports(IName, adapt = 'no')
 
 Using this definition, any value assigned to *renter* must itself implement
 the **IName** interface, otherwise an exception is raised. Try modifying and
@@ -271,7 +271,7 @@ class PersonINameAdapter(Adapter):
 # Define a class using an object that implements the 'IName' interface:
 class Apartment(HasTraits):
 
-    renter = AdaptedTo(IName)
+    renter = Supports(IName)
 
 
 # --[Example*]------------------------------------------------------------------

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3559,7 +3559,7 @@ Time = BaseInstance(datetime.time, editor=time_editor)
 # Everything from this point onwards is deprecated, and has a simple
 # drop-in replacement.
 
-#: A traits whose value must support a specified protocol. This is
+#: A trait whose value must support a specified protocol. This is
 #: an alias for :class:`Supports`. Use ``Supports`` instead.
 AdaptedTo = Supports
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3010,8 +3010,6 @@ class Supports(Instance):
         return ctrait
 
 
-# Alias defined for backward compatibility with Traits 4.3.0
-AdaptedTo = Supports
 
 
 class AdaptsTo(Supports):
@@ -3560,6 +3558,10 @@ Time = BaseInstance(datetime.time, editor=time_editor)
 
 # Everything from this point onwards is deprecated, and has a simple
 # drop-in replacement.
+
+#: A traits whose value must support a specified protocol. This is
+#: an alias for :class:`Supports`. Use ``Supports`` instead.
+AdaptedTo = Supports
 
 #: A trait whose value must be a (Unicode) string. This is an alias for
 #: :class:`BaseStr`. Use ``BaseStr`` instead.


### PR DESCRIPTION
Fixes #723 
Should the change be made to the examples (`examples/tutorials/traits_4.0/interfaces/adaptation.py `)as well ? 
Why is it under a folder named "traits_4.0" ?
