### PR TITLE
An approach to silence events from nested containers.

### DIFF
--- a/traits/tests/test_nested_container_events.py
+++ b/traits/tests/test_nested_container_events.py
@@ -1,0 +1,117 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+import unittest
+
+from traits.api import (HasTraits, List, Dict, Set, Str, Union, TraitDictEvent,
+                        TraitSetObject, TraitListEvent, TraitListObject)
+
+
+class TestClass(HasTraits):
+    list_of_sets = List(Set())
+
+    list_of_lists = List(List())
+
+    list_of_list_of_list = List(List(List()))
+
+    dict_str_list_or_set = Dict(Str(), Union(Set(), List()))
+
+    events_list = List()
+
+    def _list_of_sets_items_changed(self, event):
+        self.events_list.append(event)
+
+    def _list_of_lists_items_changed(self, event):
+        self.events_list.append(event)
+
+    def _dict_str_list_or_set_items_changed(self, event):
+        self.events_list.append(event)
+
+    def _list_of_list_of_list_changed(self, event):
+        self.events_list.append(event)
+
+
+class TestNestedContainers(unittest.TestCase):
+    def test_list_of_sets(self):
+        obj = TestClass()
+        obj.list_of_sets = [set([1, 2, 3]), set(['a', 'b', 'c'])]
+
+        # Add an item to the internal set
+        obj.list_of_sets[0].add(4)
+        # Ensure that no notification is fired
+        self.assertListEqual(obj.events_list, [])
+
+        # Add an item to the root list container
+        obj.list_of_sets.append(set(['r', 'g']))
+
+        # Ensure that only a TraitListEvent is fired
+        event, = obj.events_list
+        self.assertIsInstance(event, TraitListEvent)
+        self.assertEqual(1, len(event.added))
+        self.assertIsInstance(event.added[0], TraitSetObject)
+
+    def test_list_of_lists(self):
+        obj = TestClass()
+        obj.list_of_lists = [[1, 2, 3], ['a', 'b', 'c']]
+
+        # Ensure that no notification is fired
+        self.assertListEqual(obj.events_list, [])
+
+        # Add an item to the internal list
+        obj.list_of_lists[0].append(4)
+
+        # Ensure that no notification is fired
+        self.assertListEqual(obj.events_list, [])
+
+        # Add an item to the outer list
+        obj.list_of_lists.append(['apples', 'oranges'])
+
+        # Ensure that a TraitListEvent is fired
+        event, = obj.events_list
+        self.assertIsInstance(event, TraitListEvent)
+        self.assertEqual(1, len(event.added))
+        self.assertIsInstance(event.added[0], TraitListObject)
+
+    @unittest.skip("TODO: Why isn't this working?")
+    def test_list_of_list_of_list(self):
+        obj = TestClass()
+
+        obj.list_of_list_of_list = [[[1, 2]]]
+
+        # Add an item to the innermost list
+        obj.list_of_list_of_list[0][0].append(2)
+
+        # Ensure that no notification is fired
+        self.assertListEqual(obj.events_list, [])
+
+    def test_dict_str_to_list(self):
+        obj = TestClass()
+        obj.dict_str_list_or_set = {"nums": [1, 2, 3, 4],
+                                    "alpha": {'a', 'b', 'c'}}
+
+        self.assertListEqual(obj.events_list, [])
+
+        # Add an item to the internal value
+        obj.dict_str_list_or_set['nums'].append(4)
+
+        # Ensure that no notification is fired
+        self.assertListEqual(obj.events_list, [])
+
+        # Add a key
+        obj.dict_str_list_or_set['fruit'] = {'apples', 'mangoes'}
+
+        # Ensure event is fired
+        event, = obj.events_list
+        self.assertIsInstance(event, TraitDictEvent)
+        self.assertEqual(1, len(event.added))
+        for k, v in event.added.items():
+            self.assertIsInstance(k, str)
+            self.assertIsInstance(v, TraitSetObject)

