### PR TITLE
Improve documentation of trait container objects

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -183,10 +183,10 @@ html_use_smartypants = True
 # html_additional_pages = {}
 
 # If false, no module index is generated.
-html_use_modindex = BUILD_DOCSET
+html_use_modindex = True
 
 # If false, no index is generated.
-html_use_index = BUILD_DOCSET
+html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -182,9 +182,6 @@ html_use_smartypants = True
 # template names.
 # html_additional_pages = {}
 
-# If false, no module index is generated.
-html_use_modindex = True
-
 # If false, no index is generated.
 html_use_index = True
 

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -688,7 +688,7 @@ handler with the ``[]`` suffix as noted in the Table
 :ref:`semantics-of-extended-name-notation-table`, or you can define an
 *name*\ _items event handler.
 
-For these trait types, an auxilliary *name*\ _items Event traits are defined which
+For these trait types, an auxilliary *name*\ _items Event trait is defined which
 you can listen to either with a static handler _\ *name*\ _items_changed()
 or a dynamic handler which matches *name*\ _items, and these handlers will be
 called with notifications of changes to the contents of the list, set or
@@ -701,7 +701,7 @@ For these handlers the *new* parameter is a :index:`TraitListEvent`,
 indicate the nature of the change and, because they are Event handlers, the
 *old* parameter is Undefined.
 
-All of these event object have **added** and **removed** attributes that
+All of these event objects have **added** and **removed** attributes that
 hold a list, set or dictionary of the items that were added and removed,
 respectively.
 

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -256,7 +256,6 @@ List or Dict traits, the subsequent portion of the pattern is applied to each
 item in the list or value in the dictionary. For example, if **self.children**
 is a list, a handler set for ``'children.name'`` listens for changes to the
 **name** trait for each item in the **self.children** list.
-
 The handler routine is also invoked when items are added or removed from a list
 or dictionary, because this is treated as an implied change to the item's trait
 being monitored.
@@ -549,12 +548,10 @@ signatures.
 
 In these signatures:
 
-* *new* is the new value assigned to the trait attribute. For List and Dict
-  objects, this is a list of the items that were added.
-* *old* is the old value assigned to the trait attribute. For  List and Dict
-  objects, this is a list of the items that were deleted.
+* *new* is the new value assigned to the trait attribute.
+* *old* is the old value assigned to the trait attribute.
 * *name* is the name of the trait attribute.  The extended trait name syntax
-  is not supported. [4]_
+  is not supported.
 
 Note that these signatures follow a different pattern for argument
 interpretation from dynamic handlers and decorated static handlers. Both of
@@ -675,14 +672,43 @@ as the value of the old parameter to each handler, to indicate that the
 attribute previously had no value. Similarly, the value of a trait event is
 always Undefined.
 
-.. rubric:: Footnotes
-.. [4] For List and Dict trait attributes, you can define a handler with the
-   name _\ *name*\ _items_changed(), which receives notifications of changes to
-   the contents of the list or dictionary. This feature exists for backward
-   compatibility. The preferred approach is to use the @on_trait_change
-   decorator with extended name syntax. For a static
-   _\ *name*\ _items_changed() handler, the *new* parameter is a TraitListEvent
-   or TraitDictEvent whose **index**, **added**, and **removed** attributes
-   indicate the nature of the change, and the *old* parameter is Undefined.
+.. _trait-items-handlers:
 
+Container Items Events
+``````````````````````
+.. index::
+    pair: container items; event
+    single: _name_items_changed()
 
+For the container traits (List, Dict and Set) both static and dynamic handlers
+for the trait are only called when the entire value of the trait is replaced
+with another value; they do not get fired when the item itself is mutated
+in-place.  To listen to internal changes, you need to either use a dynamic
+handler with the ``[]`` suffix as noted in the Table
+:ref:`semantics-of-extended-name-notation-table`, or you can define an
+*name*\ _items event handler.
+
+For these trait types, an auxilliary *name*\ _items Event traits are defined which
+you can listen to either with a static handler _\ *name*\ _items_changed()
+or a dynamic handler which matches *name*\ _items, and these handlers will be
+called with notifications of changes to the contents of the list, set or
+dictionary.
+
+.. index:: TraitListEvent, TraitSetEvent, TraitDictEvent
+
+For these handlers the *new* parameter is a :index:`TraitListEvent`,
+:index:`TraitSetEvent` or :index:`TraitDictEvent` object whose attributes
+indicate the nature of the change and, because they are Event handlers, the
+*old* parameter is Undefined.
+
+All of these event object have **added** and **removed** attributes that
+hold a list, set or dictionary of the items that were added and removed,
+respectively.
+
+The TraitListEvent has an additional **index** attribute that holds either
+the index of the first item changed, or for changes involving slices with
+steps other than 1, **index** holds the _slice_ that was changed.
+
+The TraitDictEvent has an additional **changed** attribute which holds the
+keys that were modified and the _old_ values that those keys held.  The new
+values can be queried from directly from the trait value, if needed).

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -20,19 +20,32 @@ logger = logging.getLogger(__name__)
 
 
 class TraitDictEvent(object):
