### PR TITLE
Abort CI on compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   global:
     - INSTALL_EDM_VERSION=2.0.0
       PYTHONUNBUFFERED="1"
+      CFLAGS="-Werror"
 
 matrix:
   include:

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4620,7 +4620,7 @@ get_trait_modify_delegate_flag(trait_object *trait, void *closure)
 |  Sets the current modify_delegate flag value:
 +----------------------------------------------------------------------------*/
 
-static int
+static int *
 set_trait_modify_delegate_flag(
     trait_object *trait, PyObject *value, void *closure)
 {

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4620,7 +4620,7 @@ get_trait_modify_delegate_flag(trait_object *trait, void *closure)
 |  Sets the current modify_delegate flag value:
 +----------------------------------------------------------------------------*/
 
-static int *
+static int
 set_trait_modify_delegate_flag(
     trait_object *trait, PyObject *value, void *closure)
 {


### PR DESCRIPTION
This is an experimental PR, intended to make CI fail on compiler warnings. At the moment, it's way too easy to miss important warning messages from gcc/clang when testing local changes to ctraits.c.