### PR TITLE
Enable C asserts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   global:
     - INSTALL_EDM_VERSION=2.0.0
       PYTHONUNBUFFERED="1"
-      CFLAGS="-Werror"
+      CFLAGS="-Werror -UNDEBUG"
 
 matrix:
   include:


### PR DESCRIPTION
We have various C-level `assert`s in `ctraits.c`. Right now, those do us no good at all because the extension is being built with `-DNDEBUG`. This PR adds `-UNDEBUG` to the build flags, which cancels the `-DNDEBUG` out.