### PR TITLE
Maint: Refine where the expected failures are

### DIFF
--- a/traits/tests/test_extended_trait_change.py
+++ b/traits/tests/test_extended_trait_change.py
@@ -564,12 +564,18 @@ class OnTraitChangeTest(unittest.TestCase):
             # as `new` instead of the expected `[0, 1, 2, 3]`
             inst.ref.value.append(3)
 
+        # Expected failure
         # See enthought/traits#537
-        self.assertEqual(
-            inst.calls,
-            {0: 1, 1: 1, 2: 0, 3: 0, 4: 0},
-            "Behavior of a bug (#537) is not reproduced."
-        )
+        with self.assertRaises(
+                AssertionError,
+                msg="Behavior of a bug (#537) is not reproduced."):
+            # Handlers with arguments are unexpectedly called, but one of the
+            # handlers fails, leading to the rest of the handlers
+            # not to be called. Actual behavior depends on dictionary ordering
+            # (Python <3.6) or the order of handlers defined in
+            # InstanceValueListener (Python >= 3.6)
+            self.assertEqual(inst.calls, {0: 1, 1: 0, 2: 0, 3: 0, 4: 0})
+
         self.assertEqual(inst.ref.value, [0, 1, 2, 3])
 
     def test_instance_dict_value(self):
@@ -618,11 +624,17 @@ class OnTraitChangeTest(unittest.TestCase):
             # as `new` instead of the expected `{0: 0, 1: 1, 2: 2, 3: 3}`
             inst.ref.value[3] = 3
 
-        # Expected behavior of a bug, see enthought/traits#537
-        self.assertEqual(
-            inst.calls, {0: 1, 1: 1, 2: 0, 3: 0, 4: 0},
-            msg="Behavior of a bug (#537) is not reproduced."
-        )
+        # Expected failure
+        # See enthought/traits#537
+        with self.assertRaises(
+                AssertionError,
+                msg="Behavior of a bug (#537) is not reproduced."):
+            # Handlers with arguments are unexpectedly called, but one of the
+            # handlers fails, leading to the rest of the handlers
+            # not to be called. Actual behavior depends on dictionary ordering
+            # (Python <3.6) or the order of handlers defined in
+            # InstanceValueListener (Python >= 3.6)
+            self.assertEqual(inst.calls, {0: 1, 1: 0, 2: 0, 3: 0, 4: 0})
 
         self.assertEqual(inst.ref.value, {0: 0, 1: 1, 2: 2, 3: 3})
 

--- a/traits/tests/test_extended_trait_change.py
+++ b/traits/tests/test_extended_trait_change.py
@@ -518,7 +518,6 @@ class OnTraitChangeTest(unittest.TestCase):
         self.assertEqual(inst.calls, {x: 3 for x in range(5)})
         self.assertEqual(inst.ref.value, 3)
 
-    @unittest.expectedFailure  # Github issue #537
     def test_instance_list_value(self):
         inst = InstanceListValue(tc=self)
 
@@ -557,13 +556,19 @@ class OnTraitChangeTest(unittest.TestCase):
             exp_new=[0, 1, 2, 3],
             dst_new=[0, 1, 2, 3],
         )
-        inst.ref.value.append(3)
-        self.assertEqual(
-            inst.calls, {0: 1, 1: 0, 2: 0, 3: 0, 4: 0}
-        )
+        with self.assertRaises(AssertionError):
+            # Expected failure, see enthought/traits#537
+            # InstanceValueListener.arg_check1 receives a TraitListEvent
+            # as `new` instead of the expected `[0, 1, 2, 3]`
+            inst.ref.value.append(3)
+
+        with self.assertRaises(AssertionError):
+            # Expected failure, see enthought/traits#537
+            self.assertEqual(
+                inst.calls, {0: 1, 1: 1, 2: 1, 3: 1, 4: 1}
+            )
         self.assertEqual(inst.ref.value, [0, 1, 2, 3])
 
-    @unittest.expectedFailure  # Github issue #537
     def test_instance_dict_value(self):
         inst = InstanceDictValue(tc=self)
 
@@ -602,8 +607,16 @@ class OnTraitChangeTest(unittest.TestCase):
             exp_new={0: 0, 1: 1, 2: 2, 3: 3},
             dst_new={0: 0, 1: 1, 2: 2, 3: 3},
         )
