### PR TITLE
Additional class docstring fixes

### DIFF
--- a/docs/source/traits_api_reference/trait_numeric.rst
+++ b/docs/source/traits_api_reference/trait_numeric.rst
@@ -8,12 +8,16 @@ Classes
 -------
 
 .. autoclass:: AbstractArray
+   :show-inheritance:
 
 .. autoclass:: Array
+   :show-inheritance:
 
 .. autoclass:: ArrayOrNone
+   :show-inheritance:
 
 .. autoclass:: CArray
+   :show-inheritance:
 
 Function
 --------

--- a/traits/adaptation/adapter.py
+++ b/traits/adaptation/adapter.py
@@ -25,22 +25,14 @@ class PurePythonAdapter(object):
     """ Base class for pure Python adapters. """
 
     def __init__(self, adaptee):
-        """ Constructor. """
-
         self.adaptee = adaptee
-
-        return
 
 
 class Adapter(HasTraits):
     """ Base class for adapters with traits. """
 
     def __init__(self, adaptee, **traits):
-        """ Constructor. """
-
         traits["adaptee"] = adaptee
         super(Adapter, self).__init__(**traits)
-
-        return
 
     adaptee = Any

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -58,13 +58,8 @@ class ETSConfig(object):
     #### operator methods #####################################################
 
     def __init__(self):
-        """
-        Constructor.
-
-        Note that this constructor can only ever be called from within this
-        module, since we don't expose the class.
-
-        """
+        # Note that this constructor can only ever be called from within this
+        # module, since we don't expose the class.
 
         # Shadow attributes for properties.
         self._application_data = None

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -39,6 +39,28 @@ from traits.util.async_trait_wait import wait_for_condition
 class _AssertTraitChangesContext(object):
     """ A context manager used to implement the trait change assert methods.
 
+    Notes
+    -----
+    Checking if the provided xname corresponds to valid traits in the class
+    is not implemented yet.
+
+    Parameters
+    ----------
+    obj : HasTraits
+        The HasTraits class instance whose class trait will change.
+
+    xname : str
+        The extended trait name of trait changes to listen to.
+
+    count : int, optional
+        The expected number of times the event should be fired. When None
+        (default value) there is no check for the number of times the
+        change event was fired.
+
+    test_case : TestCase
+        A unittest TestCase where to raise the failureException if
+        necessary.
+
     Attributes
     ----------
     obj : HasTraits
@@ -65,31 +87,6 @@ class _AssertTraitChangesContext(object):
     """
 
     def __init__(self, obj, xname, count, test_case):
-        """ Initialize the trait change assertion context manager.
-
-        Parameters
-        ----------
-        obj : HasTraits
-            The HasTraits class instance whose class trait will change.
-
-        xname : str
-            The extended trait name of trait changes to listen to.
-
-        count : int, optional
-            The expected number of times the event should be fired. When None
-            (default value) there is no check for the number of times the
-            change event was fired.
-
-        test_case : TestCase
-            A unittest TestCase where to raise the failureException if
-            necessary.
-
-        Notes
-        -----
-        - Checking if the provided xname corresponds to valid traits in
-          the class is not implemented yet.
-
-        """
         self.obj = obj
         self.xname = xname
         self.count = count

--- a/traits/trait_numeric.py
+++ b/traits/trait_numeric.py
@@ -355,12 +355,6 @@ class CArray(AbstractArray):
         second dimension must be at least 2.)
     value : numpy array
         A default value for the array.
