### PR TITLE
Change Property API

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4951,7 +4951,8 @@ PyDoc_STRVAR(
     "    Whether to modify the delegate when the value of this trait\n"
     "    is modified.\n");
 
-PyDoc_STVAR(set_property_doc,
+PyDoc_STRVAR(
+    set_property_doc,
     "set_property(get, set, validate)\n"
     "\n"
     "Set property fields for this trait.\n"
@@ -4993,7 +4994,8 @@ PyDoc_STVAR(set_property_doc,
     "    - a triple of arguments ``obj, name, value``\n"
     "\n");
 
-PyDoc_STVAR(get_property_doc,
+PyDoc_STRVAR(
+    get_property_doc,
     "get_property()\n"
     "\n"
     "Get the property fields for this trait.\n"

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -5063,7 +5063,7 @@ static PyMethodDef trait_methods[] = {
      get_validate_doc},
     {"validate", (PyCFunction)_trait_validate, METH_VARARGS, validate_doc},
     {"delegate", (PyCFunction)_trait_delegate, METH_VARARGS,
-     PyDoc_STR("delegate(delegate_name,prefix,prefix_type,modify_delegate)")},
+     delegate_doc},
     {"set_property", (PyCFunction)_trait_set_property, METH_VARARGS,
      set_property_doc},
     {"get_property", (PyCFunction)_trait_get_property, METH_VARARGS,

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4951,21 +4951,12 @@ PyDoc_STRVAR(
     "    Whether to modify the delegate when the value of this trait\n"
     "    is modified.\n");
 
-PyDoc_STRVAR(
-    property_doc,
-    "property()\n"
-    "property(get, get_n, set, set_n, validate, validate_n)\n"
+PyDoc_STVAR(set_property_doc,
+    "set_property(get, set, validate)\n"
     "\n"
-    "Get or set property fields for this trait.\n"
+    "Set property fields for this trait.\n"
     "\n"
-    "When called with no arguments on a property trait, this method returns a\n"
-    "tuple (get, set, validate) of length 3 containing the getter, setter and\n"
-    "validator for this property trait.\n"
-    "\n"
-    "When called with no arguments on a non-property trait, this method\n"
-    "returns *None*.\n"
-    "\n"
-    "Otherwise, the *property* method expects six arguments, and uses these\n"
+    "The *set_property* method expects three arguments, and uses these\n"
     "arguments to set the get, set and validation for the trait. It also\n"
     "sets the property flag on the trait.\n"
     "\n"
@@ -4981,9 +4972,6 @@ PyDoc_STRVAR(
     "    - a pair of arguments ``obj, name``\n"
     "    - a triple of arguments ``obj, name, trait``\n"
     "\n"
-    "get_n : int\n"
-    "    Number of arguments to supply to the getter. This should be\n"
-    "    between 0 and 3, inclusive.\n"
     "set : callable\n"
     "    Function called when setting the value of this property trait.\n"
     "    This function will be called with one of the following argument\n"
@@ -4994,9 +4982,6 @@ PyDoc_STRVAR(
     "    - a pair of arguments ``obj, value``\n"
     "    - a triple of arguments ``obj, name, value``\n"
     "\n"
-    "set_n : int\n"
-    "    Number of arguments to supply to the setter. This should be\n"
-    "    between 0 and 3, inclusive.\n"
     "validate : callable or None\n"
     "    Function called for validation. This function will be called\n"
     "    with one of the following argument combinations, depending on\n"
@@ -5006,10 +4991,19 @@ PyDoc_STRVAR(
     "    - a single argument ``value``\n"
     "    - a pair of arguments ``obj, value``\n"
     "    - a triple of arguments ``obj, name, value``\n"
+    "\n");
+
+PyDoc_STVAR(get_property_doc,
+    "get_property()\n"
     "\n"
-    "validate_n : int\n"
-    "    Number of arguments to supply to the validator. This should be\n"
-    "    between 0 and 3, inclusive.\n");
+    "Get the property fields for this trait.\n"
+    "\n"
+    "When called with no arguments on a property trait, this method returns a\n"
+    "tuple (get, set, validate) of length 3 containing the getter, setter and\n"
+    "validator for this property trait.\n"
+    "\n"
+    "When called with no arguments on a non-property trait, this method\n"
+    "returns *None*.\n");
 
 PyDoc_STRVAR(
     clone_doc,
@@ -5069,9 +5063,9 @@ static PyMethodDef trait_methods[] = {
     {"delegate", (PyCFunction)_trait_delegate, METH_VARARGS,
      PyDoc_STR("delegate(delegate_name,prefix,prefix_type,modify_delegate)")},
     {"set_property", (PyCFunction)_trait_set_property, METH_VARARGS,
-     PyDoc_STR("set_property(get,set,validate)")},
+     set_property_doc},
     {"get_property", (PyCFunction)_trait_get_property, METH_VARARGS,
-     PyDoc_STR("get_property()")},
+     get_property_doc},
     {"clone", (PyCFunction)_trait_clone, METH_VARARGS,
      clone_doc},
     {"_notifiers", (PyCFunction)_trait_notifiers, METH_VARARGS,

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -573,7 +573,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
         # Merge base traits:
         for name, value in base_dict.get(BaseTraits).items():
             if name not in base_traits:
-                property_info = value.property()
+                property_info = value.get_property()
                 if property_info is not None:
                     key = id(value)
                     migrated_properties[key] = value = migrate_property(
@@ -584,7 +584,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
         # Merge class traits:
         for name, value in base_dict.get(ClassTraits).items():
             if name not in class_traits:
-                property_info = value.property()
+                property_info = value.get_property()
                 if property_info is not None:
                     new_value = migrated_properties.get(id(value))
                     if new_value is not None:

--- a/traits/tests/test_copyable_trait_names.py
+++ b/traits/tests/test_copyable_trait_names.py
@@ -105,7 +105,7 @@ class TestCopyableTraitNameQueries(unittest.TestCase):
 
     def test_property_query(self):
         names = self.foo.copyable_trait_names(
-            **{"property": lambda p: p() and p()[1].__name__ == "_set_p"}
+            **{"get_property": lambda p: p() and p()[1].__name__ == "_set_p"}
         )
 
         self.assertEqual(["p"], names)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -80,7 +80,7 @@ class TestCTrait(unittest.TestCase):
 
         self.assertFalse(trait.is_property)
 
-        trait.property(getter, 0, setter, 1, validator, 1)
+        trait.set_property(getter, setter, validator)
 
         self.assertTrue(trait.is_property)
 
@@ -188,3 +188,28 @@ class TestCTrait(unittest.TestCase):
 
         self.assertIsInstance(trait.comparison_mode, ComparisonMode)
         self.assertEqual(trait.comparison_mode, ComparisonMode.equality)
+
+    def test_set_property(self):
+        trait = CTrait(TraitKind.trait)
+
+        def __value_get(self):
+            return self.__dict__.get("_value", 0)
+
+        def __value_set(self, value):
+            old_value = self.__dict__.get("_value", 0)
+            if value != old_value:
+                self._value = value
+                self.trait_property_changed("value", old_value, value)
+
+        trait.set_property(__value_get, __value_set, None)
+
+    def test_set_invalid_property(self):
+        trait = CTrait(TraitKind.trait)
+
+        with self.assertRaises(ValueError):
+            trait.set_property()
+
+    def test_get_property(self):
+        trait = CTrait(TraitKind.trait)
+
+        self.assertIsNone(trait.get_property())

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -170,7 +170,7 @@ class TestRegression(unittest.TestCase):
             prop = Property()
 
         a = A()
-        self.assertEqual(sys.getrefcount(a.trait("prop").property()), 1)
+        self.assertEqual(sys.getrefcount(a.trait("prop").get_property()), 1)
 
     def test_delegate_initializer(self):
         mess = DelegateMess()

--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -381,17 +381,11 @@ class TraitType(BaseTraitHandler):
                 setter = _read_only
                 metadata.setdefault("transient", True)
             trait = CTrait(TraitKind.property)
-            n = 0
             validate = getattr(self, "validate", None)
-            if validate is not None:
-                n = _arg_count(validate)
-            trait.property(
+            trait.set_property(
                 getter,
-                _arg_count(getter),
                 setter,
-                _arg_count(setter),
                 validate,
-                n,
             )
             metadata.setdefault("type", "property")
         else:

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -59,7 +59,6 @@ from .trait_converters import (
 
 from .trait_handler import TraitHandler
 from .trait_type import (
-    _arg_count,
     _infer_default_value_type,
     _read_only,
     _write_only,
@@ -656,14 +655,11 @@ def Property(
     ):
         metadata.setdefault("cached", True)
 
-    n = 0
     trait = CTrait(TraitKind.property)
     trait.__dict__ = metadata.copy()
-    if fvalidate is not None:
-        n = _arg_count(fvalidate)
 
-    trait.property(
-        fget, _arg_count(fget), fset, _arg_count(fset), fvalidate, n
+    trait.set_property(
+        fget, fset, fvalidate
     )
     trait.handler = handler
 


### PR DESCRIPTION
Fixes #825 , #673 

This PR makes changes to a `Property` trait's setter and getter API. It removes the `property` method (which had a dual purpose as a setter and a getter) while introducing two new methods `set_property` and `get_property` which together offer the same functionality.

When `get_property` is called on a `Property` trait, it returns a tuple (delegate_name, delegate_prefix, py_validate) for the trait. It returns a `None` for every other trait. In the old API, this is equal to calling `property()` with no arguments on a `Property` trait, code is unchanged.

The method `set_property` can be used to set the values of the trait's `setattr` , `getattr` and `validate` handlers. Also, the names of these callables are assigned to `delegate_name`, `delegate_prefix` and `py_validate` for the trait. 

Unlike in the old API, where using `property` to set values required passing in 6 arguments (`getter`, `n_getter_args`, `setter`, `n_setter_args`, `validator`, `n_validator_args`), This API only requires 3 arguments which are callables:  setter, getter and validate functions. It automatically introspects the callables to determine the number of arguments for each of the functions. 

It achieves this with the help of a helper function `_get_callable_argument_count` which uses the Python/C api and handles 3 different cases; callables that are python methods bound to some object, python functions, callables that do not belong to the previous 2 categories (Eg: Cython functions).
Essentially, this helper function does the same thing as `traits.trait_type._arg_count(func)`.

Once the argument count is determined, the code flow is indifferent from the old setter API.


These changes are not backward compatible.
This PR also makes changes to `traits/trait_types.py` and `traits/traits.py` that used to previously rely on `_arg_count(func)` for argument counting.
Tests have also been changed to suit the new API.