-        inst.ref.value[3] = 3
-        self.assertEqual(inst.calls, {0: 1, 1: 0, 2: 0, 3: 0, 4: 0})
+        with self.assertRaises(AssertionError):
+            # Expected failure, see enthought/traits#537
+            # InstanceValueListener.arg_check1 receives a TraitDictEvent
+            # as `new` instead of the expected `{0: 0, 1: 1, 2: 2, 3: 3}`
+            inst.ref.value[3] = 3
+
+        with self.assertRaises(AssertionError):
+            # Expected failure, see enthought/traits#537
+            self.assertEqual(inst.calls, {0: 1, 1: 1, 2: 1, 3: 1, 4: 1})
+
         self.assertEqual(inst.ref.value, {0: 0, 1: 1, 2: 2, 3: 3})
 
     def test_instance_value_list_listener(self):
@@ -680,7 +693,6 @@ class OnTraitChangeTest(unittest.TestCase):
         )
         self.assertEqual(inst.ref.value, [0, 1, 2, 3])
 
-    @unittest.expectedFailure  # Github issue #538
     def test_list1(self):
         l1 = List1(tc=self)
         for i in range(3):
@@ -693,7 +705,11 @@ class OnTraitChangeTest(unittest.TestCase):
                 type_new=TraitListEvent,
             )
             l1.refs.append(ac)
-        self.assertEqual(l1.calls, {0: 3, 3: 3, 4: 3})
+
+        # Expected failure, see enthought/traits#538
+        with self.assertRaises(AssertionError):
+            self.assertEqual(l1.calls, {0: 3, 3: 3, 4: 3})
+
         for i in range(3):
             self.assertEqual(l1.refs[i].value, 0)
 
@@ -734,7 +750,6 @@ class OnTraitChangeTest(unittest.TestCase):
     def test_list3(self):
         self.check_list(List3(tc=self))
 
-    @unittest.expectedFailure  # Github issue #538
     def test_dict1(self):
         d1 = Dict1(tc=self)
         for i in range(3):
@@ -747,7 +762,11 @@ class OnTraitChangeTest(unittest.TestCase):
                 type_new=TraitDictEvent,
             )
             d1.refs[i] = ac
-        self.assertEqual(d1.calls, {0: 3, 3: 3, 4: 3})
+
+        # Expected failure, see enthought/traits#538
+        with self.assertRaises(AssertionError):
+            self.assertEqual(d1.calls, {0: 3, 3: 3, 4: 3})
+
         for i in range(3):
             self.assertEqual(d1.refs[i].value, 0)
 

--- a/traits/tests/test_extended_trait_change.py
+++ b/traits/tests/test_extended_trait_change.py
@@ -556,17 +556,21 @@ class OnTraitChangeTest(unittest.TestCase):
             exp_new=[0, 1, 2, 3],
             dst_new=[0, 1, 2, 3],
         )
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(
+                AssertionError,
+                msg="Behavior of a bug is not reproduced."):
             # Expected failure, see enthought/traits#537
             # InstanceValueListener.arg_check1 receives a TraitListEvent
             # as `new` instead of the expected `[0, 1, 2, 3]`
             inst.ref.value.append(3)
 
-        with self.assertRaises(AssertionError):
-            # Expected failure, see enthought/traits#537
-            self.assertEqual(
-                inst.calls, {0: 1, 1: 1, 2: 1, 3: 1, 4: 1}
-            )
+        # Behavior of an existing bug
+        # See enthought/traits#537
+        self.assertEqual(
+            inst.calls,
+            {0: 1, 1: 1, 2: 0, 3: 0, 4: 0},
+            "Behavior of a bug is not reproduced."
+        )
         self.assertEqual(inst.ref.value, [0, 1, 2, 3])
 
     def test_instance_dict_value(self):
@@ -706,9 +710,13 @@ class OnTraitChangeTest(unittest.TestCase):
             )
             l1.refs.append(ac)
 
-        # Expected failure, see enthought/traits#538
-        with self.assertRaises(AssertionError):
-            self.assertEqual(l1.calls, {0: 3, 3: 3, 4: 3})
+        # Behavior of an existing bug.
+        # The expected value should be {0: 3, 3: 3, 4: 3}
+        # See enthought/traits#538
+        self.assertEqual(
+            l1.calls, {0: 3, 3: 0, 4: 0},
+            "Behavior of a bug is not reproduced."
+        )
 
         for i in range(3):
             self.assertEqual(l1.refs[i].value, 0)
