### PR TITLE
Make DefaultValue, ValidateTrait and TraitKind available in traits.api

### DIFF
--- a/traits/api.py
+++ b/traits/api.py
@@ -16,6 +16,9 @@ Use this module for importing Traits names into your namespace. For example::
 
 from .constants import (  # noqa: F401
     ComparisonMode,
+    DefaultValue,
+    TraitKind,
+    ValidateTrait,
     NO_COMPARE,
     OBJECT_IDENTITY_COMPARE,
     RICH_COMPARE,


### PR DESCRIPTION
Closes #856 

No unit tests because we don't test contents of `traits.api`. Perhaps we should.