### PR TITLE
Improved API documentation for trait_types

### DIFF
--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -8,163 +8,238 @@ Traits
 ------
 
 .. autoclass:: Any
+   :show-inheritance:
 
 .. autoclass:: BaseInt
+   :show-inheritance:
 
 .. autoclass:: Int
+   :show-inheritance:
 
 .. autoclass:: BaseFloat
+   :show-inheritance:
 
 .. autoclass:: Float
+   :show-inheritance:
 
 .. autoclass:: BaseComplex
+   :show-inheritance:
 
 .. autoclass:: Complex
+   :show-inheritance:
 
 .. autoclass:: BaseStr
+   :show-inheritance:
 
 .. autoclass:: Str
+   :show-inheritance:
 
 .. autoclass:: Title
+   :show-inheritance:
 
 .. autoclass:: BaseBytes
+   :show-inheritance:
 
 .. autoclass:: Bytes
+   :show-inheritance:
 
 .. autoclass:: BaseBool
+   :show-inheritance:
 
 .. autoclass:: Bool
+   :show-inheritance:
 
 .. autoclass:: BaseCInt
+   :show-inheritance:
 
 .. autoclass:: CInt
+   :show-inheritance:
 
 .. autoclass:: BaseCFloat
+   :show-inheritance:
 
 .. autoclass:: CFloat
+   :show-inheritance:
 
 .. autoclass:: BaseCComplex
+   :show-inheritance:
 
 .. autoclass:: CComplex
+   :show-inheritance:
 
 .. autoclass:: BaseCStr
+   :show-inheritance:
 
 .. autoclass:: CStr
+   :show-inheritance:
 
 .. autoclass:: BaseCBytes
+   :show-inheritance:
 
 .. autoclass:: CBytes
+   :show-inheritance:
 
 .. autoclass:: BaseCBool
+   :show-inheritance:
 
 .. autoclass:: CBool
+   :show-inheritance:
 
 .. autoclass:: String
+   :show-inheritance:
 
 .. autoclass:: Regex
+   :show-inheritance:
 
 .. autoclass:: Code
+   :show-inheritance:
 
 .. autoclass:: HTML
+   :show-inheritance:
 
 .. autoclass:: Password
+   :show-inheritance:
 
 .. autoclass:: BaseCallable
+   :show-inheritance:
 
 .. autoclass:: Callable
+   :show-inheritance:
 
 .. autoclass:: BaseType
+   :show-inheritance:
 
 .. autoclass:: This
+   :show-inheritance:
 
 .. autoclass:: self
+   :show-inheritance:
 
 .. autoclass:: Function
+   :show-inheritance:
 
 .. autoclass:: Method
+   :show-inheritance:
 
 .. autoclass:: Module
+   :show-inheritance:
 
 .. autoclass:: Python
+   :show-inheritance:
 
 .. autoclass:: ReadOnly
+   :show-inheritance:
 
 .. autoclass:: Disallow
+   :show-inheritance:
 
 .. autoclass:: Constant
+   :show-inheritance:
 
 .. autoclass:: Delegate
+   :show-inheritance:
 
 .. autoclass:: DelegatesTo
+   :show-inheritance:
 
 .. autoclass:: PrototypedFrom
+   :show-inheritance:
 
 .. autoclass:: Expression
+   :show-inheritance:
 
 .. autoclass:: PythonValue
+   :show-inheritance:
 
 .. autoclass:: BaseFile
+   :show-inheritance:
 
 .. autoclass:: File
+   :show-inheritance:
 
 .. autoclass:: BaseDirectory
+   :show-inheritance:
 
 .. autoclass:: Directory
+   :show-inheritance:
 
 .. autoclass:: BaseRange
+   :show-inheritance:
 
 .. autoclass:: Range
+   :show-inheritance:
 
 .. autoclass:: BaseEnum
+   :show-inheritance:
 
 .. autoclass:: Enum
+   :show-inheritance:
 
 .. autoclass:: BaseTuple
-   :special-members: __init__
+   :show-inheritance:
 
 .. autoclass:: Tuple
+   :show-inheritance:
 
 .. autoclass:: ValidatedTuple
-   :special-members: __init__
+   :show-inheritance:
 
 .. autoclass:: List
+   :show-inheritance:
 
 .. autoclass:: CList
+   :show-inheritance:
 
 .. autoclass:: Set
+   :show-inheritance:
 
 .. autoclass:: CSet
+   :show-inheritance:
 
 .. autoclass:: Dict
+   :show-inheritance:
 
 .. autoclass:: BaseClass
+   :show-inheritance:
 
 .. autoclass:: BaseInstance
+   :show-inheritance:
 
 .. autoclass:: Instance
+   :show-inheritance:
 
 .. autoclass:: Supports
+   :show-inheritance:
 
 .. autoclass:: AdaptsTo
+   :show-inheritance:
 
 .. autoclass:: Type
+   :show-inheritance:
 
 .. autoclass:: Subclass
+   :show-inheritance:
 
 .. autoclass:: Event
+   :show-inheritance:
 
 .. autoclass:: Button
+   :show-inheritance:
 
 .. autoclass:: ToolbarButton
+   :show-inheritance:
 
 .. autoclass:: Either
+   :show-inheritance:
 
 .. autoclass:: Symbol
+   :show-inheritance:
 
 .. autoclass:: UUID
+   :show-inheritance:
 
 .. autoclass:: WeakRef
-    :members: __init__
+   :show-inheritance:
 
 .. autodata:: Date
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -127,7 +127,7 @@ except ImportError:
 
 
 def default_text_editor(trait, type=None):
-    """ Returns a default text editor for a trait.
+    """ Return a default text editor for a trait.
 
     Parameters
     ----------

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -231,7 +231,7 @@ class BaseInt(TraitType):
 class Int(BaseInt):
     """ A fast-validating trait type whose value must be an integer.
 
-    Values which support the Python index protocol will validated and will be
+    Values which support the Python index protocol will validate and will be
     converted to the corresponding int value.
     """
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -11,10 +11,6 @@
 """ Core Trait definitions.
 """
 
-# -------------------------------------------------------------------------------
-#  Imports:
-# -------------------------------------------------------------------------------
-
 import datetime
 import enum
 from importlib import import_module
@@ -129,12 +125,23 @@ except ImportError:
     # Tuple or single type suitable for an isinstance check.
     _BOOL_TYPES = bool
 
-# -------------------------------------------------------------------------------
-#  Returns a default text editor:
-# -------------------------------------------------------------------------------
-
 
 def default_text_editor(trait, type=None):
+    """ Returns a default text editor for a trait.
+
+    Parameters
+    ----------
+    trait : TraitType
+        The trait we are constructing the editor for.
+    type : callable or None
+        A callable (usually a Python type) to use to evaluate the text content
+        of the editor and return the correct type of value for the trait.
+
+    Returns
+    -------
+    TextEditor
+        A TraitsUI TextEditor instance for the trait.
+    """
     auto_set = trait.auto_set
     if auto_set is None:
         auto_set = True
@@ -149,11 +156,12 @@ def default_text_editor(trait, type=None):
     return TextEditor(auto_set=auto_set, enter_set=enter_set, evaluate=type)
 
 
+# -------------------------------------------------------------------------------
 # Generic validators
+# -------------------------------------------------------------------------------
 
 def _validate_int(value):
-    """
-    Convert an integer-like Python object to an int, or raise TypeError.
+    """ Convert an integer-like Python object to an int, or raise TypeError.
     """
     if type(value) is int:
         return value
@@ -162,8 +170,7 @@ def _validate_int(value):
 
 
 def _validate_float(value):
-    """
-    Convert an arbitrary Python object to a float, or raise TypeError.
+    """ Convert an arbitrary Python object to a float, or raise TypeError.
     """
     if type(value) is float:  # fast path for common case
         return value
@@ -177,9 +184,8 @@ def _validate_float(value):
 
 
 # -------------------------------------------------------------------------------
-#  'Any' trait:
+# Trait Types
 # -------------------------------------------------------------------------------
-
 
 class Any(TraitType):
     """ Defines a trait whose value can be anything.
@@ -190,11 +196,6 @@ class Any(TraitType):
 
     #: A description of the type of value this trait accepts:
     info_text = "any value"
-
-
-# -------------------------------------------------------------------------------
-#  'BaseInt' and 'Int' traits:
-# -------------------------------------------------------------------------------
 
 
 class BaseInt(TraitType):
@@ -225,17 +226,11 @@ class BaseInt(TraitType):
 
 
 class Int(BaseInt):
-    """ Defines a trait whose type must be an integer using a C-level fast
-        validator.
+    """ Defines trait that holds an int and uses a C-level fast validator.
     """
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.int,)
-
-
-# -------------------------------------------------------------------------------
-#  'BaseFloat' and 'Float' traits:
-# -------------------------------------------------------------------------------
 
 
 class BaseFloat(TraitType):
@@ -254,7 +249,7 @@ class BaseFloat(TraitType):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         try:
             return _validate_float(value)
@@ -268,17 +263,11 @@ class BaseFloat(TraitType):
 
 
 class Float(BaseFloat):
-    """ Defines a trait whose value must be a Python float using a C-level fast
-        validator.
+    """ Defines a trait that holds a float and uses a C-level fast validator.
     """
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.float,)
-
-
-# -------------------------------------------------------------------------------
-#  'BaseComplex' and 'Complex' traits:
-# -------------------------------------------------------------------------------
 
 
 class BaseComplex(TraitType):
@@ -297,7 +286,7 @@ class BaseComplex(TraitType):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         if isinstance(value, complex):
             return value
@@ -314,17 +303,11 @@ class BaseComplex(TraitType):
 
 
 class Complex(BaseComplex):
-    """ Defines a trait whose value must be a Python complex using a C-level
-        fast validator.
+    """ Defines a trait that holds a complex and uses a C-level fast validator.
     """
 
     #: The C-level fast validator to use:
     fast_validate = complex_fast_validate
-
-
-# -------------------------------------------------------------------------------
-#  'BaseStr' and 'Str' traits:
-# -------------------------------------------------------------------------------
 
 
 class BaseStr(TraitType):
@@ -340,7 +323,7 @@ class BaseStr(TraitType):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         if isinstance(value, str):
             return value
@@ -361,8 +344,7 @@ class BaseStr(TraitType):
 
 
 class Str(BaseStr):
-    """ Defines a trait whose value must be a Python string using a C-level
-        fast validator.
+    """ Defines a trait that holds a str and uses a C-level fast validator.
     """
 
     #: The C-level fast validator to use:
@@ -370,8 +352,7 @@ class Str(BaseStr):
 
 
 class Title(Str):
-    """ Defines a string type which by default uses the traits ui TitleEditor
-        when used in a View.
+    """ A Str trait which by default uses a TraitsUI TitleEditor.
     """
 
     def create_editor(self):
@@ -383,11 +364,6 @@ class Title(Str):
             return TitleEditor(allow_selection=self.allow_selection)
         else:
             return TitleEditor()
-
-
-# -------------------------------------------------------------------------------
-#  'BaseBytes' and 'Bytes' traits:
-# -------------------------------------------------------------------------------
 
 
 class BaseBytes(TraitType):
@@ -406,7 +382,7 @@ class BaseBytes(TraitType):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         if isinstance(value, bytes):
             return value
@@ -427,8 +403,7 @@ class BaseBytes(TraitType):
 
 
 class Bytes(BaseBytes):
-    """ Defines a trait whose value must be a Python bytes string using a
-        C-level fast validator.
+    """ Defines a trait that holds a bytes and uses a C-level fast validator.
     """
 
     #: The C-level fast validator to use:
@@ -456,7 +431,7 @@ class BaseBool(TraitType):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         if isinstance(value, _BOOL_TYPES):
             return bool(value)
@@ -472,22 +447,16 @@ class BaseBool(TraitType):
 
 
 class Bool(BaseBool):
-    """ Defines a trait whose value must be a Python boolean using a C-level
-        fast validator.
+    """ Defines a trait that holds a bool and uses a C-level fast validator.
     """
 
     #: The C-level fast validator to use:
     fast_validate = bool_fast_validate
 
 
-# -------------------------------------------------------------------------------
-#  'BaseCInt' and 'CInt' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseCInt(BaseInt):
     """ Defines a trait whose value must be a Python int and which supports
-        coercions of non-int values to int.
+    coercions of non-int values to int.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -496,7 +465,7 @@ class BaseCInt(BaseInt):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         try:
             return int(value)
@@ -506,21 +475,16 @@ class BaseCInt(BaseInt):
 
 class CInt(BaseCInt):
     """ Defines a trait whose value must be a Python int and which supports
-        coercions of non-int values to int using a C-level fast validator.
+    coercions of non-int values to int using a C-level fast validator.
     """
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.cast, int)
 
 
-# -------------------------------------------------------------------------------
-#  'BaseCFloat' and 'CFloat' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseCFloat(BaseFloat):
     """ Defines a trait whose value must be a Python float and which supports
-        coercions of non-float values to float.
+    coercions of non-float values to float.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -529,7 +493,7 @@ class BaseCFloat(BaseFloat):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         try:
             return float(value)
@@ -539,7 +503,7 @@ class BaseCFloat(BaseFloat):
 
 class CFloat(BaseCFloat):
     """ Defines a trait whose value must be a Python float and which supports
-        coercions of non-float values to float using a C-level fast validator.
+    coercions of non-float values to float using a C-level fast validator.
     """
 
     #: The C-level fast validator to use:
@@ -553,7 +517,7 @@ class CFloat(BaseCFloat):
 
 class BaseCComplex(BaseComplex):
     """ Defines a trait whose value must be a Python complex and which supports
-        coercions of non-complex values to complex.
+    coercions of non-complex values to complex.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -562,7 +526,7 @@ class BaseCComplex(BaseComplex):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         try:
             return complex(value)
@@ -572,8 +536,8 @@ class BaseCComplex(BaseComplex):
 
 class CComplex(BaseCComplex):
     """ Defines a trait whose value must be a Python complex and which supports
-        coercions of non-complex values to complex using a C-level fast
-        validator.
+    coercions of non-complex values to complex using a C-level fast
+    validator.
     """
 
     #: The C-level fast validator to use:
@@ -587,13 +551,13 @@ class CComplex(BaseCComplex):
 
 class BaseCStr(BaseStr):
     """ Defines a trait whose value must be a Python string and which supports
-        coercions of non-string values to string.
+    coercions of non-string values to string.
     """
 
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         try:
             return str(value)
@@ -603,28 +567,23 @@ class BaseCStr(BaseStr):
 
 class CStr(BaseCStr):
     """ Defines a trait whose value must be a Python string and which supports
-        coercions of non-string values to string using a C-level fast
-        validator.
+    coercions of non-string values to string using a C-level fast
+    validator.
     """
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.cast, str)
 
 
-# -------------------------------------------------------------------------------
-#  'BaseCBytes' and 'CBytes' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseCBytes(BaseBytes):
     """ Defines a trait whose value must be a Python bytes object and which
