### PR TITLE
Remove redundant return statements

### DIFF
--- a/traits/adaptation/adaptation_manager.py
+++ b/traits/adaptation/adaptation_manager.py
@@ -143,8 +143,6 @@ class AdaptationManager(HasTraits):
         )
         offers.append(offer)
 
-        return
-
     def register_factory(self, factory, from_protocol, to_protocol):
         """ Register an adapter factory.
 
@@ -163,16 +161,12 @@ class AdaptationManager(HasTraits):
             )
         )
 
-        return
-
     def register_provides(self, provider_protocol, protocol):
         """ Register that a protocol provides another. """
 
         self.register_factory(
             no_adapter_necessary, provider_protocol, protocol
         )
-
-        return
 
     def supports_protocol(self, obj, protocol):
         """ Does the object support a given protocol?

--- a/traits/adaptation/adaptation_offer.py
+++ b/traits/adaptation/adaptation_offer.py
@@ -94,8 +94,6 @@ class AdaptationOffer(HasTraits):
 
         self._factory = factory
 
-        return
-
     #: Shadow trait for the corresponding property.
     _from_protocol = Any
     _from_protocol_loaded = Bool(False)
@@ -116,8 +114,6 @@ class AdaptationOffer(HasTraits):
 
         self._from_protocol = from_protocol
 
-        return
-
     #: Shadow trait for the corresponding property.
     _to_protocol = Any
     _to_protocol_loaded = Bool(False)
@@ -137,8 +133,6 @@ class AdaptationOffer(HasTraits):
         """ Trait property setter. """
 
         self._to_protocol = to_protocol
-
-        return
 
     def _get_type_name(self, type_or_type_name):
         """ Returns the full dotted path for a type.

--- a/traits/adaptation/tests/test_adaptation_manager.py
+++ b/traits/adaptation/tests/test_adaptation_manager.py
@@ -30,13 +30,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
 
         self.adaptation_manager = AdaptationManager()
 
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
     #### Tests ################################################################
 
     def test_no_adapter_required(self):
@@ -57,8 +50,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         # The adaptation manager should simply return the same object.
         self.assertIs(uk_plug, plug)
 
-        return
-
     def test_no_adapter_available(self):
 
         ex = self.examples
@@ -76,8 +67,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
 
         # There should be no way to adapt a UKPlug to a EUPlug.
         self.assertEqual(eu_plug, None)
-
-        return
 
     def test_one_step_adaptation(self):
 
@@ -100,8 +89,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         # We shouldn't be able to adapt it to a *concrete* 'EUPlug' though.
         eu_plug = self.adaptation_manager.adapt(plug, ex.EUPlug, None)
         self.assertIsNone(eu_plug)
-
-        return
 
     def test_adapter_chaining(self):
 
@@ -129,8 +116,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         self.assertIsNotNone(japan_plug)
         self.assertIsInstance(japan_plug, ex.EUStandardToJapanStandard)
         self.assertIs(japan_plug.adaptee.adaptee, uk_plug)
-
-        return
 
     def test_multiple_paths_unambiguous(self):
 
@@ -172,8 +157,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         self.assertIsNotNone(iraq_plug)
         self.assertIsInstance(iraq_plug, ex.EUStandardToIraqStandard)
         self.assertIs(iraq_plug.adaptee.adaptee, uk_plug)
-
-        return
 
     def test_multiple_paths_ambiguous(self):
 
@@ -219,8 +202,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         )
         self.assertIs(iraq_plug.adaptee.adaptee, uk_plug)
 
-        return
-
     def test_conditional_adaptation(self):
 
         ex = self.examples
@@ -256,8 +237,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         )
         self.assertIsNone(eu_plug)
 
-        return
-
     def test_spillover_adaptation_behavior(self):
 
         ex = self.examples
@@ -287,8 +266,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         )
         self.assertIsNone(printable)
 
-        return
-
     def test_adaptation_prefers_subclasses(self):
 
         ex = self.examples
@@ -315,8 +292,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         printable = self.adaptation_manager.adapt(text_editor, ex.IPrintable)
         self.assertIsNotNone(printable)
         self.assertIs(type(printable), ex.TextEditorToIPrintable)
-
-        return
 
     def test_adaptation_prefers_subclasses_other_registration_order(self):
         # This test is identical to `test_adaptation_prefers_subclasses`
@@ -348,8 +323,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         self.assertIsNotNone(printable)
         self.assertIs(type(printable), ex.TextEditorToIPrintable)
 
-        return
-
     def test_circular_adaptation(self):
         # Circles in the adaptation graph should not lead to infinite loops
         # when it is impossible to reach the target.
@@ -379,8 +352,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         bar = self.adaptation_manager.adapt(obj, Bar, None)
         self.assertIsNone(bar)
 
-        return
-
     def test_default_argument_in_adapt(self):
 
         from traits.adaptation.adaptation_manager import AdaptationError
@@ -393,8 +364,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         default = "default"
         result = self.adaptation_manager.adapt("string", int, default=default)
         self.assertIs(result, default)
-
-        return
 
     def test_prefer_specific_interfaces(self):
 
@@ -437,8 +406,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         self.assertIsNotNone(target)
         self.assertIs(type(target.adaptee), ex.IChildToIIntermediate)
 
-        return
-
     def test_chaining_with_intermediate_mro_climbing(self):
 
         ex = self.examples
@@ -465,8 +432,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         end = self.adaptation_manager.adapt(start, ex.IEnd)
         self.assertIsNotNone(end)
         self.assertIs(type(end), ex.IGenericToIEnd)
-
-        return
 
     def test_conditional_recycling(self):
         # Test that an offer that has been considered but failed if considered
@@ -520,8 +485,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         self.assertIsNotNone(b)
         self.assertTrue(hasattr(b, "marker"))
 
-        return
-
     def test_provides_protocol_for_interface_subclass(self):
 
         from traits.api import Interface
@@ -534,8 +497,6 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
 
         self.assertTrue(self.adaptation_manager.provides_protocol(IB, IA))
 
-        return
-
     def test_register_provides(self):
 
         from traits.api import Interface
@@ -547,5 +508,3 @@ class TestAdaptationManagerWithABC(unittest.TestCase):
         self.assertEqual(None, self.adaptation_manager.adapt(obj, IFoo, None))
         self.adaptation_manager.register_provides(dict, IFoo)
         self.assertEqual(obj, self.adaptation_manager.adapt(obj, IFoo))
-
-        return

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -69,8 +69,6 @@ class ETSConfig(object):
         self._kiva_backend = None
         self._user_data = None
 
-        return
-
     ###########################################################################
     # 'ETSConfig' interface.
     ###########################################################################
@@ -116,8 +114,6 @@ class ETSConfig(object):
         """
 
         self._application_data = application_data
