### PR TITLE
Fix DatetimeEditor test ImportError when traitsui not installed (#848 backport)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,7 +102,7 @@ Here's a guide to dealing with some of the potentially breaking changes.
 Features
 ~~~~~~~~
 
-* Add new ``Datetime`` trait type. (#737, #814, #813, #815)
+* Add new ``Datetime`` trait type. (#737, #814, #813, #815, #848)
 * Support Python Enums as value sets for the ``Enum`` trait. (#685, #828)
 * Add ``Subclass`` alias for the ``Type`` trait type. (#739)
 * Add path-like support for the ``File`` trait. (#736)

--- a/traits/tests/test_editor_factories.py
+++ b/traits/tests/test_editor_factories.py
@@ -29,6 +29,14 @@ from traits.editor_factories import (
 from traits.testing.optional_dependencies import requires_traitsui, traitsui
 
 
+# The DatetimeEditor is not yet in a released version of TraitsUI. It
+# will be available in TraitsUI >= 6.2.0.
+try:
+    DatetimeEditor = traitsui.api.DatetimeEditor
+except AttributeError:
+    DatetimeEditor = None
+
+
 class SimpleEditorTestMixin:
 
     def setUp(self):
@@ -65,9 +73,7 @@ class TestDateEditor(SimpleEditorWithCachingTestMixin, unittest.TestCase):
     factory_name = "date_editor"
 
 
-@requires_traitsui
-@unittest.skipIf(getattr(traitsui.api, 'DatetimeEditor', None) is None,
-                 "DatetimeEditor is not in traitsui.api")
+@unittest.skipIf(DatetimeEditor is None, "DatetimeEditor not available")
 class TestDatetimeEditor(SimpleEditorTestMixin, unittest.TestCase):
     traitsui_name = "DatetimeEditor"
     factory_name = "datetime_editor"


### PR DESCRIPTION
Backport of #848 from master branch to the 6.0.x release branch