### PR TITLE
DOC: Fix module references

### DIFF
--- a/docs/source/traits_api_reference/base_trait_handler.rst
+++ b/docs/source/traits_api_reference/base_trait_handler.rst
@@ -1,5 +1,5 @@
-:mod:`base_trait_handler` Module
-================================
+:mod:`traits.base_trait_handler` Module
+=======================================
 
 .. automodule:: traits.base_trait_handler
     :no-members:

--- a/docs/source/traits_api_reference/constants.rst
+++ b/docs/source/traits_api_reference/constants.rst
@@ -1,5 +1,5 @@
-:mod:`constants` Module
-========================
+:mod:`traits.constants` Module
+==============================
 
 .. automodule:: traits.constants
     :no-members:

--- a/docs/source/traits_api_reference/ctrait.rst
+++ b/docs/source/traits_api_reference/ctrait.rst
@@ -1,5 +1,5 @@
-:mod:`ctrait` Module
-====================
+:mod:`traits.ctrait` Module
+===========================
 
 .. automodule:: traits.ctrait
     :no-members:

--- a/docs/source/traits_api_reference/editor_factories.rst
+++ b/docs/source/traits_api_reference/editor_factories.rst
@@ -1,5 +1,5 @@
-:mod:`editor_factories` Module
-==============================
+:mod:`traits.editor_factories` Module
+=====================================
 
 .. automodule:: traits.editor_factories
     :no-members:

--- a/docs/source/traits_api_reference/has_traits.rst
+++ b/docs/source/traits_api_reference/has_traits.rst
@@ -1,5 +1,5 @@
-:mod:`has_traits` Module
-========================
+:mod:`traits.has_traits` Module
+===============================
 
 .. automodule:: traits.has_traits
     :no-members:

--- a/docs/source/traits_api_reference/index.rst
+++ b/docs/source/traits_api_reference/index.rst
@@ -39,7 +39,6 @@ Subpackages
 
     traits.adaptation
     traits.etsconfig
-    traits.protocols
     traits.testing
     traits.util
 

--- a/docs/source/traits_api_reference/interface_checker.rst
+++ b/docs/source/traits_api_reference/interface_checker.rst
@@ -1,5 +1,5 @@
-:mod:`interface_checker` Module
-===============================
+:mod:`traits.interface_checker` Module
+======================================
 
 .. automodule:: traits.interface_checker
     :no-members:

--- a/docs/source/traits_api_reference/trait_base.rst
+++ b/docs/source/traits_api_reference/trait_base.rst
@@ -1,5 +1,5 @@
-:mod:`trait_base` Module
-========================
+:mod:`traits.trait_base` Module
+===============================
 
 .. automodule:: traits.trait_base
     :no-members:
@@ -49,6 +49,3 @@ Functions
 .. autofunction:: not_event
 
 .. autofunction:: is_str
-
-
-

--- a/docs/source/traits_api_reference/trait_converters.rst
+++ b/docs/source/traits_api_reference/trait_converters.rst
@@ -1,5 +1,5 @@
-:mod:`trait_converters` Module
-==============================
+:mod:`traits.trait_converters` Module
+=====================================
 
 .. automodule:: traits.trait_converters
     :no-members:

--- a/docs/source/traits_api_reference/trait_dict_object.rst
+++ b/docs/source/traits_api_reference/trait_dict_object.rst
@@ -1,5 +1,5 @@
-:mod:`trait_dict_object` Module
-===============================
+:mod:`traits.trait_dict_object` Module
+======================================
 
 .. automodule:: traits.trait_dict_object
     :no-members:

--- a/docs/source/traits_api_reference/trait_errors.rst
+++ b/docs/source/traits_api_reference/trait_errors.rst
@@ -1,5 +1,5 @@
-:mod:`trait_errors` Module
-==========================
+:mod:`traits.trait_errors` Module
+=================================
 
 .. automodule:: traits.trait_errors
     :no-members:

