### PR TITLE
Unignore long lines in flake8 check

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,8 @@ master_doc = "index"
 
 # General substitutions.
 project = "traits"
-copyright = "2008-{date.year}, Enthought Inc".format(date=datetime.date.today())
+copyright = "2008-{date.year}, Enthought Inc".format(
+    date=datetime.date.today())
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/examples/tutorials/doc_examples/examples/adapt_metadata.py
+++ b/examples/tutorials/doc_examples/examples/adapt_metadata.py
@@ -10,11 +10,11 @@
 
 # adapt_metadata.py - Example of using 'adapt' metadata
 
-# --[Imports]-------------------------------------------------------------------
+# --[Imports]------------------------------------------------------------------
 from traits.api import HasTraits, Instance
 from interface_definition import IName
 
 
-# --[Code]----------------------------------------------------------------------
+# --[Code]---------------------------------------------------------------------
 class Apartment(HasTraits):
     renter = Instance(IName, adapt="no")

--- a/examples/tutorials/doc_examples/examples/add_class_trait.py
+++ b/examples/tutorials/doc_examples/examples/add_class_trait.py
@@ -12,11 +12,11 @@
 #                        using add_class_trait()
 
 
-# --[Imports]-------------------------------------------------------------------
+# --[Imports]------------------------------------------------------------------
 from traits.api import HasTraits, Instance
 
 
-# --[Code]----------------------------------------------------------------------
+# --[Code]---------------------------------------------------------------------
 # Defining mutually-referring classes using add_class_trait()
 class Chicken(HasTraits):
     pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 exclude = examples
-ignore = E266,E501,W503,E722,E731,E741
+ignore = E266,W503,E722,E731,E741

--- a/traits/adaptation/adaptation_manager.py
+++ b/traits/adaptation/adaptation_manager.py
@@ -91,7 +91,7 @@ class AdaptationManager(HasTraits):
         """
         return issubclass(type_, protocol)
 
-    #### 'AdaptationManager' protocol ##########################################
+    #### 'AdaptationManager' protocol #########################################
 
     def adapt(self, adaptee, to_protocol, default=AdaptationError):
         """ Attempt to adapt an object to a given protocol.

--- a/traits/adaptation/adaptation_offer.py
+++ b/traits/adaptation/adaptation_offer.py
@@ -72,7 +72,7 @@ class AdaptationOffer(HasTraits):
     def _get_to_protocol_name(self):
         return self._get_type_name(self._to_protocol)
 
-    #### Private protocol ######################################################
+    #### Private protocol #####################################################
 
     #: Shadow trait for the corresponding property.
     _factory = Any

--- a/traits/adaptation/tests/test_adapter.py
+++ b/traits/adaptation/tests/test_adapter.py
@@ -20,7 +20,7 @@ from traits.adaptation.api import Adapter
 class TestAdapter(unittest.TestCase):
     """ Test the Adapter class. """
 
-    #### Tests #################################################################
+    #### Tests ################################################################
 
     def test_initializing_adaptee(self):
         # Regression test: The `adaptee` trait used to be initialized after

--- a/traits/base_trait_handler.py
+++ b/traits/base_trait_handler.py
@@ -69,9 +69,9 @@ class BaseTraitHandler(object):
         Description
         -----------
         This method is called by the validate() method when an assigned value
-        is not valid. Raising a TraitError exception either notifies the user of
-        the problem, or, in the case of compound traits, provides a chance for
-        another trait handler to handle to validate the value.
+        is not valid. Raising a TraitError exception either notifies the user
+        of the problem, or, in the case of compound traits, provides a chance
+        for another trait handler to handle to validate the value.
         """
         raise TraitError(
             object, name, self.full_info(object, name, value), value
@@ -93,13 +93,13 @@ class BaseTraitHandler(object):
         Description
         -----------
         The string should be a phrase describing the type defined by the
-        TraitHandler subclass, rather than a complete sentence. For example, use
-        the phrase, "a square sprocket" instead of the sentence, "The value must
-        be a square sprocket." The value returned by full_info() is combined
-        with other information whenever an error occurs and therefore makes more
-        sense to the user if the result is a phrase. The full_info() method is
-        similar in purpose and use to the **info** attribute of a validator
-        function.
+        TraitHandler subclass, rather than a complete sentence. For example,
+        use the phrase, "a square sprocket" instead of the sentence, "The value
+        must be a square sprocket." The value returned by full_info() is
+        combined with other information whenever an error occurs and therefore
+        makes more sense to the user if the result is a phrase. The full_info()
+        method is similar in purpose and use to the **info** attribute of a
+        validator function.
 
         Note that the result can include information specific to the particular
         trait handler instance. If the full_info() method is not overridden,
@@ -112,11 +112,11 @@ class BaseTraitHandler(object):
         trait handler.
 
         The string should be a phrase describing the type defined by the
-        TraitHandler subclass, rather than a complete sentence. For example, use
-        the phrase, "a square sprocket" instead of the sentence, "The value must
-        be a square sprocket." The value returned by info() is combined with
-        other information whenever an error occurs and therefore makes more
-        sense to the user if the result is a phrase. The info() method is
+        TraitHandler subclass, rather than a complete sentence. For example,
+        use the phrase, "a square sprocket" instead of the sentence, "The value
+        must be a square sprocket." The value returned by info() is combined
+        with other information whenever an error occurs and therefore makes
+        more sense to the user if the result is a phrase. The info() method is
         similar in purpose and use to the **info** attribute of a validator
         function.
 

--- a/traits/constants.py
+++ b/traits/constants.py
@@ -12,7 +12,8 @@ from enum import IntEnum
 
 
 class TraitKind(IntEnum):
-    """ These determine the getters and setters used by the cTrait instance. """
+    """ These determine the getters and setters used by the cTrait instance.
+    """
 
     #: A standard trait (validates and notifies).
     trait = 0
@@ -170,12 +171,12 @@ class DefaultValue(IntEnum):
     #: A new copy of the dict specified by default_value is the default value.
     dict_copy = 4
 
-    #: A new instance of TraitListObject constructed using the default_value list
-    #: is the default value.
+    #: A new instance of TraitListObject constructed using the default_value
+    #: list is the default value.
     trait_list_object = 5
 
-    #: A new instance of TraitDictObject constructed using the default_value dict
-    #: is the default value.
+    #: A new instance of TraitDictObject constructed using the default_value
+    #: dict is the default value.
     trait_dict_object = 6
 
     #: The default_value is a tuple of the form: (*callable*, *args*, *kw*),
@@ -184,10 +185,10 @@ class DefaultValue(IntEnum):
     #: ``callable(\*args, \*\*kw)``.
     callable_and_args = 7
 
-    #: The default_value is a callable. The default value is the result obtained
-    #: by invoking *default_value*(*object*), where *object* is the object
-    #: containing the trait. If the trait has a validate() method, the validate()
-    #: method is also called to validate the result.
+    #: The default_value is a callable. The default value is the result
+    #: obtained by invoking *default_value*(*object*), where *object* is the
+    #: object containing the trait. If the trait has a validate() method, the
+    #: validate() method is also called to validate the result.
     callable = 8
 
     #: A new instance of TraitSetObject constructed using the default_value set

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -274,9 +274,10 @@ class ETSConfig(object):
         """
         Deprecated: This property is no longer used.
 
-        Property getter for the Enable backend.  The value returned is, in order
-        of preference: the value set by the application; the value specified by
-        the 'ENABLE_TOOLKIT' environment variable; otherwise the empty string.
+        Property getter for the Enable backend.  The value returned is, in
+        order of preference: the value set by the application; the value
+        specified by the 'ENABLE_TOOLKIT' environment variable; otherwise the
+        empty string.
         """
         from warnings import warn
 
@@ -288,10 +289,10 @@ class ETSConfig(object):
         """
         Deprecated.
 
-        Property setter for the Enable toolkit.  The toolkit can be set more than
-        once, but only if it is the same one each time.  An application that is
-        written for a particular toolkit can explicitly set it before any other
-        module that gets the value is imported.
+        Property setter for the Enable toolkit.  The toolkit can be set more
+        than once, but only if it is the same one each time.  An application
+        that is written for a particular toolkit can explicitly set it before
+        any other module that gets the value is imported.
         """
         from warnings import warn
 
@@ -304,14 +305,16 @@ class ETSConfig(object):
     def _get_kiva_backend(self):
         """
         Property getter for the Kiva backend. The value returned is dependent
