### PR TITLE
Keep flake8 configuration in a single place

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -238,13 +238,7 @@ def flake8(edm, runtime, environment):
 
     """
     parameters = get_parameters(edm, runtime, environment)
-
-    # Ideally we'd run flake8 on all Python files, but the examples
-    # directory currently contains too many flake8 issues.
-    commands = [
-        "{edm} run -e {environment} -- python -m flake8 "
-        "--exclude=examples"
-    ]
+    commands = ["{edm} run -e {environment} -- python -m flake8"]
     execute(commands, parameters)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
+exclude = examples
 ignore = E203,E266,E302,E303,E501,W503,E722,E731,E741


### PR DESCRIPTION
Minor tweak to the flake8 configuration: put the exclusion of the "examples" directory into the flake8 config in `setup.cfg`.

This makes it easier to run flake8 during development: when inside the development environment, a developer can simply run `flake8` instead of having to go through `etstool`.