-        supports coercions of non-bytes values to bytes.
+    supports coercions of non-bytes values to bytes.
     """
 
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         try:
             return bytes(value)
@@ -634,22 +593,17 @@ class BaseCBytes(BaseBytes):
 
 class CBytes(BaseCBytes):
     """ Defines a trait whose value must be a Python bytes and which
-        supports coercions of non-bytes values bytes using a C-level
-        fast validator.
+    supports coercions of non-bytes values bytes using a C-level
+    fast validator.
     """
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.cast, bytes)
 
 
-# -------------------------------------------------------------------------------
-#  'BaseCBool' and 'CBool' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseCBool(BaseBool):
     """ Defines a trait whose value must be a Python boolean and which supports
-        coercions of non-boolean values to boolean.
+    coercions of non-boolean values to boolean.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -658,7 +612,7 @@ class BaseCBool(BaseBool):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         try:
             return bool(value)
@@ -668,42 +622,45 @@ class BaseCBool(BaseBool):
 
 class CBool(BaseCBool):
     """ Defines a trait whose value must be a Python boolean and which supports
-        coercions of non-boolean values to boolean using a C-level fast
-        validator.
+    coercions of non-boolean values to boolean using a C-level fast
+    validator.
     """
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.cast, bool)
 
 
-# -------------------------------------------------------------------------------
-#  'String' trait:
-# -------------------------------------------------------------------------------
-
-
 class String(TraitType):
     """ Defines a trait whose value must be a Python string whose length is
-        optionally in a specified range, and which optionally matches a
-        specified regular expression.
+    optionally in a specified range, and which optionally matches a specified
+    regular expression.
+
+    Parameters
+    ----------
+    value : str
+        The default value for the string.
+    minlen : integer
+        The minimum length allowed for the string.
+    maxlen : integer
+        The maximum length allowed for the string.
+    regex : str
+        A Python regular expression that the string must match.
+    **metadata
+        The trait metadata for the trait.
+
+    Attributes
+    ----------
+    minlen : integer
+        The minimum length allowed for the string.
+    maxlen : integer
+        The maximum length allowed for the string.
+    regex : str
+        A Python regular expression that the string must match.
     """
 
     def __init__(
         self, value="", minlen=0, maxlen=sys.maxsize, regex="", **metadata
     ):
-        """ Creates a String trait.
-
-        Parameters
-        ----------
-        value : str
-            The default value for the string.
-        minlen : integer
-            The minimum length allowed for the string.
-        maxlen : integer
-            The maximum length allowed for the string.
-        regex : str
-            A Python regular expression that the string must match.
-
-        """
         super(String, self).__init__(value, **metadata)
         self.minlen = max(0, minlen)
         self.maxlen = max(self.minlen, maxlen)
@@ -712,7 +669,7 @@ class String(TraitType):
 
     def _init(self):
         """ Completes initialization of the trait at construction or unpickling
-            time.
+        time.
         """
         self._validate = "validate_all"
         if self.regex != "":
@@ -756,7 +713,7 @@ class String(TraitType):
 
     def validate_len(self, object, name, value):
         """ Validates that the value is a valid string in the specified length
-            range.
+        range.
         """
         try:
             value = strx(value)
@@ -769,7 +726,7 @@ class String(TraitType):
 
     def validate_regex(self, object, name, value):
         """ Validates that the value is a valid string which matches the
-            specified regular expression.
+        specified regular expression.
         """
         try:
             value = strx(value)
@@ -821,11 +778,6 @@ class String(TraitType):
         self._init()
 
 
-# -------------------------------------------------------------------------------
-#  'Regex' trait:
-# -------------------------------------------------------------------------------
-
-
 class Regex(String):
     """ A trait whose value is a string that matches a regular expression.
 
@@ -845,23 +797,13 @@ class Regex(String):
         super(Regex, self).__init__(value=value, regex=regex, **metadata)
 
 
-# -------------------------------------------------------------------------------
-#  'Code' trait:
-# -------------------------------------------------------------------------------
-
-
 class Code(String):
     """ Defines a trait whose value is a Python string that represents source
-        code in some language.
+    code in some language.
     """
 
     #: The standard metadata for the trait:
     metadata = {"editor": code_editor}
-
-
-# -------------------------------------------------------------------------------
-#  'HTML' trait:
-# -------------------------------------------------------------------------------
 
 
 class HTML(String):
@@ -874,11 +816,6 @@ class HTML(String):
     metadata = {"editor": html_editor}
 
 
-# -------------------------------------------------------------------------------
-#  'Password' trait:
-# -------------------------------------------------------------------------------
-
-
 class Password(String):
     """ Defines a trait whose value must be a string, optionally of constrained
     length or matching a regular expression.
@@ -889,11 +826,6 @@ class Password(String):
 
     #: The standard metadata for the trait:
     metadata = {"editor": password_editor}
-
-
-# -------------------------------------------------------------------------------
-#  'BaseCallable' trait:
-# -------------------------------------------------------------------------------
 
 
 class BaseCallable(TraitType):
@@ -921,11 +853,6 @@ class BaseCallable(TraitType):
         self.error(object, name, value)
 
 
-# -------------------------------------------------------------------------------
-#  'Callable' trait:
-# -------------------------------------------------------------------------------
-
-
 class Callable(BaseCallable):
     """ Defines a trait whose value must be a Python callable using a
     C level validator.
@@ -935,10 +862,6 @@ class Callable(BaseCallable):
 
     #: The C-level fast validator to use
     fast_validate = (ValidateTrait.callable,)
-
-# -------------------------------------------------------------------------------
-#  'BaseType' base class:
-# -------------------------------------------------------------------------------
 
 
 class BaseType(TraitType):
@@ -993,7 +916,7 @@ class This(BaseType):
 
 class self(This):
     """ Defines a trait whose value must be an instance of the defining class
-        and whose default value is the object containing the trait.
+    and whose default value is the object containing the trait.
     """
 
     #: The default value type to use (i.e. 'self'):
@@ -1033,18 +956,14 @@ class Module(TraitType):
     info_text = "a module"
 
 
-# -------------------------------------------------------------------------------
-#  'Python' trait:
-# -------------------------------------------------------------------------------
-
-
 class Python(TraitType):
-    """ Defines a trait that provides behavior identical to a standard Python
-        attribute. That is, it allows any value to be assigned, and raises an
-        ValueError if an attempt is made to get the value before one has been
-        assigned. It has no default value. This trait is most often used in
-        conjunction with wildcard naming. See the *Traits User Manual* for
-        details on wildcards.
+    """ Defines a trait that behaves as to a standard Python attribute.
+
+    That is, it allows any value to be assigned, and raises an
+    ValueError if an attempt is made to get the value before one has been
+    assigned. It has no default value. This trait is most often used in
+    conjunction with wildcard naming. See the *Traits User Manual* for
+    details on wildcards.
     """
 
     #: The standard metadata for the trait:
@@ -1054,21 +973,17 @@ class Python(TraitType):
     default_value = Undefined
 
 
-# -------------------------------------------------------------------------------
-#  'ReadOnly' trait:
-# -------------------------------------------------------------------------------
-
-
 class ReadOnly(TraitType):
     """ Defines a trait that is write-once, and then read-only.
-        The initial value of the attribute is the special, singleton object
-        Undefined. The trait allows any value to be assigned to the attribute
-        if the current value is the Undefined object. Once any other value is
-        assigned, no further assignment is allowed. Normally, the initial
-        assignment to the attribute is performed in the class constructor,
-        based on information passed to the constructor. If the read-only value
-        is known in advance of run time, use the Constant() function instead of
-        ReadOnly to define the trait.
+
+    The initial value of the attribute is the special, singleton object
+    Undefined. The trait allows any value to be assigned to the attribute
+    if the current value is the Undefined object. Once any other value is
+    assigned, no further assignment is allowed. Normally, the initial
+    assignment to the attribute is performed in the class constructor,
+    based on information passed to the constructor. If the read-only value
+    is known in advance of run time, use the Constant() function instead of
+    ReadOnly to define the trait.
     """
 
     # Defines the CTrait type to use for this trait:
@@ -1081,17 +996,14 @@ class ReadOnly(TraitType):
 # Create a singleton instance as the trait:
 ReadOnly = ReadOnly()
 
-# -------------------------------------------------------------------------------
-#  'Disallow' trait:
-# -------------------------------------------------------------------------------
-
 
 class Disallow(TraitType):
     """ Defines a trait that prevents any value from being assigned or read.
-        That is, any attempt to get or set the value of the trait attribute
-        raises an exception. This trait is most often used in conjunction with
-        wildcard naming, for example, to catch spelling mistakes in attribute
-        names. See the *Traits User Manual* for details on wildcards.
+
+    That is, any attempt to get or set the value of the trait attribute
+    raises an exception. This trait is most often used in conjunction with
+    wildcard naming, for example, to catch spelling mistakes in attribute
+    names. See the *Traits User Manual* for details on wildcards.
     """
 
     #: Defines the CTrait type to use for this trait:
@@ -1101,13 +1013,9 @@ class Disallow(TraitType):
 # Create a singleton instance as the trait:
 Disallow = Disallow()
 
-# -------------------------------------------------------------------------------
-#  'Constant' trait:
-# -------------------------------------------------------------------------------
-
 
 class Constant(TraitType):
-    """  Defines a trait whose value is a constant.
+    """ Defines a trait whose value is a constant.
 
     Traits of this type are very space efficient (and fast) because
     *value* is not stored in each instance using the trait, but only in
@@ -1118,6 +1026,8 @@ class Constant(TraitType):
     ----------
     value : any type other than list or dict
         The constant value for the trait.
+    **metadata
+        Trait metadata for the trait.
     """
 
     #: Defines the CTrait type to use for this trait:
@@ -1135,13 +1045,63 @@ class Constant(TraitType):
         super(Constant, self).__init__(value, **metadata)
 
 
-# -------------------------------------------------------------------------------
-#  'Delegate' trait:
-# -------------------------------------------------------------------------------
-
-
 class Delegate(TraitType):
-    """ Defines a trait whose value is delegated to a trait on another object.
+    """ A trait whose value is delegated to a trait on another object.
+
+    This is a base class that shouldn't be used directly, rather use one of
+    the subclasses DelegatesTo or PrototypesFrom, depending on desired
+    behaviour.
+
+    An object containing a delegator trait attribute must contain a
+    second attribute that references the object containing the delegate
+    trait attribute. The name of this second attribute is passed as the
+    *delegate* argument.
+
+    The following rules govern the application of the prefix parameter:
+
+    * If *prefix* is empty or omitted, the delegation is to an attribute
+      of the delegate object with the same name as the delegator
+      attribute.
+    * If *prefix* is a valid Python attribute name, then the delegation
+      is to an attribute whose name is the value of *prefix*.
+    * If *prefix* ends with an asterisk ('*') and is longer than one
+      character, then the delegation is to an attribute whose name is
+      the value of *prefix*, minus the trailing asterisk, prepended to
+      the delegator attribute name.
+    * If *prefix* is equal to a single asterisk, the delegation is to an
+      attribute whose name is the value of the delegator object's
+      __prefix__ attribute prepended to delegator attribute name.
+
+    Parameters
+    ----------
+    delegate : str
+        The name of the trait that holds the HasTraits instance that the
+        value is delegated to.
+    prefix : str
+        The name of the trait on the delegate that holds the delegated
+        value.  If empty, then the name of this trait will be used.
+    modify : bool
+        Whether modifications of this trait are applied to the delegated
+        object.  This differentiates the behaviour of DelegatesTo and
+        PrototypedFrom.
+    listenable : bool
+        Whether changes to the delegated trait will fire listeners to
+        this trait.
+
+    Attributes
+    ----------
+    delegate : str
+        The name of the trait that holds the HasTraits instance that the
+        value is delegated to.
+    prefix : str
+        The name of the trait on the delegate that holds the delegated
+        value.  If empty, then the name of this trait will be used.
+    prefix_type : int
+        An integer giving the type of prefix being used.
+    modify : bool
+        Whether modifications of this trait are applied to the delegated
+        object.  This differentiates the behaviour of DelegatesTo and
+        PrototypedFrom.
     """
 
     #: Defines the CTrait type to use for this trait:
@@ -1188,11 +1148,6 @@ class Delegate(TraitType):
         return trait
 
 
-# -------------------------------------------------------------------------------
-#  'DelegatesTo' trait:
-# -------------------------------------------------------------------------------
-
-
 class DelegatesTo(Delegate):
     """ A trait delegate that matches the 'delegate' design pattern.
 
@@ -1233,7 +1188,9 @@ class DelegatesTo(Delegate):
         looking up the delegated attribute.
     listenable : bool
         Indicates whether a listener can be attached to this attribute
-        such that changes to the delagate attribute will trigger it.
+        such that changes to the delegated attribute will trigger it.
+    **metadata
+        Trait metadata for the trait.
     """
 
     def __init__(self, delegate, prefix="", listenable=True, **metadata):
@@ -1244,11 +1201,6 @@ class DelegatesTo(Delegate):
             listenable=listenable,
             **metadata
         )
-
-
-# -------------------------------------------------------------------------------
-#  'PrototypedFrom' trait:
-# -------------------------------------------------------------------------------
 
 
 class PrototypedFrom(Delegate):
@@ -1294,6 +1246,8 @@ class PrototypedFrom(Delegate):
         Indicates whether a listener can be attached to this attribute
         such that changes to the corresponding attribute on the
         prototype object will trigger it.
+    **metadata
+        Trait metadata for the trait.
     """
 
     def __init__(self, prototype, prefix="", listenable=True, **metadata):
@@ -1306,15 +1260,11 @@ class PrototypedFrom(Delegate):
         )
 
 
-# -------------------------------------------------------------------------------
-#  'Expression' class:
-# -------------------------------------------------------------------------------
-
-
 class Expression(TraitType):
-    """ Defines a trait whose value must be a valid Python expression. The
-        compiled form of a valid expression is stored as the mapped value of
-        the trait.
+    """ Defines a trait whose value must be a valid Python expression.
+
+    The compiled form of a valid expression is stored as the mapped value of
+    the trait.
     """
 
     #: The default value for the trait:
@@ -1354,11 +1304,6 @@ class Expression(TraitType):
         return ctrait
 
 
-# -------------------------------------------------------------------------------
-#  'PythonValue' trait:
-# -------------------------------------------------------------------------------
-
-
 class PythonValue(Any):
     """ Defines a trait whose value can be of any type, and whose default
     editor is a Python shell.
@@ -1368,13 +1313,43 @@ class PythonValue(Any):
     metadata = {"editor": shell_editor}
 
 
-# -------------------------------------------------------------------------------
-#  'BaseFile' and 'File' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseFile(BaseStr):
     """ Defines a trait whose value must be the name of a file.