-        on the value of the toolkit property. If toolkit specifies a kiva backend
-        using the extended syntax: <enable toolkit>[.<kiva backend>] then the
-        value of the property will be whatever was specified. Otherwise the
-        value will be a reasonable default for the given enable backend.
+        on the value of the toolkit property. If toolkit specifies a kiva
+        backend using the extended syntax: <enable toolkit>[.<kiva backend>]
+        then the value of the property will be whatever was specified.
+        Otherwise the value will be a reasonable default for the given enable
+        backend.
         """
         if self._toolkit is None:
             raise AttributeError(
-                "The kiva_backend attribute is dependent on toolkit, which has not been set."
+                "The kiva_backend attribute is dependent on toolkit, "
+                "which has not been set."
             )
 
         if self._kiva_backend is None:
@@ -421,7 +424,8 @@ class ETSConfig(object):
             if user is not None:
                 directory_name += "_%s" % user
             warn(
-                'Environment variable "%s" not set, setting home directory to %s'
+                'Environment variable "%s" not set, '
+                'setting home directory to %s'
                 % (environment_variable, parent_directory)
             )
 
@@ -486,9 +490,10 @@ class ETSConfig(object):
                 # naive way...
 
                 # Check if the usr_dir is C:\\John Doe\\Documents and Settings.
-                # If yes, then we should modify the usr_dir to be 'My Documents'.
-                # If no, then the user must have modified the os.environ
-                # variables and the directory chosen is a desirable one.
+                # If yes, then we should modify the usr_dir to be
+                # 'My Documents'. If no, then the user must have modified the
+                # os.environ variables and the directory chosen is a desirable
+                # one.
                 desired_dir = os.path.join(parent_directory, "My Documents")
 
                 if os.path.exists(desired_dir):

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -58,7 +58,7 @@ from .trait_errors import TraitError
 from .util.deprecated import deprecated
 from .trait_converters import check_trait, mapped_trait_for, trait_for
 
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  Set CHECK_INTERFACES to one of the following values:
 #
 #  - 0: Does not check to see if classes implement their declared interfaces.
@@ -66,25 +66,26 @@ from .trait_converters import check_trait, mapped_trait_for, trait_for
 #       logs a warning if they don't.
 #  - 2: Ensures that classes implement the interfaces they say they do, and
 #       raises an InterfaceError if they don't.
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 CHECK_INTERFACES = 0
 
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  This ABC is a placeholder for the TraitsUI ViewElement class, which should
 #  inherit from or register as implementing the API.  This has to be done here
-#  so that the metaclass machinery has something to check against when filtering
-#  out TraitsUI elements that are declared as part of a HasTraits class.
-# -------------------------------------------------------------------------------
+#  so that the metaclass machinery has something to check against when
+#  filtering out TraitsUI elements that are declared as part of a HasTraits
+#  class.
+# -----------------------------------------------------------------------------
 
 
 class AbstractViewElement(abc.ABC):
     pass
 
 
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  Constants:
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 WrapperTypes = (
     StaticAnyTraitChangeNotifyWrapper,
@@ -96,8 +97,8 @@ BoundMethodTypes = (MethodType,)
 UnboundMethodTypes = (FunctionType,)
 FunctionTypes = (FunctionType,)
 
-# Class dictionary entries used to save trait, listener and view information and
-# definitions:
+# Class dictionary entries used to save trait, listener and view information
+# and definitions:
 
 BaseTraits = "__base_traits__"
 ClassTraits = "__class_traits__"
@@ -345,21 +346,12 @@ def _add_event_handlers(trait, cls, handlers):
             handlers.append(_get_method(cls, "_%s_fired" % event))
 
 
-# -------------------------------------------------------------------------------
-#  Returns the method associated with a particular class property getter/setter:
-# -------------------------------------------------------------------------------
-
-
 def _property_method(class_dict, name):
     """ Returns the method associated with a particular class property
     getter/setter.
     """
     return class_dict.get(name)
 
-
-# -------------------------------------------------------------------------------
-#  'MetaHasTraits' class:
-# -------------------------------------------------------------------------------
 
 # This really should be 'HasTraits', but it's not defined yet:
 _HasTraits = None
@@ -751,8 +743,8 @@ def on_trait_change(name, post_init=False, dispatch="same"):
         A handler defined using this decorator is normally effective
         immediately. However, if *post_init* is **True**, then the handler only
         becomes effective after all object constructor arguments have been
-        processed. That is, trait values assigned as part of object construction
-        will not cause the handler to be invoked.
+        processed. That is, trait values assigned as part of object
+        construction will not cause the handler to be invoked.
     """
 
     def decorator(function):
@@ -793,9 +785,10 @@ def cached_property(function):
         code, is returned.
 
         Note the use, in the example, of the **depends_on** metadata attribute
-        to specify that the value of **file_contents** depends on **file_name**,
-        so that _get_file_contents() is called only when **file_name** changes.
-        For details, see the traits.traits.Property() function.
+        to specify that the value of **file_contents** depends on
+        **file_name**, so that _get_file_contents() is called only when
+        **file_name** changes. For details, see the traits.traits.Property()
+        function.
     """
     name = TraitsCache + function.__name__[5:]
 
@@ -814,14 +807,14 @@ def cached_property(function):
 def property_depends_on(dependency, settable=False, flushable=False):
     """ Marks the following method definition as being a "cached property"
         that depends on the specified extended trait names. That is, it is a
-        property getter which, for performance reasons, caches its most recently
-        computed result in an attribute whose name is of the form:
-        *_traits_cache_name*, where *name* is the name of the property. A method
-        marked as being a cached property needs only to compute and return its
-        result. The @property_depends_on decorator automatically wraps the
-        decorated method in cache management code that will cache the most
-        recently computed value and flush the cache when any of the specified
-        dependencies are modified, thus eliminating the need to write
+        property getter which, for performance reasons, caches its most
+        recently computed result in an attribute whose name is of the form:
+        *_traits_cache_name*, where *name* is the name of the property. A
+        method marked as being a cached property needs only to compute and
+        return its result. The @property_depends_on decorator automatically
+        wraps the decorated method in cache management code that will cache the
+        most recently computed value and flush the cache when any of the
+        specified dependencies are modified, thus eliminating the need to write
         boilerplate cache management code explicitly. For example::
 
             file_name = File
@@ -950,12 +943,12 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     attribute *favorite_sport* are not listed.
     """
 
-    # -- Trait Prefix Rules -----------------------------------------------------
+    # -- Trait Prefix Rules ---------------------------------------------------
 
     #: Make traits 'property cache' values private with no type checking:
     _traits_cache__ = Any(private=True, transient=True)
 
-    # -- Class Variables --------------------------------------------------------
+    # -- Class Variables ------------------------------------------------------
 
     #: Mapping from dispatch type to notification wrapper class type
     wrappers = {
@@ -966,7 +959,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         "ui": FastUITraitChangeNotifyWrapper,
     }
 
-    # -- Trait Definitions ------------------------------------------------------
+    # -- Trait Definitions ----------------------------------------------------
 
     #: An event fired when a new trait is dynamically added to the object
     trait_added = Event(str)
@@ -974,10 +967,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     #: An event that can be fired to indicate that the state of the object has
     #: been modified
     trait_modified = Event
-
-    # ---------------------------------------------------------------------------
-    #  Handles a 'trait_added' event being fired:
-    # ---------------------------------------------------------------------------
 
     def _trait_added_changed(self, name):
         """ Handles a 'trait_added' event being fired.
@@ -1397,10 +1386,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """
         return self.trait_set(trait_change_notify=False, **traits)
 
-    # ---------------------------------------------------------------------------
-    #  Resets some or all of an object's traits to their default values:
-    # ---------------------------------------------------------------------------
-
     def reset_traits(self, traits=None, **metadata):
         """ Resets some or all of an object's trait attributes to their default
         values.
@@ -1439,10 +1424,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         return unresetable
 
-    # ---------------------------------------------------------------------------
-    #  Returns the list of trait names to copy/clone by default:
-    # ---------------------------------------------------------------------------
-
     def copyable_trait_names(self, **metadata):
         """ Returns the list of trait names to copy or clone by default.
         """
@@ -1450,21 +1431,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         metadata.setdefault("transient", lambda t: t is not True)
         return self.trait_names(**metadata)
 
-    # ---------------------------------------------------------------------------
-    #  Returns the list of all trait names, including implicitly defined
-    #  traits:
-    # ---------------------------------------------------------------------------
-
     def all_trait_names(self):
         """ Returns the list of all trait names, including implicitly defined
             traits.
         """
         return list(self.__class_traits__.keys())
-
-    # --------------------------------------------------------------------------
-    #  Returns the list of trait names when calling the dir() builtin on the
-    #  object. This enables tab-completion in IPython.
-    # --------------------------------------------------------------------------
 
     def __dir__(self):
         """ Returns the list of trait names when calling the dir() builtin on
@@ -1474,10 +1445,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         method_names = [method for method in self._each_trait_method(self)]
         class_attrs = list(vars(self.__class__).keys())
         return trait_names + method_names + class_attrs
-
-    # ---------------------------------------------------------------------------
-    #  Copies another object's traits into this one:
-    # ---------------------------------------------------------------------------
 
     def copy_traits(
         self, other, traits=None, memo=None, copy=None, **metadata
@@ -1570,11 +1537,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         return unassignable
 
-    # ---------------------------------------------------------------------------
-    #  Clones a new object from this one, optionally copying only a specified
-    #  set of traits:
-    # ---------------------------------------------------------------------------
-
     def clone_traits(self, traits=None, memo=None, copy=None, **metadata):
         """ Clones a new object from this one, optionally copying only a
         specified set of traits.