-
-        return
 
     def get_application_home(self, create=False):
         """ Return the application home directory path.
@@ -177,8 +173,6 @@ class ETSConfig(object):
 
         self._application_home = application_home
 
-        return
-
     application_home = property(_get_application_home, _set_application_home)
 
     def _get_company(self):
@@ -199,8 +193,6 @@ class ETSConfig(object):
         """
 
         self._company = company
-
-        return
 
     company = property(_get_company, _set_company)
 
@@ -266,8 +258,6 @@ class ETSConfig(object):
 
         self._toolkit = toolkit
 
-        return
-
     toolkit = property(_get_toolkit, _set_toolkit)
 
     def _get_enable_toolkit(self):
@@ -297,8 +287,6 @@ class ETSConfig(object):
         from warnings import warn
 
         warn("Use of the enable_toolkit attribute is deprecated.")
-
-        return
 
     enable_toolkit = property(_get_enable_toolkit, _set_enable_toolkit)
 
@@ -360,8 +348,6 @@ class ETSConfig(object):
         """
 
         self._user_data = user_data
-
-        return
 
     user_data = property(_get_user_data, _set_user_data)
 

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -132,8 +132,6 @@ class ETSConfigTestCase(unittest.TestCase):
         self.assertEqual(os.path.exists(dirname), True)
         self.assertEqual(os.path.isdir(dirname), True)
 
-        return
-
     def test_set_application_data(self):
         """
         set application data
@@ -148,8 +146,6 @@ class ETSConfigTestCase(unittest.TestCase):
         self.ETSConfig.application_data = old
         self.assertEqual(old, self.ETSConfig.application_data)
 
-        return
-
     def test_application_data_is_idempotent(self):
         """
         application data is idempotent
@@ -159,8 +155,6 @@ class ETSConfigTestCase(unittest.TestCase):
         # Just do the previous test again!
         self.test_application_data()
         self.test_application_data()
-
-        return
 
     def test_write_to_application_data_directory(self):
         """
@@ -186,8 +180,6 @@ class ETSConfigTestCase(unittest.TestCase):
 
         self.assertEqual(data, result)
 
-        return
-
     def test_default_company(self):
         """
         default company
@@ -195,8 +187,6 @@ class ETSConfigTestCase(unittest.TestCase):
         """
 
         self.assertEqual(self.ETSConfig.company, "Enthought")
-
-        return
 
     def test_set_company(self):
         """
@@ -211,8 +201,6 @@ class ETSConfigTestCase(unittest.TestCase):
 
         self.ETSConfig.company = old
         self.assertEqual(old, self.ETSConfig.company)
-
-        return
 
     def _test_default_application_home(self):
         """
@@ -317,8 +305,6 @@ class ETSConfigTestCase(unittest.TestCase):
         self.assertEqual(os.path.exists(dirname), True)
         self.assertEqual(os.path.isdir(dirname), True)
 
