### PR TITLE
Use pickle protocol 3 in configure_traits

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2084,7 +2084,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             )
             if rc and (filename is not None):
                 with open(filename, "wb") as fd:
-                    pickle.Pickler(fd, True).dump(self)
+                    pickle.Pickler(fd, protocol=3).dump(self)
             return rc
 
         return True

--- a/traits/tests/test_configure_traits.py
+++ b/traits/tests/test_configure_traits.py
@@ -56,6 +56,23 @@ class TestConfigureTraits(unittest.TestCase):
         self.assertIsInstance(unpickled, Model)
         self.assertEqual(unpickled.count, model.count)
 
+    def test_pickle_protocol(self):
+        # Pickled files should use protocol 3 (a compromise between
+        # efficiency and wide applicability).
+
+        model = Model(count=37)
+        filename = os.path.join(self.tmpdir, "nonexistent.pkl")
+        self.assertFalse(os.path.exists(filename))
+
+        with mock.patch.object(self.toolkit, "view_application"):
+            model.configure_traits(filename=filename)
+
+        self.assertTrue(os.path.exists(filename))
+        with open(filename, "rb") as pickled_object:
+            protocol = pickled_object.read(2)
+
+        self.assertEqual(protocol, b'\x80\x03')
+
     def test_filename_with_existing_file(self):
         # Create pre-existing pickle file.
         stored_model = Model(count=52)

--- a/traits/tests/test_configure_traits.py
+++ b/traits/tests/test_configure_traits.py
@@ -10,6 +10,7 @@
 
 import os
 import pickle
+import pickletools
 import shutil
 import tempfile
 import unittest
@@ -68,10 +69,13 @@ class TestConfigureTraits(unittest.TestCase):
             model.configure_traits(filename=filename)
 
         self.assertTrue(os.path.exists(filename))
-        with open(filename, "rb") as pickled_object:
-            protocol = pickled_object.read(2)
+        with open(filename, "rb") as pickled_object_file:
+            pickled_object = pickled_object_file.read()
 
-        self.assertEqual(protocol, b'\x80\x03')
+        # Get and check the first opcode
+        opcode, arg, _ = next(pickletools.genops(pickled_object))
+        self.assertEqual(opcode.name, "PROTO")
+        self.assertEqual(arg, 3)
 
     def test_filename_with_existing_file(self):
         # Create pre-existing pickle file.


### PR DESCRIPTION
Fix a sneaky `True` that was telling `configure_traits` to use pickle protocol 1 when writing. Now that we're Python 3 only, there's little excuse for using anything lower  than protocol 3.

See also #792.