### PR TITLE
Add a DeprecationWarning for configure_traits() pickles

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -21,6 +21,7 @@ import copy as copy_module
 import os
 import pickle
 import re
+import warnings
 import weakref
 
 from types import FunctionType, MethodType
@@ -2000,6 +2001,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         Parameters
         ----------
         filename : str
+            NOTE: Deprecated as of traits 6.0.0.
             The name (including path) of a file that contains a pickled
             representation of the current object. When this parameter is
             specified, the method reads the corresponding file (if it exists)
@@ -2064,6 +2066,9 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         modified by the user.
         """
         if filename is not None:
+            message = ('Restoring from pickle will not be supported starting '
+                       'with traits 7.0.0')
+            warnings.warn(message, DeprecationWarning)
             if os.path.exists(filename):
                 with open(filename, "rb") as fd:
                     self.copy_traits(pickle.Unpickler(fd).load())

--- a/traits/tests/test_configure_traits.py
+++ b/traits/tests/test_configure_traits.py
@@ -47,7 +47,8 @@ class TestConfigureTraits(unittest.TestCase):
         self.assertFalse(os.path.exists(filename))
 
         with mock.patch.object(self.toolkit, "view_application"):
-            model.configure_traits(filename=filename)
+            with self.assertWarns(DeprecationWarning):
+                model.configure_traits(filename=filename)
 
         self.assertTrue(os.path.exists(filename))
         with open(filename, "rb") as pickled_object:
@@ -65,7 +66,8 @@ class TestConfigureTraits(unittest.TestCase):
 
         model = Model(count=19)
         with mock.patch.object(self.toolkit, "view_application"):
-            model.configure_traits(filename=filename)
+            with self.assertWarns(DeprecationWarning):
+                model.configure_traits(filename=filename)
         self.assertEqual(model.count, 52)
 
     def test_filename_with_invalid_existing_file(self):
@@ -77,7 +79,8 @@ class TestConfigureTraits(unittest.TestCase):
         model = Model(count=19)
         with mock.patch.object(self.toolkit, "view_application"):
             with self.assertRaises(pickle.PickleError):
-                model.configure_traits(filename=filename)
+                with self.assertWarns(DeprecationWarning):
+                    model.configure_traits(filename=filename)
 
     def test_filename_with_existing_file_stores_updated_model(self):
         stored_model = Model(count=52)
@@ -92,7 +95,8 @@ class TestConfigureTraits(unittest.TestCase):
         model = Model(count=19)
         with mock.patch.object(self.toolkit, "view_application") as mock_view:
             mock_view.side_effect = modify_model
-            model.configure_traits(filename=filename)
+            with self.assertWarns(DeprecationWarning):
+                model.configure_traits(filename=filename)
         self.assertEqual(model.count, 23)
 
         with open(filename, "rb") as pickled_object:


### PR DESCRIPTION
Somewhat related to #787, we should deprecate the use of pickles for saving state between invocations of `configure_traits`.