### PR TITLE
Don't use __newobj__ when pickling CTrait instances

### DIFF
--- a/traits/ctrait.py
+++ b/traits/ctrait.py
@@ -24,12 +24,6 @@ from .trait_list_object import TraitListObject
 from .trait_set_object import TraitSetObject
 
 
-def __newobj__(cls, *args):
-    """ Unpickles new-style objects.
-    """
-    return cls.__new__(cls, *args)
-
-
 class CTrait(ctraits.cTrait):
     """ Extends the underlying C-based cTrait type.
     """
@@ -226,14 +220,6 @@ class CTrait(ctraits.cTrait):
     def as_ctrait(self):
         """ Method that returns self for trait converters. """
         return self
-
-    # ---------------------------------------------------------------------------
-    #  Private methods
-    # ---------------------------------------------------------------------------
-
-    def __reduce_ex__(self, protocol):
-        """ Returns the pickleable form of a CTrait object. """
-        return (__newobj__, (self.__class__, 0), self.__getstate__())
 
 
 def _adapt_wrapper(*args, **kw):

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -28,7 +28,7 @@ from types import FunctionType, MethodType
 from . import __version__ as TraitsVersion
 from .adaptation.adaptation_error import AdaptationError
 from .constants import DefaultValue, TraitKind
-from .ctrait import CTrait, __newobj__
+from .ctrait import CTrait
 from .ctraits import CHasTraits
 from .traits import (
     ForwardProperty,
@@ -68,6 +68,13 @@ from .trait_converters import check_trait, mapped_trait_for, trait_for
 # -------------------------------------------------------------------------------
 
 CHECK_INTERFACES = 0
+
+
+def __newobj__(cls, *args):
+    """ Unpickles new-style objects.
+    """
+    return cls.__new__(cls, *args)
+
 
 # -------------------------------------------------------------------------------
 #  This ABC is a placeholder for the TraitsUI ViewElement class, which should


### PR DESCRIPTION
There's no longer any need to use `__newobj__` when pickling CTrait instances. In particular, we don't care about forward compatibility for pickling: a pickle generated on Traits 6.0 (and so necessary on Python 3) need not be readable on earlier versions of Traits.

Fixes part of #788 