--- a/docs/source/traits_api_reference/trait_factory.rst
+++ b/docs/source/traits_api_reference/trait_factory.rst
@@ -1,5 +1,5 @@
-:mod:`trait_factory` Module
-===========================
+:mod:`traits.trait_factory` Module
+==================================
 
 .. automodule:: traits.trait_factory
     :no-members:

--- a/docs/source/traits_api_reference/trait_handler.rst
+++ b/docs/source/traits_api_reference/trait_handler.rst
@@ -1,5 +1,5 @@
-:mod:`trait_handler` Module
-============================
+:mod:`traits.trait_handler` Module
+==================================
 
 .. automodule:: traits.trait_handler
     :no-members:

--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -1,5 +1,5 @@
-:mod:`trait_handlers` Module
-============================
+:mod:`traits.trait_handlers` Module
+===================================
 
 .. automodule:: traits.trait_handlers
     :no-members:

--- a/docs/source/traits_api_reference/trait_list_object.rst
+++ b/docs/source/traits_api_reference/trait_list_object.rst
@@ -1,5 +1,5 @@
-:mod:`trait_list_object` Module
-===============================
+:mod:`traits.trait_list_object` Module
+======================================
 
 .. automodule:: traits.trait_list_object
     :no-members:

--- a/docs/source/traits_api_reference/trait_notifiers.rst
+++ b/docs/source/traits_api_reference/trait_notifiers.rst
@@ -1,5 +1,5 @@
-:mod:`trait_notifiers` Module
-=============================
+:mod:`traits.trait_notifiers` Module
+====================================
 
 .. automodule:: traits.trait_notifiers
     :no-members:

--- a/docs/source/traits_api_reference/trait_numeric.rst
+++ b/docs/source/traits_api_reference/trait_numeric.rst
@@ -1,5 +1,5 @@
-:mod:`trait_numeric` Module
-===========================
+:mod:`traits.trait_numeric` Module
+==================================
 
 .. automodule:: traits.trait_numeric
     :no-members:
@@ -19,4 +19,3 @@ Function
 --------
 
 .. autofunction:: dtype2trait
-

--- a/docs/source/traits_api_reference/trait_set_object.rst
+++ b/docs/source/traits_api_reference/trait_set_object.rst
@@ -1,5 +1,5 @@
-:mod:`trait_set_object` Module
-==============================
+:mod:`traits.trait_set_object` Module
+=====================================
 
 .. automodule:: traits.trait_set_object
     :no-members:
@@ -10,4 +10,3 @@ Classes
 .. autoclass:: TraitSetEvent
 
 .. autoclass:: TraitSetObject
-

--- a/docs/source/traits_api_reference/trait_type.rst
+++ b/docs/source/traits_api_reference/trait_type.rst
@@ -1,5 +1,5 @@
-:mod:`trait_type` Module
-========================
+:mod:`traits.trait_type` Module
+===============================
 
 .. automodule:: traits.trait_type
     :no-members:

--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -1,5 +1,5 @@
-:mod:`trait_types` Module
-=========================
+:mod:`traits.trait_types` Module
+================================
 
 .. automodule:: traits.trait_types
     :no-members:

--- a/docs/source/traits_api_reference/traits.adaptation.rst
+++ b/docs/source/traits_api_reference/traits.adaptation.rst
@@ -1,6 +1,11 @@
 :mod:`traits.adaptation` Package
 ================================
 
+.. automodule:: traits.adaptation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`traits.adaptation.adaptation_error` Module
 ------------------------------------------------
 

--- a/docs/source/traits_api_reference/traits.adaptation.rst
+++ b/docs/source/traits_api_reference/traits.adaptation.rst
@@ -1,24 +1,16 @@
-:mod:`adaptation` Package
-=========================
+:mod:`traits.adaptation` Package
+================================
 
-:mod:`adaptation` Package
--------------------------
-
-.. automodule:: traits.adaptation
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-:mod:`adaptation_error` Module
-------------------------------
+:mod:`traits.adaptation.adaptation_error` Module
+------------------------------------------------
 
 .. automodule:: traits.adaptation.adaptation_error
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`adaptation_manager` Module
---------------------------------
+:mod:`traits.adaptation.adaptation_manager` Module
+--------------------------------------------------
 
 .. automodule:: traits.adaptation.adaptation_manager
     :members:
