### PR TITLE
Revert Enum default computation

### DIFF
--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -212,11 +212,11 @@ def safe_contains(value, container):
 
 
 def enum_default(values):
-    """ Get the first item of an EnumType, returning None if empty.
+    """ Get a default value from the valid values of an Enum trait.
 
     Parameters
     ----------
-    values : EnumType
+    values : tuple, list or enum.Enum
         The collection of valid values for an enum trait.
 
     Returns
@@ -225,7 +225,6 @@ def enum_default(values):
         The first valid value, or None if the collection is empty.
     """
     if isinstance(values, enum.EnumMeta):
-        # XXX special-case enum.Enums; generalize to Collections?
         default = next(iter(values), None)
     elif len(values) > 0:
         default = values[0]

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -211,20 +211,27 @@ def safe_contains(value, container):
         return False
 
 
-def collection_default(collection):
-    """ Get the first item of a collection, returning None if empty.
+def enum_default(values):
+    """ Get the first item of an EnumType, returning None if empty.
 
     Parameters
     ----------
-    collection : collection
-        A Python collection, which is presumed to be repeatably iterable.
+    values : EnumType
+        The collection of valid values for an enum trait.
 
     Returns
     -------
     default : any
-        The first item of the collection, or None if the collection is empty.
+        The first valid value, or None if the collection is empty.
     """
-    return next(iter(collection), None)
+    if isinstance(values, enum.EnumMeta):
+        # XXX special-case enum.Enums; generalize to Collections?
+        default = next(iter(values), None)
+    elif len(values) > 0:
+        default = values[0]
+    else:
+        default = None
+    return default
 
 
 # -------------------------------------------------------------------------------

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -35,7 +35,7 @@ from .trait_base import (
     get_module_name,
     HandleWeakRef,
     class_of,
-    collection_default,
+    enum_default,
     EnumTypes,
     RangeTypes,
     safe_contains,
@@ -1996,7 +1996,7 @@ class BaseEnum(TraitType):
             default_value = args[0]
             if (len(args) == 1) and isinstance(default_value, EnumTypes):
                 args = default_value
-                default_value = collection_default(args)
+                default_value = enum_default(args)
             elif (len(args) == 2) and isinstance(args[1], EnumTypes):
                 args = args[1]
 
@@ -2059,7 +2059,7 @@ class BaseEnum(TraitType):
         value = self.get_value(object, name, trait)
         values = xgetattr(object, self.name)
         if not safe_contains(value, values):
-            value = collection_default(values)
+            value = enum_default(values)
         return value
 
     def _set(self, object, name, value):


### PR DESCRIPTION
Revert enum defaults to using index 0 except for `enum.Enum`s, which instead use the first value returned from the iterator.

This restores the default behaviour to exactly what it was before the introduction of support for `enum.Enum` other than special-casing default values for `enum.Enum`.