@@ -763,9 +771,13 @@ class OnTraitChangeTest(unittest.TestCase):
             )
             d1.refs[i] = ac
 
-        # Expected failure, see enthought/traits#538
-        with self.assertRaises(AssertionError):
-            self.assertEqual(d1.calls, {0: 3, 3: 3, 4: 3})
+        # Behavior of an existing bug.
+        # The expected value should be {0: 3, 3: 3, 4: 3}
+        # See enthought/traits#538
+        self.assertEqual(
+            d1.calls, {0: 3, 3: 0, 4: 0},
+            "Behavior of a bug is not reproduced."
+        )
 
         for i in range(3):
             self.assertEqual(d1.refs[i].value, 0)

--- a/traits/tests/test_extended_trait_change.py
+++ b/traits/tests/test_extended_trait_change.py
@@ -558,18 +558,17 @@ class OnTraitChangeTest(unittest.TestCase):
         )
         with self.assertRaises(
                 AssertionError,
-                msg="Behavior of a bug is not reproduced."):
+                msg="Behavior of a bug (#537) is not reproduced."):
             # Expected failure, see enthought/traits#537
             # InstanceValueListener.arg_check1 receives a TraitListEvent
             # as `new` instead of the expected `[0, 1, 2, 3]`
             inst.ref.value.append(3)
 
-        # Behavior of an existing bug
         # See enthought/traits#537
         self.assertEqual(
             inst.calls,
             {0: 1, 1: 1, 2: 0, 3: 0, 4: 0},
-            "Behavior of a bug is not reproduced."
+            "Behavior of a bug (#537) is not reproduced."
         )
         self.assertEqual(inst.ref.value, [0, 1, 2, 3])
 
@@ -715,7 +714,7 @@ class OnTraitChangeTest(unittest.TestCase):
         # See enthought/traits#538
         self.assertEqual(
             l1.calls, {0: 3, 3: 0, 4: 0},
-            "Behavior of a bug is not reproduced."
+            "Behavior of a bug (#538) is not reproduced."
         )
 
         for i in range(3):
@@ -776,7 +775,7 @@ class OnTraitChangeTest(unittest.TestCase):
         # See enthought/traits#538
         self.assertEqual(
             d1.calls, {0: 3, 3: 0, 4: 0},
-            "Behavior of a bug is not reproduced."
+            "Behavior of a bug (#538) is not reproduced."
         )
 
         for i in range(3):

--- a/traits/tests/test_extended_trait_change.py
+++ b/traits/tests/test_extended_trait_change.py
@@ -610,15 +610,19 @@ class OnTraitChangeTest(unittest.TestCase):
             exp_new={0: 0, 1: 1, 2: 2, 3: 3},
             dst_new={0: 0, 1: 1, 2: 2, 3: 3},
         )
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(
+                AssertionError,
+                msg="Behavior of a bug (#537) is not reproduced."):
             # Expected failure, see enthought/traits#537
             # InstanceValueListener.arg_check1 receives a TraitDictEvent
             # as `new` instead of the expected `{0: 0, 1: 1, 2: 2, 3: 3}`
             inst.ref.value[3] = 3
 
-        with self.assertRaises(AssertionError):
-            # Expected failure, see enthought/traits#537
-            self.assertEqual(inst.calls, {0: 1, 1: 1, 2: 1, 3: 1, 4: 1})
+        # Expected behavior of a bug, see enthought/traits#537
+        self.assertEqual(
+            inst.calls, {0: 1, 1: 1, 2: 0, 3: 0, 4: 0},
+            msg="Behavior of a bug (#537) is not reproduced."
+        )
 
         self.assertEqual(inst.ref.value, {0: 0, 1: 1, 2: 2, 3: 3})
 


### PR DESCRIPTION
This PR replaces `unittest.expectedFailure` with a more refined scope of expected assertion error.

This allows more of the test code to be exercised.  This also prevents new unexpected errors from getting silenced by `expectedFailure` (which does not differentiate test errors from test failures).

Motivation: For my understanding, I wanted to see the test failures that illustrate #537 and #538 
