### PR TITLE
Suppress deprecation warning from test suite

### DIFF
--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -8,15 +8,15 @@
 #
 # Thanks for using Enthought open source!
 
+import io
 import unittest
-from io import StringIO
 
-from traits.api import HasTraits, Property
-
-output_buffer = StringIO()
+from traits.api import Any, HasTraits, Property
 
 
 class Test(HasTraits):
+
+    output_buffer = Any()
 
     def __value_get(self):
         return self.__dict__.get("_value", 0)
@@ -32,12 +32,14 @@ class Test(HasTraits):
 
 class Test_1(Test):
     def _value_changed(self, value):
-        output_buffer.write(value)
+        self.output_buffer.write(value)
 
 
 class TestPropertyNotifications(unittest.TestCase):
     def test_property_notifications(self):
-        test_obj = Test_1()
+        output_buffer = io.StringIO()
+
+        test_obj = Test_1(output_buffer=output_buffer)
         test_obj.value = "value_1"
         self.assertEqual(output_buffer.getvalue(), "value_1")
 

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -988,16 +988,18 @@ class test_complex_value(test_base2):
         )
 
 
-class list_value(HasTraits):
-    # Trait definitions:
-    list1 = Trait([2], TraitList(Trait([1, 2, 3, 4]), maxlen=4))
-    list2 = Trait([2], TraitList(Trait([1, 2, 3, 4]), minlen=1, maxlen=4))
-    alist = List()
-
-
 class test_list_value(test_base2):
-
     def setUp(self):
+        with self.assertWarns(DeprecationWarning):
+
+            class list_value(HasTraits):
+                # Trait definitions:
+                list1 = Trait([2], TraitList(Trait([1, 2, 3, 4]), maxlen=4))
+                list2 = Trait(
+                    [2], TraitList(Trait([1, 2, 3, 4]), minlen=1, maxlen=4)
+                )
+                alist = List()
+
         self.obj = list_value()
         self.last_event = None
 


### PR DESCRIPTION
This PR moves creation of a class that uses `TraitList` into the `setUp` method of the test that uses it, so that we can suppress the associated `DeprecationWarning`.

Closes #803