### PR TITLE
Add a PrefixList trait type

### DIFF
--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -190,6 +190,9 @@ Traits
 .. autoclass:: CList
    :show-inheritance:
 
+.. autoclass:: PrefixList
+   :show-inheritance:
+
 .. autoclass:: Set
    :show-inheritance:
 

--- a/traits/api.py
+++ b/traits/api.py
@@ -92,6 +92,7 @@ from .trait_types import (  # noqa: F401
     Tuple,
     List,
     CList,
+    PrefixList,
     Set,
     CSet,
     Dict,

--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -1,0 +1,70 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tests for the PrefixList handler.
+"""
+
+import pickle
+import unittest
+
+from traits.api import HasTraits, TraitError, PrefixList
+
+
+class TestPrefixList(unittest.TestCase):
+    def test_assignment(self):
+        class A(HasTraits):
+            foo = PrefixList("zero", "one", "two", default_value="one")
+
+        a = A()
+
+        a.foo = 'z'
+        self.assertEqual(a.foo, "zero")
+
+        with self.assertRaises(TraitError):
+            a.foo = ''
+
+    def test_repeated_prefix(self):
+        class A(HasTraits):
+            foo = PrefixList("abc1", "abc2")
+        a = A()
+
+        a.foo = "abc1"
+        self.assertEqual(a.foo, "abc1")
+
+        with self.assertRaises(TraitError):
+            a.foo = "abc"
+
+    def test_invalid_default(self):
+        with self.assertRaises(ValueError):
+            class A(HasTraits):
+                foo = PrefixList("zero", "one", "two", default_value="uno")
+
+    def test_pickle_roundtrip(self):
+        class A(HasTraits):
+            foo = PrefixList("zero", "one", "two", default_value="one")
+
+        a = A()
+        foo_trait = a.traits()["foo"]
+        reconstituted = pickle.loads(pickle.dumps(foo_trait))
+
+        self.assertEqual(
+            foo_trait.validate(a, "foo", "ze"),
+            "zero",
+        )
+        with self.assertRaises(TraitError):
+            foo_trait.validate(a, "foo", "zero-knowledge")
+
+        self.assertEqual(
+            reconstituted.validate(a, "foo", "ze"),
+            "zero",
+        )
+        with self.assertRaises(TraitError):
+            reconstituted.validate(a, "foo", "zero-knowledge")

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2429,6 +2429,99 @@ class CList(List):
         )
 
 
+class PrefixList(TraitType):
+    r"""Ensures that a value assigned to the attribute is a member of a list of
+     specified string values, or is a unique prefix of one of those values.
+
+    The values that can be assigned to a trait attribute of type PrefixList
+    type is the set of all strings supplied to the PrefixList constructor,
+    as well as any unique prefix of those strings. That is, if the set of
+    strings supplied to the constructor is described by
+    [*s*\ :sub:`1`\ , *s*\ :sub:`2`\ , ..., *s*\ :sub:`n`\ ], then the
+    string *v* is a valid value for the trait if *v* == *s*\ :sub:`i[:j]`
+    for one and only one pair of values (i, j). If *v* is a valid value,
+    then the actual value assigned to the trait attribute is the
+    corresponding *s*\ :sub:`i` value that *v* matched.
+
+    The list of legal values can be provided as a list or tuple of values.
+    That is, ``PrefixList(['one', 'two', 'three'])`` and
+    ``PrefixList('one', 'two', 'three')`` are equivalent.
+
+    Example
+    -------
+    ::
+        class Person(HasTraits):
+            married = PrefixList('yes', 'no')
+
+    The Person class has a **married** trait that accepts any of the
+    strings 'y', 'ye', 'yes', 'n', or 'no' as valid values. However, the
+    actual values assigned as the value of the trait attribute are limited
+    to either 'yes' or 'no'. That is, if the value 'y' is assigned to the
+    **married** attribute, the actual value assigned will be 'yes'.
+
+    Note that the algorithm used by TraitPrefixList in determining whether
+    a string is a valid value is fairly efficient in terms of both time and
+     space, and is not based on a brute force set of comparisons.
+
+    Parameters
+    ----------
+    *values
+        Either all legal string values for the enumeration, or a single list
+        or tuple of legal string values.
+
+    Attributes
+    ----------
+    values : tuple of strings
+        Enumeration of all legal values for a trait.
+    """
+
+    default_value = None
+
+    default_value_type = DefaultValue.constant
+
+    def __init__(self, *values, **metadata):
+
+        if (len(values) == 1) and (type(values[0]) in SequenceTypes):
+            values = values[0]
+        self.values = values[:]
+        self.values_ = values_ = {}
+        for key in values:
+            values_[key] = key
+
+        default = self.default_value
+        if 'default_value' in metadata:
+            default = metadata.pop('default_value')
+            if default not in self.values:
+                raise ValueError("Default value for PrefixTrait must be "
+                                 "present in the prefix list")
+
+        super().__init__(default, **metadata)
+
+    def validate(self, object, name, value):
+        try:
+            if value not in self.values_:
+                match = None
+                n = len(value)
+                for key in self.values:
+                    if value == key[:n]:
+                        if match is not None:
+                            match = None
+                            break
+                        match = key
+                if match is None:
+                    self.error(object, name, value)
+                self.values_[value] = match
+            return self.values_[value]
+        except:
+            self.error(object, name, value)
+
+    def info(self):
+        return (
+            " or ".join([repr(x) for x in self.values])
+            + " (or any unique prefix)"
+        )
+
+
 class Set(TraitType):
     """ A trait type for a set of values of the specified type.
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2429,7 +2429,7 @@ class CList(List):
         )
 
 
-class PrefixList(TraitType):
+class PrefixList(BaseStr):
     r"""Ensures that a value assigned to the attribute is a member of a list of
      specified string values, or is a unique prefix of one of those values.
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2461,7 +2461,7 @@ class PrefixList(TraitType):
 
     Note that the algorithm used by TraitPrefixList in determining whether
     a string is a valid value is fairly efficient in terms of both time and
-     space, and is not based on a brute force set of comparisons.
+    space, and is not based on a brute force set of comparisons.
 
     Parameters
     ----------

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2475,8 +2475,10 @@ class PrefixList(BaseStr):
         Enumeration of all legal values for a trait.
     """
 
+    #: The default value for the trait:
     default_value = None
 
+    #: The default value type to use (i.e. 'constant'):
     default_value_type = DefaultValue.constant
 
     def __init__(self, *values, **metadata):
@@ -2491,9 +2493,13 @@ class PrefixList(BaseStr):
         default = self.default_value
         if 'default_value' in metadata:
             default = metadata.pop('default_value')
-            if default not in self.values:
+            try:
+                default = self.validate(None, None, default)
+            except TraitError:
                 raise ValueError("Default value for PrefixTrait must be "
-                                 "present in the prefix list")
+                                 "a unique prefix present in the prefix list")
+        elif self.values:
+            default = self.values[0]
 
         super().__init__(default, **metadata)
 


### PR DESCRIPTION
Closes #676 
This PR creates a trait type `PrefixList` which has the same functionality as `TraitPrefixList` handler for a trait.

- No algorithm changes have been made for the validation.
- C level fast validation is not used for this trait.
- Assigning a `default_value` which is not part of the list of legal strings will throw a `ValueError` during trait declaration.
- If a `default_value` is unspecified, it is set to `None` (unsure if this is what we want)


TraitPrefixList is still available but could be deprecated in the future.