-        return
-
     def test_set_user_data(self):
         """
         set user data
@@ -333,8 +319,6 @@ class ETSConfigTestCase(unittest.TestCase):
         self.ETSConfig.user_data = old
         self.assertEqual(old, self.ETSConfig.user_data)
 
-        return
-
     def test_user_data_is_idempotent(self):
         """
         user data is idempotent
@@ -343,8 +327,6 @@ class ETSConfigTestCase(unittest.TestCase):
 
         # Just do the previous test again!
         self.test_user_data()
-
-        return
 
     def test_write_to_user_data_directory(self):
         """
@@ -369,8 +351,6 @@ class ETSConfigTestCase(unittest.TestCase):
         os.remove(path)
 
         self.assertEqual(data, result)
-
-        return
 
 
 # For running as an individual set of tests.

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -324,7 +324,6 @@ class UnittestTools(object):
             return reverse_assertion(context, msg)
         with reverse_assertion(context, msg):
             callableObj(*args, **kwargs)
-        return
 
     @contextlib.contextmanager
     def assertMultiTraitChanges(

--- a/traits/tests/test_array.py
+++ b/traits/tests/test_array.py
@@ -43,5 +43,3 @@ class ArrayTestCase(unittest.TestCase):
 
         # Confirm that the static trait handler was invoked.
         self.assertEqual(f.event_fired, True)
-
-        return

--- a/traits/tests/test_clone.py
+++ b/traits/tests/test_clone.py
@@ -105,8 +105,6 @@ class CloneTestCase(unittest.TestCase):
         bc = b.clone_traits(traits="all", copy="deep")
         self.assertNotEqual(id(bc.x), id(f), "Foo x not cloned")
 
-        return
-
     def test_instance(self):
         b = ClassWithInstance()
 
@@ -117,8 +115,6 @@ class CloneTestCase(unittest.TestCase):
 
         bc = b.clone_traits(traits="all", copy="deep")
         self.assertNotEqual(id(bc.x), id(f), "Foo x not cloned")
-
-        return
 
     def test_class_attribute_missing(self):
         """ This test demonstrates a problem with Traits objects with class
@@ -146,8 +142,6 @@ class CloneTestCase(unittest.TestCase):
         # this is failing with AttributeError: 'ClassWithClassAttribute'
         # object has no attribute 'name'
         self.assertEqual(s, c.name)
-
-        return
 
     def test_Any_circular_references(self):
 

--- a/traits/tests/test_container_events.py
+++ b/traits/tests/test_container_events.py
@@ -25,12 +25,10 @@ class MyClass(HasTraits):
     def __init__(self, callback):
         "The callback is called with the TraitDictEvent instance"
         self.callback = callback
-        return
 
     def _d_items_changed(self, event):
         if self.callback:
             self.callback(event)
-        return
 
 
 class MyOtherClass(HasTraits):
@@ -70,14 +68,12 @@ class DictEventTestCase(unittest.TestCase):
         bar = MyClass(cb)
         bar.d["g"] = "guava"
         self.assertTrue(cb.called)
-        return
 
     def test_delitem(self):
         cb = Callback(self, removed={"b": "banana"})
         foo = MyClass(cb)
         del foo.d["b"]
         self.assertTrue(cb.called)
-        return
 
     def test_clear(self):
         removed = MyClass(None).d.copy()
@@ -85,7 +81,6 @@ class DictEventTestCase(unittest.TestCase):
         foo = MyClass(cb)
         foo.d.clear()
         self.assertTrue(cb.called)
-        return
 
     def test_update(self):
         update_dict = {"a": "artichoke", "f": "fig"}
@@ -93,7 +88,6 @@ class DictEventTestCase(unittest.TestCase):
         foo = MyClass(cb)
         foo.d.update(update_dict)
         self.assertTrue(cb.called)
-        return
 
     def test_setdefault(self):
         # Test retrieving an existing value
@@ -107,7 +101,6 @@ class DictEventTestCase(unittest.TestCase):
         bar = MyClass(cb)
         self.assertTrue(bar.d.setdefault("f", "fig") == "fig")
         self.assertTrue(cb.called)
-        return
 
     def test_pop(self):
         # Test popping a non-existent key
@@ -121,7 +114,6 @@ class DictEventTestCase(unittest.TestCase):
         bar = MyClass(cb)
         self.assertEqual(bar.d.pop("c"), "cherry")
         self.assertTrue(cb.called)
-        return
 
     def test_popitem(self):
         foo = MyClass(None)
@@ -131,7 +123,6 @@ class DictEventTestCase(unittest.TestCase):
         foo.callback = cb
         self.assertEqual(foo.d.popitem(), ("x", "xylophone"))
         self.assertTrue(cb.called)
-        return
 
     def test_dynamic_listener(self):
         foo = MyOtherClass()
@@ -155,4 +146,3 @@ class DictEventTestCase(unittest.TestCase):
         foo.d["b"] = "broccoli"
         foo.on_trait_change(func3.__call__, "d_items", remove=True)
         self.assertTrue(func3.called)
-        return