@@ -1624,10 +1586,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         return new
 
-    # ---------------------------------------------------------------------------
-    #  Creates a deep copy of the object:
-    # ---------------------------------------------------------------------------
-
     def __deepcopy__(self, memo):
         """ Creates a deep copy of the object.
         """
@@ -1642,10 +1600,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         )
 
         return result
-
-    # ---------------------------------------------------------------------------
-    #  Edits the object's traits:
-    # ---------------------------------------------------------------------------
 
     def edit_traits(
         self,
@@ -1664,10 +1618,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         ----------
         view : View or string
             A View object (or its name) that defines a user interface for
-            editing trait attribute values of the current object. If the view is
-            defined as an attribute on this class, use the name of the attribute.
-            Otherwise, use a reference to the view object. If this attribute is
-            not specified, the View object returned by trait_view() is used.
+            editing trait attribute values of the current object. If the view
+            is defined as an attribute on this class, use the name of the
+            attribute. Otherwise, use a reference to the view object. If this
+            attribute is not specified, the View object returned by
+            trait_view() is used.
         parent : toolkit control
             The reference to a user interface component to use as the parent
             window for the object's UI window.
@@ -1678,8 +1633,8 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             attribute of the View object is used.
         context : object or dictionary
             A single object or a dictionary of string/object pairs, whose trait
-            attributes are to be edited. If not specified, the current object is
-            used.
+            attributes are to be edited. If not specified, the current object
+            is used.
         handler : Handler
             A handler object used for event handling in the dialog box. If
             None, the default handler for Traits UI is used.
@@ -1689,8 +1644,8 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             are saved.
         scrollable : bool
             Indicates whether the dialog box should be scrollable. When set to
-            True, scroll bars appear on the dialog box if it is not large enough
-            to display all of the items in the view at one time.
+            True, scroll bars appear on the dialog box if it is not large
+            enough to display all of the items in the view at one time.
 
         Returns
         -------
@@ -1712,19 +1667,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             args,
         )
 
-    # ---------------------------------------------------------------------------
-    #  Returns the default context to use for editing/configuring traits:
-    # ---------------------------------------------------------------------------
-
     def trait_context(self):
         """ Returns the default context to use for editing or configuring
             traits.
         """
         return {"object": self}
-
-    # ---------------------------------------------------------------------------
-    #  Gets or sets a ViewElement associated with an object's class:
-    # ---------------------------------------------------------------------------
 
     def trait_view(self, name=None, view_element=None):
         """ Gets or sets a ViewElement associated with an object's class.
@@ -1973,10 +1920,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         setattr(cls, ViewTraits, view_elements)
         return view_elements
 
-    # ---------------------------------------------------------------------------
-    #  Configure the object's traits:
-    # ---------------------------------------------------------------------------
-
     def configure_traits(
         self,
         filename=None,
@@ -2001,17 +1944,18 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             The name (including path) of a file that contains a pickled
             representation of the current object. When this parameter is
             specified, the method reads the corresponding file (if it exists)
-            to restore the saved values of the object's traits before displaying
-            them. If the user confirms the dialog box (by clicking **OK**),
-            the new values are written to the file. If this parameter is not
-            specified, the values are loaded from the in-memory object, and are
-            not persisted when the dialog box is closed.
+            to restore the saved values of the object's traits before
+            displaying them. If the user confirms the dialog box (by clicking
+            **OK**), the new values are written to the file. If this parameter
+            is not specified, the values are loaded from the in-memory object,
+            and are not persisted when the dialog box is closed.
         view : View or str
             A View object (or its name) that defines a user interface for
-            editing trait attribute values of the current object. If the view is
-            defined as an attribute on this class, use the name of the attribute.
-            Otherwise, use a reference to the view object. If this attribute is
-            not specified, the View object returned by trait_view() is used.
+            editing trait attribute values of the current object. If the view
+            is defined as an attribute on this class, use the name of the
+            attribute. Otherwise, use a reference to the view object. If this
+            attribute is not specified, the View object returned by
+            trait_view() is used.
         kind : str
             The type of user interface window to create. See the
             **traitsui.view.kind_trait** trait for values and
@@ -2024,8 +1968,8 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             user interaction.
         context : object or dictionary
             A single object or a dictionary of string/object pairs, whose trait
-            attributes are to be edited. If not specified, the current object is
-            used
+            attributes are to be edited. If not specified, the current object
+            is used
         handler : Handler
             A handler object used for event handling in the dialog box. If
             None, the default handler for Traits UI is used.
@@ -2035,8 +1979,8 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             are saved.
         scrollable : bool
             Indicates whether the dialog box should be scrollable. When set to
-            True, scroll bars appear on the dialog box if it is not large enough
-            to display all of the items in the view at one time.
+            True, scroll bars appear on the dialog box if it is not large
+            enough to display all of the items in the view at one time.
 
         Returns
         -------
@@ -2050,10 +1994,10 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         The method attempts to open and unpickle the contents of *filename*
         before displaying the dialog box. When editing is complete, the method
-        attempts to pickle the updated contents of the object back to *filename*.
-        If the file referenced by *filename* does not exist, the object is not
-        modified before displaying the dialog box. If *filename* is unspecified
-        or None, no pickling or unpickling occurs.
+        attempts to pickle the updated contents of the object back to
+        *filename*. If the file referenced by *filename* does not exist, the
+        object is not modified before displaying the dialog box. If *filename*
+        is unspecified or None, no pickling or unpickling occurs.
 
         If *edit* is True (the default), a dialog box for editing the
         current object is displayed. If *edit* is False or None, no
@@ -2090,10 +2034,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         return True
 
-    # ---------------------------------------------------------------------------
-    #  Return the list of editable traits:
-    # ---------------------------------------------------------------------------
-
     def editable_traits(self):
         """Returns an alphabetically sorted list of the names of non-event
         trait attributes associated with the current object.
@@ -2113,20 +2053,18 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
     def visible_traits(self):
         """Returns an alphabetically sorted list of the names of non-event
-        trait attributes associated with the current object, that should be GUI visible
+        trait attributes associated with the current object, that should be GUI
+        visible
         """
         return self.trait_names(type=not_event, visible=not_false)
 
     @classmethod
     def class_visible_traits(cls):
         """Returns an alphabetically sorted list of the names of non-event
-        trait attributes associated with the current class, that should be GUI visible
+        trait attributes associated with the current class, that should be GUI
+        visible
         """
         return cls.class_trait_names(type=not_event, visible=not_false)
-
-    # ---------------------------------------------------------------------------
-    #  Pretty print the traits of an object:
-    # ---------------------------------------------------------------------------
 
     def print_traits(self, show_help=False, **metadata):
         """Prints the values of all explicitly-defined, non-event trait
@@ -2173,13 +2111,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         print("\n".join(result))
 
-    # ---------------------------------------------------------------------------
-    #  Add/Remove a handler for a specified trait being changed:
-    #
-    #  If no name is specified, the handler will be invoked for any trait
-    #  change.
-    # ---------------------------------------------------------------------------
-
     def _on_trait_change(
         self,
         handler,
@@ -2195,7 +2126,8 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         Parameters
         ----------
         handler : function
-            A trait notification function for the attribute specified by *name*.
+            A trait notification function for the attribute specified by
+            *name*.
         name : str
             Specifies the trait attribute whose value changes trigger the
             notification.
@@ -2255,14 +2187,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 notifiers.insert(0, wrapper)
             else:
                 notifiers.append(wrapper)
-
-    # ---------------------------------------------------------------------------
-    #  Add/Remove handlers for an extended set of one or more traits being
-    #  changed:
-    #
-    #  If no name is specified, the handler will be invoked for any trait
-    #  change.
-    # ---------------------------------------------------------------------------
 
     def on_trait_change(
         self,
@@ -2555,10 +2479,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     # A synonym for 'on_trait_change'
     on_trait_event = on_trait_change
 
-    # ---------------------------------------------------------------------------
-    #  Synchronize the value of two traits:
-    # ---------------------------------------------------------------------------
-
     def sync_trait(
         self, trait_name, object, alias=None, mutual=True, remove=False
     ):
@@ -2703,10 +2623,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             handler.default_value_type == DefaultValue.trait_list_object
         )
 
-    # ---------------------------------------------------------------------------
-    #  Add a new trait:
-    # ---------------------------------------------------------------------------
-
     def add_trait(self, name, *trait):
         """Adds a trait attribute to this object.
 
@@ -2780,10 +2696,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         if old_trait is None:
             self.trait_added = name
 
-    # ---------------------------------------------------------------------------
-    #  Remove an existing trait:
-    # ---------------------------------------------------------------------------
-
     def remove_trait(self, name):
         """Removes a trait attribute from this object.
 
@@ -2823,10 +2735,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         return False
 
-    # ---------------------------------------------------------------------------
-    #  Returns the trait definition of a specified trait:
-    # ---------------------------------------------------------------------------
-
     def trait(self, name, force=False, copy=False):
         """Returns the trait definition for the *name* trait attribute.
 
