### PR TITLE
Add allow_none flag for Callable trait

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3677,7 +3677,7 @@ validate_trait_callable(
     trait_object *trait, has_traits_object *obj, PyObject *name,
     PyObject *value)
 {
-    int allow_none = PyObject_IsTrue(PyTuple_GetItem(trait->py_validate, 1));
+    int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
 
     if ((allow_none && value == Py_None) || PyCallable_Check(value)) {
         Py_INCREF(value);
@@ -4071,10 +4071,13 @@ validate_trait_complex(
                 return result;
 
             case 22: /* Callable check: */
-                if (value == Py_None || PyCallable_Check(value)) {
-                    goto done;
+                {
+                    int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(type_info, 1));
+                    if ((allow_none && value == Py_None) || PyCallable_Check(value)) {
+                        goto done;
+                    }
+                    break;
                 }
-                break;
 
             default: /* Should never happen...indicates an internal error: */
                 assert(0);  /* invalid validation type */

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4096,7 +4096,13 @@ validate_trait_complex(
                     }
                     else if (value == Py_None) {
 
+                        int tuple_size = PyTuple_GET_SIZE(trait->py_validate);
 
+                        //Handle callables without allow_none, default to allow None
+                        if(tuple_size < 2){
+                            Py_INCREF(value);
+                            return value;
+                        }
 
                         int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3683,6 +3683,14 @@ validate_trait_callable(
     }
     else if (value == Py_None) {
 
+        int tuple_size = PyTuple_GET_SIZE(trait->py_validate);
+
+        //Handle callables without allow_none, default to allow None
+        if(tuple_size < 2){
+            Py_INCREF(value);
+            return value;
+        }
+
         int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
 
         if (allow_none == -1) {
@@ -4088,6 +4096,8 @@ validate_trait_complex(
                     }
                     else if (value == Py_None) {
 
+
+
                         int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
 
                         if (allow_none == -1) {
@@ -4295,7 +4305,7 @@ _trait_set_validate(trait_object *trait, PyObject *args)
                     break;
 
                 case 22: /* Callable check: */
-                    if (n == 2) {
+                    if (n == 1 || n == 2) {
                         goto done;
                     }
                     break;

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3677,11 +3677,22 @@ validate_trait_callable(
     trait_object *trait, has_traits_object *obj, PyObject *name,
     PyObject *value)
 {
-    int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
-
-    if ((allow_none && value == Py_None) || PyCallable_Check(value)) {
+    if (PyCallable_Check(value)) {
         Py_INCREF(value);
         return value;
+    }
+    else if (value == Py_None) {
+
+        int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
+
+        if (allow_none == -1) {
+            return NULL;
+        }
+
+        else if(allow_none) {
+            Py_INCREF(value);
+            return value;
+        }
     }
 
     return raise_trait_error(trait, obj, name, value);
@@ -4072,9 +4083,20 @@ validate_trait_complex(
 
             case 22: /* Callable check: */
                 {
-                    int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(type_info, 1));
-                    if ((allow_none && value == Py_None) || PyCallable_Check(value)) {
+                    if (PyCallable_Check(value)) {
                         return value;
+                    }
+                    else if (value == Py_None) {
+
+                        int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
+
+                        if (allow_none == -1) {
+                            return NULL;
+                        }
+
+                        else if(allow_none) {
+                            return value;
+                        }
                     }
                     break;
                 }

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3682,22 +3682,22 @@ validate_trait_callable(
         return value;
     }
     else if (value == Py_None) {
-
+        int allow_none;
         int tuple_size = PyTuple_GET_SIZE(trait->py_validate);
 
         //Handle callables without allow_none, default to allow None
-        if(tuple_size < 2){
+        if (tuple_size < 2) {
             Py_INCREF(value);
             return value;
         }
 
-        int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
+        allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
 
         if (allow_none == -1) {
             return NULL;
         }
 
-        else if(allow_none) {
+        else if (allow_none) {
             Py_INCREF(value);
             return value;
         }
@@ -4095,22 +4095,22 @@ validate_trait_complex(
                         return value;
                     }
                     else if (value == Py_None) {
-
+                        int allow_none;
                         int tuple_size = PyTuple_GET_SIZE(trait->py_validate);
 
                         //Handle callables without allow_none, default to allow None
-                        if(tuple_size < 2){
+                        if (tuple_size < 2) {
                             Py_INCREF(value);
                             return value;
                         }
 
-                        int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
+                        allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(trait->py_validate, 1));
 
                         if (allow_none == -1) {
                             return NULL;
                         }
 
-                        else if(allow_none) {
+                        else if (allow_none) {
                             return value;
                         }
                     }

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3677,8 +3677,9 @@ validate_trait_callable(
     trait_object *trait, has_traits_object *obj, PyObject *name,
     PyObject *value)
 {
+    int allow_none = PyObject_IsTrue(PyTuple_GetItem(trait->py_validate, 1));
 
-    if ((value == Py_None) || PyCallable_Check(value)) {
+    if ((allow_none && value == Py_None) || PyCallable_Check(value)) {
         Py_INCREF(value);
         return value;
     }
@@ -4269,7 +4270,7 @@ _trait_set_validate(trait_object *trait, PyObject *args)
                     break;
 
                 case 22: /* Callable check: */
-                    if (n == 1) {
+                    if (n == 2) {
                         goto done;
                     }
                     break;

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4074,7 +4074,7 @@ validate_trait_complex(
                 {
                     int allow_none = PyObject_IsTrue(PyTuple_GET_ITEM(type_info, 1));
                     if ((allow_none && value == Py_None) || PyCallable_Check(value)) {
-                        goto done;
+                        return value;
                     }
                     break;
                 }

--- a/traits/tests/test_callable.py
+++ b/traits/tests/test_callable.py
@@ -90,6 +90,32 @@ class TestCallable(unittest.TestCase):
                 a.callable_or_str = value
             self.assertEqual(a.callable_or_str, old_value)
 
+    def test_disallow_none(self):
+
+        def func():
+            return "Success"
+
+        class MyNewCallable(HasTraits):
+            value = Callable(default_value=func, allow_none=False)
+
+        obj = MyNewCallable()
+
+        self.assertIsNotNone(obj.value)
+
+        with self.assertRaises(TraitError):
+            obj.value = None
+
+        self.assertEqual("Success", obj.value())
+
+        class MyNewCallable2(HasTraits):
+            value = Callable(func, allow_none=True)
+
+        obj = MyNewCallable2()
+        self.assertIsNotNone(obj.value)
+
+        obj.value = None
+        self.assertIsNone(obj.value)
+
 
 class TestBaseCallable(unittest.TestCase):
 

--- a/traits/tests/test_callable.py
+++ b/traits/tests/test_callable.py
@@ -20,6 +20,7 @@ from traits.api import (
     Str,
     TraitError,
     Union,
+    ValidateTrait
 )
 
 
@@ -127,6 +128,20 @@ class TestCallable(unittest.TestCase):
         with self.assertRaises(TraitError):
             obj.a_non_none_union = None
         obj.a_allow_none_union = None
+
+    def test_old_style_callable(self):
+        class OldCallable(Callable):
+            def __init__(self, value=None, **metadata):
+                self.fast_validate = (ValidateTrait.callable,)
+                super(BaseCallable, self).__init__(value, **metadata)
+
+        class MyCallable(HasTraits):
+            # allow_none flag should be ineffective
+            value = OldCallable()
+
+        obj = MyCallable()
+        obj.value = None
+        self.assertIsNone(obj.value)
 
 
 class TestBaseCallable(unittest.TestCase):

--- a/traits/tests/test_callable.py
+++ b/traits/tests/test_callable.py
@@ -108,14 +108,18 @@ class TestCallable(unittest.TestCase):
 
         class MyNewCallable2(HasTraits):
             value = Callable(pow, allow_none=True)
+            empty_callable = Callable()
             a_non_none_union = Union(Callable(allow_none=False), Int)
             a_allow_none_union = Union(Callable(allow_none=True), Int)
 
         obj = MyNewCallable2()
         self.assertIsNotNone(obj.value)
+        self.assertIsNone(obj.empty_callable)
 
         obj.value = None
+        obj.empty_callable = None
         self.assertIsNone(obj.value)
+        self.assertIsNone(obj.empty_callable)
 
         obj.a_non_none_union = 5
         obj.a_allow_none_union = 5

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -843,9 +843,13 @@ class BaseCallable(TraitType):
 class Callable(BaseCallable):
     """ A fast-validating trait type whose value must be a Python callable.
     """
+    def __init__(self, value=None, allow_none=True, **metadata):
 
-    #: The C-level fast validator to use
-    fast_validate = (ValidateTrait.callable,)
+        self.fast_validate = (ValidateTrait.callable, allow_none)
+
+        default_value = metadata.pop("default_value", value)
+
+        super().__init__(default_value, **metadata)
 
 
 class BaseType(TraitType):


### PR DESCRIPTION
Fixes #773 

PR adds a new optional argument `allow_none` to the `Callable` trait, which if set to `False`  prevents `None` from being assigned to the trait.

If not specified, defaults to `allow_none=True`, leaving the current behavior unchanged.