+
+    For Python 3.6 this will accept os.pathlib Path objects, converting them
+    to the corresponding string value.
+
+    Parameters
+    ----------
+    value : str
+        The default value for the trait.
+    filter : str
+        A wildcard string to filter filenames in the file dialog box used by
+        the attribute trait editor.
+    auto_set : bool
+        Indicates whether the file editor updates the trait value after
+        every key stroke.
+    entries : int
+        A hint to the TraitsUI editor about how many values to display in
+        the editor.
+    exists : bool
+        Indicates whether the trait value must be an existing file or
+        not.
+
+    Attributes
+    ----------
+    filter : str
+        A wildcard string to filter filenames in the file dialog box used by
+        the attribute trait editor.
+    auto_set : bool
+        Indicates whether the file editor updates the trait value after
+        every key stroke.
+    entries : int
+        A hint to the TraitsUI editor about how many values to display in
+        the editor.
+    exists : bool
+        Indicates whether the trait value must be an existing file or
+        not.
     """
 
     #: A description of the type of value this trait accepts:
@@ -1389,26 +1364,6 @@ class BaseFile(BaseStr):
         exists=False,
         **metadata
     ):
-        """ Creates a File trait.
-
-        Parameters
-        ----------
-        value : str
-            The default value for the trait.
-        filter : str
-            A wildcard string to filter filenames in the file dialog box used by
-            the attribute trait editor.
-        auto_set : bool
-            Indicates whether the file editor updates the trait value after
-            every key stroke.
-        exists : bool
-            Indicates whether the trait value must be an existing file or
-            not.
-
-        Default Value
-        -------------
-        *value* or ''
-        """
         self.filter = filter
         self.auto_set = auto_set
         self.entries = entries
@@ -1452,8 +1407,44 @@ class BaseFile(BaseStr):
 
 
 class File(BaseFile):
-    """ Defines a trait whose value must be the name of a file using a C-level
-        fast validator.
+    """ Defines a trait whose value must be the name of a file.
+
+    When possible, this uses a C-level fast validator.
+
+    For Python 3.6 this will accept os.pathlib Path objects, converting them
+    to the corresponding string value.
+
+    Parameters
+    ----------
+    value : str
+        The default value for the trait.
+    filter : str
+        A wildcard string to filter filenames in the file dialog box used by
+        the attribute trait editor.
+    auto_set : bool
+        Indicates whether the file editor updates the trait value after
+        every key stroke.
+    entries : int
+        A hint to the TraitsUI editor about how many values to display in
+        the editor.
+    exists : bool
+        Indicates whether the trait value must be an existing file or
+        not.
+
+    Attributes
+    ----------
+    filter : str
+        A wildcard string to filter filenames in the file dialog box used by
+        the attribute trait editor.
+    auto_set : bool
+        Indicates whether the file editor updates the trait value after
+        every key stroke.
+    entries : int
+        A hint to the TraitsUI editor about how many values to display in
+        the editor.
+    exists : bool
+        Indicates whether the trait value must be an existing file or
+        not.
     """
 
     def __init__(
@@ -1465,39 +1456,39 @@ class File(BaseFile):
         exists=False,
         **metadata
     ):
-        """ Creates a File trait.
-
-        Parameters
-        ----------
-        value : str
-            The default value for the trait.
-        filter : str
-            A wildcard string to filter filenames in the file dialog box used
-            by the attribute trait editor.
-        auto_set : bool
-            Indicates whether the file editor updates the trait value after
-            every key stroke.
-        exists : bool
-            Indicates whether the trait value must be an existing file or
-            not.
-
-        Default Value
-        -------------
-        *value* or ''
-        """
-
         super(File, self).__init__(
             value, filter, auto_set, entries, exists, **metadata
         )
 
 
-# -------------------------------------------------------------------------------
-#  'BaseDirectory' and 'Directory' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseDirectory(BaseStr):
     """ Defines a trait whose value must be the name of a directory.
+
+    Parameters
+    ----------
+    value : str
+        The default value for the trait.
+    auto_set : bool
+        Indicates whether the directory editor updates the trait value
+        after every key stroke.
+    entries : int
+        A hint to the TraitsUI editor about how many values to display in
+        the editor.
+    exists : bool
+        Indicates whether the trait value must be an existing directory or
+        not.
+
+    Attributes
+    ----------
+    auto_set : bool
+        Indicates whether the directory editor updates the trait value
+        after every key stroke.
+    entries : int
+        A hint to the TraitsUI editor about how many values to display in
+        the editor.
+    exists : bool
+        Indicates whether the trait value must be an existing directory or
+        not.
     """
 
     #: A description of the type of value this trait accepts:
@@ -1506,23 +1497,6 @@ class BaseDirectory(BaseStr):
     def __init__(
         self, value="", auto_set=False, entries=0, exists=False, **metadata
     ):
-        """ Creates a BaseDirectory trait.
-
-        Parameters
-        ----------
-        value : str
-            The default value for the trait.
-        auto_set : bool
-            Indicates whether the directory editor updates the trait value
-            after every key stroke.
-        exists : bool
-            Indicates whether the trait value must be an existing directory or
-            not.
-
-        Default Value
-        -------------
-        *value* or ''
-        """
         self.entries = entries
         self.auto_set = auto_set
         self.exists = exists
@@ -1532,7 +1506,7 @@ class BaseDirectory(BaseStr):
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
 
-            Note: The 'fast validator' version performs this check in C.
+        Note: The 'fast validator' version performs this check in C.
         """
         validated_value = super(BaseDirectory, self).validate(
             object, name, value
@@ -1552,30 +1526,40 @@ class BaseDirectory(BaseStr):
 
 
 class Directory(BaseDirectory):
-    """ Defines a trait whose value must be the name of a directory using a
-        C-level fast validator.
+    """ Defines a trait whose value must be the name of a directory.
+
+    When possible, this uses a C-level fast validator.
+
+    Parameters
+    ----------
+    value : str
+        The default value for the trait.
+    auto_set : bool
+        Indicates whether the directory editor updates the trait value
+        after every key stroke.
+    entries : int
+        A hint to the TraitsUI editor about how many values to display in
+        the editor.
+    exists : bool
+        Indicates whether the trait value must be an existing directory or
+        not.
+
+    Attributes
+    ----------
+    auto_set : bool
+        Indicates whether the directory editor updates the trait value
+        after every key stroke.
+    entries : int
+        A hint to the TraitsUI editor about how many values to display in
+        the editor.
+    exists : bool
+        Indicates whether the trait value must be an existing directory or
+        not.
     """
 
     def __init__(
         self, value="", auto_set=False, entries=0, exists=False, **metadata
     ):
-        """ Creates a Directory trait.
-
-        Parameters
-        ----------
-        value : str
-            The default value for the trait.
-        auto_set : bool
-            Indicates whether the directory editor updates the trait value
-            after every key stroke.
-        exists : bool
-            Indicates whether the trait value must be an existing directory or
-            not.
-
-        Default Value
-        -------------
-        *value* or ''
-        """
         # Define the C-level fast validator to use if the directory existence
         #: test is not required:
         if not exists:
@@ -1585,13 +1569,28 @@ class Directory(BaseDirectory):
         )
 
 
-# -------------------------------------------------------------------------------
-#  'BaseRange' and 'Range' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseRange(TraitType):
     """ Defines a trait whose numeric value must be in a specified range.
+
+    The *low*, *high*, and *value* arguments must be of the same type
+    (integer or float), except in the case where either *low* or *high* is
+    a string (i.e. extended trait name).
+
+    If *value* is None or omitted, the default value is *low*, unless *low*
+    is None or omitted, in which case the default value is *high*.
+
+    Parameters
+    ----------
+    low : integer, float or string (i.e. extended trait name)
+        The low end of the range.
+    high : integer, float or string (i.e. extended trait name)
+        The high end of the range.
+    value : integer, float or string (i.e. extended trait name)
+        The default value of the trait.
+    exclude_low : bool
+        Indicates whether the low end of the range is exclusive.
+    exclude_high : bool
+        Indicates whether the high end of the range is exclusive.
     """
 
     def __init__(
@@ -1603,31 +1602,6 @@ class BaseRange(TraitType):
         exclude_high=False,
         **metadata
     ):
-        """ Creates a Range trait.
-
-        Parameters
-        ----------
-        low : integer, float or string (i.e. extended trait name)
-            The low end of the range.
-        high : integer, float or string (i.e. extended trait name)
-            The high end of the range.
-        value : integer, float or string (i.e. extended trait name)
-            The default value of the trait.
-        exclude_low : bool
-            Indicates whether the low end of the range is exclusive.
-        exclude_high : bool
-            Indicates whether the high end of the range is exclusive.
-
-        The *low*, *high*, and *value* arguments must be of the same type
-        (integer or float), except in the case where either *low* or *high* is
-        a string (i.e. extended trait name).
-
-        Default Value
-        -------------
-        *value*; if *value* is None or omitted, the default value is *low*,
-        unless *low* is None or omitted, in which case the default value is
-        *high*.
-        """
         if value is None:
             if low is not None:
                 value = low
@@ -1714,7 +1688,7 @@ class BaseRange(TraitType):
 
     def init_fast_validate(self, *args):
         """ Does nothing for the BaseRange class. Used in the Range class to
-            set up the fast validator.
+        set up the fast validator.
         """
         pass
 
@@ -1921,7 +1895,7 @@ class BaseRange(TraitType):
 
 class Range(BaseRange):
     """ Defines a trait whose numeric value must be in a specified range using
-        a C-level fast validator.
+    a C-level fast validator.
     """
 
     def init_fast_validate(self, *args):
@@ -1930,35 +1904,43 @@ class Range(BaseRange):
         self.fast_validate = args
 
 
-# -------------------------------------------------------------------------------
-#  'BaseEnum' and 'Enum' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseEnum(TraitType):
     """ Defines a trait whose value must be one of a specified set of values.
+
+    The default value is the first positional argument, or the first item of
+    the list, tuple or enum.Enum if that is the only argument or if the valid
+    values are provided dynamically.
 
     Parameters
     ----------
     *args
-        The enumeration of all legal values for the trait, either as
-        positional arguments or a list, enum.Enum or tuple.  The default
-        value is the first positional argument, or the first item of
-        the sequence.
-    values : str, list, tuple or enum.Enum
-        If a sting, the name of a trait holding the values, in which
-        case there must be at most one positional argument holding the
-        default value.  If there is no default value, then the default value
-        is the first item of the value stored in the trait.
+        The enumeration of all legal values for the trait.  The expected
+        signatures are either:
+
+        - a single list, enum.Enum or tuple.  The default value is the first
+          item in the collection.
+        - a single default value, combined with the values keyword
+          argument.
+        - a default value, followed by a single list enum.Enum or tuple.
+        - arbitrary positional arguments each giving a valid value.
+    values : str
+        The name of a trait holding the legal values.  A default value may
+        be provided via a positional argument, otherwise it is the first
+        item stored in the .
+    **metadata
+        Trait metadata for the trait.
+
+    Attributes
+    ----------
+    values : tuple
+        A tuple holding the legal values.
+
+    name : str
+        The name of a trait holding the legal values, or the empty string if
+        unused.
     """
 
     def __init__(self, *args, values=None, **metadata):
-        """ Returns an Enum trait.
-
-        Default Value
-        -------------
-        values[0]
-        """
         values = metadata.pop("values", None)
         if isinstance(values, str):
             self.name = values
@@ -2000,7 +1982,7 @@ class BaseEnum(TraitType):
 
     def validate(self, object, name, value):
         """ Validates that the value is one of the enumerated set of valid
-            values.
+        values.
         """
         if safe_contains(value, self.values):
             return value
@@ -2054,65 +2036,99 @@ class BaseEnum(TraitType):
 
 
 class Enum(BaseEnum):
-    """ Defines a trait whose value must be one of a specified set of values
-        using a C-level fast validator.
+    """ Defines an Enum trait which uses C-level validation.
+
+    The default value is the first positional argument, or the first item of
+    the list, tuple or enum.Enum if that is the only argument or if the valid
+    values are provided dynamically.
+
+    Parameters
+    ----------
+    *args
+        The enumeration of all legal values for the trait.  The expected
+        signatures are either:
+
+        - a single list, enum.Enum or tuple.  The default value is the first
+          item in the collection.
+        - a single default value, combined with the values keyword
+          argument.
+        - a default value, followed by a single list enum.Enum or tuple.
+        - arbitrary positional arguments each giving a valid value.
+
+    values : str
+        The name of a trait holding the legal values.  A default value may
+        be provided via a positional argument, otherwise it is the first
+        item stored in the .
+    **metadata
+        Trait metadata for the trait.
+
+    Attributes
+    ----------
+    values : tuple
+        A tuple holding the legal values.
+
+    name : str
+        The name of a trait holding the legal values, or the empty string if
+        unused.
     """
 
     def init_fast_validate(self, *args):
-        """ Set up the C-level fast validator.
-        """
+        """ Set up C-level fast validation. """
         self.fast_validate = args
-
-
-# -------------------------------------------------------------------------------
-#  'BaseTuple' and 'Tuple' and 'ValidatedTuple' traits:
-# -------------------------------------------------------------------------------
 
 
 class BaseTuple(TraitType):
     """ Defines a trait whose value must be a tuple of specified trait types.
+
+    The default value is determined as follows:
+
+    1.  If no arguments are specified, the default value is ().
+    2.  If a tuple is specified as the first argument, it is the default
+        value.
+    3.  If a tuple is not specified as the first argument, the default
+        value is a tuple whose length is the length of the argument list,
+        and whose values are the default values for the corresponding trait
+        types.
+
+    Example for case #2::
+
+        mytuple = Tuple(('Fred', 'Betty', 5))
+
+    The trait's value must be a 3-element tuple whose first and second
+    elements are strings, and whose third element is an integer. The
+    default value is ``('Fred', 'Betty', 5)``.
+
+    Example for case #3::
+
+        mytuple = Tuple('Fred', 'Betty', 5)
+
+    The trait's value must be a 3-element tuple whose first and second
+    elements are strings, and whose third element is an integer. The
+    default value is ``('','',0)``.
+
+    Parameters
+    ----------
+    *types
+        Definition of the default and allowed tuples. If the first item of
+        *types* is a tuple, it is used as the default value.
+        The remaining argument list is used to form a tuple that constrains
+        the  values assigned to the returned trait. The trait's value must
+        be a tuple of the same length as the remaining argument list, whose
+        elements must match the types specified by the corresponding items
+        of the remaining argument list.
+    **metadata
+        Trait metadata for the trait.
+
+    Attributes
+    ----------
+    types : tuple
+        The tuple of traits specifying the type of each element in order.
+    no_type_check : bool
+        Flag to indicate whether validation should check the type of each
+        element.
     """
 
     def __init__(self, *types, **metadata):
-        """ Returns a Tuple trait.
-
-        The default value is determined as follows:
-
-        1. If no arguments are specified, the default value is ().
-        2. If a tuple is specified as the first argument, it is the default
-           value.
-        3. If a tuple is not specified as the first argument, the default
-           value is a tuple whose length is the length of the argument list,
-           and whose values are the default values for the corresponding trait
-           types.
-
-        Example for case #2::
-
-            mytuple = Tuple(('Fred', 'Betty', 5))
-
-        The trait's value must be a 3-element tuple whose first and second
-        elements are strings, and whose third element is an integer. The
-        default value is ``('Fred', 'Betty', 5)``.
-
-        Example for case #3::
-
-            mytuple = Tuple('Fred', 'Betty', 5)
-
-        The trait's value must be a 3-element tuple whose first and second
-        elements are strings, and whose third element is an integer. The
-        default value is ``('','',0)``.
-
-        Parameters
-        ----------
-        types : zero or more arguments
-            Definition of the default and allowed tuples. If the first item of
-            *types* is a tuple, it is used as the default value.
-            The remaining argument list is used to form a tuple that constrains
-            the  values assigned to the returned trait. The trait's value must
-            be a tuple of the same length as the remaining argument list, whose
-            elements must match the types specified by the corresponding items
-            of the remaining argument list.
-        """
         if len(types) == 0:
             self.init_fast_validate(ValidateTrait.coerce, tuple, None, list)
 
@@ -2217,33 +2233,33 @@ class Tuple(BaseTuple):
 
 class ValidatedTuple(BaseTuple):
     """ A Tuple trait that supports custom validation.