-    """ An object reporting in-place changes to a traits dicts. """
+    """ An object reporting in-place changes to a traits dicts.
+
+    Parameters
+    ----------
+    added : dict or None
+        New keys and values, or optionally None if nothing was added.
+    changed : dict or None
+        Updated keys and their previous values, or optionally None if nothing
+        was changed.
+    removed : dict or None
+        Old keys and values that were just removed, or optionally None if
+        nothing was removed.
+
+    Attributes
+    ----------
+    added : dict
+        New keys and values.  If nothing was added this is an empty dict.
+    changed : dict
+        Updated keys and their previous values.  If nothing was changed this
+        is an empty dict.
+    removed : dict
+        Old keys and values that were just removed.  If nothing was removed
+        this is an empty dict.
+    """
 
     def __init__(self, added=None, changed=None, removed=None):
-        """
-        Parameters
-        ----------
-        added : dict
-            New keys and values.
-        changed : dict
-            Updated keys and their previous values.
-        removed : dict
-            Old keys and values that were just removed.
-        """
         # Construct new empty dicts every time instead of using a default value
         # in the method argument, just in case someone gets the bright idea of
         # modifying the dict they get in-place.
@@ -50,7 +63,40 @@ class TraitDictEvent(object):
 
 
 class TraitDictObject(dict):
-    """ A subclass of dict that fires trait events when mutated. """
+    """ A subclass of dict that fires trait events when mutated.
+
+    This is used by the Dict trait type, and all values set into a Dict
+    trait will be copied into a new TraitDictObject instance.
+
+    Mutation of the TraitDictObject will fire a "name_items" event with
+    appropriate added, changed and removed values.
+
+    Parameters
+    ----------
+    trait : CTrait instance
+        The CTrait instance associated with the attribute that this dict
+        has been set to.
+    object : HasTraits instance
+        The HasTraits instance that the dict has been set as an attribute for.
+    name : str
+        The name of the attribute on the object.
+    value : dict
+        The dict of values to initialize the TraitDictObject with.
+
+    Attributes
+    ----------
+    trait : CTrait instance
+        The CTrait instance associated with the attribute that this dict
+        has been set to.
+    object : weak reference to a HasTraits instance
+        A weak reference to a HasTraits instance that the dict has been set
+        as an attribute for.
+    name : str
+        The name of the attribute on the object.
+    name_items : str
+        The name of the items event trait that the trait dict will fire when
+        mutated.
+    """
 
     def __init__(self, trait, object, name, value):
         self.trait = trait

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class TraitDictEvent(object):
-    """ An object reporting in-place changes to a traits dicts.
+    """ An object reporting in-place changes to a traits dict.
 
     Parameters
     ----------

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -17,19 +17,31 @@ from .trait_errors import TraitError
 
 class TraitListEvent(object):
     """ An object reporting in-place changes to a traits list.
+
+    Parameters
+    ----------
+    index : int or slice
+        An index or slice indicating the location of the changes to the list.
+    added : list or None
+        The list of values added to the list, or optionally None if nothing
+        is added.
+    removed : list or None
+        The list of values removed from the list, or optionally None if
+        nothing is removed.
+
+    Attributes
+    ----------
+    index : int or slice
+        An index or slice indicating the location of the changes to the list.
+    added : list
+        The list of values added to the list.  If nothing was added this is
+        an empty list.
+    removed : list
+        The list of values removed from the list.  If nothing was removed
+        this is an empty list.
     """
 
     def __init__(self, index=0, removed=None, added=None):
-        """
-        Parameters
-        ----------
-        index : int
-            The location of the first change in the list.
-        added : list
-            The list of values added to the list.
-        removed : list
-            The list of values removed from the list.
-        """
         self.index = index
 
         if removed is None:
@@ -42,7 +54,46 @@ class TraitListEvent(object):
 
 
 class TraitListObject(list):
