### PR TITLE
Fix the datetime-to-str converters

### DIFF
--- a/traits/editor_factories.py
+++ b/traits/editor_factories.py
@@ -151,16 +151,20 @@ def _datetime_str_to_datetime(datetime_str, format="%Y-%m-%dT%H:%M:%S"):
 
     Raises a ValueError if datetime_str does not match the format.
     """
-    if datetime_str is not None:
-        return datetime.datetime.strptime(datetime_str, format)
+    # Allow the empty string to be translated to None.
+    if not datetime_str:
+        return None
+    return datetime.datetime.strptime(datetime_str, format)
 
 
 def _datetime_to_datetime_str(datetime_obj, format="%Y-%m-%dT%H:%M:%S"):
     """ Returns a string representation for a datetime object in the specified
     format (default ISO format).
     """
-    if datetime_obj is not None:
-        return datetime.date.strftime(datetime_obj, format)
+    # A Datetime trait can contain None. We translate that to an empty string.
+    if datetime_obj is None:
+        return ""
+    return datetime.date.strftime(datetime_obj, format)
 
 
 def datetime_editor():

--- a/traits/tests/test_editor_factories.py
+++ b/traits/tests/test_editor_factories.py
@@ -13,11 +13,14 @@ Tests for Editor factories.
 
 """
 
+import datetime
 import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Instance, List, Str
 from traits.editor_factories import (
+    _datetime_to_datetime_str,
+    _datetime_str_to_datetime,
     BytesEditors,
     MultilineTextEditors,
     PasswordEditors,
@@ -77,6 +80,31 @@ class TestDateEditor(SimpleEditorWithCachingTestMixin, unittest.TestCase):
 class TestDatetimeEditor(SimpleEditorTestMixin, unittest.TestCase):
     traitsui_name = "DatetimeEditor"
     factory_name = "datetime_editor"
+
+    def test_str_to_obj_conversions(self):
+        # Roundtrip None -> str -> None
+        obj = None
+        obj_str = _datetime_to_datetime_str(obj)
+        self.assertEqual(obj_str, "")
+        self.assertEqual(_datetime_str_to_datetime(obj_str), obj)
+
+        # Roundtrip datetime -> str -> datetime
+        obj = datetime.datetime(2019, 1, 13)
+        obj_str = _datetime_to_datetime_str(obj)
+        self.assertIsInstance(obj_str, str)
+        self.assertEqual(_datetime_str_to_datetime(obj_str), obj)
+
+        # Roundtrip valid_str -> datetime -> valid_str
+        obj_str = "2020-02-15T11:12:13"
+        obj = _datetime_str_to_datetime(obj_str)
+        self.assertIsInstance(obj, datetime.datetime)
+        self.assertEqual(_datetime_to_datetime_str(obj), obj_str)
+
+        # Roundtrip "" -> None -> ""
+        obj_str = ""
+        obj = _datetime_str_to_datetime(obj_str)
+        self.assertIsNone(obj)
+        self.assertEqual(_datetime_to_datetime_str(obj), obj_str)
 
 
 @requires_traitsui


### PR DESCRIPTION
This PR fixes the datetime to-and-from string conversions used in the `DatetimeEditor`:

- For str-to-datetime, allow the empty string to be converted to `None` (a `Datetime` trait allows `None` by default)
- For str-to-datetime, we can reasonably assume that the argument is a string, so the `is not None` check is pointless. Remove it.
- For datetime-to-str, make sure we always return a string, returning the empty string for an input of `None`. 

Fixes #936