+
+    Parameters
+    ----------
+    *types
+        Definition of the default and allowed tuples. (see
+        :class:`~.BaseTuple` for more details)
+    fvalidate : callable, optional
+        A callable to provide the additional custom validation for the
+        tuple. The callable will be passed the tuple value and should
+        return True or False.
+    fvalidate_info : string, optional
+        A string describing the custom validation to use for the error
+        messages.
+    **metadata
+        Trait metadata for the trait.
+
+    Example
+    -------
+    The definition::
+
+        value_range = ValidatedTuple(Int(0), Int(1), fvalidate=lambda x: x[0] < x[1])
+
+    will accept only tuples ``(a, b)`` containing two integers that
+    satisfy ``a < b``.
     """
 
     def __init__(self, *types, **metadata):
-        """ Returns a ValidatedTuple trait
-
-        Parameters
-        ----------
-        types : zero or more arguments
-            Definition of the default and allowed tuples. (see
-            :class:`~.BaseTuple` for more details)
-        fvalidate : callable, optional
-            A callable to provide the additional custom validation for the
-            tuple. The callable will be passed the tuple value and should
-            return True or False.
-        fvalidate_info : string, optional
-            A string describing the custom validation to use for the error
-            messages.
-
-        Example
-        -------
-        The definition::
-
-          value_range = ValidatedTuple(Int(0), Int(1), fvalidate=lambda x: x[0] < x[1])
-
-        will accept only tuples ``(a, b)`` containing two integers that
-        satisfy ``a < b``.
-        """
         metadata.setdefault("fvalidate", None)
         metadata.setdefault("fvalidate_info", "")
         super(ValidatedTuple, self).__init__(*types, **metadata)
@@ -2273,14 +2289,39 @@ class ValidatedTuple(BaseTuple):
         return message.format(types_info, fvalidate_info)
 
 
-# -------------------------------------------------------------------------------
-#  'List' trait:
-# -------------------------------------------------------------------------------
-
-
 class List(TraitType):
-    """ Defines a trait whose value must be a list whose items are of the
-        specified trait type.
+    """ A trait type for a list of values of the specified type.
+
+    The length of the list assigned to the trait must be such that::
+
+        minlen <= len(list) <= maxlen
+
+    Parameters
+    ----------
+    trait : a trait or value that can be converted using trait_from()
+        The type of item that the list contains. If not specified, the list
+        can contain items of any type.
+    value : list
+        Default value for the list.
+    minlen : integer
+        The minimum length of a list that can be assigned to the trait.
+    maxlen : integer
+        The maximum length of a list that can be assigned to the trait.
+    items : bool
+        Whether there is a corresponding `<name>_items` trait.
+    **metadata
+        Trait metadata for the trait.
+
+    Attributes
+    ----------
+    item_trait : trait
+        The type of item that the list contains.
+    minlen : integer
+        The minimum length of a list that can be assigned to the trait.
+    maxlen : integer
+        The maximum length of a list that can be assigned to the trait.
+    has_items : bool
+        Whether there is a corresponding `<name>_items` trait.
     """
 
     info_trait = None
@@ -2296,28 +2337,6 @@ class List(TraitType):
         items=True,
         **metadata
     ):
-        """ Returns a List trait.
-
-        Parameters
-        ----------
-        trait : a trait or value that can be converted to a trait using Trait()
-            The type of item that the list contains. If not specified, the list
-            can contain items of any type.
-        value : list
-            Default value for the list.
-        minlen : integer
-            The minimum length of a list that can be assigned to the trait.
-        maxlen : integer
-            The maximum length of a list that can be assigned to the trait.
-
-        The length of the list assigned to the trait must be such that::
-
-            minlen <= len(list) <= maxlen
-
-        Default Value
-        -------------
-        *value* or None
-        """
         metadata.setdefault("copy", "deep")
 
         if isinstance(trait, SequenceTypes):
@@ -2396,15 +2415,10 @@ class List(TraitType):
         return cls._items_event
 
 
-# -------------------------------------------------------------------------------
-#  'CList' trait:
-# -------------------------------------------------------------------------------
-
-
 class CList(List):
     """ Defines a trait whose values must be a list whose items are of the
-        specified trait type or which can be coerced to a list whose values are
-        of the specified trait type.
+    specified trait type or which can be coerced to a list whose values are
+    of the specified trait type.
     """
 
     def validate(self, object, name, value):
@@ -2429,14 +2443,28 @@ class CList(List):
         )
 
 
-# -------------------------------------------------------------------------------
-#  'Set' trait:
-# -------------------------------------------------------------------------------
-
-
 class Set(TraitType):
-    """ Defines a trait whose value must be a set whose items are of the
-        specified trait type.
+    """ A trait type for a set of values of the specified type.
+
+    Parameters
+    ----------
+    trait : a trait or value that can be converted to a trait using Trait()
+        The type of item that the list contains. If not specified, the list
+        can contain items of any type.
+    value : set
+        Default value for the set.
+    items : bool
+        Whether there is a corresponding `<name>_items` trait.
+    **metadata
+        Trait metadata for the trait.
+
+    Attributes
+    ----------
+    item_trait : a trait or value that can be converted to a trait using Trait()
+        The type of item that the list contains. If not specified, the list
+        can contain items of any type.
+    has_items : bool
+        Whether there is a corresponding `<name>_items` trait.
     """
 
     info_trait = None
@@ -2444,20 +2472,6 @@ class Set(TraitType):
     _items_event = None
 
     def __init__(self, trait=None, value=None, items=True, **metadata):
-        """ Returns a Set trait.
-
-        Parameters
-        ----------
-        trait : a trait or value that can be converted to a trait using Trait()
-            The type of item that the list contains. If not specified, the list
-            can contain items of any type.
-        value : set
-            Default value for the set.
-
-        Default Value
-        -------------
-        *value* or None
-        """
         metadata.setdefault("copy", "deep")
 
         if isinstance(trait, SetTypes):
@@ -2516,11 +2530,6 @@ class Set(TraitType):
         return self.__class__._items_event
 
 
-# -------------------------------------------------------------------------------
-#  'CSet' trait:
-# -------------------------------------------------------------------------------
-
-
 class CSet(Set):
     """ Defines a trait whose values must be a set whose items are of the
         specified trait type or which can be coerced to a set whose values are
@@ -2549,14 +2558,36 @@ class CSet(Set):
         )
 
 
-# -------------------------------------------------------------------------------
-#  'Dict' trait:
-# -------------------------------------------------------------------------------
-
-
 class Dict(TraitType):
     """ Defines a trait whose value must be a dictionary, optionally with
-        specified types for keys and values.
+    specified types for keys and values.
+
+
+    Parameters
+    ----------
+    key_trait : a trait or value that can be converted using trait_from()
+        The trait type for keys in the dictionary; if not specified, any
+        values can be used as keys.
+    value_trait : a trait or value that can be converted using trait_from()
+        The trait type for values in the dictionary; if not specified, any
+        values can be used as dictionary values.
+    value : dict
+        The default value for the returned trait.
+    items : bool
+        Indicates whether the value contains items.
+
+    Attributes
+    ----------
+    key_trait : a trait
+        The trait type for keys in the dictionary; if not specified, any
+        values can be used as keys.
+    value_trait : a trait
+        The trait type for values in the dictionary; if not specified, any
+        values can be used as dictionary values.
+    value_trait_handler : TraitHandler
+        The TraitHandler for the value_trait.
+    has_items : bool
+        Indicates whether the value contains items.
     """
 
     info_trait = None
@@ -2571,25 +2602,6 @@ class Dict(TraitType):
         items=True,
         **metadata
     ):
-        """ Returns a Dict trait.
-
-        Parameters
-        ----------
-        key_trait : a trait or value that can convert to a trait using Trait()
-            The trait type for keys in the dictionary; if not specified, any
-            values can be used as keys.
-        value_trait : a trait or value that can convert to a trait using Trait()
-            The trait type for values in the dictionary; if not specified, any
-            values can be used as dictionary values.
-        value : dict
-            The default value for the returned trait.
-        items : bool
-            Indicates whether the value contains items.
-
-        Default Value
-        -------------
-        *value* or {}
-        """
         if isinstance(key_trait, dict):
             key_trait, value_trait, value = value_trait, value, key_trait
 
@@ -2611,11 +2623,10 @@ class Dict(TraitType):
     def validate(self, object, name, value):
         """ Validates that the value is a valid dictionary.
 
-        .. note::
-
-            `object` can be None when validating a default value (see e.g.
-            :meth:`~traits.trait_handlers.TraitType.clone`)
-
+        Note
+        ----
+        `object` can be None when validating a default value (see e.g.
+        :meth:`~traits.trait_handlers.TraitType.clone`)
         """
         if isinstance(value, dict):
             if object is None:
@@ -2657,29 +2668,49 @@ class Dict(TraitType):
         return cls._items_event
 
 
-# -------------------------------------------------------------------------------
-#  'BaseInstance' and 'Instance' traits:
-# -------------------------------------------------------------------------------
-
-# Allowed values and mappings for the 'adapt' keyword:
+#: Allowed values and mappings for the 'adapt' keyword.
+#:
+#: - 'no': Adaptation is not allowed.
+#: - 'yes': Adaptation is allowed. If adaptation fails, an
+#:   exception should be raised.
+#: - 'default': Adaptation is allowed. If adaptation fails, the
+#:   default value for the trait should be used.
 AdaptMap = {"no": 0, "yes": 1, "default": 2}
 
 
 class BaseClass(TraitType):
-    """ Base class for types which have an associated class which can be
-        determined dynamically by specifying a string name for the class (e.g.
-        'package1.package2.module.class'.
+    """ Base class for types which have an associated class.
 
-        Any subclass must define instances with 'klass' and 'module' attributes
-        that contain the string name of the class (or actual class object) and
-        the module name that contained the original trait definition (used for
-        resolving local class names (e.g. 'LocalClass')).
+    Traits sometimes need to be able to access classes which have not
+    yet been defined, or which are from a module that we want to defer
+    importing from.  To support this, classes can be determined
+    dynamically by specifying a string name for the class (e.g.
+    ``'package1.package2.module.class'``).  This base class provides the
+    machinery for this sort of deferred access to classes.
 
-        This is an abstract class that only provides helper methods used to
-        resolve the class name into an actual class object.
+    Any subclass must define instances with 'klass' and 'module' attributes
+    that contain the string name of the class (or actual class object) and
+    the module name that contained the original trait definition (used for
+    resolving local class names (e.g. 'LocalClass')).
+
+    This is an abstract class that only provides helper methods used to
+    resolve the class name into an actual class object.
+
+    Attributes
+    ----------
+    klass : type or str
+        The class object or a string that refers to it.
+    module : str
+        The name of the module that contains the class.
     """
 
     def resolve_class(self, object, name, value):
+        """ Resolve the class object as part of validation.
+
+        This is called when the ``klass`` attribute is a string and sets the
+        ``klass`` attribute to the actual klass object as a side-effect.  If
+        the class cannot be resolved, it will call validate_failed().
+        """
         klass = self.validate_class(self.find_class(self.klass))
         if klass is None:
             self.validate_failed(object, name, value)
@@ -2687,9 +2718,12 @@ class BaseClass(TraitType):
         self.klass = klass
 
     def validate_class(self, klass):
+        """ Validate a class object. """
         return klass
 
     def find_class(self, klass):
+        """ Given a string describing a class, get the class object.
+        """
         module = self.module
         col = klass.rfind(".")
         if col >= 0:
@@ -2707,13 +2741,69 @@ class BaseClass(TraitType):
         return theClass
 
     def validate_failed(self, object, name, value):
-
+        """ Raise a TraitError if the class could not be resolved. """
         self.error(object, name, value)
 
 
 class BaseInstance(BaseClass):
     """ Defines a trait whose value must be an instance of a specified class,