-    """ A subclass of list that fires trait events when mutated. """
+    """ A subclass of list that fires trait events when mutated.
+
+    This is used by the List trait type, and all values set into a List
+    trait will be copied into a new TraitListObject instance.
+
+    Mutation of the TraitListObject will fire a "name_items" event with
+    appropriate index, added and removed values.  In the case of setting
+    or deleting items with a slice, the index will hold either:
+
+    - the location of the first element changed, if the step is 1.  In
+      this case the last element changed can be inferred from the
+      length of the removed values.
+    - the slice that was used, otherwise.
+
+    Parameters
+    ----------
+    trait : CTrait instance
+        The CTrait instance associated with the attribute that this list
+        has been set to.
+    object : HasTraits instance
+        The HasTraits instance that the list has been set as an attribute for.
+    name : str
+        The name of the attribute on the object.
+    value : list
+        The list of values to initialize the TraitListObject with.
+
+    Attributes
+    ----------
+    trait : CTrait instance
+        The CTrait instance associated with the attribute that this list
+        has been set to.
+    object : weak reference to a HasTraits instance
+        A weak reference to a HasTraits instance that the list has been set
+        as an attribute for.
+    name : str
+        The name of the attribute on the object.
+    name_items : str
+        The name of the items event trait that the trait list will fire when
+        mutated.
+    """
 
     def __init__(self, trait, object, name, value):
         self.trait = trait
@@ -427,6 +478,7 @@ class TraitListObject(list):
             )
 
     def len_error(self, len):
+        """ Utility method that raises an error if length is incorrect. """
         raise TraitError(
             "The '%s' trait of %s instance must be %s, "
             "but you attempted to change its length to %d element%s."

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -16,17 +16,27 @@ from .trait_errors import TraitError
 
 
 class TraitSetEvent(object):
-    """ An object reporting in-place changes to a traits sets. """
+    """ An object reporting in-place changes to a traits sets.
+
+    Parameters
+    ----------
+    added : dict or None
+        New values added to the set, or optionally None if nothing was added.
+    removed : dict or None
+        Old values that were removed, or optionally None if nothing was
+        removed.
+
+    Attributes
+    ----------
+    added : dict
+        New values added to the set. If nothing was added this is an empty
+        set.
+    removed : dict
+        Old values that were removed. If nothing was removed this is an empty
+        set.
+    """
 
     def __init__(self, removed=None, added=None):
-        """
-        Parameters
-        ----------
-        added : dict
-            New values added to the set.
-        removed : dict
-            Old values that were removed.
-        """
         if removed is None:
             removed = set()
         self.removed = removed
@@ -37,7 +47,40 @@ class TraitSetEvent(object):
 
 
 class TraitSetObject(set):
-    """ A subclass of set that fires trait events when mutated. """
+    """ A subclass of set that fires trait events when mutated.
+
+    This is used by the Set trait type, and all values set into a Set
+    trait will be copied into a new TraitSetObject instance.
+
+    Mutation of the TraitSetObject will fire a "name_items" event with
+    appropriate added and removed values.
+
+    Parameters
+    ----------
+    trait : CTrait instance
+        The CTrait instance associated with the attribute that this Set
+        has been set to.
+    object : HasTraits instance
+        The HasTraits instance that the set has been set as an attribute for.
+    name : str
+        The name of the attribute on the object.
+    value : set
+        The set of values to initialize the TraitSetObject with.
+
+    Attributes
+    ----------
+    trait : CTrait instance
+        The CTrait instance associated with the attribute that this set
+        has been set to.
+    object : weak reference to a HasTraits instance
+        A weak reference to a HasTraits instance that the set has been set
+        as an attribute for.
+    name : str
+        The name of the attribute on the object.
+    name_items : str
+        The name of the items event trait that the trait set will fire when
+        mutated.
+    """
 
     def __init__(self, trait, object, name, value):
         self.trait = trait
@@ -62,7 +105,7 @@ class TraitSetObject(set):
             raise excp
 
     def _send_trait_items_event(self, name, event, items_event=None):
-        """ Send a TraitDictEvent to the owning object if there is one.
+        """ Send a TraitSetEvent to the owning object if there is one.
         """
         object = self.object()
         if object is not None:


### PR DESCRIPTION
This PR improves the documentation of the `TraitListObject`, `TraitSetObject` and `TraitDictObject` and the corresponding `TraitListEvent`, `TraitSetEvent` and `TraitDictEvent` classes.

In particular it details the behaviour of `TraitListObject`s which have slices set or deleted.  It also generally improves the documentation of `_<name>_items_changed()` and associated infrastructure.

This should fix #772 (I don't think we should change the behaviour as it will likely break code, but we may want to open a new issue).

Finally, because I needed to test whether new index entries were included, this fixes #809.