### PR TITLE
Tweaks to etstool.py

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -183,12 +183,11 @@ def install(edm, runtime, environment, editable, source):
         "{edm} run -e {environment} -- "
         "python -m pip install copyright_header/"
     )
-    commands = [
+    commands.extend([
         install_cmd,
         install_stubs_cmd,
         install_copyright_checker,
-    ]
-    commands.append(install_copyright_checker)
+    ])
 
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)

--- a/etstool.py
+++ b/etstool.py
@@ -177,9 +177,8 @@ def install(edm, runtime, environment, editable, source):
     install_stubs = _get_install_command_string(
         "./traits-stubs/", editable=editable
     )
-    install_copyright_checker = (
-        "{edm} run -e {environment} -- "
-        "python -m pip install copyright_header/"
+    install_copyright_checker = _get_install_command_string(
+        "copyright_header/", editable=False, no_deps=False
     )
     commands = [
         "{edm} environments create {environment} --force --version={runtime}",

--- a/etstool.py
+++ b/etstool.py
@@ -170,24 +170,22 @@ def install(edm, runtime, environment, editable, source):
     # EDM commands to set up the development environment. The installation
     # of TraitsUI from EDM installs Traits as a dependency, so we need
     # to explicitly uninstall it before re-installing from source.
-    commands = [
-        "{edm} environments create {environment} --force --version={runtime}",
-        "{edm} --config edm.yaml install -y -e {environment} " + packages,
-        "{edm} plumbing remove-package -e {environment} traits",
-    ]
-
-    install_cmd = _get_install_command_string(".", editable=editable)
-    install_stubs_cmd = _get_install_command_string("./traits-stubs/",
-                                                    editable=editable)
+    install_traits = _get_install_command_string(".", editable=editable)
+    install_stubs = _get_install_command_string(
+        "./traits-stubs/", editable=editable
+    )
     install_copyright_checker = (
         "{edm} run -e {environment} -- "
         "python -m pip install copyright_header/"
     )
-    commands.extend([
-        install_cmd,
-        install_stubs_cmd,
+    commands = [
+        "{edm} environments create {environment} --force --version={runtime}",
+        "{edm} --config edm.yaml install -y -e {environment} " + packages,
+        "{edm} plumbing remove-package -e {environment} traits",
+        install_traits,
+        install_stubs,
         install_copyright_checker,
-    ])
+    ]
 
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
@@ -249,7 +247,7 @@ def test(edm, runtime, verbose, environment):
         "{edm} run -e {environment} -- coverage run -p -m "
         "unittest discover " + options + "traits",
         "{edm} run -e {environment} -- coverage run -p -m "
-        "unittest discover " + options + "traits_stubs_tests"
+        "unittest discover " + options + "traits_stubs_tests",
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traits

--- a/etstool.py
+++ b/etstool.py
@@ -88,7 +88,6 @@ common_dependencies = {
     "cython",
     "enthought_sphinx_theme",
     "flake8",
-    "mypy",
     "numpy",
     "pyqt",
     "Sphinx",
@@ -165,6 +164,10 @@ def install(edm, runtime, environment, editable, source):
     dependencies = common_dependencies.copy()
     if sys.platform != "win32":
         dependencies.update(unix_dependencies)
+    # For Python 3.5, we don't have mypy builds from packages.enthought.com.
+    if runtime != "3.5":
+        dependencies.add("mypy")
+
     packages = " ".join(dependencies)
 
     # EDM commands to set up the development environment. The installation
@@ -246,9 +249,12 @@ def test(edm, runtime, verbose, environment):
     commands = [
         "{edm} run -e {environment} -- coverage run -p -m "
         "unittest discover " + options + "traits",
-        "{edm} run -e {environment} -- coverage run -p -m "
-        "unittest discover " + options + "traits_stubs_tests",
     ]
+    if runtime != "3.5":
+        commands += [
+            "{edm} run -e {environment} -- coverage run -p -m "
+            "unittest discover " + options + "traits_stubs_tests",
+        ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traits
     # code from a local dir.  We need to ensure a good .coveragerc is in


### PR DESCRIPTION
- Install `mypy` from EDM instead of via `pip`
- Remove the `docs` argument to `install` (which prints a message about having installed `enthought_sphinx_theme` even when it's done no such thing).
- Fix space handling in `_get_install_command_string` to avoid double spaces