### PR TITLE
Fix test for DatetimeEditor to avoid failure if TraitsUI not installed

### DIFF
--- a/traits/tests/test_editor_factories.py
+++ b/traits/tests/test_editor_factories.py
@@ -29,13 +29,11 @@ from traits.editor_factories import (
 from traits.testing.optional_dependencies import requires_traitsui, traitsui
 
 
-# The DatetimeEditor is not yet in a released version of TraitsUI.
-if traitsui is not None:
-    try:
-        DatetimeEditor = traitsui.api.DatetimeEditor
-    except AttributeError:
-        DatetimeEditor = None
-else:
+# The DatetimeEditor is not yet in a released version of TraitsUI. It
+# will be available in TraitsUI >= 6.2.0.
+try:
+    DatetimeEditor = traitsui.api.DatetimeEditor
+except AttributeError:
     DatetimeEditor = None
 
 

--- a/traits/tests/test_editor_factories.py
+++ b/traits/tests/test_editor_factories.py
@@ -29,6 +29,16 @@ from traits.editor_factories import (
 from traits.testing.optional_dependencies import requires_traitsui, traitsui
 
 
+# The DatetimeEditor is not yet in a released version of TraitsUI.
+if traitsui is not None:
+    try:
+        DatetimeEditor = traitsui.api.DatetimeEditor
+    except AttributeError:
+        DatetimeEditor = None
+else:
+    DatetimeEditor = None
+
+
 class SimpleEditorTestMixin:
 
     def setUp(self):
@@ -65,9 +75,7 @@ class TestDateEditor(SimpleEditorWithCachingTestMixin, unittest.TestCase):
     factory_name = "date_editor"
 
 
-@requires_traitsui
-@unittest.skipIf(getattr(traitsui.api, 'DatetimeEditor', None) is None,
-                 "DatetimeEditor is not in traitsui.api")
+@unittest.skipIf(DatetimeEditor is None, "DatetimeEditor not available")
 class TestDatetimeEditor(SimpleEditorTestMixin, unittest.TestCase):
     traitsui_name = "DatetimeEditor"
     factory_name = "datetime_editor"


### PR DESCRIPTION
Fixes #847 

Needs backport to the 6.0 release branch.