### PR TITLE
Remove containing list around added and removed items in some list events

### DIFF
--- a/traits/tests/test_list_events.py
+++ b/traits/tests/test_list_events.py
@@ -192,3 +192,39 @@ class ListEventTestCase(unittest.TestCase):
         foo.l.clear()
 
         self.assertEqual(len(foo.l_events), 0)
+
+    def test_delete_step_slice(self):
+        foo = MyClass()
+        foo.l = [0, 1, 2, 3, 4]
+
+        del foo.l[0:5:2]
+
+        self.assertEqual(len(foo.l_events), 1)
+        event, = foo.l_events
+        self.assertEqual(event.index, slice(0, 5, 2))
+        self.assertEqual(event.removed, [0, 2, 4])
+        self.assertEqual(event.added, [])
+
+    def test_delete_step_slice_empty_list(self):
+        foo = MyClass()
+        foo.l = []
+
+        del foo.l[::-1]
+
+        self.assertEqual(len(foo.l_events), 1)
+        event, = foo.l_events
+        self.assertEqual(event.index, slice(None, None, -1))
+        self.assertEqual(event.removed, [])
+        self.assertEqual(event.added, [])
+
+    def test_assignment_step_slice(self):
+        foo = MyClass()
+        foo.l = [1, 2, 3]
+
+        foo.l[::2] = [3, 4]
+
+        self.assertEqual(len(foo.l_events), 1)
+        event, = foo.l_events
+        self.assertEqual(event.index, slice(None, None, 2))
+        self.assertEqual(event.added, [3, 4])
+        self.assertEqual(event.removed, [1, 3])

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -1093,10 +1093,10 @@ class test_list_value(test_base2):
         self.assertIs(self.last_event, old_event)
         self.obj.alist[0:4:2] = [10, 11]
         self.assertLastTraitListEventEqual(
-            slice(0, 4, 2), [[8, 4]], [[10, 11]]
+            slice(0, 4, 2), [8, 4], [10, 11]
         )
         del self.obj.alist[1:4:2]
-        self.assertLastTraitListEventEqual(slice(1, 4, 2), [[9, 5]], [])
+        self.assertLastTraitListEventEqual(slice(1, 4, 2), [9, 5], [])
         self.obj.alist = [1, 2, 3, 4]
         del self.obj.alist[2:4]
         self.assertLastTraitListEventEqual(2, [3, 4], [])

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -134,12 +134,7 @@ class TraitListObject(list):
                     # are.
                     index = 0 if key.start is None else key.start
                 else:
-                    # Otherwise, we have an extended slice which was handled,
-                    # badly, by __setitem__ before. In this case, we return the
-                    # removed and added lists wrapped in another list.
                     index = key
-                    values = [values]
-                    removed = [removed]
             else:
                 if validate is not None:
                     value = validate(object, name, value)
@@ -187,7 +182,6 @@ class TraitListObject(list):
                 index = 0 if key.start is None else key.start
             else:
                 index = key
-                removed = [removed]
         else:
             delta = 1
             index = len(self) + key + 1 if key < 0 else key


### PR DESCRIPTION
Closes #742

Updates the behaviour of list events when setting or deleting list objects via a slice with step size != 1.

Previously the added and deleted elements would be wrapped in an extra containing list:
https://github.com/enthought/traits/blob/d8d851e72ae9d32920eb9216a583484dda0dc4e1/traits/tests/test_traits.py#L1110-L1115

This PR removes this containing list to bring the behaviour more in line with that of other list actions.

Note there is still some bugwards-compatibility code in `TraitListObject`'s `__setitem__` and `__delitem__` that is out-of-scope of this PR: the `index` of certain events is 0 in cases where the expectation would be a slice:
https://github.com/enthought/traits/blob/d8d851e72ae9d32920eb9216a583484dda0dc4e1/traits/tests/test_traits.py#L1100-L1105

Opened #772 for that.