@@ -2862,10 +2770,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         return _clone_trait(result)
 
-    # ---------------------------------------------------------------------------
-    #  Returns the base trait definition of a specified trait:
-    # ---------------------------------------------------------------------------
-
     def base_trait(self, name):
         """Returns the base trait definition for a trait attribute.
 
@@ -2884,21 +2788,12 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """
         return self._trait(name, -2)
 
-    # ---------------------------------------------------------------------------
-    #  Validates whether or not a specified value is legal for a specified
-    # trait and returns the validated value if valid:
-    # ---------------------------------------------------------------------------
-
     def validate_trait(self, name, value):
         """ Validates whether a value is legal for a trait.
 
         Returns the validated value if it is valid.
         """
         return self.base_trait(name).validate(self, name, value)
-
-    # ---------------------------------------------------------------------------
-    #  Return a dictionary of all traits which match a set of metadata:
-    # ---------------------------------------------------------------------------
 
     def traits(self, **metadata):
         """Returns a dictionary containing the definitions of all of the trait
@@ -2924,13 +2819,13 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         metadata attribute must have in order to be included in the search
         results.
 
-        The *metadata* values either may be simple Python values like strings or
-        integers, or may be lambda expressions or functions that return True
+        The *metadata* values either may be simple Python values like strings
+        or integers, or may be lambda expressions or functions that return True
         if the trait attribute is to be included in the result. A lambda
         expression or function must receive a single argument, which is the
         value of the trait metadata attribute being tested. If more than one
-        metadata keyword is specified, a trait attribute must match the metadata
-        values of all keywords to be included in the result.
+        metadata keyword is specified, a trait attribute must match the
+        metadata values of all keywords to be included in the result.
         """
         traits = self.__base_traits__.copy()
 
@@ -2962,10 +2857,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         return result
 
-    # ---------------------------------------------------------------------------
-    #  Return a dictionary of all traits which match a set of metadata:
-    # ---------------------------------------------------------------------------
-
     @classmethod
     def class_traits(cls, **metadata):
         """Returns a dictionary containing the definitions of all of the trait
@@ -2991,13 +2882,13 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         metadata attribute must have in order to be included in the search
         results.
 
-        The *metadata* values either may be simple Python values like strings or
-        integers, or may be lambda expressions or functions that return **True**
-        if the trait attribute is to be included in the result. A lambda
-        expression or function must receive a single argument, which is the
-        value of the trait metadata attribute being tested. If more than one
-        metadata keyword is specified, a trait attribute must match the metadata
-        values of all keywords to be included in the result.
+        The *metadata* values either may be simple Python values like strings
+        or integers, or may be lambda expressions or functions that return
+        **True** if the trait attribute is to be included in the result. A
+        lambda expression or function must receive a single argument, which is
+        the value of the trait metadata attribute being tested. If more than
+        one metadata keyword is specified, a trait attribute must match the
+        metadata values of all keywords to be included in the result.
         """
         if len(metadata) == 0:
             return cls.__base_traits__.copy()
@@ -3017,13 +2908,9 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         return result
 
-    # ---------------------------------------------------------------------------
-    #  Return a list of all trait names which match a set of metadata:
-    # ---------------------------------------------------------------------------
-
     def trait_names(self, **metadata):
-        """Returns a list of the names of all trait attributes whose definitions
-        match the set of *metadata* criteria specified.
+        """Returns a list of the names of all trait attributes whose
+        definitions match the set of *metadata* criteria specified.
 
         Parameters
         ----------
@@ -3054,10 +2941,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """
         return list(cls.class_traits(**metadata).keys())
 
-    # ---------------------------------------------------------------------------
-    #  Explicitly sets the value of a cached property:
-    # ---------------------------------------------------------------------------
-
     def _set_traits_cache(self, name, value):
         """ Explicitly sets the value of a cached property.
         """
@@ -3067,10 +2950,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         if old_value != value:
             self.trait_property_changed(name, old_value, value)
 
-    # ---------------------------------------------------------------------------
-    #  Explicitly flushes the value of a cached property:
-    # ---------------------------------------------------------------------------
-
     def _flush_traits_cache(self, name, value):
         """ Explicitly flushes the value of a cached property.
         """
@@ -3078,12 +2957,10 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             name, self.__dict__.pop(TraitsCache + name, Undefined)
         )
 
-    # ---------------------------------------------------------------------------
-    #  Returns the trait definition for a specified name when there is no
-    #  explicit definition in the class:
-    # ---------------------------------------------------------------------------
-
     def __prefix_trait__(self, name, is_set):
+        """ Return the trait definition for a specified name when there is
+        no explicit definition in the class.
+        """
         # Check to see if the name is of the form '__xxx__':
         if (name[:2] == "__") and (name[-2:] == "__"):
             if name == "__class__":
@@ -3145,14 +3022,12 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             "for an object of type '%s'" % (name, self.__class__.__name__)
         )
 
-    # ---------------------------------------------------------------------------
-    #  Adds/Removes (Java-style) event listeners to an object:
-    # ---------------------------------------------------------------------------
-
     def add_trait_listener(self, object, prefix=""):
+        """ Add (Java-style) event listener to an object. """
         self._trait_listener(object, prefix, False)
 
     def remove_trait_listener(self, object, prefix=""):
+        """ Remove (Java-style) event listener to an object. """
         self._trait_listener(object, prefix, True)
 
     def _trait_listener(self, object, prefix, remove):
@@ -3183,10 +3058,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                             getattr(object, name), remove=remove
                         )
 
-    # ---------------------------------------------------------------------------
-    #  Generates each (name, method) pair for a specified object:
-    # ---------------------------------------------------------------------------
-
     def _each_trait_method(self, object):
         """ Generates each (name, method) pair for a specified object.
         """
@@ -3196,10 +3067,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 if (type(method) is FunctionType) and (name not in dic):
                     dic[name] = True
                     yield name
-
-    # ---------------------------------------------------------------------------
-    #  Handles adding/removing listeners for a generic 'Instance' trait:
-    # ---------------------------------------------------------------------------
 
     def _instance_changed_handler(self, name, old, new):
         """ Handles adding/removing listeners for a generic 'Instance' trait.
@@ -3213,10 +3080,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         if new is not None:
             for args in arg_lists:
                 new.on_trait_change(*args)
-
-    # ---------------------------------------------------------------------------
-    #  Handles adding/removing listeners for a generic 'List( Instance )' trait:
-    # ---------------------------------------------------------------------------
 
     def _list_changed_handler(self, name, old, new):
         """ Handles adding/removing listeners for a generic 'List( Instance )'
@@ -3491,8 +3354,9 @@ class HasPrivateTraits(HasTraits):
 
     This feature is useful in cases where a class needs private attributes to
     keep track of its internal object state, which are not part of the class's
-    public API. Such attributes do not need to be type-checked, because they are
-    manipulated only by the (presumably correct) methods of the class itself.
+    public API. Such attributes do not need to be type-checked, because they
+    are manipulated only by the (presumably correct) methods of the class
+    itself.
     """
 
     # Make 'private' traits (leading '_') have no type checking:
@@ -3502,9 +3366,9 @@ class HasPrivateTraits(HasTraits):
     _ = Disallow
 
 
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # ABC classes with traits:
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 class ABCMetaHasTraits(abc.ABCMeta, MetaHasTraits):

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -262,11 +262,10 @@ class UnittestTools(object):
         Returns
         -------
         context : context manager or None
-            If ``callableObj`` is None, an assertion context manager is returned,
-            inside of which a trait-change trigger can be invoked. Otherwise,
-            the context is used internally with ``callableObj`` as the trigger,
-            in which case None is returned.
-
+            If ``callableObj`` is None, an assertion context manager is
+            returned, inside of which a trait-change trigger can be invoked.
+            Otherwise, the context is used internally with ``callableObj`` as
+            the trigger, in which case None is returned.
 
         Notes
         -----
@@ -313,11 +312,10 @@ class UnittestTools(object):
         Returns
         -------
         context : context manager or None
-            If ``callableObj`` is None, an assertion context manager is returned,
-            inside of which a trait-change trigger can be invoked. Otherwise,
-            the context is used internally with ``callableObj`` as the trigger,
-            in which case None is returned.
-
+            If ``callableObj`` is None, an assertion context manager is
+            returned, inside of which a trait-change trigger can be invoked.
+            Otherwise, the context is used internally with ``callableObj`` as
+            the trigger, in which case None is returned.
 
         """
         msg = "A change event was fired for: {0}".format(trait)

--- a/traits/tests/test_listeners.py
+++ b/traits/tests/test_listeners.py
@@ -135,7 +135,8 @@ class TestListeners(unittest.TestCase):
         self.assertEqual(events, {})
 
     def test_trait_exception_handler_can_access_exception(self):
-        """ Tests if trait exception handlers can access the traceback of the exception.
+        """ Tests if trait exception handlers can access the traceback of the
+        exception.
         """
         from traits import trait_notifiers
 

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -83,8 +83,8 @@ class _Uninitialized(object):
         return (_Uninitialized, ())
 
 
