### PR TITLE
Enable the coverage extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,7 @@ sys.path.append(os.path.abspath("../../"))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "sphinx.ext.autosummary",
+    "sphinx.ext.coverage",
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",


### PR DESCRIPTION
The coverage extension is valuable for discovering which objects, classes, methods, etc. are undocumented. Use it with (for example) `sphinx-build -b coverage source/ build/` from the `docs` directory.