### PR TITLE
Deprecate SingletonHasTraits & related classes

### DIFF
--- a/docs/source/traits_api_reference/has_traits.rst
+++ b/docs/source/traits_api_reference/has_traits.rst
@@ -35,12 +35,6 @@ Classes
 
 .. autoclass:: HasPrivateTraits
 
-.. autoclass:: SingletonHasTraits
-
-.. autoclass:: SingletonHasStrictTraits
-
-.. autoclass:: SingletonHasPrivateTraits
-
 .. autoclass:: Vetoable
 
 .. autoclass:: Interface
@@ -74,3 +68,16 @@ Functions
 .. autofunction:: provides
 
 .. autofunction:: weak_arg
+
+Deprecated Classes
+------------------
+
+The following :class:`~.HasTraits` classes and instances are deprecated,
+and may be removed in a future version of Traits.
+
+.. autoclass:: SingletonHasTraits
+
+.. autoclass:: SingletonHasStrictTraits
+
+.. autoclass:: SingletonHasPrivateTraits
+

--- a/docs/source/traits_api_reference/has_traits.rst
+++ b/docs/source/traits_api_reference/has_traits.rst
@@ -72,7 +72,7 @@ Functions
 Deprecated Classes
 ------------------
 
-The following :class:`~.HasTraits` classes and instances are deprecated,
+The following :class:`~.HasTraits` subclasses are deprecated,
 and may be removed in a future version of Traits.
 
 .. autoclass:: SingletonHasTraits

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3274,6 +3274,8 @@ class SingletonHasTraits(HasTraits):
     """ Singleton class that support trait attributes.
     """
 
+    @deprecated("SingletonHasTraits has been deprecated and will be removed "
+                "in the future. Avoid using it")
     def __new__(cls, *args, **traits):
         if "_the_instance" not in cls.__dict__:
             cls._the_instance = HasTraits.__new__(cls, *args, **traits)
@@ -3286,6 +3288,8 @@ class SingletonHasStrictTraits(HasStrictTraits):
         Non-trait attributes generate an exception.
     """
 
+    @deprecated("SingletonHasStrictTraits has been deprecated and will be "
+                "removed in the future. Avoid using it")
     def __new__(cls, *args, **traits):
         return SingletonHasTraits.__new__(cls, *args, **traits)
 
@@ -3295,6 +3299,8 @@ class SingletonHasPrivateTraits(HasPrivateTraits):
         being unchecked.
     """
 
+    @deprecated("SingletonHasPrivateTraits has been deprecated and will be "
+                "removed in the future. Avoid using it")
     def __new__(cls, *args, **traits):
         return SingletonHasTraits.__new__(cls, *args, **traits)
 

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -19,6 +19,9 @@ from traits.has_traits import (
     ListenerTraits,
     InstanceTraits,
     HasTraits,
+    SingletonHasTraits,
+    SingletonHasStrictTraits,
+    SingletonHasPrivateTraits,
 )
 from traits.ctrait import CTrait
 from traits.traits import ForwardProperty, generic_trait
@@ -321,3 +324,24 @@ class TestHasTraits(unittest.TestCase):
         foo._trait_set_inited()
 
         self.assertTrue(foo.traits_inited())
+
+
+class TestDeprecatedHasTraits(unittest.TestCase):
+    def test_deprecated(self):
+        class TestSingletonHasTraits(SingletonHasTraits):
+            pass
+
+        class TestSingletonHasStrictTraits(SingletonHasStrictTraits):
+            pass
+
+        class TestSingletonHasPrivateTraits(SingletonHasPrivateTraits):
+            pass
+
+        with self.assertWarns(DeprecationWarning):
+            TestSingletonHasTraits()
+
+        with self.assertWarns(DeprecationWarning):
+            TestSingletonHasStrictTraits()
+
+        with self.assertWarns(DeprecationWarning):
+            TestSingletonHasPrivateTraits()


### PR DESCRIPTION
Fix #881 
PR updates creates a Deprecated Classes section in the has_traits docs.