### PR TITLE
Deprecate traits.testing.nose_tools

### DIFF
--- a/traits/testing/nose_tools.py
+++ b/traits/testing/nose_tools.py
@@ -8,7 +8,15 @@
 #
 # Thanks for using Enthought open source!
 
-"Non-standard functions for the 'nose' testing framework."
+""" Non-standard functions for the 'nose' testing framework
+
+This module is deprecated, and will be removed in a future release.
+
+.. deprecated:: 6.1.0
+
+"""
+
+import warnings
 
 try:
     from nose import DeprecatedTest, SkipTest
@@ -16,7 +24,16 @@ try:
 
     def skip(f):
         """ Decorator to indicate a test should be skipped.
+
+        .. deprecated:: 6.1.0
+
         """
+        warnings.warn(
+            "The traits.testing.nose_tools module and its contents "
+            "are deprecated",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         def g(*args, **kw):
             raise SkipTest()
@@ -25,7 +42,16 @@ try:
 
     def deprecated(f):
         """ Decorator to indicate a test is deprecated.
+
+        .. deprecated:: 6.1.0
+
         """
+        warnings.warn(
+            "The traits.testing.nose_tools module and its contents "
+            "are deprecated",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         def g(*args, **kw):
             raise DeprecatedTest()
@@ -36,12 +62,18 @@ try:
 except ImportError:
     # Define stubs in case nose isn't installed.
 
-    import warnings
-
     def skip(f):
         """ Stub replacement for marking a unit test to be skipped in the
         absence of 'nose'.
+
+        .. deprecated:: 6.1.0
         """
+        warnings.warn(
+            "The traits.testing.nose_tools module and its contents "
+            "are deprecated",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         warnings.warn("skipping unit tests requires the package 'nose'")
         return f
@@ -49,7 +81,15 @@ except ImportError:
     def deprecated(f):
         """ Stub replacement for marking a unit test deprecated in the absence
         of 'nose'.
+
+        .. deprecated:: 6.1.0
         """
+        warnings.warn(
+            "The traits.testing.nose_tools module and its contents "
+            "are deprecated",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         warnings.warn(
             "skipping deprecated unit tests requires the package 'nose'"
@@ -60,6 +100,16 @@ except ImportError:
 def performance(f):
     """ Decorator to add an attribute to the test to mark it as
     a performance-measuring test.
+
+    .. deprecated:: 6.1.0
+
     """
+    warnings.warn(
+        "The traits.testing.nose_tools module and its contents "
+        "are deprecated",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     f.performance = True
     return f

--- a/traits/testing/tests/test_nose_tools.py
+++ b/traits/testing/tests/test_nose_tools.py
@@ -1,0 +1,42 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+from traits.testing.nose_tools import deprecated, performance, skip
+
+
+class TestNoseTools(unittest.TestCase):
+    def test_deprecated_deprecated(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+
+            @deprecated
+            def some_func():
+                pass
+
+        self.assertIn("test_nose_tools", cm.filename)
+
+    def test_performance_deprecated(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+
+            @performance
+            def some_func():
+                pass
+
+        self.assertIn("test_nose_tools", cm.filename)
+
+    def test_skip_deprecated(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+
+            @skip
+            def some_func():
+                pass
+
+        self.assertIn("test_nose_tools", cm.filename)


### PR DESCRIPTION
We don't test the machinery in `traits.testing.nose_tools`, but ~there are other parts of ETS that still use it~. Those users are likely no longer using `nose` to run their test suites.

EDIT: I'm only seeing uses of `nose_tools` in etsproxy, which we don't care about at this point. No other uses of `nose_tools` in ETS. Still, there might be external uses that we don't know about, so we can't simply delete without warning.

Related: #852.