### PR TITLE
Don't pretend to return a value when nothing is being returned

### DIFF
--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -147,7 +147,9 @@ class TraitListObject(list):
     def __setitem__(self, key, value):
         self_trait = getattr(self, "trait", None)
         if self_trait is None:
-            return list.__setitem__(self, key, value)
+            list.__setitem__(self, key, value)
+            return
+
         try:
             removed = self[key]
         except Exception:
@@ -217,7 +219,8 @@ class TraitListObject(list):
     def __delitem__(self, key):
         trait = getattr(self, "trait", None)
         if trait is None:
-            return list.__delitem__(self, key)
+            list.__delitem__(self, key)
+            return
 
         try:
             removed = self[key]
@@ -308,7 +311,9 @@ class TraitListObject(list):
     def insert(self, index, value):
         trait = getattr(self, "trait", None)
         if trait is None:
-            return list.insert(self, index, value)
+            list.insert(self, index, value)
+            return
+
         if trait.minlen <= (len(self) + 1) <= trait.maxlen:
             try:
                 validate = trait.item_trait.handler.validate

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -127,7 +127,9 @@ class TraitSetObject(set):
 
     def update(self, value):
         if not hasattr(self, "trait"):
-            return set.update(self, value)
+            set.update(self, value)
+            return
+
         try:
             if not isinstance(value, set):
                 value = set(value)
@@ -173,7 +175,9 @@ class TraitSetObject(set):
 
     def symmetric_difference_update(self, value):
         if not hasattr(self, "trait"):
-            return set.symmetric_difference_update(self, value)
+            set.symmetric_difference_update(self, value)
+            return
+
         if not isinstance(value, set):
             value = set(value)
         removed = self.intersection(value)
@@ -199,7 +203,9 @@ class TraitSetObject(set):
 
     def add(self, value):
         if not hasattr(self, "trait"):
-            return set.add(self, value)
+            set.add(self, value)
+            return
+
         if value not in self:
             try:
                 object = self.object()


### PR DESCRIPTION
Fix code that pretends it's returning a value, when it's not. It looks as though this was simply a hacky shortcut for calling the superclass for its side-effect and then doing a plain return.

The old code confuses some static analysis tools (like PyLint, for example).
