### PR TITLE
Refactor: fix duplication of DEFAULT_VALUE constants

### DIFF
--- a/traits/constants.py
+++ b/traits/constants.py
@@ -10,6 +10,8 @@
 
 from enum import IntEnum
 
+import traits.ctraits
+
 
 class TraitKind(IntEnum):
     """ These determine the getters and setters used by the cTrait instance.
@@ -157,48 +159,48 @@ class DefaultValue(IntEnum):
     unspecified = -1
 
     #: The default_value of the trait is the default value.
-    constant = 0
+    constant = traits.ctraits._CONSTANT_DEFAULT_VALUE
 
     #: The default_value of the trait is Missing.
-    missing = 1
+    missing = traits.ctraits._MISSING_DEFAULT_VALUE
 
     #: The object containing the trait is the default value.
-    object = 2
+    object = traits.ctraits._OBJECT_DEFAULT_VALUE
 
     #: A new copy of the list specified by default_value is the default value.
-    list_copy = 3
+    list_copy = traits.ctraits._LIST_COPY_DEFAULT_VALUE
 
     #: A new copy of the dict specified by default_value is the default value.
-    dict_copy = 4
+    dict_copy = traits.ctraits._DICT_COPY_DEFAULT_VALUE
 
     #: A new instance of TraitListObject constructed using the default_value
     #: list is the default value.
-    trait_list_object = 5
+    trait_list_object = traits.ctraits._TRAIT_LIST_OBJECT_DEFAULT_VALUE
 
     #: A new instance of TraitDictObject constructed using the default_value
     #: dict is the default value.
-    trait_dict_object = 6
+    trait_dict_object = traits.ctraits._TRAIT_DICT_OBJECT_DEFAULT_VALUE
 
     #: The default_value is a tuple of the form: (*callable*, *args*, *kw*),
     #: where *callable* is a callable, *args* is a tuple, and *kw* is either a
     #: dictionary or None. The default value is the result obtained by invoking
     #: ``callable(\*args, \*\*kw)``.
-    callable_and_args = 7
+    callable_and_args = traits.ctraits._CALLABLE_AND_ARGS_DEFAULT_VALUE
 
     #: The default_value is a callable. The default value is the result
     #: obtained by invoking *default_value*(*object*), where *object* is the
     #: object containing the trait. If the trait has a validate() method, the
     #: validate() method is also called to validate the result.
-    callable = 8
+    callable = traits.ctraits._CALLABLE_DEFAULT_VALUE
 
     #: A new instance of TraitSetObject constructed using the default_value set
     #: is the default value.
-    trait_set_object = 9
+    trait_set_object = traits.ctraits._TRAIT_SET_OBJECT_DEFAULT_VALUE
 
 
 #: Maximum legal value for default_value_type, for use in testing
 #: and validation.
-MAXIMUM_DEFAULT_VALUE_TYPE = max(DefaultValue)
+MAXIMUM_DEFAULT_VALUE_TYPE = traits.ctraits._MAXIMUM_DEFAULT_VALUE_TYPE
 
 
 #: Mapping from 'ctrait' default value types to a string representation:

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -5492,6 +5492,7 @@ PyInit_ctraits(void)
     PyObject *module;
     PyObject *trait_base;
     PyObject *trait_errors;
+    int error;
 
     module = PyModule_Create(&ctraitsmodule);
     if (module == NULL) {
@@ -5571,6 +5572,97 @@ PyInit_ctraits(void)
         return NULL;
     }
     Py_DECREF(trait_errors);
+
+    /* Export default-value constants, so that they can be re-used in
+       the DefaultValue enumeration. */
+    error = PyModule_AddIntConstant(
+        module,
+        "_CONSTANT_DEFAULT_VALUE",
+        CONSTANT_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_MISSING_DEFAULT_VALUE",
+        MISSING_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_OBJECT_DEFAULT_VALUE",
+        OBJECT_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_LIST_COPY_DEFAULT_VALUE",
+        LIST_COPY_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_DICT_COPY_DEFAULT_VALUE",
+        DICT_COPY_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_TRAIT_LIST_OBJECT_DEFAULT_VALUE",
+        TRAIT_LIST_OBJECT_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_TRAIT_DICT_OBJECT_DEFAULT_VALUE",
+        TRAIT_DICT_OBJECT_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_TRAIT_SET_OBJECT_DEFAULT_VALUE",
+        TRAIT_SET_OBJECT_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_CALLABLE_DEFAULT_VALUE",
+        CALLABLE_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_CALLABLE_AND_ARGS_DEFAULT_VALUE",
+        CALLABLE_AND_ARGS_DEFAULT_VALUE
+    );
+    if (error < 0) {
+        return NULL;
+    }
+    error = PyModule_AddIntConstant(
+        module,
+        "_MAXIMUM_DEFAULT_VALUE_TYPE",
+        MAXIMUM_DEFAULT_VALUE_TYPE
+    );
+    if (error < 0) {
+        return NULL;
+    }
 
     return module;
 }

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -19,7 +19,6 @@ from os.path import dirname, exists, join
 from weakref import ref
 
 from .etsconfig.api import ETSConfig
-from .constants import ValidateTrait
 
 # backwards compatibility: trait_base used to provide a patched enumerate
 enumerate = enumerate
@@ -162,12 +161,6 @@ def strx(arg):
 # Constants
 
 StringTypes = (str, int, float, complex)
-
-# Mapping of coercable types.
-CoercableTypes = {
-    float: (ValidateTrait.coerce, float, int),
-    complex: (ValidateTrait.coerce, complex, float, int),
-}
 
 
 def safe_contains(value, container):

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -25,7 +25,6 @@ from .constants import DefaultValue, ValidateTrait
 from .trait_base import (
     SequenceTypes,
     TypeTypes,
-    CoercableTypes,
     class_of,
 )
 from .trait_base import RangeTypes  # noqa: F401, used by TraitsUI
@@ -44,6 +43,12 @@ logger = logging.getLogger(__name__)
 # Constants
 
 CallableTypes = (FunctionType, MethodType)
+
+# Mapping of coercable types.
+CoercableTypes = {
+    float: (ValidateTrait.coerce, float, int),
+    complex: (ValidateTrait.coerce, complex, float, int),
+}
 
 _WARNING_FORMAT_STR = ("'{handler}' trait handler has been deprecated. "
                        "Use {replacement} instead.")


### PR DESCRIPTION
This is a recreation of #688. This PR re-uses the *_DEFAULT_VALUE constants defined in `ctraits.c` in `constants.py`, instead  of duplicating the integer values.

This is pure refactor, so there should be no change in behaviour (and consequently, no new tests or documentation needed).

Closes #686.