@@ -26,16 +18,16 @@
     :show-inheritance:
 
 
-:mod:`adaptation_offer` Module
-------------------------------
+:mod:`traits.adaptation.adaptation_offer` Module
+------------------------------------------------
 
 .. automodule:: traits.adaptation.adaptation_offer
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`adapter` Module
----------------------
+:mod:`traits.adaptation.adapter` Module
+---------------------------------------
 
 .. automodule:: traits.adaptation.adapter
     :members:

--- a/docs/source/traits_api_reference/traits.etsconfig.rst
+++ b/docs/source/traits_api_reference/traits.etsconfig.rst
@@ -1,6 +1,9 @@
 :mod:`traits.etsconfig` Package
 ===============================
 
+.. automodule:: traits.etsconfig
+    :no-members:
+
 :mod:`traits.etsconfig.etsconfig` Module
 ----------------------------------------
 

--- a/docs/source/traits_api_reference/traits.etsconfig.rst
+++ b/docs/source/traits_api_reference/traits.etsconfig.rst
@@ -1,14 +1,8 @@
-:mod:`etsconfig` Package
-========================
+:mod:`traits.etsconfig` Package
+===============================
 
-:mod:`etsconfig` Package
-------------------------
-
-.. automodule:: traits.etsconfig
-    :no-members:
-
-:mod:`etsconfig` Module
------------------------
+:mod:`traits.etsconfig.etsconfig` Module
+----------------------------------------
 
 .. automodule:: traits.etsconfig.etsconfig
     :no-members:

--- a/docs/source/traits_api_reference/traits.protocols.rst
+++ b/docs/source/traits_api_reference/traits.protocols.rst
@@ -1,4 +1,0 @@
-:mod:`protocols` Package
-========================
-
-.. note:: The :mod:`traits.protocols` package is removed.  Use the :mod:`traits.adaptation` package instead in new code.

--- a/docs/source/traits_api_reference/traits.rst
+++ b/docs/source/traits_api_reference/traits.rst
@@ -1,5 +1,5 @@
-:mod:`traits` Module
-====================
+:mod:`traits.traits` Module
+===========================
 
 .. automodule:: traits.traits
     :no-members:

--- a/docs/source/traits_api_reference/traits.testing.rst
+++ b/docs/source/traits_api_reference/traits.testing.rst
@@ -6,24 +6,32 @@
     :undoc-members:
     :show-inheritance:
 
-:mod:`doctest_tools` Module
----------------------------
+:mod:`traits.testing.doctest_tools` Module
+------------------------------------------
 
 .. automodule:: traits.testing.doctest_tools
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`nose_tools` Module
-------------------------
+:mod:`traits.testing.nose_tools` Module
+---------------------------------------
 
 .. automodule:: traits.testing.nose_tools
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`trait_assert_tools` Module
---------------------------------
+:mod:`traits.testing.optional_dependencies` Module
+--------------------------------------------------
+
+.. automodule:: traits.testing.optional_dependencies
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+:mod:`traits.testing.unittest_tools` Module
+-------------------------------------------
 
 .. automodule:: traits.testing.unittest_tools
     :members:

--- a/docs/source/traits_api_reference/traits.testing.rst
+++ b/docs/source/traits_api_reference/traits.testing.rst
@@ -1,6 +1,11 @@
 :mod:`traits.testing` Package
 =============================
 
+.. automodule:: traits.testing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`doctest_tools` Module
 ---------------------------
 

--- a/docs/source/traits_api_reference/traits.testing.rst
+++ b/docs/source/traits_api_reference/traits.testing.rst
@@ -1,13 +1,5 @@
-:mod:`testing` Package
-======================
-
-:mod:`testing` Package
-----------------------
-
-.. automodule:: traits.testing
-    :members:
-    :undoc-members:
-    :show-inheritance:
+:mod:`traits.testing` Package
+=============================
 
 :mod:`doctest_tools` Module
 ---------------------------