-        or one of its subclasses.
+    or one of its subclasses.
+
+    **None** if *klass* is an instance or if it is a class and *args* and
+    *kw* are not specified. Otherwise, the default value is the instance
+    obtained by calling ``klass(*args, **kw)``. Note that the constructor
+    call is performed each time a default value is assigned, so each
+    default value assigned is a unique instance.
+
+    Parameters
+    ----------
+    klass : class, str or instance
+        The object that forms the basis for the trait; if it is an
+        instance, then trait values must be instances of the same class or
+        a subclass. This object is not the default value, even if it is an
+        instance.  If the provided value is a string, it is expected to be
+        a reference to a class that will be resolved at run-time.
+    factory : callable
+        A callable, typically a class, that when called with *args* and
+        *kw*, returns the default value for the trait. If not specified,
+        or *None*, *klass* is used as the factory.
+    args : tuple
+        Positional arguments for generating the default value.
+    kw : dictionary
+        Keyword arguments for generating the default value.
+    allow_none : bool
+        Indicates whether None is allowed as a value.
+    adapt : str
+        A string specifying how adaptation should be applied. The possible
+        values are:
+
+        - 'no': Adaptation is not allowed.
+        - 'yes': Adaptation is allowed. If adaptation fails, an
+          exception should be raised.
+        - 'default': Adaptation is allowed. If adaptation fails, the
+          default value for the trait should be used.
+
+    Attributes
+    ----------
+    factory : callable
+        A callable, typically a class, that when called with *args* and
+        *kw*, returns the default value for the trait. If not specified,
+        or *None*, *klass* is used as the factory.
+    args : tuple
+        Positional arguments for generating the default value.
+    kw : dictionary
+        Keyword arguments for generating the default value.
+    allow_none : bool
+        Indicates whether None is allowed as a value.
+    adapt : str
+        A string specifying how adaptation should be applied. The possible
+        values are:
+
+        - 'no': Adaptation is not allowed.
+        - 'yes': Adaptation is allowed. If adaptation fails, an
+          exception should be raised.
+        - 'default': Adaptation is allowed. If adaptation fails, the
+          default value for the trait should be used.
     """
 
     adapt_default = "no"
@@ -2729,43 +2819,6 @@ class BaseInstance(BaseClass):
         module=None,
         **metadata
     ):
-        """ Returns an Instance trait.
-
-        Parameters
-        ----------
-        klass : class or instance
-            The object that forms the basis for the trait; if it is an
-            instance, then trait values must be instances of the same class or
-            a subclass. This object is not the default value, even if it is an
-            instance.
-        factory : callable
-            A callable, typically a class, that when called with *args* and
-            *kw*, returns the default value for the trait. If not specified,
-            or *None*, *klass* is used as the factory.
-        args : tuple
-            Positional arguments for generating the default value.
-        kw : dictionary
-            Keyword arguments for generating the default value.
-        allow_none : bool
-            Indicates whether None is allowed as a value.
-        adapt : str
-            A string specifying how adaptation should be applied. The possible
-            values are:
-
-                - 'no': Adaptation is not allowed.
-                - 'yes': Adaptation is allowed. If adaptation fails, an
-                    exception should be raised.
-                - 'default': Adaptation is allowed. If adaptation fails, the
-                    default value for the trait should be used.
-
-        Default Value
-        -------------
-        **None** if *klass* is an instance or if it is a class and *args* and
-        *kw* are not specified. Otherwise, the default value is the instance
-        obtained by calling ``klass(*args, **kw)``. Note that the constructor
-        call is performed each time a default value is assigned, so each
-        default value assigned is a unique instance.
-        """
         if klass is None:
             raise TraitError(
                 "A %s trait must have a class specified."
@@ -2979,7 +3032,7 @@ class BaseInstance(BaseClass):
 
 class Instance(BaseInstance):
     """ Defines a trait whose value must be an instance of a specified class,
-        or one of its subclasses using a C-level fast validator.
+    or one of its subclasses using a C-level fast validator.
     """
 
     def init_fast_validate(self):
@@ -3054,36 +3107,39 @@ class AdaptsTo(Supports):
         return ctrait
 
 
-# -------------------------------------------------------------------------------
-#  'Type' trait:
-# -------------------------------------------------------------------------------
-
-
 class Type(BaseClass):
     """ Defines a trait whose value must be a subclass of a specified class.
+
+    Parameters
+    ----------
+    value : class or None
+        The default value of the trait.
+    klass : class, str or None
+        The class that trait values must be subclasses of.  If None, then
+        the default value is used instead.  If both are None, then the
+        ``object`` type is used.  If it is a string, the first time that
+        the validate method is called, the class will be imported and
+        the value replaced with the class object.
+    allow_none : bool
+        Indicates whether None is allowed as an assignable value. Even if
+        **False**, the default *value* may be **None**.
+    **metadata
+        Trait metadata for the trait.
+
+    Attributes
+    ----------
+    klass : class or str
+        The class that trait values must be subclasses of.  If this is a
+        string, the first time that the validate method is called, the
+        class will be imported and the value replaced with the class object.
+    module : str
+        The name of the module where local class names (ie. class names
+        with no module components) are presumed to be importable from.
+        This is the caller's caller's module, as determined by the
+        ``get_module_method``.
     """
 
     def __init__(self, value=None, klass=None, allow_none=True, **metadata):
-        """ Returns an Type trait.
-
-        Parameters
-        ----------
-        value : class or None
-
-        klass : class or None
-
-        allow_none : bool
-            Indicates whether None is allowed as an assignable value. Even if
-            **False**, the default *value* may be **None**.
-
-        Default Value
-        -------------
-        **None** if *klass* is an instance or if it is a class and *args* and
-        *kw* are not specified. Otherwise, the default value is the instance
-        obtained by calling ``klass(*args, **kw)``. Note that the constructor
-        call is performed each time a default value is assigned, so each
-        default value assigned is a unique instance.
-        """
         if value is None:
             if klass is None:
                 klass = object
@@ -3142,7 +3198,7 @@ class Type(BaseClass):
 
     def get_default_value(self):
         """ Returns a tuple of the form: ( default_value_type, default_value )
-            which describes the default value for this trait.
+        which describes the default value for this trait.
         """
         if not isinstance(self.default_value, str):
             return super(Type, self).get_default_value()
@@ -3168,17 +3224,8 @@ class Type(BaseClass):
         return self.klass
 
 
-# -------------------------------------------------------------------------------
-#  'Subclass' trait:
-# -------------------------------------------------------------------------------
-
-# Is just an alias for the Type trait
+#: An alias for the Type trait
 Subclass = Type
-
-
-# -------------------------------------------------------------------------------
-#  'Event' trait:
-# -------------------------------------------------------------------------------
 
 
 class Event(TraitType):
@@ -3204,13 +3251,57 @@ class Event(TraitType):
 
         return trait.full_info(object, name, value)
 
-# -------------------------------------------------------------------------------
-#  'Button' trait:
-# -------------------------------------------------------------------------------
-
 
 class Button(Event):
-    """ Defines a trait whose UI editor is a button.
+    """ Defines an Event trait whose UI editor is a button.
+
+    Parameters
+    ----------
+    label : str
+        The label for the button.
+    image : pyface.ImageResource
+        An image to display on the button.
+    style : 'button', 'radio', 'toolbar' or 'checkbox'
+        The style of button to display.
+    values_trait : str
+        For a "button" or "toolbar" style, the name of an enum
+        trait whose values will populate a drop-down menu on the button.
+        The selected value will replace the label on the button.
+    orientation : 'horizontal' or 'vertical'
+        The orientation of the label relative to the image.
+    width_padding : integer between 0 and 31
+        Extra padding (in pixels) added to the left and right sides of
+        the button.
+    height_padding : integer between 0 and 31
+        Extra padding (in pixels) added to the top and bottom of the
+        button.
+    view : traitsui View or None
+        An optional View to display when the button is clicked.
+    **metadata
+        Trait metadata for the trait.
+
+    Attributes
+    ----------
+    label : str
+        The label for the button.
+    image : pyface.ImageResource
+        An image to display on the button.
+    style : 'button', 'radio', 'toolbar' or 'checkbox'
+        The style of button to display.
+    values_trait : str
+        For a "button" or "toolbar" style, the name of an enum
+        trait whose values will populate a drop-down menu on the button.
+        The selected value will replace the label on the button.
+    orientation : 'horizontal' or 'vertical'
+        The orientation of the label relative to the image.
+    width_padding : integer between 0 and 31
+        Extra padding (in pixels) added to the left and right sides of
+        the button.
+    height_padding : integer between 0 and 31
+        Extra padding (in pixels) added to the top and bottom of the
+        button.
+    view : traitsui View or None
+        An optional View to display when the button is clicked.
     """
 
     def __init__(
@@ -3225,33 +3316,6 @@ class Button(Event):
         view=None,
         **metadata
     ):
-        """ Returns a trait event whose editor is a button.
-
-            Parameters
-            ----------
-            label : str
-                The label for the button.
-            image : pyface.ImageResource
-                An image to display on the button.
-            style : one of: 'button', 'radio', 'toolbar', 'checkbox'
-                The style of button to display.
-            values_trait : str
-                For a "button" or "toolbar" style, the name of an enum
-                trait whose values will populate a drop-down menu on the button.
-                The selected value will replace the label on the button.
-            orientation : one of: 'horizontal', 'vertical'
-                The orientation of the label relative to the image.
-            width_padding : integer between 0 and 31
-                Extra padding (in pixels) added to the left and right sides of
-                the button.
-            height_padding : integer between 0 and 31
-                Extra padding (in pixels) added to the top and bottom of the
-                button.
-
-            Default Value
-            -------------
-            No default value because events do not store values.
-        """
         self.label = label
         self.values_trait = values_trait
         self.image = image
@@ -3278,14 +3342,53 @@ class Button(Event):
         return editor
 
 
-# -------------------------------------------------------------------------------
-#  'ToolbarButton' trait:
-# -------------------------------------------------------------------------------
-
-
 class ToolbarButton(Button):
-    """ Defines a trait whose UI editor is a button that can be used on a
-        toolbar.
+    """ Defines a trait whose UI editor is a toolbar button.
+
+    This is just a Button trait with different defaults to style it like
+    a toolbar button.
+
+    Parameters
+    ----------
+    label : str
+        The label for the button.
+    image : pyface.ImageResource
+        An image to display on the button.
+    style : 'button', 'radio', 'toolbar' or 'checkbox'
+        The style of button to display.
+    orientation : 'horizontal' or 'vertical'
+        The orientation of the label relative to the image.
+    width_padding : integer between 0 and 31
+        Extra padding (in pixels) added to the left and right sides of
+        the button.
+    height_padding : integer between 0 and 31
+        Extra padding (in pixels) added to the top and bottom of the
+        button.
+    **metadata
+        Trait metadata for the trait.
+
+    Attributes
+    ----------
+    label : str
+        The label for the button.
+    image : pyface.ImageResource
+        An image to display on the button.
+    style : 'button', 'radio', 'toolbar' or 'checkbox'
+        The style of button to display.
+    values_trait : str
+        For a "button" or "toolbar" style, the name of an enum
+        trait whose values will populate a drop-down menu on the button.
+        The selected value will replace the label on the button.
+    orientation : 'horizontal' or 'vertical'
+        The orientation of the label relative to the image.
+    width_padding : integer between 0 and 31
+        Extra padding (in pixels) added to the left and right sides of
+        the button.
+    height_padding : integer between 0 and 31
+        Extra padding (in pixels) added to the top and bottom of the
+        button.
+    view : traitsui View or None
+        An optional View to display when the button is clicked.
     """
 
     def __init__(
@@ -3298,30 +3401,6 @@ class ToolbarButton(Button):
         height_padding=2,
         **metadata
     ):
-        """ Returns a trait event whose editor is a toolbar button.
-
-            Parameters
-            ----------
-            label : str
-                The label for the button
-            image : pyface.ImageResource
-                An image to display on the button
-            style : one of: 'button', 'radio', 'toolbar', 'checkbox'
-                The style of button to display
-            orientation : one of ['horizontal', 'vertical']
-                The orientation of the label relative to the image
-            width_padding : integer between 0 and 31
-                Extra padding (in pixels) added to the left and right sides of
-                the button
-            height_padding : integer between 0 and 31
-                Extra padding (in pixels) added to the top and bottom of the
-                button
-
-            Default Value
-            -------------
-            No default value because events do not store values.
-
-        """
         super(ToolbarButton, self).__init__(
             label,
             image=image,
@@ -3333,19 +3412,23 @@ class ToolbarButton(Button):
         )
 
 
-# -------------------------------------------------------------------------------
-#  'Either' trait:
-# -------------------------------------------------------------------------------
-
-
 class Either(TraitType):
     """ Defines a trait whose value can be any of of a specified list of traits.
+
+    Parameters
+    ----------
+    *traits
+        Arguments that define allowable trait values.
+    **metadata
+        Trait metadata for the trait.
+
+    Attributes
+    ----------
+    trait_maker : TraitHandler
+        A TraitHandler generated by _TraitMaker from the arguments.
     """
 
     def __init__(self, *traits, **metadata):
-        """ Creates a trait whose value can be any of of a specified list of
-            traits.
-        """
         self.trait_maker = _TraitMaker(
             metadata.pop("default", None), *traits, **metadata
         )
@@ -3356,12 +3439,16 @@ class Either(TraitType):
         return self.trait_maker.as_ctrait()
 
 
-# -------------------------------------------------------------------------------
-#  'Symbol' trait:
-# -------------------------------------------------------------------------------
-
-
 class Symbol(TraitType):
+    """ A property trait type that refers to a Python object.
+
+    The value set to the trait must be a value of the form
+    ``'[package.package...package.]module[:symbol[([arg1,...,argn])]]'``
+    which is imported and evaluated to get underlying value.
+
+    The value returned by the trait is the actual object that this string
+    refers to.  The value is cached, so any calls are only evaluated once.
+    """
 
     #: A description of the type of value this trait accepts:
     info_text = (
@@ -3414,12 +3501,17 @@ class Symbol(TraitType):
             )
 
 
-# ---------------------------------------------------------------------------
-#  'UUID' trait:
-# ---------------------------------------------------------------------------
-
 class UUID(TraitType):
-    """ Defines a trait whose value is a globally unique UUID (type 4).
+    """ Defines a read-only trait whose value is a globally unique UUID (type 4).
+
+    Parameters
+    ----------
+    can_init : bool
+        Whether the value can be set during object instantiation.  Otherwise
+        the UUID is generated automatically.
+
+    Example
+    -------
 
     Passing `can_init=True` allows the UUID value to be set during
     object instantiation, e.g.::
@@ -3445,8 +3537,6 @@ class UUID(TraitType):
     info_text = "a read-only UUID"
 
     def __init__(self, can_init=False, **metadata):
-        """ Returns a UUID trait.
-        """
         super(UUID, self).__init__(None, **metadata)
         self.can_init = can_init
 
@@ -3476,6 +3566,10 @@ class UUID(TraitType):
             raise TraitError(msg.format(name, type(object).__name__, value))
 
     def get_default_value(self):
+        """ Return a Traits default value tuple for the trait.
+
+        This uses the _create_uuid method to generate the defualt value.
+        """
         return (
             DefaultValue.callable_and_args,
             (self._create_uuid, (), None),
@@ -3487,16 +3581,27 @@ class UUID(TraitType):
         return uuid.uuid4()
 
 
-# -------------------------------------------------------------------------------
-#  'WeakRef' trait:
-# -------------------------------------------------------------------------------
-
-
 class WeakRef(Instance):
-    """ Returns a trait whose value must be an instance of the same type
-    (or a subclass) of the specified *klass*, which can be a class or an
-    instance. Note that the trait only maintains a weak reference to the
-    assigned value.
+    """ A trait holding a weak reference to an instance of a class.
+
+    Only a weak reference is maintained to any object assigned to a WeakRef
+    trait. If no other references exist to the assigned value, the value
+    may be garbage collected, in which case the value of the trait becomes
+    None. In all other cases, the value returned by the trait is the
+    original object.
+
+    Parameters
+    ----------
+    klass : class, str or instance
+        The object that forms the basis for the trait. If *klass* is
+        omitted, then values must be an instance of HasTraits.  If a string,
+        the value will be resolved to a class object at runtime.
+    allow_none : boolean
+        Indicates whether None can be _assigned_.  The trait attribute may
+        give a None value if the object referred to has been garbage collected
+        even if allow_none is False.
+    adapt : str
+        How to use the adaptation infrastructure when setting the value.
     """
 
     def __init__(
@@ -3506,27 +3611,6 @@ class WeakRef(Instance):
         adapt="yes",
         **metadata
     ):