-#: When the first reference to a trait is a 'get' reference, the default value of
-#: the trait is implicitly assigned and returned as the value of the trait.
+#: When the first reference to a trait is a 'get' reference, the default value
+#: of the trait is implicitly assigned and returned as the value of the trait.
 #: Because of this implicit assignment, a trait change notification is
 #: generated with the Uninitialized object as the 'old' value of the trait, and
 #: the default trait value as the 'new' value. This allows other parts of the
@@ -207,8 +207,9 @@ def safe_contains(value, container):
     """
     # Do a LBYL check for Enums, to avoid the DeprecationWarning issued
     # by Python 3.7. Ref: enthought/traits#853.
-    if isinstance(container, enum.EnumMeta) and not isinstance(value, enum.Enum):
-        return False
+    if isinstance(container, enum.EnumMeta):
+        if not isinstance(value, enum.Enum):
+            return False
 
     try:
         return value in container

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -296,7 +296,7 @@ class TraitDictObject(dict):
 
         self.__dict__.update(state)
 
-    # -- Private Methods ------------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def _validate_dic(self, dic):
         name = self.name

--- a/traits/trait_errors.py
+++ b/traits/trait_errors.py
@@ -31,22 +31,22 @@ def repr_type(obj):
     return msg
 
 
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  'TraitError' class:
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 class TraitError(Exception):
     def __init__(self, args=None, name=None, info=None, value=None):
         if name is None:
-            # If the given args is not a tuple then assume that the user intended
-            # it to be the single item in a one-element tuple.
+            # If the given args is not a tuple then assume that the user
+            # intended it to be the single item in a one-element tuple.
             if not isinstance(args, tuple):
                 args = (args,)
             self.args = args
         else:
-            # Save the information, in case the 'args' object is not the correct
-            # one, and we need to regenerate the message later:
+            # Save the information, in case the 'args' object is not the
+            # correct one, and we need to regenerate the message later:
             self.name = name
             self.info = info
             self.value = value

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -263,8 +263,8 @@ class TraitInstance(TraitHandler):
     attribute, which accepts either None or an instance of Employee
     as its value.
 
-    TraitInstance ensures that assigned values are exactly of the type specified
-    (i.e., no coercion is performed).
+    TraitInstance ensures that assigned values are exactly of the type
+    specified (i.e., no coercion is performed).
 
     Parameters
     ----------
@@ -361,8 +361,8 @@ class TraitInstance(TraitHandler):
         self.aClass = aClass
 
         # fixme: The following is quite ugly, because it wants to try and fix
-        # the trait referencing this handler to use the 'fast path' now that the
-        # actual class has been resolved. The problem is finding the trait,
+        # the trait referencing this handler to use the 'fast path' now that
+        # the actual class has been resolved. The problem is finding the trait,
         # especially in the case of List(Instance('foo')), where the
         # object.base_trait(...) value is the List trait, not the Instance
         # trait, so we need to check for this and pull out the List
@@ -529,18 +529,20 @@ class TraitEnum(TraitHandler):
 
 
 class TraitPrefixList(TraitHandler):
-    r"""Ensures that a value assigned to a trait attribute is a member of a list
-    of specified string values, or is a unique prefix of one of those values.
+    r"""Ensures that a value assigned to a trait attribute is a member of a
+    list of specified string values, or is a unique prefix of one of those
+    values.
 
     TraitPrefixList is a variation on TraitEnum. The values that can be
-    assigned to a trait attribute defined using a TraitPrefixList handler is the
-    set of all strings supplied to the TraitPrefixList constructor, as well as
-    any unique prefix of those strings. That is, if the set of strings supplied
-    to the constructor is described by [*s*\ :sub:`1`\ , *s*\ :sub:`2`\ , ...,
-    *s*\ :sub:`n`\ ], then the string *v* is a valid value for the trait if
-    *v* == *s*\ :sub:`i[:j]` for one and only one pair of values (i, j). If *v*
-    is a valid value, then the actual value assigned to the trait attribute is
-    the corresponding *s*\ :sub:`i` value that *v* matched.
+    assigned to a trait attribute defined using a TraitPrefixList handler is
+    the set of all strings supplied to the TraitPrefixList constructor, as well
+    as any unique prefix of those strings. That is, if the set of strings
+    supplied to the constructor is described by
+    [*s*\ :sub:`1`\ , *s*\ :sub:`2`\ , ..., *s*\ :sub:`n`\ ], then the string
+    *v* is a valid value for the trait if *v* == *s*\ :sub:`i[:j]` for one and
+    only one pair of values (i, j). If *v* is a valid value, then the actual
+    value assigned to the trait attribute is the corresponding *s*\ :sub:`i`
+    value that *v* matched.
 
     As with TraitEnum, the list of legal values can be provided as a list
     or tuple of values.  That is, ``TraitPrefixList(['one', 'two', 'three'])``
@@ -560,8 +562,8 @@ class TraitPrefixList(TraitHandler):
     attribute, the actual value assigned will be 'yes'.
 
     Note that the algorithm used by TraitPrefixList in determining whether a
-    string is a valid value is fairly efficient in terms of both time and space,
-    and is not based on a brute force set of comparisons.
+    string is a valid value is fairly efficient in terms of both time and
+    space, and is not based on a brute force set of comparisons.
 
     Parameters
     ----------
@@ -775,8 +777,8 @@ class TraitCompound(TraitHandler):
     """ Provides a logical-OR combination of other trait handlers.
 
     This class provides a means of creating complex trait definitions by
-    combining several simpler trait definitions. TraitCompound is the underlying
-    handler for the general forms of the Trait() function.
+    combining several simpler trait definitions. TraitCompound is the
+    underlying handler for the general forms of the Trait() function.
 
     A value is a valid value for a trait attribute based on a TraitCompound
     instance if the value is valid for at least one of the TraitHandler or

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -165,7 +165,8 @@ class TraitListObject(list):
                 step = 1 if key.step is None else key.step
                 if step != 1 and delta != 0:
                     raise ValueError(
-                        "attempt to assign sequence of size %d to extended slice of size %d"
+                        "attempt to assign sequence of size %d to extended "
+                        "slice of size %d"
                         % (len(values), slice_len)
                     )
                 newlen = len(self) + delta
@@ -179,8 +180,8 @@ class TraitListObject(list):
                     ]
                 value = values
                 if step == 1:
-                    # FIXME: Bug-for-bug compatibility with old __setslice__ code.
-                    # In this case, we return a TraitListEvent with an
+                    # FIXME: Bug-for-bug compatibility with old __setslice__
+                    # code. In this case, we return a TraitListEvent with an
                     # index=key.start and the removed and added lists as they
                     # are.
                     index = 0 if key.start is None else key.start
@@ -321,8 +322,8 @@ class TraitListObject(list):
                     # Length before the insertion.
                     original_len = len(self) - 1
 
-                    # Indices outside [-original_len, original_len] are clipped.
-                    # This matches the behaviour of insert on the
+                    # Indices outside [-original_len, original_len] are
+                    # clipped. This matches the behaviour of insert on the
                     # underlying list.
                     if index < 0:
                         index += original_len
@@ -401,7 +402,8 @@ class TraitListObject(list):
                     self.name_items, TraitListEvent(index, removed)
                 )
         elif len(self) == 0:
-            # Let whatever system error (ValueError) should be raised be raised.
+            # Let whatever system error (ValueError) should be raised be
+            # raised.
             list.remove(self, value)
         else:
             self.len_error(len(self) - 1)

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -58,21 +58,11 @@ def ui_dispatch(handler, *args, **kw):
         ui_handler(handler, *args, **kw)
 
 
-# -------------------------------------------------------------------------------
-#  'NotificationExceptionHandlerState' class:
-# -------------------------------------------------------------------------------
-
-
 class NotificationExceptionHandlerState(object):
     def __init__(self, handler, reraise_exceptions, locked):
         self.handler = handler
         self.reraise_exceptions = reraise_exceptions
         self.locked = locked
-
-
-# -------------------------------------------------------------------------------
-#  'NotificationExceptionHandler' class:
-# -------------------------------------------------------------------------------
 
 
 class NotificationExceptionHandler(object):
@@ -81,7 +71,7 @@ class NotificationExceptionHandler(object):
         self.main_thread = None
         self.thread_local = thread_local()
 
-    # -- Private Methods ------------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def _push_handler(
         self, handler=None, reraise_exceptions=False, main=False, locked=False
@@ -353,9 +343,9 @@ class AbstractStaticChangeNotifyWrapper(object):
         if arg_count > 4:
             raise TraitNotificationError(
                 (
-                    "Invalid number of arguments for the static anytrait change "
-                    "notification handler: %s. A maximum of 4 arguments is "
-                    "allowed, but %s were specified."
+                    "Invalid number of arguments for the static anytrait "
+                    "change notification handler: %s. A maximum of 4 "
+                    "arguments is allowed, but %s were specified."
                 )
                 % (handler.__name__, arg_count)
             )
