### PR TITLE
Deprecate non-essential trait handlers

### DIFF
--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -13,6 +13,10 @@ Classes
 
 .. autoclass:: TraitInstance
 
+.. autodata:: TraitFunction
+
+.. autodata:: TraitEnum
+
 .. autoclass:: TraitPrefixList
 
 .. autoclass:: TraitMap
@@ -39,10 +43,6 @@ and may be removed in a future version of Traits.
 .. autodata:: ThisClass
 
 .. autodata:: TraitDict
-
-.. autodata:: TraitEnum
-
-.. autodata:: TraitFunction
 
 .. autodata:: TraitList
 

--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -13,9 +13,9 @@ Classes
 
 .. autoclass:: TraitInstance
 
-.. autodata:: TraitFunction
+.. autoclass:: TraitFunction
 
-.. autodata:: TraitEnum
+.. autoclass:: TraitEnum
 
 .. autoclass:: TraitPrefixList
 

--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -11,13 +11,9 @@ Classes
 
 .. autoclass:: TraitCastType
 
-.. autoclass:: ThisClass
-
 .. autoclass:: TraitInstance
 
 .. autoclass:: TraitFunction
-
-.. autoclass:: TraitEnum
 
 .. autoclass:: TraitPrefixList
 
@@ -27,15 +23,27 @@ Classes
 
 .. autoclass:: TraitCompound
 
-.. autoclass:: TraitTuple
-
-.. autoclass:: TraitList
-
-.. autoclass:: TraitDict
-
 Private Functions
 -----------------
 
 .. autofunction:: traits.trait_handlers._undefined_get
 
 .. autofunction:: traits.trait_handlers._undefined_set
+
+Deprecated Handlers
+-------------------
+
+.. deprecated:: 6.0.0
+
+The following :class:`~.TraitHandler` classes and instances are deprecated,
+and may be removed in a future version of Traits.
+
+.. autodata:: ThisClass
+
+.. autodata:: TraitDict
+
+.. autodata:: TraitEnum
+
+.. autodata:: TraitList
+
+.. autodata:: TraitTuple

--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -13,8 +13,6 @@ Classes
 
 .. autoclass:: TraitInstance
 
-.. autoclass:: TraitFunction
-
 .. autoclass:: TraitPrefixList
 
 .. autoclass:: TraitMap
@@ -47,9 +45,5 @@ and may be removed in a future version of Traits.
 .. autodata:: TraitFunction
 
 .. autodata:: TraitList
-
-.. autodata:: TraitMap
-
-.. autodata:: TraitPrefixList
 
 .. autodata:: TraitTuple

--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -44,6 +44,12 @@ and may be removed in a future version of Traits.
 
 .. autodata:: TraitEnum
 
+.. autodata:: TraitFunction
+
 .. autodata:: TraitList
+
+.. autodata:: TraitMap
+
+.. autodata:: TraitPrefixList
 
 .. autodata:: TraitTuple

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -15,20 +15,32 @@ from traits.api import (
     ThisClass,
     TraitDict,
     TraitEnum,
+    TraitFunction,
     TraitList,
+    TraitMap,
+    TraitPrefixList,
     TraitTuple,
 )
 
 class TestTraitHandlerDeprecatedWarnings(unittest.TestCase):
 
     def test_handler_warning(self):
-        handlers = [ThisClass, TraitDict, TraitEnum, TraitList, TraitTuple]
+        handlers = {
+            "ThisClass": ThisClass,
+            "TraitDict": TraitDict,
+            "TraitEnum": TraitEnum,
+            "TraitList": TraitList,
+            "TraitMap": lambda: TraitMap({}),
+            "TraitFunction": lambda: TraitFunction(lambda x: 0),
+            "TraitPrefixList": TraitPrefixList,
+            "TraitTuple": TraitTuple
+        }
 
-        for handler in handlers:
-            with self.subTest(handler=handler):
+        for name, handler_factory in handlers.items():
+            with self.subTest(handler=name):
                 with warnings.catch_warnings(record=True):
                     warnings.simplefilter("error", DeprecationWarning)
 
                     with self.assertRaises(DeprecationWarning) as cm:
-                        handler()
-                self.assertIn(handler.__name__, str(cm.exception))
+                        handler_factory()
+                self.assertIn(name, str(cm.exception))

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -14,8 +14,6 @@ import warnings
 from traits.api import (
     ThisClass,
     TraitDict,
-    TraitEnum,
-    TraitFunction,
     TraitList,
     TraitTuple,
 )
@@ -26,9 +24,7 @@ class TestTraitHandlerDeprecatedWarnings(unittest.TestCase):
         handlers = {
             "ThisClass": ThisClass,
             "TraitDict": TraitDict,
-            "TraitEnum": TraitEnum,
             "TraitList": TraitList,
-            "TraitFunction": lambda: TraitFunction(lambda x: 0),
             "TraitTuple": TraitTuple
         }
 

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -8,8 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-#  Imports
-
 import unittest
 import warnings
 

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -17,8 +17,6 @@ from traits.api import (
     TraitEnum,
     TraitFunction,
     TraitList,
-    TraitMap,
-    TraitPrefixList,
     TraitTuple,
 )
 
@@ -30,9 +28,7 @@ class TestTraitHandlerDeprecatedWarnings(unittest.TestCase):
             "TraitDict": TraitDict,
             "TraitEnum": TraitEnum,
             "TraitList": TraitList,
-            "TraitMap": lambda: TraitMap({}),
             "TraitFunction": lambda: TraitFunction(lambda x: 0),
