### PR TITLE
Refactor ctraits.c for calling trait and object notifiers

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2197,7 +2197,8 @@ call_notifiers(
     PyListObject *tnotifiers, PyListObject *onotifiers, has_traits_object *obj,
     PyObject *name, PyObject *old_value, PyObject *new_value)
 {
-    int i, t_len, o_len, new_value_has_traits;
+    Py_ssize_t i, t_len, o_len;
+    int new_value_has_traits;
     PyObject *result, *item, *all_notifiers, *args;
     int rc = 0;
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2170,12 +2170,26 @@ setattr_generic(
 /*-----------------------------------------------------------------------------
 |  Call all notifiers for a specified trait:
 |
-|  `tnotifiers` is expected to be either NULL or a list of callables.
-|  `onotifiers` is expected to be either NULL or a list of callables.
-|  `obj` is expected to be an instance of HasTraits.
-|  `name` is the name of the trait changed.
-|  `old_value` is the previous value of the trait.
-|  `new_value` is the new value of the trait.
+|  Parameters
+|  ----------
+|  tnotifiers : NULL or a list of callables.
+|     Notifiers attached to the trait.
+|  onotifiers : NULL or a list of callables.
+|     Notifiers attached to the HasTraits instance.
+|  obj : instance of HasTraits
+|     Instance on which the trait changed.
+|  name : str
+|     Name of the trait changed.
+|  old_value : any
+|     Value of the trait before the change.
+|  new_value : any
+|     Value of the trait after the change.
+|
+|  Returns
+|  -------
+|  return_code : int
+|      0 indicates success.
+|     -1 indicates unexpected errors.
 +----------------------------------------------------------------------------*/
 
 static int

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2169,6 +2169,13 @@ setattr_generic(
 
 /*-----------------------------------------------------------------------------
 |  Call all notifiers for a specified trait:
+|
+|  `tnotifiers` is expected to be either NULL or a list of callables.
+|  `onotifiers` is expected to be either NULL or a list of callables.
+|  `obj` is expected to be an instance of HasTraits.
+|  `name` is the name of the trait changed.
+|  `old_value` is the previous value of the trait.
+|  `new_value` is the new value of the trait.
 +----------------------------------------------------------------------------*/
 
 static int

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2244,7 +2244,7 @@ call_notifiers(
         Py_INCREF(item);
     }
 
-    for (i = 0; i < (t_len + o_len); i++) {
+    for (i = 0; i < t_len + o_len; i++) {
         if (new_value_has_traits
             && ((has_traits_object *)new_value)->flags
                 & HASTRAITS_VETO_NOTIFY) {

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -19,7 +19,7 @@ from traits.constants import (
 )
 from traits.ctrait import CTrait
 from traits.trait_errors import TraitError
-from traits.trait_types import Any, List
+from traits.trait_types import Any, Int, List
 
 
 def getter():
@@ -278,3 +278,34 @@ class TestCTrait(unittest.TestCase):
         self.assertEqual(foo.bar, "baz")
         self.assertEqual(len(foo.bar_changed), 1)
         self.assertEqual(foo.bar_changed[0], "baz")
+
+
+
+class TestCTraitNotifiers(unittest.TestCase):
+    """ Test calling trait notifiers and object notifiers. """
+
+    def test_notifiers_empty(self):
+
+        class Foo(HasTraits):
+            x = Int()
+
+        foo = Foo(x=1)
+        x_ctrait = foo.trait("x")
+
+        self.assertEqual(x_ctrait._notifiers(True), [])
+
+    def test_notifiers_on_trait(self):
+
+        class Foo(HasTraits):
+            x = Int()
+
+            def _x_changed(self):
+                pass
+
+        foo = Foo(x=1)
+        x_ctrait = foo.trait("x")
+
+        tnotifiers = x_ctrait._notifiers(True)
+        self.assertEqual(len(tnotifiers), 1)
+        notifier, = tnotifiers
+        self.assertEqual(notifier.handler, Foo._x_changed)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -280,7 +280,6 @@ class TestCTrait(unittest.TestCase):
         self.assertEqual(foo.bar_changed[0], "baz")
 
 
-
 class TestCTraitNotifiers(unittest.TestCase):
     """ Test calling trait notifiers and object notifiers. """
 

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -326,6 +326,38 @@ class TestHasTraits(unittest.TestCase):
         self.assertTrue(foo.traits_inited())
 
 
+class TestObjectNotifiers(unittest.TestCase):
+    """ Test calling object notifiers. """
+
+    def test_notifiers_empty(self):
+
+        class Foo(HasTraits):
+            x = Int()
+
+        foo = Foo(x=1)
+        self.assertEqual(foo._notifiers(True), [])
+
+    def test_notifiers_on_object(self):
+
+        class Foo(HasTraits):
+            x = Int()
+
+        foo = Foo(x=1)
+        self.assertEqual(foo._notifiers(True), [])
+
+        # when
+        def handler():
+            pass
+
+        foo.on_trait_change(handler, name="anytrait")
+
+        # then
+        notifiers = foo._notifiers(True)
+        self.assertEqual(len(notifiers), 1)
+        onotifier, = notifiers
+        self.assertEqual(onotifier.handler, handler)
+
+
 class TestDeprecatedHasTraits(unittest.TestCase):
     def test_deprecated(self):
         class TestSingletonHasTraits(SingletonHasTraits):

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -358,6 +358,40 @@ class TestObjectNotifiers(unittest.TestCase):
         self.assertEqual(onotifier.handler, handler)
 
 
+class TestCallNotifiers(unittest.TestCase):
+
+    def test_trait_and_object_notifiers_called(self):
+
+        side_effects = []
+
+        class Foo(HasTraits):
+            x = Int()
+            y = Int()
+
+            def _x_changed(self):
+                side_effects.append("x")
+
+        def object_handler():
+            side_effects.append("object")
+
+        foo = Foo()
+        foo.on_trait_change(object_handler, name="anytrait")
+
+        # when
+        side_effects.clear()
+        foo.x = 3
+
+        # then
+        self.assertEqual(side_effects, ["x", "object"])
+
+        # when
+        side_effects.clear()
+        foo.y = 4
+
+        # then
+        self.assertEqual(side_effects, ["object"])
+
+
 class TestDeprecatedHasTraits(unittest.TestCase):
     def test_deprecated(self):
         class TestSingletonHasTraits(SingletonHasTraits):


### PR DESCRIPTION
Part of #914 

This PR refactors calling trait and object notifiers by concatenating the lists of notifiers and then call them all.

~This PR will have a trivial merge conflict with #917 due to the change in exit code name.~ Resolved.

*UPDATED*
There is a behaviour change, see comment 👇 