-
-    Default Value
-    -------------
-    *value* or ``zeros(min(shape))``, where ``min(shape)`` refers to the
-    minimum shape allowed by the array. If *shape* is not specified, the
-    minimum shape is (0,).
     """
 
     def __init__(

--- a/traits/trait_numeric.py
+++ b/traits/trait_numeric.py
@@ -23,16 +23,10 @@ from .trait_errors import TraitError
 from .trait_type import TraitType
 from .trait_types import Str, Any, Int as TInt, Float as TFloat
 
-# -------------------------------------------------------------------------------
-#  Deferred imports from numpy:
-# -------------------------------------------------------------------------------
 
+# Deferred imports from numpy:
 ndarray = None
 asarray = None
-
-# -------------------------------------------------------------------------------
-#  numpy dtype mapping:
-# -------------------------------------------------------------------------------
 
 
 def dtype2trait(dtype):
@@ -54,11 +48,6 @@ def dtype2trait(dtype):
         return Any
 
 
-# -------------------------------------------------------------------------------
-#  'AbstractArray' trait base class:
-# -------------------------------------------------------------------------------
-
-
 class AbstractArray(TraitType):
     """ Abstract base class for defining numpy-based arrays.
     """
@@ -72,8 +61,6 @@ class AbstractArray(TraitType):
         typecode=None,
         **metadata
     ):
-        """ Returns an AbstractArray trait.
-        """
         global ndarray, asarray
 
         try:
@@ -296,104 +283,89 @@ class AbstractArray(TraitType):
         return value
 
 
-# -------------------------------------------------------------------------------
-#  'Array' trait:
-# -------------------------------------------------------------------------------
-
-
 class Array(AbstractArray):
-    """ Defines a trait whose value must be a numpy array.
+    """ A trait type whose value must be a Numpy array.
+
+    An Array trait allows only upcasting of assigned values that are
+    already numpy arrays. It automatically casts tuples and lists of the
+    right shape to the specified *dtype* (just like numpy's **array**
+    does).
+
+    The default value is either the *value* argument or
+    ``zeros(min(shape))``, where ``min(shape)`` refers to the minimum
+    shape allowed by the array. If *shape* is not specified, the minimum
+    shape is (0,).
+
+    Parameters
+    ----------
+    dtype : a numpy dtype (e.g., int32)
+        The type of elements in the array; if omitted, no type-checking is
+        performed on assigned values.
+    shape : a tuple
+        Describes the required shape of any assigned value. Wildcards and
+        ranges are allowed. The value None within the *shape* tuple means
+        that the corresponding dimension is not checked. (For example,
+        ``shape=(None,3)`` means that the first dimension can be any size,
+        but the second must be 3.) A two-element tuple within the *shape*
+        tuple means that the dimension must be in the specified range. The
+        second element can be None to indicate that there is no upper
+        bound. (For example, ``shape=((3,5),(2,None))`` means that the
+        first dimension must be in the range 3 to 5 (inclusive), and the
+        second dimension must be at least 2.)
+    value : numpy array
+        A default value for the array.
     """
 
     def __init__(
         self, dtype=None, shape=None, value=None, typecode=None, **metadata
     ):
-        """ Returns an Array trait.
-
-        Parameters
-        ----------
-        dtype : a numpy dtype (e.g., int32)
-            The type of elements in the array; if omitted, no type-checking is
-            performed on assigned values.
-        shape : a tuple
-            Describes the required shape of any assigned value. Wildcards and
-            ranges are allowed. The value None within the *shape* tuple means
-            that the corresponding dimension is not checked. (For example,
-            ``shape=(None,3)`` means that the first dimension can be any size,
-            but the second must be 3.) A two-element tuple within the *shape*
-            tuple means that the dimension must be in the specified range. The
-            second element can be None to indicate that there is no upper
-            bound. (For example, ``shape=((3,5),(2,None))`` means that the
-            first dimension must be in the range 3 to 5 (inclusive), and the
-            second dimension must be at least 2.)
-        value : numpy array
-            A default value for the array.
-
-        Default Value
-        -------------
-        *value* or ``zeros(min(shape))``, where ``min(shape)`` refers to the
-        minimum shape allowed by the array. If *shape* is not specified, the
-        minimum shape is (0,).
-
-        Description
-        -----------
-        An Array trait allows only upcasting of assigned values that are
-        already numpy arrays. It automatically casts tuples and lists of the
-        right shape to the specified *dtype* (just like numpy's **array**
-        does).
-        """
         super(Array, self).__init__(
             dtype, shape, value, False, typecode=typecode, **metadata
         )
 
 
-# -------------------------------------------------------------------------------
-#  'CArray' trait:
-# -------------------------------------------------------------------------------
-
-
 class CArray(AbstractArray):
