### PR TITLE
CLN: Follow best practices when opening files

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,6 @@
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 import datetime
-import io
 import os
 import sys
 
@@ -66,7 +65,7 @@ copyright = "2008-{date.year}, Enthought Inc".format(date=datetime.date.today())
 # other places throughout the built documents.
 version_info = {}
 traits_init_path = os.path.join("..", "..", "traits", "__init__.py")
-with io.open(traits_init_path, "r", encoding="utf-8") as version_module:
+with open(traits_init_path, "r", encoding="utf-8") as version_module:
     version_code = compile(version_module.read(), "__init__.py", "exec")
     exec(version_code, version_info)
 version = release = version_info["__version__"]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-import io
 import os
 import runpy
 import subprocess
@@ -122,7 +121,7 @@ def write_version_file(version, git_revision):
     git_revision : str
         The full commit hash for the current Git revision.
     """
-    with io.open(VERSION_FILE, "w", encoding="ascii") as version_file:
+    with open(VERSION_FILE, "w", encoding="ascii") as version_file:
         version_file.write(
             VERSION_FILE_TEMPLATE.format(
                 version=version, git_revision=git_revision, company="Enthought"
@@ -253,7 +252,7 @@ def resolve_version():
 
 def get_long_description():
     """ Read long description from README.txt. """
-    with io.open("README.rst", "r", encoding="utf-8") as readme:
+    with open("README.rst", "r", encoding="utf-8") as readme:
         return readme.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ def write_version_file(version, git_revision):
     git_revision : str
         The full commit hash for the current Git revision.
     """
