### PR TITLE
Fix validation of Callable in a compound trait

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3838,6 +3838,12 @@ validate_trait_complex(
                 }
                 return result;
 
+            case 22: /* Callable check: */
+                if (value == Py_None || PyCallable_Check(value)) {
+                    goto done;
+                }
+                break;
+
             default: /* Should never happen...indicates an internal error: */
                 goto error;
         }
@@ -4223,7 +4229,7 @@ static int
 _set_trait_comparison_mode(trait_object *trait, PyObject *value, void *closure)
 {
     long comparison_mode = PyLong_AsLong(value);
-    
+
     if (comparison_mode == -1 && PyErr_Occurred()) {
         return -1;
     }
@@ -4272,7 +4278,7 @@ _get_trait_comparison_mode_int(trait_object *trait, void *closure)
     else {
         assert(compare_flag == TRAIT_EQUALITY_COMPARE);
         i_comparison_mode = 2;
-    } 
+    }
 
     return PyLong_FromLong(i_comparison_mode);
 }

--- a/traits/tests/test_callable.py
+++ b/traits/tests/test_callable.py
@@ -73,9 +73,25 @@ class TestCallable(unittest.TestCase):
         self.assertIn(
             "must be a callable value", str(exception_context.exception))
 
+    def test_callable_in_complex_trait(self):
+        a = MyCallable()
+
+        self.assertIsNone(a.callable_or_str)
+
+        acceptable_values = [pow, "pow", None, int]
+        for value in acceptable_values:
+            a.callable_or_str = value
+            self.assertEqual(a.callable_or_str, value)
+
+        unacceptable_values = [1.0, 3j, (5, 6, 7)]
+        for value in unacceptable_values:
+            old_value = a.callable_or_str
+            with self.assertRaises(TraitError):
+                a.callable_or_str = value
+            self.assertEqual(a.callable_or_str, old_value)
+
 
 class TestBaseCallable(unittest.TestCase):
-
     def test_override_validate(self):
         """ Verify `BaseCallable` can be subclassed to create new traits.
         """

--- a/traits/tests/test_callable.py
+++ b/traits/tests/test_callable.py
@@ -92,6 +92,7 @@ class TestCallable(unittest.TestCase):
 
 
 class TestBaseCallable(unittest.TestCase):
+
     def test_override_validate(self):
         """ Verify `BaseCallable` can be subclassed to create new traits.
         """

--- a/traits/tests/test_callable.py
+++ b/traits/tests/test_callable.py
@@ -11,7 +11,14 @@
 import inspect
 import unittest
 
-from traits.api import BaseCallable, Callable, HasTraits, TraitError
+from traits.api import (
+    BaseCallable,
+    Callable,
+    Either,
+    HasTraits,
+    Str,
+    TraitError,
+)
 
 
 def function():
@@ -27,6 +34,8 @@ class Dummy(object):
 class MyCallable(HasTraits):
 
     value = Callable()
+
+    callable_or_str = Either(Callable(), Str())
 
 
 class MyBaseCallable(HasTraits):


### PR DESCRIPTION
Fix validation of a `Callable` trait inside an `Either`.

Fixes #793 
