### PR TITLE
Remove a redundant assertion in test

### DIFF
--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -64,5 +64,4 @@ class TestMap(unittest.TestCase):
         self.assertEqual(reconstituted.validate(p, "married", "yes"), "yes")
 
         with self.assertRaises(TraitError):
-            self.assertEqual(reconstituted.validate(p, "married", "uknown"),
-                             "unknown")
+            reconstituted.validate(p, "married", "uknown")

--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -64,4 +64,4 @@ class TestMap(unittest.TestCase):
         self.assertEqual(reconstituted.validate(p, "married", "yes"), "yes")
 
         with self.assertRaises(TraitError):
-            reconstituted.validate(p, "married", "uknown")
+            reconstituted.validate(p, "married", "unknown")


### PR DESCRIPTION
There is an assertion in test that is redundant - this PR removes it.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