--- a/traits/tests/test_copy_traits.py
+++ b/traits/tests/test_copy_traits.py
@@ -52,8 +52,6 @@ class CopyTraitsBase(unittest.TestCase):
         self.bar2 = Bar(shared=self.shared2, foo=self.foo2, s="bar2")
         self.baz2 = Baz(shared=self.shared2, bar=self.bar2, s="baz2")
 
-        return
-
     def set_shared_copy(self, value):
         """ Change the copy style for the 'shared' traits. """
         self.foo.base_trait("shared").copy = value
@@ -171,7 +169,6 @@ class TestCopyTraitsSharedCopyNone(CopyTraits, CopyTraitsSharedCopyNone):
 
         # deep is the default value for Instance trait copy
         self.set_shared_copy("deep")
-        return
 
 
 class TestCopyTraitsCopyNotSpecified(
@@ -184,7 +181,6 @@ class TestCopyTraitsCopyNotSpecified(
         CopyTraitsBase.setUp(self)
         TestCopyTraitsSharedCopyNone.setUp(self)
         self.baz2.copy_traits(self.baz)
-        return
 
 
 class TestCopyTraitsCopyShallow(CopyTraitsBase, TestCopyTraitsSharedCopyNone):
@@ -195,7 +191,6 @@ class TestCopyTraitsCopyShallow(CopyTraitsBase, TestCopyTraitsSharedCopyNone):
         CopyTraitsBase.setUp(self)
         TestCopyTraitsSharedCopyNone.setUp(self)
         self.baz2.copy_traits(self.baz, copy="shallow")
-        return
 
 
 class TestCopyTraitsCopyDeep(CopyTraitsBase, TestCopyTraitsSharedCopyNone):
@@ -206,7 +201,6 @@ class TestCopyTraitsCopyDeep(CopyTraitsBase, TestCopyTraitsSharedCopyNone):
         CopyTraitsBase.setUp(self)
         TestCopyTraitsSharedCopyNone.setUp(self)
         self.baz2.copy_traits(self.baz, copy="deep")
-        return
 
 
 class CopyTraitsSharedCopyRef(object):
@@ -241,7 +235,6 @@ class TestCopyTraitsSharedCopyRef(CopyTraits, CopyTraitsSharedCopyRef):
     def setUp(self):
         # super(TestCopyTraitsSharedCopyRef,self).setUp()
         self.set_shared_copy("ref")
-        return
 
 
 # The next three tests demonstrate that a 'ref' trait is always copied as a
@@ -256,7 +249,6 @@ class TestCopyTraitsCopyNotSpecifiedSharedRef(
         CopyTraitsBase.setUp(self)
         TestCopyTraitsSharedCopyRef.setUp(self)
         self.baz2.copy_traits(self.baz)
-        return
 
 
 class TestCopyTraitsCopyShallowSharedRef(
@@ -268,7 +260,6 @@ class TestCopyTraitsCopyShallowSharedRef(
         CopyTraitsBase.setUp(self)
         TestCopyTraitsSharedCopyRef.setUp(self)
         self.baz2.copy_traits(self.baz, copy="shallow")
-        return
 
 
 class TestCopyTraitsCopyDeepSharedRef(
@@ -280,4 +271,3 @@ class TestCopyTraitsCopyDeepSharedRef(
         CopyTraitsBase.setUp(self)
         TestCopyTraitsSharedCopyRef.setUp(self)
         self.baz2.copy_traits(self.baz, copy="deep")
-        return

--- a/traits/tests/test_delegate.py
+++ b/traits/tests/test_delegate.py
@@ -29,12 +29,10 @@ class Foo(HasTraits):
     def _s_changed(self, name, old, new):
         global foo_s_handler_self
         foo_s_handler_self = self
-        return
 
     def _t_changed(self, name, old, new):
         global foo_t_handler_self
         foo_t_handler_self = self
-        return
 
 
 class Bar(HasTraits):
@@ -52,22 +50,18 @@ class BazModify(HasTraits):
         # should never be called
         global baz_s_handler_self
         baz_s_handler_self = self
-        return
 
     def _sd_changed(self, name, old, new):
         global baz_sd_handler_self
         baz_sd_handler_self = self
-        return
 
     def _t_changed(self, name, old, new):
         global baz_t_handler_self
         baz_t_handler_self = self
-        return
 
     def _u_changed(self, name, old, new):
         global baz_u_handler_self
         baz_u_handler_self = self
-        return
 
 
 class BazNoModify(HasTraits):
@@ -79,22 +73,18 @@ class BazNoModify(HasTraits):
     def _s_changed(self, name, old, new):
         global baz_s_handler_self
         baz_s_handler_self = self
-        return
 
     def _sd_changed(self, name, old, new):
         global baz_sd_handler_self
         baz_sd_handler_self = self
-        return
 
     def _t_changed(self, name, old, new):
         global baz_t_handler_self
         baz_t_handler_self = self
-        return
 
     def _u_changed(self, name, old, new):
         global baz_u_handler_self
         baz_u_handler_self = self
-        return
 
 
 class DelegateTestCase(unittest.TestCase):
@@ -133,7 +123,6 @@ class DelegateTestCase(unittest.TestCase):
         # really testing for.
         del b.s
         self.assertEqual(f.s, b.s)
-        return
 
     # Below are 8 tests to check the calling of change notification handlers.
     # There are 8 cases for the 2x2x2 matrix with axes:
@@ -155,7 +144,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Do expect '_sd_changed' to be called with b as self
         self.assertEqual(baz_sd_handler_self, b)
-        return
 
     def test_modify_prefix_handler_on_delegatee(self):
         f = Foo()
@@ -168,7 +156,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Foo expects its '_s_changed' handler to be called with f as self
         self.assertEqual(foo_s_handler_self, f)
-        return
 
     def test_no_modify_prefix_handler_on_delegator(self):
         f = Foo()
@@ -185,7 +172,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Do expect '_sd_changed' to be called with b as self
         self.assertEqual(baz_sd_handler_self, b)
-        return
 
     def test_no_modify_prefix_handler_on_delegatee_not_called(self):
         f = Foo()
@@ -198,7 +184,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Foo expects its '_s_changed' handler to be called with f as self
         self.assertEqual(foo_s_handler_self, None)
-        return
 
     def test_modify_handler_on_delegator(self):
         f = Foo()
@@ -211,7 +196,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Do expect '_t_changed' to be called with b as self
         self.assertEqual(baz_t_handler_self, b)
-        return
 
     def test_modify_handler_on_delegatee(self):
         f = Foo()
@@ -224,7 +208,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Foo t did change so '_t_changed' handler should be called
         self.assertEqual(foo_t_handler_self, f)
-        return
 
     def test_no_modify_handler_on_delegator(self):
         f = Foo()
@@ -237,7 +220,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Do expect '_t_changed' to be called with b as self
         self.assertEqual(baz_t_handler_self, b)
-        return
 
     def test_no_modify_handler_on_delegatee_not_called(self):
         f = Foo()
@@ -250,7 +232,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Foo t did not change so '_t_changed' handler should not be called
         self.assertEqual(foo_t_handler_self, None)
-        return
 
     # Below are 4 tests for notification when the delegated trait is changed
     # directly rather than through the delegator.
@@ -265,7 +246,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Foo t did change so '_t_changed' handler should be called
         self.assertEqual(foo_t_handler_self, f)
-        return
 
     def test_no_modify_handler_on_delegator_direct_change(self):
         f = Foo()
@@ -278,7 +258,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Do expect '_t_changed' to be called with b as self
         self.assertEqual(baz_t_handler_self, b)
-        return
 
     def test_modify_handler_on_delegatee_direct_change(self):
         f = Foo()
@@ -291,7 +270,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Foo t did change so '_t_changed' handler should be called
         self.assertEqual(foo_t_handler_self, f)
-        return
 
     def test_modify_handler_on_delegator_direct_change(self):
         f = Foo()
@@ -304,7 +282,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Do expect '_t_changed' to be called with b as self
         self.assertEqual(baz_t_handler_self, b)
-        return
 
     # Below are tests which check that we can turn off listenableness.
     def test_modify_handler_not_listenable(self):
@@ -318,7 +295,6 @@ class DelegateTestCase(unittest.TestCase):
 
         # Do not expect '_u_changed' to be called.
         self.assertEqual(baz_u_handler_self, None)
-        return
 
     def test_no_modify_handler_not_listenable(self):
         f = Foo()
@@ -331,4 +307,3 @@ class DelegateTestCase(unittest.TestCase):
 
         # Do not expect '_u_changed' to be called.
         self.assertEqual(baz_u_handler_self, None)
-        return

--- a/traits/tests/test_dict.py
+++ b/traits/tests/test_dict.py
@@ -29,7 +29,6 @@ def create_listener():
         listener.new = new
         listener.old = old
         listener.called += 1
-        return
 
     listener.initialize = lambda: initialize_listener(listener)
     return initialize_listener(listener)
@@ -63,7 +62,6 @@ class TestDict(unittest.TestCase):
             @on_trait_change("name")
             def _fire_modified_event(self):
                 self.modified = True
-                return
 
         class Bar(HasTraits):
             foos = Dict(Str, Foo)
@@ -72,7 +70,6 @@ class TestDict(unittest.TestCase):
             @on_trait_change("foos_items,foos.modified")
             def _fire_modified_event(self, obj, trait_name, old, new):
                 self.modified = True
-                return
 
         bar = Bar()
         listener = create_listener()
@@ -101,8 +98,6 @@ class TestDict(unittest.TestCase):
         bar.foos["fred"] = Foo(name="wilma")
         self.assertEqual(1, listener.called)
         self.assertEqual("modified", listener.trait_name)
-
-        return
 
     def test_validate(self):
         """ Check the validation method.

--- a/traits/tests/test_event_order.py
+++ b/traits/tests/test_event_order.py
@@ -55,12 +55,9 @@ class Bar(HasTraits):
         if new is not None:
             new.on_trait_change(self._cause_changed, name="cause")
 
-        return
-
     def _cause_changed(self, obj, name, old, new):
         self.test.events_delivered.append("Bar._caused_changed")
         self.effect = new.lower()
-        return
 
 
 class Baz(HasTraits):
@@ -80,12 +77,8 @@ class Baz(HasTraits):
             new.foo.on_trait_change(self._cause_changed, name="cause")
             new.on_trait_change(self._effect_changed, name="effect")
 
-        return
-
     def _cause_changed(self, obj, name, old, new):
         self.test.events_delivered.append("Baz._caused_changed")
-        return
 
     def _effect_changed(self, obj, name, old, new):
         self.test.events_delivered.append("Baz._effect_changed")
-        return

--- a/traits/tests/test_interface_checker.py
+++ b/traits/tests/test_interface_checker.py
@@ -47,8 +47,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
         """ Prepares the test fixture before each test method is called. """
         reset_global_adaptation_manager()
 
-        return
-
     ###########################################################################
     # Tests.
     ###########################################################################
@@ -70,8 +68,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
         # the interface.
         check_implements(Foo, IFoo, 2)
 
-        return
-
     def test_single_interface(self):
         """ single interface """
 
@@ -87,8 +83,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
         # The checker will raise an exception if the class does not implement
         # the interface.
         check_implements(Foo, IFoo, 2)
-
-        return
 
     def test_single_interface_with_invalid_method_signature(self):
         """ single interface with invalid method signature """
@@ -106,8 +100,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
 
         self.assertRaises(InterfaceError, check_implements, Foo, IFoo, 2)
 
-        return
-
     def test_single_interface_with_missing_trait(self):
         """ single interface with missing trait """
 
@@ -120,7 +112,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             pass
 
         self.assertRaises(InterfaceError, check_implements, Foo, IFoo, 2)
-        return
 
     def test_single_interface_with_missing_method(self):
         """ single interface with missing method """
@@ -135,8 +126,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             pass
 
         self.assertRaises(InterfaceError, check_implements, Foo, IFoo, 2)
-
-        return
 
     def test_multiple_interfaces(self):
         """ multiple interfaces """
@@ -160,8 +149,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
         # The checker will raise an exception if the class does not implement
         # the interface.
         check_implements(Foo, [IFoo, IBar, IBaz], 2)
-
-        return
 
     def test_multiple_interfaces_with_invalid_method_signature(self):
         """ multiple interfaces with invalid method signature """
@@ -195,8 +182,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             InterfaceError, check_implements, Foo, [IFoo, IBar, IBaz], 2
         )
 
-        return
-
     def test_multiple_interfaces_with_missing_trait(self):
         """ multiple interfaces with missing trait """
 
@@ -219,8 +204,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
         self.assertRaises(
             InterfaceError, check_implements, Foo, [IFoo, IBar, IBaz], 2
         )
-
-        return
 
     def test_multiple_interfaces_with_missing_method(self):
         """ multiple interfaces with missing method """
@@ -250,8 +233,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             InterfaceError, check_implements, Foo, [IFoo, IBar, IBaz], 2
         )
 
-        return
-
     def test_inherited_interfaces(self):
         """ inherited interfaces """
 
@@ -274,8 +255,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
         # The checker will raise an exception if the class does not implement
         # the interface.
         check_implements(Foo, IBaz, 2)
-
-        return
 
     def test_inherited_interfaces_with_invalid_method_signature(self):
         """ inherited with invalid method signature """
@@ -307,8 +286,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
 
         self.assertRaises(InterfaceError, check_implements, Foo, IBaz, 2)
 
-        return
-
     def test_inherited_interfaces_with_missing_trait(self):
         """ inherited interfaces with missing trait """
 
@@ -329,8 +306,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             y = Int
 
         self.assertRaises(InterfaceError, check_implements, Foo, IBaz, 2)
-
-        return
 
     def test_inherited_interfaces_with_missing_method(self):
         """ inherited interfaces with missing method """
@@ -357,8 +332,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
                 pass
 
         self.assertRaises(InterfaceError, check_implements, Foo, IBaz, 2)
-
-        return
 
     def test_subclasses_with_wrong_signature_methods(self):
         """ Subclasses with incorrect method signatures """
@@ -394,8 +367,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
             foo = Instance(IFoo)
 
         Bar(foo=Foo())
-
-        return
 
     def test_callable(self):
         """ callable """

--- a/traits/tests/test_list.py
+++ b/traits/tests/test_list.py
@@ -47,33 +47,28 @@ class ListTestCase(unittest.TestCase):
         f = Foo()
         self.assertNotEqual(f.l, None)
         self.assertEqual(len(f.l), 0)
-        return
 
     def test_initializer(self):
         f = Foo(l=["a", "list"])
         self.assertNotEqual(f.l, None)
         self.assertEqual(f.l, ["a", "list"])
-        return
 
     def test_type_check(self):
         f = Foo()
         f.l.append("string")
 
         self.assertRaises(TraitError, f.l.append, 123.456)
-        return
 
     def test_append(self):
         f = Foo()
         f.l.append("bar")
         self.assertEqual(f.l, ["bar"])
-        return
 
     def test_remove(self):
         f = Foo()
         f.l.append("bar")
         f.l.remove("bar")
         self.assertEqual(f.l, [])
-        return
 
     def test_slice(self):
         f = Foo(l=["zero", "one", "two", "three"])
@@ -85,7 +80,6 @@ class ListTestCase(unittest.TestCase):
         self.assertEqual(f.l[-1], "three")
         self.assertEqual(f.l[-2], "two")
         self.assertEqual(f.l[:-1], ["zero", "one", "two"])
-        return
 
     def test_slice_assignment(self):
         # Exhaustive testing.
@@ -156,7 +150,6 @@ class ListTestCase(unittest.TestCase):
 
         f.l.append("more change")
         self.assertEqual(l, ["initial", "value", "change", "more change"])
-        return
 
     def test_assignment_makes_copy(self):
         f = Foo(l=["initial", "value"])
@@ -175,8 +168,6 @@ class ListTestCase(unittest.TestCase):
 
         f.l.append("f.l change")
         self.assertNotIn("f.l change", l)
-
-        return
 
     def test_should_not_allow_none(self):
         f = Foo(l=["initial", "value"])
@@ -207,8 +198,6 @@ class ListTestCase(unittest.TestCase):
         baz_copy_bar_names.sort()
         self.assertEqual(baz_copy_bar_names, baz_bar_names)
 
-        return
-
     def test_clone_ref(self):
         baz = BazRef()
         for name in ["a", "b", "c", "d"]:
@@ -224,8 +213,6 @@ class ListTestCase(unittest.TestCase):
         self.assertEqual(len(baz_copy.bars), len(baz.bars))
         for bar in baz.bars:
             self.assertIn(bar, baz_copy.bars)
-
-        return
 
     def test_clone_deep_baz(self):
         baz = Baz()
@@ -255,7 +242,6 @@ class ListTestCase(unittest.TestCase):
         baz_bar_names.sort()
         baz_copy_bar_names.sort()
         self.assertEqual(baz_copy_bar_names, baz_bar_names)
-        return
 
     def test_clone_deep_baz_ref(self):
         baz = BazRef()
@@ -277,7 +263,6 @@ class ListTestCase(unittest.TestCase):
         self.assertEqual(len(baz_copy.bars), len(baz.bars))
         for bar in baz.bars:
             self.assertIn(bar, baz_copy.bars)
-        return
 
     def test_coercion(self):
         f = CFoo()

--- a/traits/tests/test_rich_compare.py
+++ b/traits/tests/test_rich_compare.py
@@ -43,7 +43,6 @@ class RichCompareTests:
         self.assertEqual(trait, self.changed_trait)
         self.assertIs(old, self.changed_old)
         self.assertIs(new, self.changed_new)
-        return
 
     def test_id_first_assignment(self):
         ic = IdentityCompare()
@@ -54,7 +53,6 @@ class RichCompareTests:
         default_value = ic.bar
         ic.bar = self.a
         self.check_tracker(ic, "bar", default_value, self.a, 1)
-        return
 
     def test_rich_first_assignment(self):
         rich = RichCompare()
@@ -65,7 +63,6 @@ class RichCompareTests:
         default_value = rich.bar
         rich.bar = self.a
         self.check_tracker(rich, "bar", default_value, self.a, 1)
-        return
 
     def test_id_same_object(self):
         ic = IdentityCompare()
@@ -79,7 +76,6 @@ class RichCompareTests:
 
         ic.bar = self.a
         self.check_tracker(ic, "bar", default_value, self.a, 1)
-        return
 
     def test_rich_same_object(self):
         rich = RichCompare()
@@ -93,7 +89,6 @@ class RichCompareTests:
 
         rich.bar = self.a
         self.check_tracker(rich, "bar", default_value, self.a, 1)
-        return
 
     def test_id_different_object(self):
         ic = IdentityCompare()
@@ -107,7 +102,6 @@ class RichCompareTests:
 
         ic.bar = self.different_from_a
         self.check_tracker(ic, "bar", self.a, self.different_from_a, 2)
-        return
 
     def test_rich_different_object(self):
         rich = RichCompare()
@@ -121,7 +115,6 @@ class RichCompareTests:
 
         rich.bar = self.different_from_a
         self.check_tracker(rich, "bar", self.a, self.different_from_a, 2)
-        return
 
     def test_id_different_object_same_as(self):
         ic = IdentityCompare()
@@ -135,7 +128,6 @@ class RichCompareTests:
 
         ic.bar = self.same_as_a
         self.check_tracker(ic, "bar", self.a, self.same_as_a, 2)
-        return
 
     def test_rich_different_object_same_as(self):
         rich = RichCompare()
@@ -151,7 +143,6 @@ class RichCompareTests:
         # be considered a change.
         rich.bar = self.same_as_a
         self.check_tracker(rich, "bar", default_value, self.a, 1)
-        return
 
 
 class Foo(HasTraits):
@@ -172,7 +163,6 @@ class RichCompareHasTraitsTestCase(unittest.TestCase, RichCompareTests):
         self.a = Foo(name="a")
         self.same_as_a = Foo(name="a")
         self.different_from_a = Foo(name="not a")
-        return
 
     def test_assumptions(self):
         self.assertIsNot(self.a, self.same_as_a)
@@ -180,7 +170,6 @@ class RichCompareHasTraitsTestCase(unittest.TestCase, RichCompareTests):
 
         self.assertEqual(self.a.name, self.same_as_a.name)
         self.assertNotEqual(self.a.name, self.different_from_a.name)
-        return
 
 
 class OldRichCompareTestCase(unittest.TestCase):

--- a/traits/tests/test_str_handler.py
+++ b/traits/tests/test_str_handler.py
@@ -37,8 +37,6 @@ class MyHandler(TraitHandler):
             pass
         self.error(object, name, value)
 
-        return
-
     def info(self):
         msg = "a string not containing the character sequence 'fail'"
         return msg
@@ -63,8 +61,6 @@ class StrHandlerCase(unittest.TestCase):
         self.assertRaises(TraitError, setattr, f, "s", "should fail.")
         self.assertEqual(f.s, "ok")
 
-        return
-
     def test_validator_handler(self):
         b = Bar()
         self.assertEqual(b.s, "")
@@ -74,5 +70,3 @@ class StrHandlerCase(unittest.TestCase):
 
         self.assertRaises(TraitError, setattr, b, "s", "should fail.")
         self.assertEqual(b.s, "ok")
-
-        return

--- a/traits/tests/test_undefined.py
+++ b/traits/tests/test_undefined.py
@@ -33,13 +33,11 @@ class UndefinedTestCase(unittest.TestCase):
     def test_initial_value(self):
         b = Bar()
         self.assertEqual(b.name, Undefined)
-        return
 
     def test_name_change(self):
         b = Bar()
         b.name = "first"
         self.assertEqual(b.name, "first")
-        return
 
     def test_read_only_write_once(self):
         f = Foo()
@@ -55,8 +53,6 @@ class UndefinedTestCase(unittest.TestCase):
         self.assertEqual(f.name, "second")
         self.assertEqual(f.original_name, "first")
 
-        return
-
     def test_read_only_write_once_from_constructor(self):
         f = Foo(name="first")
 
@@ -67,5 +63,3 @@ class UndefinedTestCase(unittest.TestCase):
         f.name = "second"
         self.assertEqual(f.name, "second")
         self.assertEqual(f.original_name, "first")
-
-        return

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -98,8 +98,6 @@ class TraitSetObject(set):
 
             super(TraitSetObject, self).__init__(value)
 
-            return
-
         except TraitError as excp:
             excp.set_prefix("Each element of the")
             raise excp

--- a/traits/util/resource.py
+++ b/traits/util/resource.py
@@ -160,7 +160,7 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
         # script is called directly from the command line using
         # 'python %SOMEPATH%/<script>'
         if alt_path is None:
-            return
+            return None
         if return_path:
             return os.path.join(sys.path[0], alt_path)
 
@@ -168,7 +168,7 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
         try:
             return open(os.path.join(sys.path[0], alt_path), "rb")
         except:
-            return
+            return None
 
 
 def store_resource(project, resource_path, filename):

--- a/traits/util/tests/test_import_symbol.py
+++ b/traits/util/tests/test_import_symbol.py
@@ -26,8 +26,6 @@ class TestImportSymbol(unittest.TestCase):
         symbol = import_symbol("tarfile.TarFile")
         self.assertEqual(symbol, tarfile.TarFile)
 
-        return
-
     def test_import_nested_symbol(self):
         """ import nested symbol """
 
@@ -36,13 +34,9 @@ class TestImportSymbol(unittest.TestCase):
         symbol = import_symbol("tarfile:TarFile.open")
         self.assertEqual(symbol, tarfile.TarFile.open)
 
-        return
-
     def test_import_dotted_module(self):
         """ import dotted module """
 
         symbol = import_symbol("traits.util.import_symbol:import_symbol")
 
         self.assertEqual(symbol, import_symbol)
-
-        return


### PR DESCRIPTION
This PR removes redundant return statements at the ends of functions and methods.

Note: with 3 exceptions (noted in review comments), these are all simply removal of a `return` at the end of a function or method.