--- a/traits/tests/test_nested_container_events.py
+++ b/traits/tests/test_nested_container_events.py
@@ -12,18 +12,18 @@
 import unittest
 
 from traits.api import (
-    HasTraits,
-    List,
     Dict,
+    Either,
+    HasTraits,
+    Int,
+    List,
     Set,
     Str,
-    Union,
     TraitDictEvent,
-    TraitSetObject,
     TraitListEvent,
     TraitListObject,
-    Either,
-    Int
+    TraitSetObject,
+    Union,
 )
 
 

--- a/traits/tests/test_nested_container_events.py
+++ b/traits/tests/test_nested_container_events.py
@@ -146,4 +146,6 @@ class TestNestedContainers(unittest.TestCase):
 
         a = A()
         a.foo.append(dict(x=10))
+
+        # Ensure that no exception is thrown.
         a.foo[0]['x'] = 20

--- a/traits/tests/test_nested_container_events.py
+++ b/traits/tests/test_nested_container_events.py
@@ -11,8 +11,20 @@
 
 import unittest
 
-from traits.api import (HasTraits, List, Dict, Set, Str, Union, TraitDictEvent,
-                        TraitSetObject, TraitListEvent, TraitListObject)
+from traits.api import (
+    HasTraits,
+    List,
+    Dict,
+    Set,
+    Str,
+    Union,
+    TraitDictEvent,
+    TraitSetObject,
+    TraitListEvent,
+    TraitListObject,
+    Either,
+    Int
+)
 
 
 class TestClass(HasTraits):
@@ -23,6 +35,8 @@ class TestClass(HasTraits):
     list_of_list_of_list = List(List(List()))
 
     dict_str_list_or_set = Dict(Str(), Union(Set(), List()))
+
+    maybe_set = Either(Set(Int), None)
 
     events_list = List()
 
@@ -114,3 +128,22 @@ class TestNestedContainers(unittest.TestCase):
         for k, v in event.added.items():
             self.assertIsInstance(k, str)
             self.assertIsInstance(v, TraitSetObject)
+
+    def test_either_set_none(self):
+        # Issue #359
+        obj = TestClass(maybe_set={1, 2, 3})
+        # Following should not raise an error
+        obj.maybe_set |= {4, 5, 6}
+
+        # Ensure that no notification is fired
+        self.assertListEqual(obj.events_list, [])
+
+    def test_add_dict_to_list(self):
+        # Issue #25
+        class A(HasTraits):
+            # Note: Will not work with bare trait eg: foo = List(Dict)
+            foo = List(Dict())
+
+        a = A()
+        a.foo.append(dict(x=10))
+        a.foo[0]['x'] = 20

--- a/traits/tests/test_nested_container_events.py
+++ b/traits/tests/test_nested_container_events.py
@@ -35,7 +35,7 @@ class TestClass(HasTraits):
     def _dict_str_list_or_set_items_changed(self, event):
         self.events_list.append(event)
 
-    def _list_of_list_of_list_changed(self, event):
+    def _list_of_list_of_list_items_changed(self, event):
         self.events_list.append(event)
 
 
@@ -80,17 +80,16 @@ class TestNestedContainers(unittest.TestCase):
         self.assertEqual(1, len(event.added))
         self.assertIsInstance(event.added[0], TraitListObject)
 
-    @unittest.skip("TODO: Why isn't this working?")
     def test_list_of_list_of_list(self):
-        obj = TestClass()
-
-        obj.list_of_list_of_list = [[[1, 2]]]
+        obj = TestClass(list_of_list_of_list=[[[1, 2]]])
+        # Ensure that no notification is fired
+        self.assertListEqual([], obj.events_list)
 
         # Add an item to the innermost list
         obj.list_of_list_of_list[0][0].append(2)
 
         # Ensure that no notification is fired
-        self.assertListEqual(obj.events_list, [])
+        self.assertListEqual([], obj.events_list)
 
     def test_dict_str_to_list(self):
         obj = TestClass()

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -82,6 +82,8 @@ class TraitDictObject(dict):
         The name of the attribute on the object.
     value : dict
         The dict of values to initialize the TraitDictObject with.