-            "TraitPrefixList": TraitPrefixList,
             "TraitTuple": TraitTuple
         }
 

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -1,0 +1,70 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+#  Imports
+
+import unittest
+import warnings
+
+from traits.api import (
+    Any,
+    ThisClass,
+    TraitDict,
+    TraitEnum,
+    TraitList,
+    TraitTuple,
+)
+
+class TestTraitHandlerDeprecatedWarnings(unittest.TestCase):
+
+    def test_this_class_warning(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("error", DeprecationWarning)
+
+            with self.assertRaises(DeprecationWarning) as cm:
+                ThisClass()
+
+        self.assertIn("ThisClass", str(cm.exception))
+
+    def test_trait_dict_warning(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("error", DeprecationWarning)
+
+            with self.assertRaises(DeprecationWarning) as cm:
+                TraitDict()
+
+        self.assertIn("TraitDict", str(cm.exception))
+
+    def test_trait_enum_warning(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("error", DeprecationWarning)
+
+            with self.assertRaises(DeprecationWarning) as cm:
+                TraitEnum([1, 2, 3])
+
+        self.assertIn("TraitEnum", str(cm.exception))
+
+    def test_trait_list_warning(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("error", DeprecationWarning)
+
+            with self.assertRaises(DeprecationWarning) as cm:
+                TraitList()
+
+        self.assertIn("TraitList", str(cm.exception))
+
+    def test_trait_tuple_warning(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("error", DeprecationWarning)
+
+            with self.assertRaises(DeprecationWarning) as cm:
+                TraitTuple([Any, Any])
+
+        self.assertIn("TraitTuple", str(cm.exception))

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -31,4 +31,4 @@ class TestTraitHandlerDeprecatedWarnings(unittest.TestCase):
 
                     with self.assertRaises(DeprecationWarning) as cm:
                         handler()
-            self.assertIn(handler.__name__, str(cm.exception))
+                self.assertIn(handler.__name__, str(cm.exception))

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -14,7 +14,6 @@ import unittest
 import warnings
 
 from traits.api import (
-    Any,
     ThisClass,
     TraitDict,
     TraitEnum,
@@ -24,47 +23,14 @@ from traits.api import (
 
 class TestTraitHandlerDeprecatedWarnings(unittest.TestCase):
 
-    def test_this_class_warning(self):
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("error", DeprecationWarning)
+    def test_handler_warning(self):
+        handlers = [ThisClass, TraitDict, TraitEnum, TraitList, TraitTuple]
 
-            with self.assertRaises(DeprecationWarning) as cm:
-                ThisClass()
+        for handler in handlers:
+            with self.subTest(handler=handler):
+                with warnings.catch_warnings(record=True):
+                    warnings.simplefilter("error", DeprecationWarning)
 
-        self.assertIn("ThisClass", str(cm.exception))
-
-    def test_trait_dict_warning(self):
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("error", DeprecationWarning)
-
-            with self.assertRaises(DeprecationWarning) as cm:
-                TraitDict()
-
-        self.assertIn("TraitDict", str(cm.exception))
-
-    def test_trait_enum_warning(self):
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("error", DeprecationWarning)
-
-            with self.assertRaises(DeprecationWarning) as cm:
-                TraitEnum([1, 2, 3])
-
-        self.assertIn("TraitEnum", str(cm.exception))
-
-    def test_trait_list_warning(self):
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("error", DeprecationWarning)
-
-            with self.assertRaises(DeprecationWarning) as cm:
-                TraitList()
-
-        self.assertIn("TraitList", str(cm.exception))
-
-    def test_trait_tuple_warning(self):
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("error", DeprecationWarning)
-
-            with self.assertRaises(DeprecationWarning) as cm:
-                TraitTuple([Any, Any])
-
-        self.assertIn("TraitTuple", str(cm.exception))
+                    with self.assertRaises(DeprecationWarning) as cm:
+                        handler()
+            self.assertIn(handler.__name__, str(cm.exception))

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -51,7 +51,8 @@ logger = logging.getLogger(__name__)
 
 CallableTypes = (FunctionType, MethodType)
 
-_WARNING_FORMAT_STR = "'{handler}' trait handler has been deprecated."
+_WARNING_FORMAT_STR = ("'{handler}' trait handler has been deprecated. "
+                       "Use {replacement} instead.")
 
 # -------------------------------------------------------------------------------
 #  Private functions:
@@ -286,7 +287,7 @@ class ThisClass(TraitHandler):
             Flag indicating whether None is accepted as a valid value
             (True or non-zero) or not (False or 0).
         """
-        message = _WARNING_FORMAT_STR.format(handler="ThisClass")
+        message = _WARNING_FORMAT_STR.format(handler="ThisClass", replacement="This")
         warnings.warn(message, DeprecationWarning)
         if allow_none:
             self.validate = self.validate_none
@@ -516,7 +517,7 @@ class TraitFunction(TraitHandler):
         actual value assigned to the trait attribute. If it is not, the
         function must raise a TraitError exception.
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitFunction")
+        message = _WARNING_FORMAT_STR.format(handler="TraitFunction", replacement="Callable")
         warnings.warn(message, DeprecationWarning)
         if not isinstance(aFunc, CallableTypes):
             raise TraitError("Argument must be callable.")
@@ -583,7 +584,7 @@ class TraitEnum(TraitHandler):
         this example to the form shown in the preceding example whenever it
         encounters them in a trait definition.
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitEnum")
+        message = _WARNING_FORMAT_STR.format(handler="TraitEnum", replacement="Enum")
         warnings.warn(message, DeprecationWarning)
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
@@ -1057,7 +1058,7 @@ class TraitTuple(TraitHandler):
         *args*, and whose *i*\ th element is of the type specified by
         *trait*\ :sub:`i`.
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitTuple")
+        message = _WARNING_FORMAT_STR.format(handler="TraitTuple", replacement="Tuple")
         warnings.warn(message, DeprecationWarning)
         self.types = tuple([trait_from(arg) for arg in args])
         self.fast_validate = (ValidateTrait.tuple, self.types)
@@ -1159,7 +1160,7 @@ class TraitList(TraitHandler):
         a value that can be converted to a trait using the Trait() function.
 
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitList")
+        message = _WARNING_FORMAT_STR.format(handler="TraitList", replacement="List")
         warnings.warn(message, DeprecationWarning)
         self.item_trait = trait_from(trait)
         self.minlen = max(0, minlen)
@@ -1276,7 +1277,7 @@ class TraitDict(TraitHandler):
         of the type specified by *value_trait*.
 
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitDict")
+        message = _WARNING_FORMAT_STR.format(handler="TraitDict", replacement="Dict")
         warnings.warn(message, DeprecationWarning)
         self.key_trait = trait_from(key_trait)
         self.value_trait = trait_from(value_trait)

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 CallableTypes = (FunctionType, MethodType)
 
-_warning_format_str = "'{handler}' trait handler has been deprecated."
+_WARNING_FORMAT_STR = "'{handler}' trait handler has been deprecated."
 
 # -------------------------------------------------------------------------------
 #  Private functions:
@@ -286,7 +286,7 @@ class ThisClass(TraitHandler):
             Flag indicating whether None is accepted as a valid value
             (True or non-zero) or not (False or 0).
         """
-        message = _warning_format_str.format(handler="ThisClass")
+        message = _WARNING_FORMAT_STR.format(handler="ThisClass")
         warnings.warn(message, DeprecationWarning)
         if allow_none:
             self.validate = self.validate_none
@@ -516,7 +516,7 @@ class TraitFunction(TraitHandler):
         actual value assigned to the trait attribute. If it is not, the
         function must raise a TraitError exception.
         """
-        message = _warning_format_str.format(handler="TraitFunction")
+        message = _WARNING_FORMAT_STR.format(handler="TraitFunction")
         warnings.warn(message, DeprecationWarning)
         if not isinstance(aFunc, CallableTypes):
             raise TraitError("Argument must be callable.")
@@ -583,7 +583,7 @@ class TraitEnum(TraitHandler):
         this example to the form shown in the preceding example whenever it
         encounters them in a trait definition.
         """
-        message = _warning_format_str.format(handler="TraitEnum")
+        message = _WARNING_FORMAT_STR.format(handler="TraitEnum")
         warnings.warn(message, DeprecationWarning)
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
@@ -660,8 +660,6 @@ class TraitPrefixList(TraitHandler):
         of values.  That is, ``TraitPrefixList(['one', 'two', 'three'])`` and
         ``TraitPrefixList('one', 'two', 'three')`` are equivalent.
         """
-        message = _warning_format_str.format(handler="TraitPrefixList")
-        warnings.warn(message, DeprecationWarning)
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
         self.values = values[:]
@@ -759,8 +757,6 @@ class TraitMap(TraitHandler):
             and whose corresponding values are the values for the shadow
             trait attribute.
         """
-        message = _warning_format_str.format(handler="TraitMap")
-        warnings.warn(message, DeprecationWarning)
         self.map = map
         self.fast_validate = (ValidateTrait.map, map)
 
@@ -1061,7 +1057,7 @@ class TraitTuple(TraitHandler):
         *args*, and whose *i*\ th element is of the type specified by
         *trait*\ :sub:`i`.
         """
-        message = _warning_format_str.format(handler="TraitTuple")
+        message = _WARNING_FORMAT_STR.format(handler="TraitTuple")
         warnings.warn(message, DeprecationWarning)
         self.types = tuple([trait_from(arg) for arg in args])
         self.fast_validate = (ValidateTrait.tuple, self.types)
@@ -1163,7 +1159,7 @@ class TraitList(TraitHandler):
         a value that can be converted to a trait using the Trait() function.
 
         """
-        message = _warning_format_str.format(handler="TraitList")
+        message = _WARNING_FORMAT_STR.format(handler="TraitList")
         warnings.warn(message, DeprecationWarning)
         self.item_trait = trait_from(trait)
         self.minlen = max(0, minlen)
@@ -1280,7 +1276,7 @@ class TraitDict(TraitHandler):
         of the type specified by *value_trait*.
 
         """
-        message = _warning_format_str.format(handler="TraitDict")
+        message = _WARNING_FORMAT_STR.format(handler="TraitDict")
         warnings.warn(message, DeprecationWarning)
         self.key_trait = trait_from(key_trait)
         self.value_trait = trait_from(value_trait)

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -24,6 +24,7 @@ consistent.
 from importlib import import_module
 import sys
 from types import FunctionType, MethodType
+import warnings
 
 from .constants import DefaultValue, ValidateTrait
 from .trait_base import (
@@ -50,6 +51,11 @@ logger = logging.getLogger(__name__)
 
 CallableTypes = (FunctionType, MethodType)
 
+_warning_format_str = (
+    "'{handler}' trait handler has been deprecated. Its usage can be "
+    "replaced by, for example, {replacement}. Please refer "
+    "documentation for details."
+)
 
 # -------------------------------------------------------------------------------
 #  Private functions:
@@ -284,6 +290,9 @@ class ThisClass(TraitHandler):
             Flag indicating whether None is accepted as a valid value
             (True or non-zero) or not (False or 0).
         """
+        message = _warning_format_str.format(
+            handler="ThisClass", replacement="TraitInstance(<klass>)")
+        warnings.warn(message, DeprecationWarning, stacklevel=5)
         if allow_none:
             self.validate = self.validate_none
             self.info = self.info_none
@@ -577,6 +586,8 @@ class TraitEnum(TraitHandler):
         this example to the form shown in the preceding example whenever it
         encounters them in a trait definition.
         """
+        message = _warning_format_str.format(handler="TraitMap", replacement="Tuple")
+        warnings.warn(message, DeprecationWarning, stacklevel=5)
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
         self.values = tuple(values)
@@ -650,7 +661,7 @@ class TraitPrefixList(TraitHandler):
         -----------
         As with TraitEnum, the list of legal values can be provided as a list
         of values.  That is, ``TraitPrefixList(['one', 'two', 'three'])`` and
-        ``TraitPrefixList('one', 'two', 'three')`` are equivalent.
+        ``List('one', 'two', 'three')`` are equivalent.
         """
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
@@ -1049,6 +1060,8 @@ class TraitTuple(TraitHandler):
         *args*, and whose *i*\ th element is of the type specified by
         *trait*\ :sub:`i`.
         """
+        message = _warning_format_str.format(handler="TraitMap", replacement="Tuple")
+        warnings.warn(message, DeprecationWarning, stacklevel=5)
         self.types = tuple([trait_from(arg) for arg in args])
         self.fast_validate = (ValidateTrait.tuple, self.types)
 
@@ -1149,6 +1162,9 @@ class TraitList(TraitHandler):
         a value that can be converted to a trait using the Trait() function.
 
         """
+        message = _warning_format_str.format(
+            handler="TraitList", replacement="List(<Trait>)")
+        warnings.warn(message, DeprecationWarning, stacklevel=5)
         self.item_trait = trait_from(trait)
         self.minlen = max(0, minlen)
         self.maxlen = max(minlen, maxlen)
@@ -1264,6 +1280,9 @@ class TraitDict(TraitHandler):
         of the type specified by *value_trait*.
 
         """
+        message = _warning_format_str.format(
+            handler="TraitDict", replacement="Dict(key_trait, value_trait)")
+        warnings.warn(message, DeprecationWarning, stacklevel=5)
         self.key_trait = trait_from(key_trait)
         self.value_trait = trait_from(value_trait)
         self.has_items = has_items

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -661,7 +661,7 @@ class TraitPrefixList(TraitHandler):
         -----------
         As with TraitEnum, the list of legal values can be provided as a list
         of values.  That is, ``TraitPrefixList(['one', 'two', 'three'])`` and
-        ``List('one', 'two', 'three')`` are equivalent.
+        ``TraitPrefixList('one', 'two', 'three')`` are equivalent.
         """
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -499,8 +499,7 @@ class TraitFunction(TraitHandler):
     **Function**, and for the use of function references as arguments to the
     Trait() function.
     """
-    @deprecated(_WARNING_FORMAT_STR.format(
-        handler="TraitFunction", replacement="Callable"))
+
     def __init__(self, aFunc):
         """ Creates a TraitFunction handler.
 
@@ -550,8 +549,7 @@ class TraitEnum(TraitHandler):
     TraitEnum is the underlying handler for the forms of the Trait() function
     that take a list of possible values
     """
-    @deprecated(_WARNING_FORMAT_STR.format(
-        handler="TraitEnum", replacement="Enum"))
+
     def __init__(self, *values):
         """ Creates a TraitEnum handler.
 

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -51,11 +51,7 @@ logger = logging.getLogger(__name__)
 
 CallableTypes = (FunctionType, MethodType)
 
-_warning_format_str = (
-    "'{handler}' trait handler has been deprecated. Its usage can be "
-    "replaced by, for example, {replacement}. Please refer "
-    "documentation for details."
-)
+_warning_format_str = "'{handler}' trait handler has been deprecated."
 
 # -------------------------------------------------------------------------------
 #  Private functions:
@@ -290,8 +286,7 @@ class ThisClass(TraitHandler):
             Flag indicating whether None is accepted as a valid value
             (True or non-zero) or not (False or 0).
         """
-        message = _warning_format_str.format(
-            handler="ThisClass", replacement="TraitInstance(<klass>)")
+        message = _warning_format_str.format(handler="ThisClass")
         warnings.warn(message, DeprecationWarning)
         if allow_none:
             self.validate = self.validate_none
@@ -521,6 +516,8 @@ class TraitFunction(TraitHandler):
         actual value assigned to the trait attribute. If it is not, the
         function must raise a TraitError exception.
         """
+        message = _warning_format_str.format(handler="TraitFunction")
+        warnings.warn(message, DeprecationWarning)
         if not isinstance(aFunc, CallableTypes):
             raise TraitError("Argument must be callable.")
         self.aFunc = aFunc
@@ -586,7 +583,7 @@ class TraitEnum(TraitHandler):
         this example to the form shown in the preceding example whenever it
         encounters them in a trait definition.
         """
-        message = _warning_format_str.format(handler="TraitEnum", replacement="Enum")
+        message = _warning_format_str.format(handler="TraitEnum")
         warnings.warn(message, DeprecationWarning)
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
@@ -663,6 +660,8 @@ class TraitPrefixList(TraitHandler):
         of values.  That is, ``TraitPrefixList(['one', 'two', 'three'])`` and
         ``TraitPrefixList('one', 'two', 'three')`` are equivalent.
         """
+        message = _warning_format_str.format(handler="TraitPrefixList")
+        warnings.warn(message, DeprecationWarning)
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
         self.values = values[:]
@@ -760,6 +759,8 @@ class TraitMap(TraitHandler):
             and whose corresponding values are the values for the shadow
             trait attribute.
         """
+        message = _warning_format_str.format(handler="TraitMap")
+        warnings.warn(message, DeprecationWarning)
         self.map = map
         self.fast_validate = (ValidateTrait.map, map)
 
@@ -1060,7 +1061,7 @@ class TraitTuple(TraitHandler):
         *args*, and whose *i*\ th element is of the type specified by
         *trait*\ :sub:`i`.
         """
-        message = _warning_format_str.format(handler="TraitTuple", replacement="Tuple")
+        message = _warning_format_str.format(handler="TraitTuple")
         warnings.warn(message, DeprecationWarning)
         self.types = tuple([trait_from(arg) for arg in args])
         self.fast_validate = (ValidateTrait.tuple, self.types)
@@ -1162,8 +1163,7 @@ class TraitList(TraitHandler):
         a value that can be converted to a trait using the Trait() function.
 
         """
-        message = _warning_format_str.format(
-            handler="TraitList", replacement="List(<Trait>)")
+        message = _warning_format_str.format(handler="TraitList")
         warnings.warn(message, DeprecationWarning)
         self.item_trait = trait_from(trait)
         self.minlen = max(0, minlen)
@@ -1280,8 +1280,7 @@ class TraitDict(TraitHandler):
         of the type specified by *value_trait*.
 
         """
-        message = _warning_format_str.format(
-            handler="TraitDict", replacement="Dict(key_trait, value_trait)")
+        message = _warning_format_str.format(handler="TraitDict")
         warnings.warn(message, DeprecationWarning)
         self.key_trait = trait_from(key_trait)
         self.value_trait = trait_from(value_trait)

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -39,6 +39,7 @@ from .trait_dict_object import TraitDictEvent, TraitDictObject
 from .trait_converters import trait_from
 from .trait_handler import TraitHandler
 from .trait_list_object import TraitListEvent, TraitListObject
+from .util.deprecated import deprecated
 
 # Set up a logger:
 import logging
@@ -277,7 +278,8 @@ class ThisClass(TraitHandler):
        ThisClass is the underlying handler for the predefined traits **This**
        and **self**, and the elements of ListThis.
     """
-
+    @deprecated(_WARNING_FORMAT_STR.format(
+        handler="ThisClass", replacement="This"))
     def __init__(self, allow_none=False):
         """Creates a ThisClass handler.
 
@@ -287,8 +289,6 @@ class ThisClass(TraitHandler):
             Flag indicating whether None is accepted as a valid value
             (True or non-zero) or not (False or 0).
         """
-        message = _WARNING_FORMAT_STR.format(handler="ThisClass", replacement="This")
-        warnings.warn(message, DeprecationWarning)
         if allow_none:
             self.validate = self.validate_none
             self.info = self.info_none
@@ -499,7 +499,8 @@ class TraitFunction(TraitHandler):
     **Function**, and for the use of function references as arguments to the
     Trait() function.
     """
-
+    @deprecated(_WARNING_FORMAT_STR.format(
+        handler="TraitFunction", replacement="Callable"))
     def __init__(self, aFunc):
         """ Creates a TraitFunction handler.
 
@@ -517,8 +518,6 @@ class TraitFunction(TraitHandler):
         actual value assigned to the trait attribute. If it is not, the
         function must raise a TraitError exception.
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitFunction", replacement="Callable")
-        warnings.warn(message, DeprecationWarning)
         if not isinstance(aFunc, CallableTypes):
             raise TraitError("Argument must be callable.")
         self.aFunc = aFunc
@@ -551,7 +550,8 @@ class TraitEnum(TraitHandler):
     TraitEnum is the underlying handler for the forms of the Trait() function
     that take a list of possible values
     """
-
+    @deprecated(_WARNING_FORMAT_STR.format(
+        handler="TraitEnum", replacement="Enum"))
     def __init__(self, *values):
         """ Creates a TraitEnum handler.
 
@@ -584,8 +584,6 @@ class TraitEnum(TraitHandler):
         this example to the form shown in the preceding example whenever it
         encounters them in a trait definition.
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitEnum", replacement="Enum")
-        warnings.warn(message, DeprecationWarning)
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
         self.values = tuple(values)
@@ -1041,6 +1039,8 @@ class TraitTuple(TraitHandler):
     strings, 'Hearts', 'Diamonds', 'Spades', or 'Clubs'.
     """
 
+    @deprecated(_WARNING_FORMAT_STR.format(
+        handler="TraitTuple", replacement="Tuple"))
     def __init__(self, *args):
         r""" Creates a TraitTuple handler.
 
@@ -1058,8 +1058,6 @@ class TraitTuple(TraitHandler):
         *args*, and whose *i*\ th element is of the type specified by
         *trait*\ :sub:`i`.
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitTuple", replacement="Tuple")
-        warnings.warn(message, DeprecationWarning)
         self.types = tuple([trait_from(arg) for arg in args])
         self.fast_validate = (ValidateTrait.tuple, self.types)
 
@@ -1137,6 +1135,8 @@ class TraitList(TraitHandler):
     default_value_type = DefaultValue.trait_list_object
     _items_event = None
 
+    @deprecated(_WARNING_FORMAT_STR.format(
+        handler="TraitList", replacement="List"))
     def __init__(
         self, trait=None, minlen=0, maxlen=sys.maxsize, has_items=True
     ):
@@ -1160,8 +1160,6 @@ class TraitList(TraitHandler):
         a value that can be converted to a trait using the Trait() function.
 
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitList", replacement="List")
-        warnings.warn(message, DeprecationWarning)
         self.item_trait = trait_from(trait)
         self.minlen = max(0, minlen)
         self.maxlen = max(minlen, maxlen)
@@ -1250,6 +1248,8 @@ class TraitDict(TraitHandler):
     default_value_type = DefaultValue.trait_list_object
     _items_event = None
 
+    @deprecated(_WARNING_FORMAT_STR.format(
+        handler="TraitDict", replacement="Dict"))
     def __init__(self, key_trait=None, value_trait=None, has_items=True):
         """ Creates a TraitDict handler.
 
@@ -1277,8 +1277,6 @@ class TraitDict(TraitHandler):
         of the type specified by *value_trait*.
 
         """
-        message = _WARNING_FORMAT_STR.format(handler="TraitDict", replacement="Dict")
-        warnings.warn(message, DeprecationWarning)
         self.key_trait = trait_from(key_trait)
         self.value_trait = trait_from(value_trait)
         self.has_items = has_items

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -24,7 +24,6 @@ consistent.
 from importlib import import_module
 import sys
 from types import FunctionType, MethodType
-import warnings
 
 from .constants import DefaultValue, ValidateTrait
 from .trait_base import (

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -586,7 +586,7 @@ class TraitEnum(TraitHandler):
         this example to the form shown in the preceding example whenever it
         encounters them in a trait definition.
         """
-        message = _warning_format_str.format(handler="TraitMap", replacement="Tuple")
+        message = _warning_format_str.format(handler="TraitEnum", replacement="Enum")
         warnings.warn(message, DeprecationWarning, stacklevel=5)
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
@@ -1060,7 +1060,7 @@ class TraitTuple(TraitHandler):
         *args*, and whose *i*\ th element is of the type specified by
         *trait*\ :sub:`i`.
         """
-        message = _warning_format_str.format(handler="TraitMap", replacement="Tuple")
+        message = _warning_format_str.format(handler="TraitTuple", replacement="Tuple")
         warnings.warn(message, DeprecationWarning, stacklevel=5)
         self.types = tuple([trait_from(arg) for arg in args])
         self.fast_validate = (ValidateTrait.tuple, self.types)

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -292,7 +292,7 @@ class ThisClass(TraitHandler):
         """
         message = _warning_format_str.format(
             handler="ThisClass", replacement="TraitInstance(<klass>)")
-        warnings.warn(message, DeprecationWarning, stacklevel=5)
+        warnings.warn(message, DeprecationWarning)
         if allow_none:
             self.validate = self.validate_none
             self.info = self.info_none
@@ -587,7 +587,7 @@ class TraitEnum(TraitHandler):
         encounters them in a trait definition.
         """
         message = _warning_format_str.format(handler="TraitEnum", replacement="Enum")
-        warnings.warn(message, DeprecationWarning, stacklevel=5)
+        warnings.warn(message, DeprecationWarning)
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
         self.values = tuple(values)
@@ -1061,7 +1061,7 @@ class TraitTuple(TraitHandler):
         *trait*\ :sub:`i`.
         """
         message = _warning_format_str.format(handler="TraitTuple", replacement="Tuple")
-        warnings.warn(message, DeprecationWarning, stacklevel=5)
+        warnings.warn(message, DeprecationWarning)
         self.types = tuple([trait_from(arg) for arg in args])
         self.fast_validate = (ValidateTrait.tuple, self.types)
 
@@ -1164,7 +1164,7 @@ class TraitList(TraitHandler):
         """
         message = _warning_format_str.format(
             handler="TraitList", replacement="List(<Trait>)")
-        warnings.warn(message, DeprecationWarning, stacklevel=5)
+        warnings.warn(message, DeprecationWarning)
         self.item_trait = trait_from(trait)
         self.minlen = max(0, minlen)
         self.maxlen = max(minlen, maxlen)
@@ -1282,7 +1282,7 @@ class TraitDict(TraitHandler):
         """
         message = _warning_format_str.format(
             handler="TraitDict", replacement="Dict(key_trait, value_trait)")
-        warnings.warn(message, DeprecationWarning, stacklevel=5)
+        warnings.warn(message, DeprecationWarning)
         self.key_trait = trait_from(key_trait)
         self.value_trait = trait_from(value_trait)
         self.has_items = has_items


### PR DESCRIPTION
closes #697

Added deprecation warning messages to these handlers
```
ThisClass
TraitDict
TraitEnum
TraitFunction
TraitList
TraitMap
TraitPrefixList
TraitTuple
```