@@ -479,9 +469,9 @@ class TraitChangeNotifyWrapper(object):
                 if arg_count > 4:
                     raise TraitNotificationError(
                         (
-                            "Invalid number of arguments for the dynamic trait "
-                            "change notification handler: %s. A maximum of 4 "
-                            "arguments is allowed, but %s were specified."
+                            "Invalid number of arguments for the dynamic "
+                            "trait change notification handler: %s. A maximum "
+                            "of 4 arguments is allowed, but %s were specified."
                         )
                         % (func.__name__, arg_count)
                     )

--- a/traits/trait_numeric.py
+++ b/traits/trait_numeric.py
@@ -237,7 +237,7 @@ class AbstractArray(TraitType):
             )
         return editor
 
-    # -- Private Methods --------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def get_default_value(self):
         """ Returns the default value constructor for the type (called from the
@@ -365,16 +365,16 @@ class CArray(AbstractArray):
         )
 
 
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  'ArrayOrNone' trait
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 class ArrayOrNone(CArray):
     """ A coercing trait whose value may be either a NumPy array or None.
 
-    This trait is designed to avoid the comparison issues with numpy arrays that
-    can arise from the use of constructs like Either(None, Array).
+    This trait is designed to avoid the comparison issues with numpy arrays
+    that can arise from the use of constructs like Either(None, Array).
 
     The default value is None.
     """

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -84,7 +84,8 @@ SetTypes = SequenceTypes + (set,)
 # (see validate_trait_coerce_type in ctraits.c).
 #
 # The tuples below are of the form
-# (ValidateTrait.coerce, type1, [type2, type3, ...], [None, ctype1, [ctype2, ...]])
+# (ValidateTrait.coerce, type1, [type2, type3, ...],
+#     [None, ctype1, [ctype2, ...]])
 #
 # 'type1' corresponds to the main type for the trait
 # 'None' acts as the separator between 'types' and 'ctypes' (coercible types)
@@ -102,7 +103,14 @@ try:
     from numpy import integer, floating, complexfloating, bool_
 
     int_fast_validate = (ValidateTrait.coerce, int, integer)
-    float_fast_validate = (ValidateTrait.coerce, float, floating, None, int, integer)
+    float_fast_validate = (
+        ValidateTrait.coerce,
+        float,
+        floating,
+        None,
+        int,
+        integer,
+    )
     complex_fast_validate = (
         ValidateTrait.coerce,
         complex,
@@ -183,9 +191,9 @@ def _validate_float(value):
     return nb_float(value)
 
 
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Trait Types
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 class Any(TraitType):
     """ A trait type whose value can be anything.
@@ -2241,7 +2249,8 @@ class ValidatedTuple(BaseTuple):
     -------
     The definition::
 
-        value_range = ValidatedTuple(Int(0), Int(1), fvalidate=lambda x: x[0] < x[1])
+        value_range = ValidatedTuple(
+            Int(0), Int(1), fvalidate=lambda x: x[0] < x[1])
 
     will accept only tuples ``(a, b)`` containing two integers that
     satisfy ``a < b``.
@@ -2391,7 +2400,7 @@ class List(TraitType):
         """
         return (self.item_trait,)
 
-    # -- Private Methods --------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def items_event(self):
         cls = self.__class__
@@ -2446,7 +2455,7 @@ class Set(TraitType):
 
     Attributes
     ----------
-    item_trait : a trait or value that can be converted to a trait using Trait()
+    item_trait : a trait or value that can be converted to a trait
         The type of item that the list contains. If not specified, the list
         can contain items of any type.
     has_items : bool
@@ -2505,7 +2514,7 @@ class Set(TraitType):
         """
         return (self.item_trait,)
 
-    # -- Private Methods --------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def items_event(self):
         if self.__class__._items_event is None:
@@ -2641,7 +2650,7 @@ class Dict(TraitType):
         """
         return (self.key_trait, self.value_trait)
 
-    # -- Private Methods --------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def items_event(self):
         cls = self.__class__
@@ -2956,7 +2965,7 @@ class BaseInstance(BaseClass):
             kind=self.kind or "live",
         )
 
-    # -- Private Methods --------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def create_default_value(self, *args, **kw):
         klass = args[0]
@@ -2982,9 +2991,9 @@ class BaseInstance(BaseClass):
     def resolve_class(self, object, name, value):
         super(BaseInstance, self).resolve_class(object, name, value)
 
-        #: fixme: The following is quite ugly, because it wants to try and fix
-        #: the trait referencing this handler to use the 'fast path' now that the
-        #: actual class has been resolved. The problem is finding the trait,
+        # fixme: The following is quite ugly, because it wants to try and fix
+        # the trait referencing this handler to use the 'fast path' now that
+        # the actual class has been resolved. The problem is finding the trait,
         # especially in the case of List(Instance('foo')), where the
         # object.base_trait(...) value is the List trait, not the Instance
         # trait, so we need to check for this and pull out the List
@@ -2998,8 +3007,8 @@ class BaseInstance(BaseClass):
             if set_validate is not None:
                 # The outer trait is a TraitCompound. Recompute its
                 # fast_validate table now that we have updated ours.
-                # FIXME: there are probably still issues if the TraitCompound is
-                # further nested.
+                # FIXME: there are probably still issues if the TraitCompound
+                # is further nested.
                 set_validate()
             else:
                 item_trait = getattr(handler, "item_trait", None)
@@ -3032,7 +3041,8 @@ class Instance(BaseInstance):
 
             self.fast_validate = tuple(fast_validate)
         else:
-            self.fast_validate = (ValidateTrait.adapt, self.klass, self.adapt, self._allow_none)
+            self.fast_validate = (
+                ValidateTrait.adapt, self.klass, self.adapt, self._allow_none)
 
 
 class Supports(Instance):
@@ -3155,8 +3165,8 @@ class Type(BaseClass):
 
     def resolve(self, object, name, value):
         """ Resolves a class originally specified as a string into an actual
-            class, then resets the trait so that future calls will be handled by
-            the normal validate method.
+            class, then resets the trait so that future calls will be handled
+            by the normal validate method.
         """
         if isinstance(self.klass, str):
             self.resolve_class(object, name, value)

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -33,10 +33,6 @@ Visualization:
     feature.
 """
 
-# -------------------------------------------------------------------------------
-#  Imports:
-# -------------------------------------------------------------------------------
-
 from types import FunctionType, MethodType
 import warnings
 
@@ -79,9 +75,9 @@ from .trait_factory import (
     TraitFactory,
 )
 
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  Constants:
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 NoneType = type(None)  # Python 3's types does not include NoneType
 
@@ -128,7 +124,7 @@ def __newobj__(cls, *args):
     return cls.__new__(cls, *args)
 
 
-# --- 'instance' traits ---------------------------------------------------------
+# --- 'instance' traits -------------------------------------------------------
 
 
 class _InstanceArgs(object):
@@ -137,7 +133,7 @@ class _InstanceArgs(object):
         self.kw = kw
 
 
-# --- 'creates a run-time default value' ----------------------------------------
+# --- 'creates a run-time default value' --------------------------------------
 
 
 class Default(object):
@@ -248,9 +244,9 @@ def Trait(*value_type, **metadata):
         interface editor for the trait. See the "Traits UI User Guide" for
         more information on trait editors.
     comparison_mode : int
-        Indicates when trait change notifications should be generated based upon
-        the result of comparing the old and new values of a trait assignment.
-        Possible values come from the ``ComparisonMode`` enum:
+        Indicates when trait change notifications should be generated based
+        upon the result of comparing the old and new values of a trait
+        assignment. Possible values come from the ``ComparisonMode`` enum:
 
         * 0 (none): The values are not compared and a trait change
           notification is generated on each assignment.
@@ -477,7 +473,8 @@ class _TraitMaker(object):
 
     def as_ctrait(self):
         metadata = self.metadata
-        trait = CTrait(self.type_map.get(metadata.get("type"), TraitKind.trait))
+        trait = CTrait(
+            self.type_map.get(metadata.get("type"), TraitKind.trait))
         clone = self.clone
         if clone is not None:
             trait.clone(clone)