-    with open(VERSION_FILE, "w", encoding="ascii") as version_file:
+    with open(VERSION_FILE, "w", encoding="utf-8") as version_file:
         version_file.write(
             VERSION_FILE_TEMPLATE.format(
                 version=version, git_revision=git_revision, company="Enthought"

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -174,15 +174,13 @@ class ETSConfigTestCase(unittest.TestCase):
         path = os.path.join(dirname, "dummy.txt")
         data = str(time.time())
 
-        f = open(path, "w")
-        f.write(data)
-        f.close()
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(data)
 
         self.assertEqual(os.path.exists(path), True)
 
-        f = open(path)
-        result = f.read()
-        f.close()
+        with open(path, "r", encoding="utf-8") as f:
+            result = f.read()
 
         os.remove(path)
 
@@ -360,15 +358,13 @@ class ETSConfigTestCase(unittest.TestCase):
         path = os.path.join(dirname, "dummy.txt")
         data = str(time.time())
 
-        f = open(path, "w")
-        f.write(data)
-        f.close()
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(data)
 
         self.assertEqual(os.path.exists(path), True)
 
-        f = open(path)
-        result = f.read()
-        f.close()
+        with open(path, "r", encoding="utf-8") as f:
+            result = f.read()
 
         os.remove(path)
 

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -783,10 +783,8 @@ def cached_property(function):
 
             @cached_property
             def _get_file_contents(self):
-                fh = open(self.file_name, 'rb')
-                result = fh.read()
-                fh.close()
-                return result
+                with open(self.file_name, 'rb') as fh:
+                    return fh.read()
 
         In this example, accessing the *file_contents* trait calls the
         _get_file_contents() method only once each time after the **file_name**
@@ -831,10 +829,8 @@ def property_depends_on(dependency, settable=False, flushable=False):
 
             @property_depends_on( 'file_name' )
             def _get_file_contents(self):
-                fh = open(self.file_name, 'rb')
-                result = fh.read()
-                fh.close()
-                return result
+                with open(self.file_name, 'rb') as fh:
+                    return fh.read()
 
         In this example, accessing the *file_contents* trait calls the
         _get_file_contents() method only once each time after the **file_name**

--- a/traits/tests/test_trait_types.py
+++ b/traits/tests/test_trait_types.py
@@ -53,7 +53,7 @@ class TraitTypesTest(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         try:
             tmpfile = os.path.join(tmpdir, "test_script.py")
-            with open(tmpfile, "w") as f:
+            with open(tmpfile, "w", encoding="utf-8") as f:
                 f.write(test_script)
             cmd = [this_python, tmpfile]
             output = subprocess.check_output(cmd).decode("utf-8")

--- a/traits/util/event_tracer.py
+++ b/traits/util/event_tracer.py
@@ -154,7 +154,7 @@ class RecordContainer(object):
         """ Save the records into a file.
 
         """
-        with open(filename, "w") as fh:
+        with open(filename, "w", encoding="utf-8") as fh:
             for record in self._records:
                 fh.write(str(record))
 

--- a/traits/util/resource.py
+++ b/traits/util/resource.py
@@ -188,8 +188,7 @@ def store_resource(project, resource_path, filename):
             % (project, resource_path)
         )
 
-    fo = open(filename, "wb")
-    fo.write(fi.read())
-    fo.close()
+    with open(filename, "wb") as fo:
+        fo.write(fi.read())
 
     fi.close()

--- a/traits/util/tests/test_record_containers.py
+++ b/traits/util/tests/test_record_containers.py
@@ -40,7 +40,7 @@ class TestRecordContainers(unittest.TestCase):
         # save records
         container.save_to_file(self.filename)
 
-        with open(self.filename, "r") as handle:
+        with open(self.filename, "r", encoding="utf-8") as handle:
             lines = handle.readlines()
         self.assertEqual(lines, ["\n"] * 7)
 
@@ -69,6 +69,6 @@ class TestRecordContainers(unittest.TestCase):
         container.save_to_directory(self.directory)
         for name in container._record_containers:
             filename = os.path.join(self.directory, "{0}.trace".format(name))
-            with open(filename, "r") as handle:
+            with open(filename, "r", encoding="utf-8") as handle:
                 lines = handle.readlines()
             self.assertEqual(lines, ["\n"])

--- a/traits/util/tests/test_record_events.py
+++ b/traits/util/tests/test_record_events.py
@@ -60,7 +60,7 @@ class TestRecordEvents(unittest.TestCase):
 
         filename = os.path.join(self.directory, "MainThread.trace")
         container.save_to_file(filename)
-        with open(filename, "r") as handle:
+        with open(filename, "r", encoding="utf-8") as handle:
             lines = handle.readlines()
             self.assertEqual(len(lines), 4)
             # very basic checking
@@ -93,7 +93,7 @@ class TestRecordEvents(unittest.TestCase):
         container.save_to_directory(self.directory)
         for name in container._record_containers:
             filename = os.path.join(self.directory, "{0}.trace".format(name))
-            with open(filename, "r") as handle:
+            with open(filename, "r", encoding="utf-8") as handle:
                 lines = handle.readlines()
             self.assertEqual(len(lines), 4)
             # very basic checking
@@ -124,7 +124,7 @@ class TestRecordEvents(unittest.TestCase):
         container.save_to_directory(self.directory)
         for name in container._record_containers:
             filename = os.path.join(self.directory, "{0}.trace".format(name))
-            with open(filename, "r") as handle:
+            with open(filename, "r", encoding="utf-8") as handle:
                 lines = handle.readlines()
             self.assertEqual(len(lines), 4)
             # very basic checking

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -145,7 +145,7 @@ class TestTraitDocumenter(unittest.TestCase):
         with self.tmpdir() as tmpdir:
             # The configuration file must exist, but it's okay if it's empty.
             conf_file = os.path.join(tmpdir, "conf.py")
-            with io.open(conf_file, "w", encoding="utf-8"):
+            with open(conf_file, "w", encoding="utf-8"):
                 pass
 
             app = SphinxTestApp(srcdir=path(tmpdir))


### PR DESCRIPTION
- Always specify an encoding for text files.
- Use a `with` statement to open the file where possible.
- Replace some leftover uses of `io.open` with `open` (the two are identical in Python 3; the `io.open` version was present for backwards compatibility with Python 2).