### PR TITLE
Fix reST markup in a documentation example

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -207,7 +207,7 @@ casting traits::
     >>> class Person ( HasTraits ):
     ...    weight  = Float
     ...    cweight = CFloat
-    >>>
+    ...
     >>> bill = Person()
     >>> bill.weight  = 180    # OK, coerced to 180.0
     >>> bill.cweight = 180    # OK, cast to float(180)
@@ -219,7 +219,7 @@ casting traits::
     >>> bill.cweight = '180'  # OK, cast to float('180')
     >>> print(bill.cweight)
     180.0
-    >>>
+
 
 .. _other-predefined-traits:
 
@@ -529,7 +529,7 @@ The following example illustrates the difference between `Either` and `Union`::
     >>> i = IntegerClass(primes=4)
     traits.trait_errors.TraitError: The 'primes' trait of an IntegerClass instance must be 2 or None or 5 or 7 or 11 or '3', but a value of 4 <class 'int'> was specified.
     >>>
-    >>> # But Union does not allow such declerations.
+    >>> # But Union does not allow such declarations.
     >>> class IntegerClass(HasTraits):
     ...     primes = Union([2], None, {'3':6}, 5, 7, 11)
     ValueError: Union trait declaration expects a trait type or an instance of trait type or None, but got [2] instead

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -869,14 +869,14 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     **add_trait()**.
     For example::
 
-        >>>class Person(HasTraits):
-        ...    name = Str
-        ...    age  = Int
-        ...    temp_ = Any
-        >>>bob = Person()
-        >>>bob.temp_lunch = 'sandwich'
-        >>>bob.add_trait('favorite_sport', Str('football'))
-        >>>print(bob.trait_names())
+        >>> class Person(HasTraits):
+        ...     name = Str
+        ...     age  = Int
+        ...     temp_ = Any
+        >>> bob = Person()
+        >>> bob.temp_lunch = 'sandwich'
+        >>> bob.add_trait('favorite_sport', Str('football'))
+        >>> print(bob.trait_names())
         ['trait_added', 'age', 'name']
 
     In this example, the trait_names() method returns only the *age* and

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -206,15 +206,15 @@ class TraitCastType(TraitCoerceType):
     To understand the difference between TraitCoerceType and TraitCastType (and
     also between Float and CFloat), consider the following example::
 
-        >>>class Person(HasTraits):
-        ...    weight = Float
-        ...    cweight = CFloat
-        >>>
-        >>>bill = Person()
-        >>>bill.weight = 180    # OK, coerced to 180.0
-        >>>bill.cweight = 180   # OK, cast to 180.0
-        >>>bill.weight = '180'  # Error, invalid coercion
-        >>>bill.cweight = '180' # OK, cast to float('180')
+        >>> class Person(HasTraits):
+        ...     weight = Float
+        ...     cweight = CFloat
+        ...
+        >>> bill = Person()
+        >>> bill.weight = 180    # OK, coerced to 180.0
+        >>> bill.cweight = 180   # OK, cast to 180.0
+        >>> bill.weight = '180'  # Error, invalid coercion
+        >>> bill.cweight = '180' # OK, cast to float('180')
 
     Parameters
     ----------
@@ -639,13 +639,13 @@ class TraitMap(TraitHandler):
 
     The following example defines a ``Person`` class::
 
-        >>>class Person(HasTraits):
-        ...    married = Trait('yes', TraitMap({'yes': 1, 'no': 0 })
-        >>>
-        >>>bob = Person()
-        >>>print bob.married
+        >>> class Person(HasTraits):
+        ...     married = Trait('yes', TraitMap({'yes': 1, 'no': 0 })
+        ...
+        >>> bob = Person()
+        >>> print bob.married
         yes
-        >>>print bob.married_
+        >>> print bob.married_
         1
 
     In this example, the default value of the ``married`` attribute of the

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2787,13 +2787,13 @@ class Map(TraitType):
 
         The following example defines a ``Person`` class::
 
-            >>>class Person(HasTraits):
-            ...    married = Map({'yes': 1, 'no': 0 }, default_value="yes")
+            >>> class Person(HasTraits):
+            ...     married = Map({'yes': 1, 'no': 0 }, default_value="yes")
             >>>
-            >>>bob = Person()
-            >>>print(bob.married)
+            >>> bob = Person()
+            >>> print(bob.married)
             yes
-            >>>print(bob.married_)
+            >>> print(bob.married_)
             1
 
         In this example, the default value of the ``married`` attribute of the

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2789,7 +2789,7 @@ class Map(TraitType):
 
             >>> class Person(HasTraits):
             ...     married = Map({'yes': 1, 'no': 0 }, default_value="yes")
-            >>>
+            ...
             >>> bob = Person()
             >>> print(bob.married)
             yes


### PR DESCRIPTION
Fix a Python example in a docstring (without this, the example code doesn't get syntax highlighted properly in the output).

EDIT: Added some more similar fixes after a search through the codebase.