### PR TITLE
Defensive assert on failed fast_validator

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3838,11 +3838,11 @@ validate_trait_complex(
                 }
                 return result;
 
-            case 22: /* Callable check: */
-                if (value == Py_None || PyCallable_Check(value)) {
-                    goto done;
-                }
-                break;
+            // case 22: /* Callable check: */
+                // if (value == Py_None || PyCallable_Check(value)) {
+                    // goto done;
+                // }
+                // break;
 
             default: /* Should never happen...indicates an internal error: */
                 assert(0);  /* invalid validation type */

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3845,7 +3845,7 @@ validate_trait_complex(
                 break;
 
             default: /* Should never happen...indicates an internal error: */
-                assert("Unexpected validator; please report");
+                assert(0);  /* invalid validation type */
                 goto error;
         }
     }

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3845,6 +3845,7 @@ validate_trait_complex(
                 break;
 
             default: /* Should never happen...indicates an internal error: */
+                assert("Unexpected validator; please report");
                 goto error;
         }
     }

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3838,11 +3838,11 @@ validate_trait_complex(
                 }
                 return result;
 
-            // case 22: /* Callable check: */
-                // if (value == Py_None || PyCallable_Check(value)) {
-                    // goto done;
-                // }
-                // break;
+            case 22: /* Callable check: */
+                if (value == Py_None || PyCallable_Check(value)) {
+                    goto done;
+                }
+                break;
 
             default: /* Should never happen...indicates an internal error: */
                 assert(0);  /* invalid validation type */


### PR DESCRIPTION
Add a defensive C `assert` to catch the case of an invalid validator code.