### PR TITLE
Maint: Check trait_change_notify early in call_notifiers

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2182,7 +2182,7 @@ call_notifiers(
 
     // Do nothing if the user has explicitly requested no traits notifications
     // to be sent.
-    if ((obj->flags & HASTRAITS_NO_NOTIFY)) {
+    if (obj->flags & HASTRAITS_NO_NOTIFY) {
         return rc;
     }
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2180,18 +2180,18 @@ call_notifiers(
     PyObject *result, *item, *temp, *args;
     int rc = 0;
 
+    // Do nothing if the user has explicitly requested no traits notifications
+    // to be sent.
+    if ((obj->flags & HASTRAITS_NO_NOTIFY)) {
+        return rc;
+    }
+
     args = PyTuple_Pack(4, (PyObject *)obj, name, old_value, new_value);
     if (args == NULL) {
         return -1;
     }
 
     new_value_has_traits = PyHasTraits_Check(new_value);
-
-    // Do nothing if the user has explicitly requested no traits notifications
-    // to be sent.
-    if ((obj->flags & HASTRAITS_NO_NOTIFY)) {
-        goto exit2;
-    }
 
     if (tnotifiers != NULL) {
         n = PyList_GET_SIZE(tnotifiers);

--- a/traits/tests/test_trait_get_set.py
+++ b/traits/tests/test_trait_get_set.py
@@ -85,3 +85,21 @@ class TestTraitGet(UnittestTools, unittest.TestCase):
         with self.assertDeprecated():
             values = obj.get("string")
         self.assertEqual(values, {"string": "foo"})
+
+    def test_trait_set_quiet(self):
+        obj = TraitsObject()
+        obj.string = "foo"
+
+        with self.assertTraitDoesNotChange(obj, "string"):
+            obj.trait_set(trait_change_notify=False, string="bar")
+
+        self.assertEqual(obj.string, "bar")
+
+    def test_trait_setq(self):
+        obj = TraitsObject()
+        obj.string = "foo"
+
+        with self.assertTraitDoesNotChange(obj, "string"):
+            obj.trait_setq(string="bar")
+
+        self.assertEqual(obj.string, "bar")


### PR DESCRIPTION
Part of #914 

This PR:
(1) Makes `call_notifiers` terminates early if `trait_change_notify` is set to `True`.
(2) Adds two tests to exercise the public API `trait_set` and `trait_setq` relevant for the same logic.

The logic has been exercised by an existing test, e.g. if I commented out the relevant code in `ctraits.c`, the following existing test fails:
```
======================================================================
FAIL: test__trait_notifications_enabled (traits.tests.test_has_traits.TestHasTraits)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/.edm/envs/traits-test-3.5/lib/python3.5/site-packages/traits/tests/test_has_traits.py", line 268, in test__trait_notifications_enabled
    self.assertEqual(a.foo_notify_count, old_count)
AssertionError: 2 != 1
```
