### PR TITLE
Use PyTuple_Pack where possible

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4527,7 +4527,7 @@ static trait_setattr setattr_property_handlers[] = {
 static PyObject *
 _trait_property(trait_object *trait, PyObject *args)
 {
-    PyObject *get, *set, *validate, *result, *temp;
+    PyObject *get, *set, *validate;
     int get_n, set_n, validate_n;
 
     if (PyTuple_GET_SIZE(args) == 0) {


### PR DESCRIPTION
Since I already had this half-done in the meeting, here's a PR that cleans up remaining uses of `PyTuple_New(n)` with `n` a positive constant. One exception: I didn't replace the use of `PyTuple_New` to create a tuple of length 15 when pickling ...