### PR TITLE
Refactor PrefixMap

### DIFF
--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -465,7 +465,16 @@ class Map(_Map):
     ...
 
 
-class PrefixMap(_Map):
+class _PrefixMap(_TraitType[_S, _T]):
+    def __init__(
+            self,
+            map: _DictType[_S, _T],
+            **metadata: _Any
+    ) -> None:
+        ...
+
+
+class PrefixMap(_PrefixMap):
     ...
 
 


### PR DESCRIPTION
**Checklist**
~~- [ ] Tests~~ Exists
~~- [ ] Update API reference (`docs/source/traits_api_reference`)~~ Remains the same.
~~- [ ] Update User manual (`docs/source/traits_user_manual`)~~ Had no mention of if. 
- [x] Update type annotation hints in `traits-stubs`

This PR fixes #952
- Refactors the `PrefixMap` class to inherit from `TraitType` instead of `Map`
- Removes fast validation for `PrefixMap`