@@ -597,8 +594,8 @@ def Property(
             axle     = Instanced( Axle )
             position = Property( depends_on = 'axle.chassis.position' )
 
-    For details of the extended trait name syntax, refer to the on_trait_change()
-    method of the HasTraits class.
+    For details of the extended trait name syntax, refer to the
+    on_trait_change() method of the HasTraits class.
     """
     metadata["type"] = "property"
 

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -118,9 +118,9 @@ def indent(text, first_line=True, n=1, width=4):
     return indented
 
 
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  Metadata filters:
-# -------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 def is_not_none(value):
@@ -135,16 +135,11 @@ def not_event(value):
     return value != "event"
 
 
-# -------------------------------------------------------------------------------
-#  'ListenerBase' class:
-# -------------------------------------------------------------------------------
-
-
 class ListenerBase(HasPrivateTraits):
 
-    # ---------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #  Trait definitions:
-    # ---------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
 
     # The handler to be called when any listened to trait is changed:
     # handler = Any
@@ -170,63 +165,35 @@ class ListenerBase(HasPrivateTraits):
     # be deferred until the associated trait is first read or set?
     # deferred = Bool
 
-    # ---------------------------------------------------------------------------
-    #  Registers new listeners:
-    # ---------------------------------------------------------------------------
-
     def register(self, new):
         """ Registers new listeners.
         """
         raise NotImplementedError
-
-    # ---------------------------------------------------------------------------
-    #  Unregisters any existing listeners:
-    # ---------------------------------------------------------------------------
 
     def unregister(self, old):
         """ Unregisters any existing listeners.
         """
         raise NotImplementedError
 
-    # ---------------------------------------------------------------------------
-    #  Handles a trait change for a simple trait:
-    # ---------------------------------------------------------------------------
-
     def handle(self, object, name, old, new):
         """ Handles a trait change for a simple trait.
         """
         raise NotImplementedError
-
-    # ---------------------------------------------------------------------------
-    #  Handles a trait change for a list trait:
-    # ---------------------------------------------------------------------------
 
     def handle_list(self, object, name, old, new):
         """ Handles a trait change for a list trait.
         """
         raise NotImplementedError
 
-    # ---------------------------------------------------------------------------
-    #  Handles a trait change for a list traits items:
-    # ---------------------------------------------------------------------------
-
     def handle_list_items(self, object, name, old, new):
         """ Handles a trait change for a list traits items.
         """
         raise NotImplementedError
 
-    # ---------------------------------------------------------------------------
-    #  Handles a trait change for a dictionary trait:
-    # ---------------------------------------------------------------------------
-
     def handle_dict(self, object, name, old, new):
         """ Handles a trait change for a dictionary trait.
         """
         raise NotImplementedError
-
-    # ---------------------------------------------------------------------------
-    #  Handles a trait change for a dictionary traits items:
-    # ---------------------------------------------------------------------------
 
     def handle_dict_items(self, object, name, old, new):
         """ Handles a trait change for a dictionary traits items.
@@ -234,16 +201,7 @@ class ListenerBase(HasPrivateTraits):
         raise NotImplementedError
 
 
-# -------------------------------------------------------------------------------
-#  'ListenerItem' class:
-# -------------------------------------------------------------------------------
-
-
 class ListenerItem(ListenerBase):
-
-    # ---------------------------------------------------------------------------
-    #  Trait definitions:
-    # ---------------------------------------------------------------------------
 
     #: The name of the trait to listen to:
     name = Str
@@ -287,8 +245,8 @@ class ListenerItem(ListenerBase):
     is_any_trait = Bool(False)
 
     #: Is the associated handler a special list handler that handles both
-    #: 'foo' and 'foo_items' events by receiving a list of 'deleted' and 'added'
-    #: items as the 'old' and 'new' arguments?
+    #: 'foo' and 'foo_items' events by receiving a list of 'deleted' and
+    #: 'added' items as the 'old' and 'new' arguments?
     is_list_handler = Bool(False)
 
     #: A dictionary mapping objects to a list of all current active
@@ -296,17 +254,13 @@ class ListenerItem(ListenerBase):
     #: listener, one of: (SIMPLE_LISTENER, LIST_LISTENER, DICT_LISTENER).
     active = Instance(WeakIDKeyDict, ())
 
-    # -- 'ListenerBase' Class Method Implementations ----------------------------
-
-    # ---------------------------------------------------------------------------
-    #  String representation:
-    # ---------------------------------------------------------------------------
+    # -- 'ListenerBase' Class Method Implementations --------------------------
 
     def __repr__(self, seen=None):
         """Returns a string representation of the object.
 
-        Since the object graph may have cycles, we extend the basic __repr__ API
-        to include a set of objects we've already seen while constructing
+        Since the object graph may have cycles, we extend the basic __repr__
+        API to include a set of objects we've already seen while constructing
         a string representation. When this method tries to get the repr of
         a ListenerItem or ListenerGroup, we will use the extended API and build
         up the set of seen objects. The repr of a seen object will just be
@@ -575,11 +529,6 @@ class ListenerItem(ListenerBase):
                 unregister(obj)
                 register(dict[key])
 
-    # ---------------------------------------------------------------------------
-    #  Handles an invalid intermediate trait change to a handler that must be
-    #  applied to the final destination object.trait:
-    # ---------------------------------------------------------------------------
-
     def handle_error(self, obj, name, old, new):
         """ Handles an invalid intermediate trait change to a handler that must
             be applied to the final destination object.trait.
@@ -590,11 +539,7 @@ class ListenerItem(ListenerBase):
                 "incompatible with a change to an intermediate trait"
             )
 
-    # -- Event Handlers ---------------------------------------------------------
-
-    # ---------------------------------------------------------------------------
-    #  Handles the 'handler' trait being changed:
-    # ---------------------------------------------------------------------------
+    # -- Event Handlers -------------------------------------------------------
 
     def _handler_changed(self, handler):
         """ Handles the **handler** trait being changed.
@@ -602,19 +547,11 @@ class ListenerItem(ListenerBase):
         if self.next is not None:
             self.next.handler = handler
 
-    # ---------------------------------------------------------------------------
-    #  Handles the 'wrapped_handler_ref' trait being changed:
-    # ---------------------------------------------------------------------------
-
     def _wrapped_handler_ref_changed(self, wrapped_handler_ref):
         """ Handles the 'wrapped_handler_ref' trait being changed.
         """
         if self.next is not None:
             self.next.wrapped_handler_ref = wrapped_handler_ref
-
-    # ---------------------------------------------------------------------------
-    #  Handles the 'dispatch' trait being changed:
-    # ---------------------------------------------------------------------------
 
     def _dispatch_changed(self, dispatch):
         """ Handles the **dispatch** trait being changed.
@@ -622,21 +559,13 @@ class ListenerItem(ListenerBase):
         if self.next is not None:
             self.next.dispatch = dispatch
 
-    # ---------------------------------------------------------------------------
-    #  Handles the 'priority' trait being changed:
-    # ---------------------------------------------------------------------------
-
     def _priority_changed(self, priority):
         """ Handles the **priority** trait being changed.
         """
         if self.next is not None:
             self.next.priority = priority
 
-    # -- Private Methods --------------------------------------------------------
-
-    # ---------------------------------------------------------------------------
-    #  Registers any 'anytrait' listener:
-    # ---------------------------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def _register_anytrait(self, object, name, remove):
         """ Registers any 'anytrait' listener.
@@ -652,10 +581,6 @@ class ListenerItem(ListenerBase):
             )
 
         return (object, name)
-
-    # ---------------------------------------------------------------------------
-    #  Registers a handler for a simple trait:
-    # ---------------------------------------------------------------------------
 
     def _register_simple(self, object, name, remove):
         """ Registers a handler for a simple trait.
@@ -711,8 +636,8 @@ class ListenerItem(ListenerBase):
             return next.unregister(getattr(object, name))
 
         if not self.deferred or name in object.__dict__:
-            # Sometimes, the trait may already be assigned. This can happen when
-            # there are chains of dynamic initializers and 'delegate'
+            # Sometimes, the trait may already be assigned. This can happen
+            # when there are chains of dynamic initializers and 'delegate'
             # notifications. If 'trait_a' and 'trait_b' have dynamic
             # initializers and 'trait_a's initializer creates 'trait_b', *and*
             # we have a DelegatesTo trait that delegates to 'trait_a', then the
@@ -720,15 +645,11 @@ class ListenerItem(ListenerBase):
             # thus 'trait_b'. If we are creating an extended trait change
             # listener on 'trait_b.something', and the 'trait_a' delegate
             # listeners just happen to get hooked up before this one, then
-            # 'trait_b' will have been initialized already, and the registration
-            # that we are deferring will never happen.
+            # 'trait_b' will have been initialized already, and the
+            # registration that we are deferring will never happen.
             return next.register(getattr(object, name))
 
         return (object, name)
-
-    # ---------------------------------------------------------------------------
-    #  Registers a handler for a list trait:
-    # ---------------------------------------------------------------------------
 
     def _register_list(self, object, name, remove):
         """ Registers a handler for a list trait.
@@ -835,18 +756,14 @@ class ListenerItem(ListenerBase):
         return INVALID_DESTINATION
 
     # Handle 'sets' the same as 'lists':
-    # Note: Currently the behavior of sets is almost identical to that of lists,
-    # so we are able to share the same code for both. This includes some 'duck
-    # typing' that occurs with the TraitListEvent and TraitSetEvent, that define
-    # 'removed' and 'added' attributes that behave similarly enough (from the
-    # point of view of this module) that they can be treated as equivalent. If
-    # the behavior of sets ever diverges from that of lists, then this code may
-    # need to be changed.
+    # Note: Currently the behavior of sets is almost identical to that of
+    # lists, so we are able to share the same code for both. This includes some
+    # 'duck typing' that occurs with the TraitListEvent and TraitSetEvent, that
+    # define 'removed' and 'added' attributes that behave similarly enough
+    # (from the point of view of this module) that they can be treated as
+    # equivalent. If the behavior of sets ever diverges from that of lists,
+    # then this code may need to be changed.
     _register_set = _register_list
-
-    # ---------------------------------------------------------------------------
-    #  Registers a handler for a dictionary trait:
-    # ---------------------------------------------------------------------------
 
     def _register_dict(self, object, name, remove):
         """ Registers a handler for a dictionary trait.