+    is_root_container : bool
+        True if the container has no children.
 
     Attributes
     ----------
@@ -103,11 +105,9 @@ class TraitDictObject(dict):
         self.object = ref(object)
         self.name = name
         self.name_items = None
+        self.is_root_container = is_root_container
         if trait.has_items:
             self.name_items = name + "_items"
-
-        if not hasattr(self, 'is_root_container'):
-            self.is_root_container = is_root_container
 
         if len(value) > 0:
             dict.update(self, self._validate_dic(value))

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -98,7 +98,7 @@ class TraitDictObject(dict):
         mutated.
     """
 
-    def __init__(self, trait, object, name, value):
+    def __init__(self, trait, object, name, value, is_root_container=True):
         self.trait = trait
         self.object = ref(object)
         self.name = name
@@ -106,12 +106,17 @@ class TraitDictObject(dict):
         if trait.has_items:
             self.name_items = name + "_items"
 
+        self.is_root_container = is_root_container
+
         if len(value) > 0:
             dict.update(self, self._validate_dic(value))
 
     def _send_trait_items_event(self, name, event, items_event=None):
         """ Send a TraitDictEvent to the owning object if there is one.
         """
+        if not self.is_root_container:
+            return
+
         object = self.object()
         if object is not None:
             if items_event is None and hasattr(self, "trait"):

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -106,7 +106,8 @@ class TraitDictObject(dict):
         if trait.has_items:
             self.name_items = name + "_items"
 
-        self.is_root_container = is_root_container
+        if not hasattr(self, 'is_root_container'):
+            self.is_root_container = is_root_container
 
         if len(value) > 0:
             dict.update(self, self._validate_dic(value))
@@ -133,6 +134,7 @@ class TraitDictObject(dict):
             lambda: None,
             self.name,
             dict(copy.deepcopy(x, memo) for x in self.items()),
+            self.is_root_container,
         )
 
         return result

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -83,7 +83,7 @@ class TraitDictObject(dict):
     value : dict
         The dict of values to initialize the TraitDictObject with.
     is_root_container : bool
-        True if the container has no children.
+        True if the container is a top level container.
 
     Attributes
     ----------

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -79,6 +79,8 @@ class TraitListObject(list):
         The name of the attribute on the object.
     value : list
         The list of values to initialize the TraitListObject with.
+    is_root_container : bool
+        True if the container has no children.
 
     Attributes
     ----------
@@ -100,10 +102,9 @@ class TraitListObject(list):
         self.object = ref(object)
         self.name = name
         self.name_items = None
+        self.is_root_container = is_root_container
         if trait.has_items:
             self.name_items = name + "_items"
-
-        self.is_root_container = is_root_container
 
         # Do the validated 'setslice' assignment without raising an
         # 'items_changed' event:
@@ -145,6 +146,7 @@ class TraitListObject(list):
             lambda: None,
             self.name,
             [copy.deepcopy(x, memo) for x in self],
+            self.is_root_container
         )
 
         return result

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -95,13 +95,15 @@ class TraitListObject(list):
         mutated.
     """
 
-    def __init__(self, trait, object, name, value):
+    def __init__(self, trait, object, name, value, is_root_container=True):
         self.trait = trait
         self.object = ref(object)
         self.name = name
         self.name_items = None
         if trait.has_items:
             self.name_items = name + "_items"
+
+        self.is_root_container = is_root_container
 
         # Do the validated 'setslice' assignment without raising an
         # 'items_changed' event:
@@ -124,6 +126,9 @@ class TraitListObject(list):
     def _send_trait_items_event(self, name, event, items_event=None):
         """ Send a TraitListEvent to the owning object if there is one.
         """
+        if not self.is_root_container:
+            return
+
         object = self.object()
         if object is not None:
             if items_event is None and hasattr(self, "trait"):

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -80,7 +80,7 @@ class TraitListObject(list):
     value : list
         The list of values to initialize the TraitListObject with.
     is_root_container : bool
