### PR TITLE
Improve HasTraits introspection with `dir()`

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1355,7 +1355,8 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         trait_names = self.trait_names()
         method_names = [method for method in self._each_trait_method(self)]
         class_attrs = list(vars(self.__class__).keys())
-        return trait_names + method_names + class_attrs
+        return list(
+            set(trait_names + method_names + class_attrs + super().__dir__()))
 
     def copy_traits(
         self, other, traits=None, memo=None, copy=None, **metadata

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1352,11 +1352,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """ Returns the list of trait names when calling the dir() builtin on
             the object. This enables tab-completion in IPython.
         """
-        trait_names = self.trait_names()
-        method_names = [method for method in self._each_trait_method(self)]
-        class_attrs = list(vars(self.__class__).keys())
-        return list(
-            set(trait_names + method_names + class_attrs + super().__dir__()))
+        return super().__dir__() + self.trait_names()
 
     def copy_traits(
         self, other, traits=None, memo=None, copy=None, **metadata

--- a/traits/tests/test_get_traits.py
+++ b/traits/tests/test_get_traits.py
@@ -72,6 +72,13 @@ class GetTraitTestCase(unittest.TestCase):
 
     def test_dir(self):
         b = FooBar()
-        self.assertIn("baz", dir(b))
-        self.assertIn("num", dir(b))
-        self.assertIn("edit_traits", dir(b))
+        names = dir(b)
+        self.assertIn("baz", names)
+        self.assertIn("num", names)
+        self.assertIn("edit_traits", names)
+
+        # Issue 925: _notifiers not shown in dir()
+        self.assertIn("_notifiers", names)
+
+        # Ensure no duplicates
+        self.assertEqual(len(set(names)), len(names))

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -366,18 +366,6 @@ class TestHasTraits(unittest.TestCase):
 
         self.assertTrue(foo.traits_inited())
 
-    def test___dir__(self):
-        class Base(HasTraits):
-            pass
-        base_obj = Base()
-        names = dir(base_obj)
-
-        # Issue 925: _notifiers not shown in dir()
-        self.assertIn("_notifiers", names)
-
-        # Ensure no duplicates
-        self.assertEqual(len(set(names)), len(names))
-
 
 class TestObjectNotifiers(unittest.TestCase):
     """ Test calling object notifiers. """

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -366,6 +366,18 @@ class TestHasTraits(unittest.TestCase):
 
         self.assertTrue(foo.traits_inited())
 
+    def test___dir__(self):
+        class Base(HasTraits):
+            pass
+        base_obj = Base()
+        names = dir(base_obj)
+
+        # Issue 925: _notifiers not shown in dir()
+        self.assertIn("_notifiers", names)
+
+        # Ensure no duplicates
+        self.assertEqual(len(set(names)), len(names))
+
 
 class TestObjectNotifiers(unittest.TestCase):
     """ Test calling object notifiers. """


### PR DESCRIPTION
Fix #925 
Includes the names from `super().__dir__()` in the `HasTraits.__dir__`'s output.