-        """ Returns a WeakRef trait.
-
-        Only a weak reference is maintained to any object assigned to a WeakRef
-        trait. If no other references exist to the assigned value, the value
-        may be garbage collected, in which case the value of the trait becomes
-        None. In all other cases, the value returned by the trait is the
-        original object.
-
-        Parameters
-        ----------
-        klass : class or instance
-            The object that forms the basis for the trait. If *klass* is
-            omitted, then values must be an instance of HasTraits.
-        allow_none : boolean
-            Indicates whether None can be assigned.
-
-        Default Value
-        -------------
-        **None** (even if allow_none==False)
-        """
-
         metadata.setdefault("copy", "ref")
 
         super(WeakRef, self).__init__(
@@ -3566,16 +3650,15 @@ class WeakRef(Instance):
 
         self.klass = klass
 
-
-# -- Date Trait definition ----------------------------------------------------
+#: Trait type for datetime.date instances.
 Date = BaseInstance(datetime.date, editor=date_editor)
 
 
-# -- Datetime Trait definition ------------------------------------------------
+#: Trait type for datetime.datetime instances.
 Datetime = BaseInstance(datetime.datetime, editor=datetime_editor)
 
 
-# -- Time Trait definition ----------------------------------------------------
+#: Trait type for datetime.time instances.
 Time = BaseInstance(datetime.time, editor=time_editor)
 
 
@@ -3630,7 +3713,7 @@ CLong = CInt
 #: deprecated. Use ``Bool(False)`` or ``Bool()`` instead.
 false = Bool
 
-#:  Boolean values only; default value is ``True``. This trait type is
+#: Boolean values only; default value is ``True``. This trait type is
 #: deprecated. Use ``Bool(True)`` instead.
 true = Bool(True)
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1940,7 +1940,7 @@ class BaseEnum(TraitType):
         unused.
     """
 
-    def __init__(self, *args, values=None, **metadata):
+    def __init__(self, *args, **metadata):
         values = metadata.pop("values", None)
         if isinstance(values, str):
             self.name = values
@@ -3649,6 +3649,7 @@ class WeakRef(Instance):
             self.validate_failed(object, name, value)
 
         self.klass = klass
+
 
 #: Trait type for datetime.date instances.
 Date = BaseInstance(datetime.date, editor=date_editor)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -199,7 +199,10 @@ class Any(TraitType):
 
 
 class BaseInt(TraitType):
-    """ A trait type whose value must be an integer.
+    """ A trait type whose value must be an int.
+
+    Values which support the Python index protocol will validated and will be
+    converted to the corresponding int value.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -227,6 +230,9 @@ class BaseInt(TraitType):
 
 class Int(BaseInt):
     """ A fast-validating trait type whose value must be an integer.
+
+    Values which support the Python index protocol will validated and will be
+    converted to the corresponding int value.
     """
 
     #: The C-level fast validator to use:
@@ -236,8 +242,9 @@ class Int(BaseInt):
 class BaseFloat(TraitType):
     """ A trait type whose value must be a float.
 
-    Integers assigned to the trait will be converted to the corresponding
-    float.
+    Values which support automatic conversion to floats via the Python
+    __float__ method will validate and will be converted to the corresponding
+    float value.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -268,8 +275,9 @@ class BaseFloat(TraitType):
 class Float(BaseFloat):
     """ A fast-validating trait type whose value must be a float.
 
-    Integers assigned to the trait will be converted to the corresponding
-    float.
+    Values which support automatic conversion to floats via the Python
+    __float__ method will validate and will be converted to the corresponding
+    float value.
     """
 
     #: The C-level fast validator to use:
@@ -1298,8 +1306,8 @@ class PythonValue(Any):
 class BaseFile(BaseStr):
     """ A trait type whose value must be a file path string.
 
-    For Python 3.6 this will accept os.pathlib Path objects, converting them
-    to the corresponding string value.
+    For Python 3.6 and later this will accept os.pathlib Path objects,
+    converting them to the corresponding string value.
 
     Parameters
     ----------
@@ -1391,8 +1399,8 @@ class BaseFile(BaseStr):
 class File(BaseFile):
     """ A fast-validating trait type whose value must be a file path string.
 
-    For Python 3.6 this will accept os.pathlib Path objects, converting them
-    to the corresponding string value.
+    For Python 3.6 and later this will accept os.pathlib Path objects,
+    converting them to the corresponding string value.
 
     Parameters
     ----------

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -133,7 +133,7 @@ def default_text_editor(trait, type=None):
     ----------
     trait : TraitType
         The trait we are constructing the editor for.
-    type : callable or None
+    type : callable, optional
         A callable (usually a Python type) to use to evaluate the text content
         of the editor and return the correct type of value for the trait.
 
@@ -3275,7 +3275,7 @@ class Button(Event):
     height_padding : integer between 0 and 31
         Extra padding (in pixels) added to the top and bottom of the
         button.
-    view : traitsui View or None
+    view : traitsui View, optional
         An optional View to display when the button is clicked.
     **metadata
         Trait metadata for the trait.
@@ -3300,7 +3300,7 @@ class Button(Event):
     height_padding : integer between 0 and 31
         Extra padding (in pixels) added to the top and bottom of the
         button.
-    view : traitsui View or None
+    view : traitsui View, optional
         An optional View to display when the button is clicked.
     """
 
@@ -3387,7 +3387,7 @@ class ToolbarButton(Button):
     height_padding : integer between 0 and 31
         Extra padding (in pixels) added to the top and bottom of the
         button.
-    view : traitsui View or None
+    view : traitsui View, optional
         An optional View to display when the button is clicked.
     """
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -287,7 +287,7 @@ class Float(BaseFloat):
 class BaseComplex(TraitType):
     """ A trait type whose value must be a complex number.
 
-    Integers and floating point numbers will be converted to the
+    Integers and floating-point numbers will be converted to the
     corresponding complex value.
     """
 
@@ -322,7 +322,7 @@ class BaseComplex(TraitType):
 class Complex(BaseComplex):
     """ A fast-validating trait type whose value must be a complex number.
 
-    Integers and floating point numbers will be converted to the
+    Integers and floating-point numbers will be converted to the
     corresponding complex value.
     """
 
@@ -364,7 +364,7 @@ class BaseStr(TraitType):
 
 
 class Str(BaseStr):
-    """ A fast-validating trait type whose value must be a complex number..
+    """ A fast-validating trait type whose value must be a complex number.
     """
 
     #: The C-level fast validator to use:
@@ -945,7 +945,7 @@ class Module(TraitType):
 
 
 class Python(TraitType):
-    """ A trait type that behaves as to a standard Python attribute.
+    """ A trait type that behaves as a standard Python attribute.
 
     This trait type allows any value to be assigned, and raises an
     ValueError if an attempt is made to get the value before one has been
@@ -3036,7 +3036,7 @@ class Instance(BaseInstance):
 
 
 class Supports(Instance):
-    """ A trait type whose value is adatped to a specified protocol.
+    """ A trait type whose value is adapted to a specified protocol.
 
     In other words, the value of the trait directly provide, or can be adapted
     to, the given protocol (Interface or type).
@@ -3211,7 +3211,7 @@ Subclass = Type
 
 
 class Event(TraitType):
-    """ A trait type that holds no value but can be set and listend to.
+    """ A trait type that holds no value but can be set and listened to.
 
     Event traits are write-only traits.  They do not hold any value, but
     they can be assigned to, and listeners to the trait will be notified

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -188,7 +188,7 @@ def _validate_float(value):
 # -------------------------------------------------------------------------------
 
 class Any(TraitType):
-    """ Defines a trait whose value can be anything.
+    """ A trait type whose value can be anything.
     """
 
     #: The default value for the trait:
@@ -199,7 +199,7 @@ class Any(TraitType):
 
 
 class BaseInt(TraitType):
-    """ Defines a trait whose type must be an integer.
+    """ A trait type whose value must be an integer.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -226,7 +226,7 @@ class BaseInt(TraitType):
 
 
 class Int(BaseInt):
-    """ Defines trait that holds an int and uses a C-level fast validator.
+    """ A fast-validating trait type whose value must be an integer.
     """
 
     #: The C-level fast validator to use:
@@ -234,7 +234,10 @@ class Int(BaseInt):
 
 
 class BaseFloat(TraitType):
-    """ Defines a trait whose value must be a Python float.
+    """ A trait type whose value must be a float.
+
+    Integers assigned to the trait will be converted to the corresponding
+    float.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -263,7 +266,10 @@ class BaseFloat(TraitType):
 
 
 class Float(BaseFloat):
-    """ Defines a trait that holds a float and uses a C-level fast validator.
+    """ A fast-validating trait type whose value must be a float.
+
+    Integers assigned to the trait will be converted to the corresponding
+    float.
     """
 
     #: The C-level fast validator to use:
@@ -271,7 +277,10 @@ class Float(BaseFloat):
 
 
 class BaseComplex(TraitType):
-    """ Defines a trait whose value must be a Python complex.
+    """ A trait type whose value must be a complex number.
+
+    Integers and floating point numbers will be converted to the
+    corresponding complex value.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -303,7 +312,10 @@ class BaseComplex(TraitType):
 
 
 class Complex(BaseComplex):
-    """ Defines a trait that holds a complex and uses a C-level fast validator.
+    """ A fast-validating trait type whose value must be a complex number.
+
+    Integers and floating point numbers will be converted to the
+    corresponding complex value.
     """
 
     #: The C-level fast validator to use:
@@ -311,7 +323,7 @@ class Complex(BaseComplex):
 
 
 class BaseStr(TraitType):
-    """ Defines a trait whose value must be a Python string.
+    """ A trait type whose value must be a string.
     """
 
     #: The default value for the trait:
@@ -344,7 +356,7 @@ class BaseStr(TraitType):
 
 
 class Str(BaseStr):
-    """ Defines a trait that holds a str and uses a C-level fast validator.
+    """ A fast-validating trait type whose value must be a complex number..
     """
 
     #: The C-level fast validator to use:
@@ -367,7 +379,7 @@ class Title(Str):
 
 
 class BaseBytes(TraitType):
-    """ Defines a trait whose value must be a Python bytes string.
+    """ A trait type whose value must be a bytestring.
     """
 
     #: The default value for the trait:
@@ -403,20 +415,15 @@ class BaseBytes(TraitType):
 
 
 class Bytes(BaseBytes):
-    """ Defines a trait that holds a bytes and uses a C-level fast validator.
+    """ A fast-validating trait type whose value must be a bytestring.
     """
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.coerce, bytes)
 
 
-# -------------------------------------------------------------------------------
-#  'BaseBool' and 'Bool' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseBool(TraitType):
-    """ Defines a trait whose value must be a Python boolean.
+    """ A trait type whose value must be a bool.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -447,7 +454,7 @@ class BaseBool(TraitType):
 
 
 class Bool(BaseBool):
-    """ Defines a trait that holds a bool and uses a C-level fast validator.
+    """ A fast-validating trait type whose value must be a bool.
     """
 
     #: The C-level fast validator to use:
@@ -455,8 +462,7 @@ class Bool(BaseBool):
 
 
 class BaseCInt(BaseInt):
-    """ Defines a trait whose value must be a Python int and which supports
-    coercions of non-int values to int.
+    """ A coercing trait type whose value is an integer.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -474,8 +480,7 @@ class BaseCInt(BaseInt):
 
 
 class CInt(BaseCInt):
-    """ Defines a trait whose value must be a Python int and which supports
-    coercions of non-int values to int using a C-level fast validator.
+    """ A fast-validating, coercing trait type whose value is an int.
     """
 
     #: The C-level fast validator to use:
@@ -483,8 +488,7 @@ class CInt(BaseCInt):
 
 
 class BaseCFloat(BaseFloat):
-    """ Defines a trait whose value must be a Python float and which supports
-    coercions of non-float values to float.
+    """ A coercing trait type whose value is a float.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -502,22 +506,15 @@ class BaseCFloat(BaseFloat):
 
 
 class CFloat(BaseCFloat):
-    """ Defines a trait whose value must be a Python float and which supports
-    coercions of non-float values to float using a C-level fast validator.
+    """ A fast-validating, coercing trait type whose value is a float.
     """
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.cast, float)
 
 
-# -------------------------------------------------------------------------------
-#  'BaseCComplex' and 'CComplex' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseCComplex(BaseComplex):
-    """ Defines a trait whose value must be a Python complex and which supports
-    coercions of non-complex values to complex.
+    """ A coercing trait type whose value is a complex number.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -535,23 +532,15 @@ class BaseCComplex(BaseComplex):
 
 
 class CComplex(BaseCComplex):
-    """ Defines a trait whose value must be a Python complex and which supports
-    coercions of non-complex values to complex using a C-level fast
-    validator.
+    """ A fast-validating, coercing trait type whose value is a complex number.
     """
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.cast, complex)
 
 
-# -------------------------------------------------------------------------------
-#  'BaseCStr' and 'CStr' traits:
-# -------------------------------------------------------------------------------
-
-
 class BaseCStr(BaseStr):
-    """ Defines a trait whose value must be a Python string and which supports
-    coercions of non-string values to string.
+    """ A coercing trait type whose value is a string.
     """
 
     def validate(self, object, name, value):
@@ -566,9 +555,7 @@ class BaseCStr(BaseStr):
 
 
 class CStr(BaseCStr):
-    """ Defines a trait whose value must be a Python string and which supports
-    coercions of non-string values to string using a C-level fast
-    validator.
+    """ A fast-validating, coercing trait type whose value is a string.
     """
 
     #: The C-level fast validator to use:
@@ -576,8 +563,7 @@ class CStr(BaseCStr):
 
 
 class BaseCBytes(BaseBytes):
-    """ Defines a trait whose value must be a Python bytes object and which
-    supports coercions of non-bytes values to bytes.
+    """ A coercing trait type whose value is a bytestring.
     """
 
     def validate(self, object, name, value):
@@ -592,9 +578,7 @@ class BaseCBytes(BaseBytes):
 
 
 class CBytes(BaseCBytes):
-    """ Defines a trait whose value must be a Python bytes and which
-    supports coercions of non-bytes values bytes using a C-level
-    fast validator.
+    """ A fast-validating, coercing trait type whose value is a bytestring.
     """
 
     #: The C-level fast validator to use:
@@ -602,8 +586,7 @@ class CBytes(BaseCBytes):
 
 
 class BaseCBool(BaseBool):
-    """ Defines a trait whose value must be a Python boolean and which supports
-    coercions of non-boolean values to boolean.
+    """ A coercing trait type whose value is a bool.
     """
 
     #: The function to use for evaluating strings to this type:
@@ -621,9 +604,7 @@ class BaseCBool(BaseBool):
 
 
 class CBool(BaseCBool):
