### PR TITLE
[ON HOLD]: Remove ill defined sort in adaptation manager

### DIFF
--- a/traits/adaptation/adaptation_manager.py
+++ b/traits/adaptation/adaptation_manager.py
@@ -14,7 +14,6 @@
 from heapq import heappop, heappush
 import inspect
 import itertools
-import functools
 
 from traits.adaptation.adaptation_error import AdaptationError
 from traits.has_traits import HasTraits


### PR DESCRIPTION
contributes #172
- The step to sort the edges is meant to support virtual subclass ordering using `_by_weight_then_from_protocol_specificity` because classes in the normal inheritance hierarchy would show up in the mro weight.

https://github.com/enthought/traits/blob/a6411e971619b5566233be0f4e32e5e01bb37dbb/traits/adaptation/adaptation_manager.py#L262-L266

-  Removing the sort results in the failed unit test: `test_prefer_specific_interfaces` which tests virtual subclasses.

I am not sure what is a good solution to handle virtual subclasses. Is there a way to get an mro like order for these?