@@ -1030,7 +947,7 @@ class ListenerGroup(ListenerBase):
     # The list of ListenerBase objects in the group
     items = List(ListenerBase)
 
-    # -- Property Implementations -----------------------------------------------
+    # -- Property Implementations ---------------------------------------------
 
     def _set_handler(self, handler):
         if self._handler is None:
@@ -1050,17 +967,13 @@ class ListenerGroup(ListenerBase):
             for item in self.items:
                 item.dispatch = dispatch
 
-    # -- 'ListenerBase' Class Method Implementations ----------------------------
-
-    # ---------------------------------------------------------------------------
-    #  String representation:
-    # ---------------------------------------------------------------------------
+    # -- 'ListenerBase' Class Method Implementations --------------------------
 
     def __repr__(self, seen=None):
         """Returns a string representation of the object.
 
-        Since the object graph may have cycles, we extend the basic __repr__ API
-        to include a set of objects we've already seen while constructing
+        Since the object graph may have cycles, we extend the basic __repr__
+        API to include a set of objects we've already seen while constructing
         a string representation. When this method tries to get the repr of
         a ListenerItem or ListenerGroup, we will use the extended API and build
         up the set of seen objects. The repr of a seen object will just be
@@ -1081,10 +994,6 @@ class ListenerGroup(ListenerBase):
 
         return "\n".join(lines)
 
-    # ---------------------------------------------------------------------------
-    #  Registers new listeners:
-    # ---------------------------------------------------------------------------
-
     def register(self, new):
         """ Registers new listeners.
         """
@@ -1093,10 +1002,6 @@ class ListenerGroup(ListenerBase):
 
         return INVALID_DESTINATION
 
-    # ---------------------------------------------------------------------------
-    #  Unregisters any existing listeners:
-    # ---------------------------------------------------------------------------
-
     def unregister(self, old):
         """ Unregisters any existing listeners.
         """
@@ -1104,16 +1009,11 @@ class ListenerGroup(ListenerBase):
             item.unregister(old)
 
 
-# -------------------------------------------------------------------------------
-#  'ListenerParser' class:
-# -------------------------------------------------------------------------------
-
-
 class ListenerParser(HasPrivateTraits):
 
-    # -------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #  Trait definitions:
-    # -------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
 
     #: The string being parsed
     text = Str
@@ -1139,7 +1039,7 @@ class ListenerParser(HasPrivateTraits):
     #: The ListenerBase object resulting from parsing **text**
     listener = Instance(ListenerBase)
 
-    # -- Property Implementations -----------------------------------------------
+    # -- Property Implementations ---------------------------------------------
 
     def _get_next(self):
         index = self.index
@@ -1167,18 +1067,13 @@ class ListenerParser(HasPrivateTraits):
 
         return match.group(1)
 
-    # -- object Method Overrides ------------------------------------------------
+    # -- object Method Overrides ----------------------------------------------
 
     def __init__(self, text="", **traits):
         self.text = text
         super(ListenerParser, self).__init__(**traits)
 
-    # -- Private Methods --------------------------------------------------------
-
-    # ---------------------------------------------------------------------------
-    #  Parses the text and returns the appropriate collection of ListenerBase
-    #  objects described by the text:
-    # ---------------------------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def parse(self):
         """ Parses the text and returns the appropriate collection of
@@ -1201,10 +1096,6 @@ class ListenerParser(HasPrivateTraits):
 
         return self.parse_group(EOS)
 
-    # ---------------------------------------------------------------------------
-    #  Parses the contents of a group:
-    # ---------------------------------------------------------------------------
-
     def parse_group(self, terminator="]"):
         """ Parses the contents of a group.
         """
@@ -1226,10 +1117,6 @@ class ListenerParser(HasPrivateTraits):
             return items[0]
 
         return ListenerGroup(items=items)
-
-    # ---------------------------------------------------------------------------
-    #  Parses a single, complete listener item/group string:
-    # ---------------------------------------------------------------------------
 
     def parse_item(self, terminator):
         """ Parses a single, complete listener item or group string.
@@ -1306,10 +1193,6 @@ class ListenerParser(HasPrivateTraits):
 
         return result
 
-    # ---------------------------------------------------------------------------
-    #  Parses the metadata portion of a listener item:
-    # ---------------------------------------------------------------------------
-
     def parse_metadata(self, item):
         """ Parses the metadata portion of a listener item.
         """
@@ -1318,10 +1201,6 @@ class ListenerParser(HasPrivateTraits):
         if name == "":
             self.backspace
 
-    # ---------------------------------------------------------------------------
-    #  Raises a syntax error:
-    # ---------------------------------------------------------------------------
-
     def error(self, msg):
         """ Raises a syntax error.
         """
@@ -1329,11 +1208,7 @@ class ListenerParser(HasPrivateTraits):
             "%s at column %d of '%s'" % (msg, self.index, self.text)
         )
 
-    # -- Event Handlers ---------------------------------------------------------
-
-    # ---------------------------------------------------------------------------
-    #  Handles the 'text' trait being changed:
-    # ---------------------------------------------------------------------------
+    # -- Event Handlers -------------------------------------------------------
 
     def _text_changed(self):
         self.index = 0
@@ -1341,14 +1216,9 @@ class ListenerParser(HasPrivateTraits):
         self.listener = self.parse()
 
 
-# -------------------------------------------------------------------------------
-#  'ListenerNotifyWrapper' class:
-# -------------------------------------------------------------------------------
-
-
 class ListenerNotifyWrapper(TraitChangeNotifyWrapper):
 
-    # -- TraitChangeNotifyWrapper Method Overrides ------------------------------
+    # -- TraitChangeNotifyWrapper Method Overrides ----------------------------
 
     def __init__(self, handler, owner, id, listener, target=None):
         self.type = ListenerType.get(
@@ -1375,11 +1245,6 @@ class ListenerNotifyWrapper(TraitChangeNotifyWrapper):
 
     def owner_deleted(self, ref):
         self.object = self.owner = None
-
-
-# -------------------------------------------------------------------------------
-#  'ListenerHandler' class:
-# -------------------------------------------------------------------------------
 
 
 class ListenerHandler(object):

--- a/traits/util/resource.py
+++ b/traits/util/resource.py
@@ -8,20 +8,20 @@
 #
 # Thanks for using Enthought open source!
 
-""" Utility functions for managing and finding resources (ie. images/files etc).
+""" Utility functions for managing and finding resources (e.g. images, files).
 
     get_path :           Returns the absolute path of a class or instance
 
     create_unique_name : Creates a name with a given prefix that is not in a
-                         given list of existing names. The separator between the
-                         prefix and the rest of the name can also be specified
-                         (default is a '_')
+                         given list of existing names. The separator between
+                         the prefix and the rest of the name can also be
+                         specified (default is a '_')
 
     find_resource:       Given a setuptools project specification string
                          ('MyProject>=2.1') and a partial path leading from the
                          projects base directory to the desired resource, will
-                         return either an opened file object or, if specified, a
-                         full path to the resource.
+                         return either an opened file object or, if specified,
+                         a full path to the resource.
 """
 
 
@@ -87,7 +87,8 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
     ----------
     project : str
         The name of the project to look for the resource in. Can be the name or
-        a requirement string. Ex: 'MyProject', 'MyProject>1.0', 'MyProject==1.1'
+        a requirement string. Ex: 'MyProject', 'MyProject>1.0',
+        'MyProject==1.1'
     resource_path : str
         The path to the file from inside the package. If the file desired is
         MyProject/data/image.jpg, resource_path would be 'data/image.jpg'.
@@ -121,9 +122,9 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
 
     try:
         # Get the image using the pkg_resources resource_stream module, which
-        # will find the file by getting the Chaco install path and appending the
-        # image path. This method works in all cases as long as setuptools is
-        # installed. If setuptools isn't installed, the backup sys.path[0]
+        # will find the file by getting the Chaco install path and appending
+        # the image path. This method works in all cases as long as setuptools
+        # is installed. If setuptools isn't installed, the backup sys.path[0]
         # method is used.
         from pkg_resources import resource_stream, working_set, Requirement
 


### PR DESCRIPTION
- Remove E501 (line too long) from the flake8 ignore list
- Fix existing violations of E501
- Opportunistically remove banner-style docstrings. (There are some remaining.)