-    """ Defines a trait whose value must be a numpy array, with casting
-        allowed.
+    """ A coercing trait type whose value is a numpy array.
+
+    The trait returned by CArray() is similar to that returned by Array(),
+    except that it allows both upcasting and downcasting of assigned values
+    that are already numpy arrays. It automatically casts tuples and
+    lists of the right shape to the specified *dtype* (just like
+    numpy's **array** does).
+
+    The default value is either the *value* argument or
+    ``zeros(min(shape))``, where ``min(shape)`` refers to the minimum
+    shape allowed by the array. If *shape* is not specified, the minimum
+    shape is (0,).
+
+    Parameters
+    ----------
+    dtype : a numpy dtype (e.g., int32)
+        The type of elements in the array.
+    shape : a tuple
+        Describes the required shape of any assigned value. Wildcards and
+        ranges are allowed. The value None within the *shape* tuple means
+        that the corresponding dimension is not checked. (For example,
+        ``shape=(None,3)`` means that the first dimension can be any size,
+        but the second must be 3.) A two-element tuple within the *shape*
+        tuple means that the dimension must be in the specified range. The
+        second element can be None to indicate that there is no upper
+        bound. (For example, ``shape=((3,5),(2,None))`` means that the
+        first dimension must be in the range 3 to 5 (inclusive), and the
+        second dimension must be at least 2.)
+    value : numpy array
+        A default value for the array.
+
+    Default Value
+    -------------
+    *value* or ``zeros(min(shape))``, where ``min(shape)`` refers to the
+    minimum shape allowed by the array. If *shape* is not specified, the
+    minimum shape is (0,).
     """
 
     def __init__(
         self, dtype=None, shape=None, value=None, typecode=None, **metadata
     ):
-        """ Returns a CArray trait.
-
-        Parameters
-        ----------
-        dtype : a numpy dtype (e.g., int32)
-            The type of elements in the array.
-        shape : a tuple
-            Describes the required shape of any assigned value. Wildcards and
-            ranges are allowed. The value None within the *shape* tuple means
-            that the corresponding dimension is not checked. (For example,
-            ``shape=(None,3)`` means that the first dimension can be any size,
-            but the second must be 3.) A two-element tuple within the *shape*
-            tuple means that the dimension must be in the specified range. The
-            second element can be None to indicate that there is no upper
-            bound. (For example, ``shape=((3,5),(2,None))`` means that the
-            first dimension must be in the range 3 to 5 (inclusive), and the
-            second dimension must be at least 2.)
-        value : numpy array
-            A default value for the array.
-
-        Default Value
-        -------------
-        *value* or ``zeros(min(shape))``, where ``min(shape)`` refers to the
-        minimum shape allowed by the array. If *shape* is not specified, the
-        minimum shape is (0,).
-
-        Description
-        -----------
-        The trait returned by CArray() is similar to that returned by Array(),
-        except that it allows both upcasting and downcasting of assigned values
-        that are already numpy arrays. It automatically casts tuples and
-        lists of the right shape to the specified *dtype* (just like
-        numpy's **array** does).
-        """
         super(CArray, self).__init__(
             dtype, shape, value, True, typecode=typecode, **metadata
         )
@@ -405,8 +377,12 @@ class CArray(AbstractArray):
 
 
 class ArrayOrNone(CArray):
-    """ A trait whose value may be either a NumPy array or None, with
-        casting allowed.  The default is None.
+    """ A coercing trait whose value may be either a NumPy array or None.
+
+    This trait is designed to avoid the comparison issues with numpy arrays that
+    can arise from the use of constructs like Either(None, Array).
+
+    The default value is None.
     """
 
     def __init__(self, *args, **metadata):

--- a/traits/trait_numeric.py
+++ b/traits/trait_numeric.py
@@ -284,7 +284,7 @@ class AbstractArray(TraitType):
 
 
 class Array(AbstractArray):
-    """ A trait type whose value must be a Numpy array.
+    """ A trait type whose value must be a NumPy array.
 
     An Array trait allows only upcasting of assigned values that are
     already numpy arrays. It automatically casts tuples and lists of the
@@ -325,7 +325,7 @@ class Array(AbstractArray):
 
 
 class CArray(AbstractArray):
-    """ A coercing trait type whose value is a numpy array.
+    """ A coercing trait type whose value is a NumPy array.
 
     The trait returned by CArray() is similar to that returned by Array(),
     except that it allows both upcasting and downcasting of assigned values

--- a/traits/util/event_tracer.py
+++ b/traits/util/event_tracer.py
@@ -206,17 +206,20 @@ class MultiThreadRecordContainer(object):
 class ChangeEventRecorder(object):
     """ A single thread trait change event recorder.
 
+    Parameters
+    ----------
+    container : MultiThreadRecordContainer
+        A container to store the records for each trait change.
+
+    Attributes
+    ----------
+    container : MultiThreadRecordContainer
+        A container to store the records for each trait change.
+    indent : int
+        Indentation level when reporting chained events.
     """
 
     def __init__(self, container):
-        """ Class constructor
-
-        Parameters
-        ----------
-        container : MultiThreadRecordContainer
-           An container to store the records for each trait change.
-
-        """
         self.indent = 1
         self.container = container
 
@@ -281,18 +284,22 @@ class MultiThreadChangeEventRecorder(object):
     The class manages multiple ChangeEventRecorders which record trait change
     events for each thread in a separate file.
 
+    Parameters
+    ----------
+    container : MultiThreadChangeEventRecorder
+        The container of RecordContainers to keep the trait change records
+        for each thread.
+
+    Attributes
+    ----------
+    container : MultiThreadChangeEventRecorder
+        The container of RecordContainers to keep the trait change records
+        for each thread.
+    tracers : dict
+        Mapping from threads to ChangeEventRecorder instances.
     """
 
     def __init__(self, container):
-        """ Object constructor
-
-        Parameters
-        ----------
-        container : MultiThreadChangeEventRecorder
-            The container of RecordContainers to keep the trait change records
-            for each thread.
-
-        """
         self.tracers = {}
         self._tracer_lock = threading.Lock()
         self.container = container


### PR DESCRIPTION
This cleans up a few more class docstrings where there was an `__init__` docstring, either moving the information to the class docstring, or removing entirely when it was non-informative.

This includes a couple of drive-by cleanups of functions with bare `return` statements at the end.