-    """ Defines a trait whose value must be a Python boolean and which supports
-    coercions of non-boolean values to boolean using a C-level fast
-    validator.
+    """ A fast-validating, coercing trait type whose value is a bool.
     """
 
     #: The C-level fast validator to use:
@@ -631,9 +612,10 @@ class CBool(BaseCBool):
 
 
 class String(TraitType):
-    """ Defines a trait whose value must be a Python string whose length is
-    optionally in a specified range, and which optionally matches a specified
-    regular expression.
+    """ A trait type whose value must be a string with optional constraints.
+
+    The value is a string whose length is in a specified range, and which
+    optionally matches a specified regular expression.
 
     Parameters
     ----------
@@ -779,9 +761,7 @@ class String(TraitType):
 
 
 class Regex(String):
-    """ A trait whose value is a string that matches a regular expression.
-
-    This is a special case of the String trait.
+    """ A trait type whose value must match a regular expression.
 
     Parameters
     ----------
@@ -798,8 +778,10 @@ class Regex(String):
 
 
 class Code(String):
-    """ Defines a trait whose value is a Python string that represents source
-    code in some language.
+    """ A trait type whose value holds a string of source code.
+
+    Validation does not perform any sort of syntax checking. The default
+    TraitsUI editor is a CodeEditor.
     """
 
     #: The standard metadata for the trait:
@@ -807,9 +789,10 @@ class Code(String):
 
 
 class HTML(String):
-    """ Defines a trait whose value must be a string that is interpreted as
-    being HTML. By default the value is parsed and displayed as HTML in
-    TraitsUI views. The validation of the value does not enforce HTML syntax.
+    """ A trait type whose value holds an HTML string.
+
+    The validation of the value does not enforce HTML syntax.  The default
+    TraitsUI editor is an HTMLEditor.
     """
 
     #: The standard metadata for the trait:
@@ -817,11 +800,10 @@ class HTML(String):
 
 
 class Password(String):
-    """ Defines a trait whose value must be a string, optionally of constrained
-    length or matching a regular expression.
+    """ A trait type whose value holds a password string.
 
-    The trait is identical to a String trait except that by default it uses a
-    PasswordEditor in TraitsUI views, which obscures text entered by the user.
+    The default TraitsUI editor is an PasswordEditor, which obscures text
+    entered by the user.
     """
 
     #: The standard metadata for the trait:
@@ -829,10 +811,7 @@ class Password(String):
 
 
 class BaseCallable(TraitType):
-    """ Defines a trait whose value must be a Python callable.
-
-    This class can be subclassed to define new callable trait types; for
-    example, by overriding the validate method.
+    """ A trait type whose value must be a Python callable.
     """
 
     #: The standard metadata for the trait:
@@ -854,10 +833,7 @@ class BaseCallable(TraitType):
 
 
 class Callable(BaseCallable):
-    """ Defines a trait whose value must be a Python callable using a
-    C level validator.
-
-    Subclass :class:`~.BaseCallable` to define new callable trait types.
+    """ A fast-validating trait type whose value must be a Python callable.
     """
 
     #: The C-level fast validator to use
@@ -865,7 +841,9 @@ class Callable(BaseCallable):
 
 
 class BaseType(TraitType):
-    """ Defines a trait whose value must be an instance of a simple Python type.
+    """ A trait type whose value must be an instance of a Python type.
+
+    This is an abstract class and should not be directly instantiated.
     """
 
     def validate(self, object, name, value):
@@ -878,7 +856,7 @@ class BaseType(TraitType):
 
 
 class This(BaseType):
-    """ Defines a trait whose value must be an instance of the defining class.
+    """ A trait type whose value must be an instance of the defining class.
     """
 
     #: The C-level fast validator to use:
@@ -915,8 +893,10 @@ class This(BaseType):
 
 
 class self(This):
-    """ Defines a trait whose value must be an instance of the defining class
-    and whose default value is the object containing the trait.
+    """ A trait type whose default value is the object containing the trait.
+
+    The trait can be assigned to, but any new value must be an instance of
+    the defining class.
     """
 
     #: The default value type to use (i.e. 'self'):
@@ -924,7 +904,7 @@ class self(This):
 
 
 class Function(TraitType):
-    """ Defines a trait whose value must be a Python function.
+    """ A trait type whose value must be a function.
     """
 
     #: The C-level fast validator to use:
@@ -935,7 +915,7 @@ class Function(TraitType):
 
 
 class Method(TraitType):
-    """ Defines a trait whose value must be a Python method.
+    """ A trait type whose value must be a method.
     """
 
     #: The C-level fast validator to use:
@@ -946,7 +926,7 @@ class Method(TraitType):
 
 
 class Module(TraitType):
-    """ Defines a trait whose value must be a Python module.
+    """ A trait type whose value must be a module.
     """
 
     #: The C-level fast validator to use:
@@ -957,9 +937,9 @@ class Module(TraitType):
 
 
 class Python(TraitType):
-    """ Defines a trait that behaves as to a standard Python attribute.
+    """ A trait type that behaves as to a standard Python attribute.
 
-    That is, it allows any value to be assigned, and raises an
+    This trait type allows any value to be assigned, and raises an
     ValueError if an attempt is made to get the value before one has been
     assigned. It has no default value. This trait is most often used in
     conjunction with wildcard naming. See the *Traits User Manual* for
@@ -974,7 +954,7 @@ class Python(TraitType):
 
 
 class ReadOnly(TraitType):
-    """ Defines a trait that is write-once, and then read-only.
+    """ A trait type that is write-once, and then read-only.
 
     The initial value of the attribute is the special, singleton object
     Undefined. The trait allows any value to be assigned to the attribute
@@ -982,8 +962,8 @@ class ReadOnly(TraitType):
     assigned, no further assignment is allowed. Normally, the initial
     assignment to the attribute is performed in the class constructor,
     based on information passed to the constructor. If the read-only value
-    is known in advance of run time, use the Constant() function instead of
-    ReadOnly to define the trait.
+    is known in advance of run time, use Constant instead of ReadOnly to
+    define the trait.
     """
 
     # Defines the CTrait type to use for this trait:
@@ -998,12 +978,13 @@ ReadOnly = ReadOnly()
 
 
 class Disallow(TraitType):
-    """ Defines a trait that prevents any value from being assigned or read.
+    """ A trait that prevents any value from being assigned or read.
 
-    That is, any attempt to get or set the value of the trait attribute
-    raises an exception. This trait is most often used in conjunction with
-    wildcard naming, for example, to catch spelling mistakes in attribute
-    names. See the *Traits User Manual* for details on wildcards.
+    Any attempt to get or set the value of the trait attribute raises an
+    exception. This trait is most often used in conjunction with wildcard
+    naming, for example, to catch spelling mistakes in attribute names.
+
+    See the *Traits User Manual* for details on wildcards.
     """
 
     #: Defines the CTrait type to use for this trait:
@@ -1015,7 +996,7 @@ Disallow = Disallow()
 
 
 class Constant(TraitType):
-    """ Defines a trait whose value is a constant.
+    """ A trait type whose value is a constant.
 
     Traits of this type are very space efficient (and fast) because
     *value* is not stored in each instance using the trait, but only in
@@ -1046,7 +1027,7 @@ class Constant(TraitType):
 
 
 class Delegate(TraitType):
-    """ A trait whose value is delegated to a trait on another object.
+    """ A trait type whose value is delegated to a trait on another object.
 
     This is a base class that shouldn't be used directly, rather use one of
     the subclasses DelegatesTo or PrototypesFrom, depending on desired
@@ -1149,7 +1130,7 @@ class Delegate(TraitType):
 
 
 class DelegatesTo(Delegate):
-    """ A trait delegate that matches the 'delegate' design pattern.
+    """ A trait type that matches the 'delegate' design pattern.
 
     This defines a trait whose value and definition is "delegated" to
     another trait on a different object.
@@ -1204,7 +1185,7 @@ class DelegatesTo(Delegate):
 
 
 class PrototypedFrom(Delegate):
-    """ A trait delegate that matches the 'prototype' design pattern.
+    """ A trait type that matches the 'prototype' design pattern.
 
     This defines a trait whose default value and definition is "prototyped"
     from another trait on a different object.
@@ -1261,7 +1242,7 @@ class PrototypedFrom(Delegate):
 
 
 class Expression(TraitType):
-    """ Defines a trait whose value must be a valid Python expression.
+    """ A trait type whose value must be a valid Python expression.
 
     The compiled form of a valid expression is stored as the mapped value of
     the trait.
@@ -1305,8 +1286,9 @@ class Expression(TraitType):
 
 
 class PythonValue(Any):
-    """ Defines a trait whose value can be of any type, and whose default
-    editor is a Python shell.
+    """ A trait type whose value can be of any type.
+
+    The default editor is a ShellEditor.
     """
 
     #: The standard metadata for the trait:
@@ -1314,7 +1296,7 @@ class PythonValue(Any):
 
 
 class BaseFile(BaseStr):
-    """ Defines a trait whose value must be the name of a file.
+    """ A trait type whose value must be a file path string.
 
     For Python 3.6 this will accept os.pathlib Path objects, converting them
     to the corresponding string value.
@@ -1407,9 +1389,7 @@ class BaseFile(BaseStr):
 
 
 class File(BaseFile):
-    """ Defines a trait whose value must be the name of a file.
-
-    When possible, this uses a C-level fast validator.
+    """ A fast-validating trait type whose value must be a file path string.
 
     For Python 3.6 this will accept os.pathlib Path objects, converting them
     to the corresponding string value.
@@ -1462,7 +1442,7 @@ class File(BaseFile):
 
 
 class BaseDirectory(BaseStr):
-    """ Defines a trait whose value must be the name of a directory.
+    """ A trait type whose value is a directory path string.
 
     Parameters
     ----------
@@ -1526,9 +1506,7 @@ class BaseDirectory(BaseStr):
 
 
 class Directory(BaseDirectory):
-    """ Defines a trait whose value must be the name of a directory.
-
-    When possible, this uses a C-level fast validator.
+    """ A fast-validating trait type whose value is a directory path string.
 
     Parameters
     ----------
@@ -1570,7 +1548,11 @@ class Directory(BaseDirectory):
 
 
 class BaseRange(TraitType):
-    """ Defines a trait whose numeric value must be in a specified range.
+    """ A trait type whose numeric value lies inside a range.
+
+    The value held will be either an integer or a float, which type is
+    determined by whether the *low*, *high* and *value* arguments are
+    integers or floats.
 
     The *low*, *high*, and *value* arguments must be of the same type
     (integer or float), except in the case where either *low* or *high* is
@@ -1894,8 +1876,7 @@ class BaseRange(TraitType):
 
 
 class Range(BaseRange):
-    """ Defines a trait whose numeric value must be in a specified range using
-    a C-level fast validator.
+    """ A fast-validating trait type whose numeric value lies inside a range.
     """
 
     def init_fast_validate(self, *args):
@@ -1905,7 +1886,7 @@ class Range(BaseRange):
 
 
 class BaseEnum(TraitType):
-    """ Defines a trait whose value must be one of a specified set of values.
+    """ A trait type whose value is one of a set of values.
 
     The default value is the first positional argument, or the first item of
     the list, tuple or enum.Enum if that is the only argument or if the valid
@@ -2036,7 +2017,7 @@ class BaseEnum(TraitType):
 
 
 class Enum(BaseEnum):
-    """ Defines an Enum trait which uses C-level validation.
+    """ A fast-validating trait type whose value is one of a set of values.
 
     The default value is the first positional argument, or the first item of
     the list, tuple or enum.Enum if that is the only argument or if the valid
@@ -2078,7 +2059,7 @@ class Enum(BaseEnum):
 
 
 class BaseTuple(TraitType):
-    """ Defines a trait whose value must be a tuple of specified trait types.
+    """ A trait type holding a tuple with typed elements.
 
     The default value is determined as follows:
 
@@ -2219,8 +2200,7 @@ class BaseTuple(TraitType):
 
 
 class Tuple(BaseTuple):
-    """ Defines a trait whose value must be a tuple of specified trait types
-        using a C-level fast validator.
+    """ A fast-validating trait type holding a tuple with typed elements.
     """
 
     def init_fast_validate(self, *args):
@@ -2232,7 +2212,7 @@ class Tuple(BaseTuple):
 
 
 class ValidatedTuple(BaseTuple):
-    """ A Tuple trait that supports custom validation.
+    """ A trait type holding a tuple with customized validation.
 
     Parameters
     ----------
@@ -2416,9 +2396,7 @@ class List(TraitType):
 
 
 class CList(List):
-    """ Defines a trait whose values must be a list whose items are of the
-    specified trait type or which can be coerced to a list whose values are
-    of the specified trait type.
+    """ A coercing trait type for a list of values of the specified type.
     """
 
     def validate(self, object, name, value):
@@ -2531,9 +2509,7 @@ class Set(TraitType):
 
 
 class CSet(Set):
-    """ Defines a trait whose values must be a set whose items are of the
-        specified trait type or which can be coerced to a set whose values are
-        of the specified trait type.
+    """ A coercing trait type for a set of values of the specified type.
     """
 
     def validate(self, object, name, value):
@@ -2559,8 +2535,7 @@ class CSet(Set):
 
 
 class Dict(TraitType):
-    """ Defines a trait whose value must be a dictionary, optionally with
-    specified types for keys and values.
+    """ A trait type for a dictionary with specified key and value types.
 
 
     Parameters
@@ -2679,7 +2654,7 @@ AdaptMap = {"no": 0, "yes": 1, "default": 2}
 
 
 class BaseClass(TraitType):
-    """ Base class for types which have an associated class.
+    """ A base trait type for trait types which have an associated class.
 
     Traits sometimes need to be able to access classes which have not
     yet been defined, or which are from a module that we want to defer
@@ -2746,14 +2721,13 @@ class BaseClass(TraitType):
 
 
 class BaseInstance(BaseClass):
-    """ Defines a trait whose value must be an instance of a specified class,
-    or one of its subclasses.
+    """ A trait type whose value is an instance of a class or its subclasses.
 
-    **None** if *klass* is an instance or if it is a class and *args* and
-    *kw* are not specified. Otherwise, the default value is the instance
-    obtained by calling ``klass(*args, **kw)``. Note that the constructor
-    call is performed each time a default value is assigned, so each
-    default value assigned is a unique instance.
+    The default value is **None** if *klass* is an instance or if it is a
+    class and *args* and *kw* are not specified. Otherwise, the default value
+    is the instance obtained by calling ``klass(*args, **kw)``. Note that the
+    constructor call is performed each time a default value is assigned, so
+    each default value assigned is a unique instance.
 
     Parameters
     ----------
@@ -2806,6 +2780,7 @@ class BaseInstance(BaseClass):
           default value for the trait should be used.
     """
 