--- a/docs/source/traits_api_reference/traits.util.rst
+++ b/docs/source/traits_api_reference/traits.util.rst
@@ -1,6 +1,11 @@
 :mod:`traits.util` Package
 ==========================
 
+.. automodule:: traits.util
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`async_trait_wait` Module
 ------------------------------
 

--- a/docs/source/traits_api_reference/traits.util.rst
+++ b/docs/source/traits_api_reference/traits.util.rst
@@ -1,13 +1,5 @@
-:mod:`util` Package
-===================
-
-:mod:`util` Package
--------------------
-
-.. automodule:: traits.util
-    :members:
-    :undoc-members:
-    :show-inheritance:
+:mod:`traits.util` Package
+==========================
 
 :mod:`async_trait_wait` Module
 ------------------------------

--- a/docs/source/traits_api_reference/traits.util.rst
+++ b/docs/source/traits_api_reference/traits.util.rst
@@ -6,80 +6,80 @@
     :undoc-members:
     :show-inheritance:
 
-:mod:`async_trait_wait` Module
-------------------------------
+:mod:`traits.util.async_trait_wait` Module
+------------------------------------------
 
 .. automodule:: traits.util.async_trait_wait
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`camel_case` Module
-------------------------
+:mod:`traits.util.camel_case` Module
+------------------------------------
 
 .. automodule:: traits.util.camel_case
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`clean_strings` Module
----------------------------
+:mod:`traits.util.clean_strings` Module
+---------------------------------------
 
 .. automodule:: traits.util.clean_strings
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`deprecated` Module
-------------------------
+:mod:`traits.util.deprecated` Module
+------------------------------------
 
 .. automodule:: traits.util.deprecated
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`home_directory` Module
-----------------------------
+:mod:`traits.util.home_directory` Module
+----------------------------------------
 
 .. automodule:: traits.util.home_directory
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`resource` Module
-----------------------
+:mod:`traits.util.resource` Module
+----------------------------------
 
 .. automodule:: traits.util.resource
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`import_symbol` Module
------------------------------
+:mod:`traits.util.import_symbol` Module
+---------------------------------------
 
 .. automodule:: traits.util.import_symbol
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`toposort` Module
-----------------------
+:mod:`traits.util.toposort` Module
+----------------------------------
 
 .. automodule:: traits.util.toposort
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`trait_documenter` Module
-------------------------------
+:mod:`traits.util.trait_documenter` Module
+------------------------------------------
 
 .. automodule:: traits.util.trait_documenter
     :members:
     :undoc-members:
     :show-inheritance:
 
-:mod:`event_tracer` Module
-------------------------------
+:mod:`traits.util.event_tracer` Module
+--------------------------------------
 
 .. automodule:: traits.util.event_tracer
     :members:

--- a/docs/source/traits_api_reference/traits_listener.rst
+++ b/docs/source/traits_api_reference/traits_listener.rst
@@ -1,8 +1,7 @@
-:mod:`traits_listener` Module
-=============================
+:mod:`traits.traits_listener` Module
+====================================
 
 .. automodule:: traits.traits_listener
     :members:
     :undoc-members:
     :show-inheritance:
-

--- a/docs/source/traits_api_reference/version.rst
+++ b/docs/source/traits_api_reference/version.rst
@@ -1,5 +1,5 @@
-:mod:`version` Module
-=====================
+:mod:`traits.version` Module
+============================
 
 .. automodule:: traits.version
     :no-members:


### PR DESCRIPTION
Fix module references in the API documentation. Module titles are now of the form "traits.trait_types" rather than simply "trait_types".  (We could fix the references *and* have the module titles simply be the name of the module, but I prefer having the full package path in the section titles.)

Also:
- Remove the `traits.protocols.rst` stub. The `protocols` package was removed a long time ago, now, and is ancient history.
- Remove the extra section titles for the traits subpackages (`traits.testing`, `traits.adaptation`, ...).
- Add missing module `traits.testing.optional_dependencies`