-        True if the container has no children.
+        True if the container is a top level container.
 
     Attributes
     ----------

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -66,6 +66,8 @@ class TraitSetObject(set):
         The name of the attribute on the object.
     value : set
         The set of values to initialize the TraitSetObject with.
+    is_root_container : bool
+        True if the container has no children.
 
     Attributes
     ----------
@@ -87,10 +89,9 @@ class TraitSetObject(set):
         self.object = ref(object)
         self.name = name
         self.name_items = None
+        self.is_root_container = is_root_container
         if trait.has_items:
             self.name_items = name + "_items"
-
-        self.is_root_container = is_root_container
 
         # Validate and assign the initial set value:
         try:
@@ -126,6 +127,7 @@ class TraitSetObject(set):
             lambda: None,
             self.name,
             [copy.deepcopy(x, memo) for x in self],
+            self.is_root_container,
         )
 
         return result

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -82,13 +82,15 @@ class TraitSetObject(set):
         mutated.
     """
 
-    def __init__(self, trait, object, name, value):
+    def __init__(self, trait, object, name, value, is_root_container=True):
         self.trait = trait
         self.object = ref(object)
         self.name = name
         self.name_items = None
         if trait.has_items:
             self.name_items = name + "_items"
+
+        self.is_root_container = is_root_container
 
         # Validate and assign the initial set value:
         try:
@@ -105,6 +107,9 @@ class TraitSetObject(set):
     def _send_trait_items_event(self, name, event, items_event=None):
         """ Send a TraitSetEvent to the owning object if there is one.
         """
+        if not self.is_root_container:
+            return
+
         object = self.object()
         if object is not None:
             if items_event is None and hasattr(self, "trait"):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -67,7 +67,7 @@ class TraitSetObject(set):
     value : set
         The set of values to initialize the TraitSetObject with.
     is_root_container : bool
-        True if the container has no children.
+        True if the container is a top level container.
 
     Attributes
     ----------

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3776,7 +3776,6 @@ class Union(TraitType):
         for trait in traits:
             if trait is None:
                 trait = NoneTrait
-
             ctrait_instance = trait_cast(trait)
             if ctrait_instance is None:
                 raise ValueError("Union trait declaration expects a trait "

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2385,8 +2385,9 @@ class List(TraitType):
             if object is None:
                 return value
 
+            is_root_container = getattr(self, 'is_root_container', True)
             return TraitListObject(self, object, name, value,
-                                   self.is_root_container)
+                                   is_root_container)
 
         self.error(object, name, value)
 
@@ -2614,8 +2615,9 @@ class Set(TraitType):
             if object is None:
                 return value
 
+            is_root_container = getattr(self, 'is_root_container', True)
             return TraitSetObject(self, object, name, value,
-                                  self.is_root_container)
+                                  is_root_container)
 
         self.error(object, name, value)
 
@@ -2750,8 +2752,9 @@ class Dict(TraitType):
         if isinstance(value, dict):
             if object is None:
                 return value
+            is_root_container = getattr(self, 'is_root_container', True)
             return TraitDictObject(self, object, name, value,
-                                   self.is_root_container)
+                                   is_root_container)
 
         self.error(object, name, value)
 


### PR DESCRIPTION
**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [ ] Update User manual (`docs/source/traits_user_manual`)
~~- [ ] Update type annotation hints in `traits-stubs`~~

Opened this PR for discussion/suggestions on the approach.(Description will be improved)

The objective is to somehow figure out which container is the outermost one and enable it to fire events.

All its children are not allowed to fire notifications.

Approach Outline:
Since the innermost containers are initialized first, it is initially assumed to be a root and marked accordingly, until its parent is created and we discover that our assumption is wrong un-marking it as a root. This process happens until we discover the correct root.

Before firing an event, all we need to do now is check if it is marked a root and fire only if it is one.