### PR TITLE
Include traits.ctraits in API documentation

### DIFF
--- a/docs/source/traits_api_reference/ctraits.rst
+++ b/docs/source/traits_api_reference/ctraits.rst
@@ -1,0 +1,12 @@
+:mod:`traits.ctraits` Module
+============================
+
+.. automodule:: traits.ctraits
+    :no-members:
+
+Classes
+-------
+
+.. autoclass:: CHasTraits
+
+.. autoclass:: cTrait

--- a/docs/source/traits_api_reference/index.rst
+++ b/docs/source/traits_api_reference/index.rst
@@ -13,6 +13,7 @@ Traits core
     base_trait_handler
     constants
     ctrait
+    ctraits
     editor_factories
     interface_checker
     trait_base


### PR DESCRIPTION
This PR adds `traits.ctraits` to the API documentation.

Note that the module section title in this PR is inconsistent with master, but consistent with the changes in #823.

Closes #822 