+    #: Default adaptation behavior.
     adapt_default = "no"
 
     def __init__(
@@ -3031,8 +3006,7 @@ class BaseInstance(BaseClass):
 
 
 class Instance(BaseInstance):
-    """ Defines a trait whose value must be an instance of a specified class,
-    or one of its subclasses using a C-level fast validator.
+    """ A fast-validated trait type whose value is an instance of a class.
     """
 
     def init_fast_validate(self):
@@ -3054,7 +3028,7 @@ class Instance(BaseInstance):
 
 
 class Supports(Instance):
-    """ A traits whose value must support a specified protocol.
+    """ A trait type whose value is adatped to a specified protocol.
 
     In other words, the value of the trait directly provide, or can be adapted
     to, the given protocol (Interface or type).
@@ -3089,7 +3063,7 @@ class Supports(Instance):
 
 
 class AdaptsTo(Supports):
-    """ A traits whose value must support a specified protocol.
+    """ A trait type whose value must support a specified protocol.
 
     In other words, the value of the trait directly provide, or can be adapted
     to, the given protocol (Interface or type).
@@ -3108,7 +3082,7 @@ class AdaptsTo(Supports):
 
 
 class Type(BaseClass):
-    """ Defines a trait whose value must be a subclass of a specified class.
+    """ A trait type whose value must be a subclass of a specified class.
 
     Parameters
     ----------
@@ -3229,6 +3203,24 @@ Subclass = Type
 
 
 class Event(TraitType):
+    """ A trait type that holds no value but can be set and listend to.
+
+    Event traits are write-only traits.  They do not hold any value, but
+    they can be assigned to, and listeners to the trait will be notified
+    of the assignment.  Since no value is held, trait change functions that
+    ask for the ``old`` value of the trait will be given the Undefined
+    special value.
+
+    Event traits can be given an optional trait type that is used to validate
+    values assigned to the trait.  If the assigned value does not validate,
+    then a TraitError will occur.
+
+    Parameters
+    ----------
+    trait : a trait
+        The type of value that can be assigned to the event.
+    """
+
     def __init__(self, trait=None, **metadata):
         metadata["type"] = "event"
         metadata["transient"] = True
@@ -3253,7 +3245,7 @@ class Event(TraitType):
 
 
 class Button(Event):
-    """ Defines an Event trait whose UI editor is a button.
+    """ An Event trait type whose UI editor is a button.
 
     Parameters
     ----------
@@ -3343,7 +3335,7 @@ class Button(Event):
 
 
 class ToolbarButton(Button):
-    """ Defines a trait whose UI editor is a toolbar button.
+    """ A Button trait type whose UI editor is a toolbar button.
 
     This is just a Button trait with different defaults to style it like
     a toolbar button.
@@ -3413,7 +3405,7 @@ class ToolbarButton(Button):
 
 
 class Either(TraitType):
-    """ Defines a trait whose value can be any of of a specified list of traits.
+    """ A trait type whose value can be any of of a specified list of traits.
 
     Parameters
     ----------
@@ -3440,7 +3432,7 @@ class Either(TraitType):
 
 
 class Symbol(TraitType):
-    """ A property trait type that refers to a Python object.
+    """ A property trait type that refers to a Python object by name.
 
     The value set to the trait must be a value of the form
     ``'[package.package...package.]module[:symbol[([arg1,...,argn])]]'``
@@ -3502,7 +3494,7 @@ class Symbol(TraitType):
 
 
 class UUID(TraitType):
-    """ Defines a read-only trait whose value is a globally unique UUID (type 4).
+    """ A read-only trait type whose value is a globally unique UUID (type 4).
 
     Parameters
     ----------
@@ -3582,7 +3574,7 @@ class UUID(TraitType):
 
 
 class WeakRef(Instance):
-    """ A trait holding a weak reference to an instance of a class.
+    """ A trait type holding a weak reference to an instance of a class.
 
     Only a weak reference is maintained to any object assigned to a WeakRef
     trait. If no other references exist to the assigned value, the value
@@ -3651,15 +3643,15 @@ class WeakRef(Instance):
         self.klass = klass
 
 
-#: Trait type for datetime.date instances.
+#: A trait type for datetime.date instances.
 Date = BaseInstance(datetime.date, editor=date_editor)
 
 
-#: Trait type for datetime.datetime instances.
+#: A trait type for datetime.datetime instances.
 Datetime = BaseInstance(datetime.datetime, editor=datetime_editor)
 
 
-#: Trait type for datetime.time instances.
+#: A trait type for datetime.time instances.
 Time = BaseInstance(datetime.time, editor=time_editor)
 
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -827,24 +827,21 @@ class String(TraitType):
 
 
 class Regex(String):
-    """ Defines a trait whose value is a Python string that matches a specified
-        regular expression.
+    """ A trait whose value is a string that matches a regular expression.
+
+    This is a special case of the String trait.
+
+    Parameters
+    ----------
+    value : str
+        The default value of the trait.
+    regex : str
+        The regular expression that the trait value must match.
+    **metadata
+        Trait metadata.
     """
 
     def __init__(self, value="", regex=".*", **metadata):
-        """ Creates a Regex trait.
-
-        Parameters
-        ----------
-        value : str
-            The default value of the trait.
-        regex : str
-            The regular expression that the trait value must match.
-
-        Default Value
-        -------------
-        *value* or ''
-        """
         super(Regex, self).__init__(value=value, regex=regex, **metadata)
 
 
@@ -1111,6 +1108,16 @@ Disallow = Disallow()
 
 class Constant(TraitType):
     """  Defines a trait whose value is a constant.
+
+    Traits of this type are very space efficient (and fast) because
+    *value* is not stored in each instance using the trait, but only in
+    the trait object itself. The *value* cannot be a list or dictionary,
+    because those types have mutable values.
+
+    Parameters
+    ----------
+    value : any type other than list or dict
+        The constant value for the trait.
     """
 
     #: Defines the CTrait type to use for this trait:
@@ -1120,24 +1127,6 @@ class Constant(TraitType):
     metadata = {"type": "constant", "transient": True}
 
     def __init__(self, value, **metadata):
-        """ Returns a constant, read-only trait whose value is *value*.
-
-            Parameters
-            ----------
-            value : any type except a list or dictionary
-                The default value for the trait.
-
-            Default Value
-            -------------
-            *value*
-
-            Description
-            -----------
-            Traits of this type are very space efficient (and fast) because
-            *value* is not stored in each instance using the trait, but only in
-            the trait object itself. The *value* cannot be a list or dictionary,
-            because those types have mutable values.
-        """
         if type(value) in MutableTypes:
             raise TraitError(
                 "Cannot define a constant using a mutable list or dictionary"
@@ -1205,52 +1194,49 @@ class Delegate(TraitType):
 
 
 class DelegatesTo(Delegate):
-    """ Defines a trait delegate that matches the standard 'delegate' design
-        pattern.
+    """ A trait delegate that matches the 'delegate' design pattern.
+
+    This defines a trait whose value and definition is "delegated" to
+    another trait on a different object.
+
+    An object containing a delegator trait attribute must contain a
+    second attribute that references the object containing the delegate
+    trait attribute. The name of this second attribute is passed as the
+    *delegate* argument to the DelegatesTo() function.
+
+    The following rules govern the application of the prefix parameter:
+
+    * If *prefix* is empty or omitted, the delegation is to an attribute
+      of the delegate object with the same name as the delegator
+      attribute.
+    * If *prefix* is a valid Python attribute name, then the delegation
+      is to an attribute whose name is the value of *prefix*.
+    * If *prefix* ends with an asterisk ('*') and is longer than one
+      character, then the delegation is to an attribute whose name is
+      the value of *prefix*, minus the trailing asterisk, prepended to
+      the delegator attribute name.
+    * If *prefix* is equal to a single asterisk, the delegation is to an
+      attribute whose name is the value of the delegator object's
+      __prefix__ attribute prepended to delegator attribute name.
+
+    Note that any changes to the delegator attribute are actually
+    applied to the corresponding attribute on the delegate object. The
+    original object containing the delegator trait is not modified.
+
+    Parameters
+    ----------
+    delegate : str
+        Name of the attribute on the current object which references
+        the object that is the trait's delegate.
+    prefix : str
+        A prefix or substitution applied to the original attribute when
+        looking up the delegated attribute.
+    listenable : bool
+        Indicates whether a listener can be attached to this attribute
+        such that changes to the delagate attribute will trigger it.
     """
 
     def __init__(self, delegate, prefix="", listenable=True, **metadata):
-        """ Creates a "delegator" trait, whose definition and default value are
-            delegated to a *delegate* trait attribute on another object.
-
-            Parameters
-            ----------
-            delegate : str
-                Name of the attribute on the current object which references
-                the object that is the trait's delegate.
-            prefix : str
-                A prefix or substitution applied to the original attribute when
-                looking up the delegated attribute.
-            listenable : bool
-                Indicates whether a listener can be attached to this attribute
-                such that changes to the delagate attribute will trigger it.
-
-            Description
-            -----------
-            An object containing a delegator trait attribute must contain a
-            second attribute that references the object containing the delegate
-            trait attribute. The name of this second attribute is passed as the
-            *delegate* argument to the DelegatesTo() function.
-
-            The following rules govern the application of the prefix parameter:
-
-            * If *prefix* is empty or omitted, the delegation is to an attribute
-              of the delegate object with the same name as the delegator
-              attribute.
-            * If *prefix* is a valid Python attribute name, then the delegation
-              is to an attribute whose name is the value of *prefix*.
-            * If *prefix* ends with an asterisk ('*') and is longer than one
-              character, then the delegation is to an attribute whose name is
-              the value of *prefix*, minus the trailing asterisk, prepended to
-              the delegator attribute name.
-            * If *prefix* is equal to a single asterisk, the delegation is to an
-              attribute whose name is the value of the delegator object's
-              __prefix__ attribute prepended to delegator attribute name.
-
-            Note that any changes to the delegator attribute are actually
-            applied to the corresponding attribute on the delegate object. The
-            original object containing the delegator trait is not modified.
-        """
         super(DelegatesTo, self).__init__(
             delegate,
             prefix=prefix,
@@ -1266,55 +1252,51 @@ class DelegatesTo(Delegate):
 
 
 class PrototypedFrom(Delegate):
-    """ Defines a trait delegate that matches the standard 'prototype' design
-        pattern.
+    """ A trait delegate that matches the 'prototype' design pattern.
+
+    This defines a trait whose default value and definition is "prototyped"
+    from another trait on a different object.
+
+    An object containing a prototyped trait attribute must contain a
+    second attribute that references the object containing the prototype
+    trait attribute. The name of this second attribute is passed as the
+    *prototype* argument to the PrototypedFrom() function.
+
+    The following rules govern the application of the prefix parameter:
+
+    * If *prefix* is empty or omitted, the prototype delegation is to an
+      attribute of the prototype object with the same name as the
+      prototyped attribute.
+    * If *prefix* is a valid Python attribute name, then the prototype
+      delegation is to an attribute whose name is the value of *prefix*.
+    * If *prefix* ends with an asterisk ('*') and is longer than one
+      character, then the prototype delegation is to an attribute whose
+      name is the value of *prefix*, minus the trailing asterisk,
+      prepended to the prototyped attribute name.
+    * If *prefix* is equal to a single asterisk, the prototype
+      delegation is to an attribute whose name is the value of the
+      prototype object's __prefix__ attribute prepended to the
+      prototyped attribute name.
+
+    Note that any changes to the prototyped attribute are made to the
+    original object, not the prototype object. The prototype object is
+    only used to define to trait type and default value.
+
+    Parameters
+    ----------
+    prototype : str
+        Name of the attribute on the current object which references the
+        object that is the trait's prototype.
+    prefix : str
+        A prefix or substitution applied to the original attribute when
+        looking up the prototyped attribute.
+    listenable : bool
+        Indicates whether a listener can be attached to this attribute
+        such that changes to the corresponding attribute on the
+        prototype object will trigger it.
     """
 
     def __init__(self, prototype, prefix="", listenable=True, **metadata):
-        """ Creates a "prototyped" trait, whose definition and default value are
-            obtained from a trait attribute on another object.
-
-            Parameters
-            ----------
-            prototype : str
-                Name of the attribute on the current object which references the
-                object that is the trait's prototype.
-            prefix : str
-                A prefix or substitution applied to the original attribute when
-                looking up the prototyped attribute.
-            listenable : bool
-                Indicates whether a listener can be attached to this attribute
-                such that changes to the corresponding attribute on the
-                prototype object will trigger it.
-
-            Description
-            -----------
-            An object containing a prototyped trait attribute must contain a
-            second attribute that references the object containing the prototype
-            trait attribute. The name of this second attribute is passed as the
-            *prototype* argument to the PrototypedFrom() function.
-
-            The following rules govern the application of the prefix parameter:
-
-            * If *prefix* is empty or omitted, the prototype delegation is to an
-              attribute of the prototype object with the same name as the
-              prototyped attribute.
-            * If *prefix* is a valid Python attribute name, then the prototype
-              delegation is to an attribute whose name is the value of *prefix*.
-            * If *prefix* ends with an asterisk ('*') and is longer than one
-              character, then the prototype delegation is to an attribute whose
-              name is the value of *prefix*, minus the trailing asterisk,
-              prepended to the prototyped attribute name.
-            * If *prefix* is equal to a single asterisk, the prototype
-              delegation is to an attribute whose name is the value of the
-              prototype object's __prefix__ attribute prepended to the
-              prototyped attribute name.
-
-            Note that any changes to the prototyped attribute are made to the
-            original object, not the prototype object. The prototype object is
-            only used to define to trait type and default value.
-
-        """
         super(PrototypedFrom, self).__init__(
             prototype,
             prefix=prefix,
@@ -1955,23 +1937,23 @@ class Range(BaseRange):
 
 class BaseEnum(TraitType):
     """ Defines a trait whose value must be one of a specified set of values.
+
+    Parameters
+    ----------
+    *args
+        The enumeration of all legal values for the trait, either as
+        positional arguments or a list, enum.Enum or tuple.  The default
+        value is the first positional argument, or the first item of
+        the sequence.
+    values : str, list, tuple or enum.Enum
+        If a sting, the name of a trait holding the values, in which
+        case there must be at most one positional argument holding the
+        default value.  If there is no default value, then the default value
+        is the first item of the value stored in the trait.
     """
 
-    def __init__(self, *args, **metadata):
+    def __init__(self, *args, values=None, **metadata):
         """ Returns an Enum trait.
-
-        Parameters
-        ----------
-        *args : *values or (default, values) or values
-            The enumeration of all legal values for the trait, either as
-            positional arguments or a list, enum.Enum or tuple.  The default
-            value is the first positional argument, or the first item of
-            the sequence.
-        values : str
-            The name of a trait holding the values, in which case there
-            must be at most one positional argument holding the default
-            value.  If there is no default value, then the default value
-            is the first item of the value stored in the trait.
 
         Default Value
         -------------

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -201,7 +201,7 @@ class Any(TraitType):
 class BaseInt(TraitType):
     """ A trait type whose value must be an int.
 
-    Values which support the Python index protocol will validated and will be
+    Values which support the Python index protocol will validate and will be
     converted to the corresponding int value.
     """
 


### PR DESCRIPTION
General overhaul of docstrings in the `traits.trait_types` module.

- Moved parameters from __init__ to class docstrings
- Added class attributes.
- Cleaned up exposition where it was needed.