### PR TITLE
Bump version, update changelog for the 6.0 final release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Traits CHANGELOG
 Release 6.0.0
 -------------
 
-Released: 2020-02-13
+Released: 2020-02-14
 
 No changes since the 6.0.0rc0 release candidate.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Traits CHANGELOG
 ================
 
+Release 6.0.0
+-------------
+
+Released: 2020-02-13
+
+No changes since the 6.0.0rc0 release candidate.
+
+
 Release 6.0.0rc0
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 MAJOR = 6
 MINOR = 0
 MICRO = 0
-PRERELEASE = "rc0"
+PRERELEASE = ""
 IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",


### PR DESCRIPTION
In the two weeks since the 6.0.0rc0 release, no blocking issues have emerged. So we'll re-release as 6.0.0 final.

This PR updates the changelog and bumps the version accordingly.

Once released, we still need to build and update docs.