### PR TITLE
Add extras_require entry for testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -298,6 +298,7 @@ setuptools.setup(
         "test": [
             "Cython",
             "numpy",
+            "pyface",
             "PySide2",
             "setuptools",
             "Sphinx",

--- a/setup.py
+++ b/setup.py
@@ -294,6 +294,15 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     download_url="https://github.com/enthought/traits",
     install_requires=[],
+    extras_require={
+        "test": [
+            "Cython",
+            "numpy",
+            "PySide2",
+            "Sphinx",
+            "traitsui",
+        ],
+    },
     ext_modules=[setuptools.Extension("traits.ctraits", ["traits/ctraits.c"])],
     package_data={
         "traits.tests": [

--- a/setup.py
+++ b/setup.py
@@ -299,6 +299,7 @@ setuptools.setup(
             "Cython",
             "numpy",
             "PySide2",
+            "setuptools",
             "Sphinx",
             "traitsui",
         ],


### PR DESCRIPTION
[Broken out of #878 as an independently useful piece]

This PR adds an `extras_require` containing the optional dependencies of the test suite. This means that running the Traits test suite with minimal skipped tests is as easy as:

```bash
$ python -m venv --clear ~/.venvs/traits
$ source ~/.venvs/traits/bin/activate
$ pip install -e .[test]
$ python -m unittest
```