### PR TITLE
Fix exception swallowing by Trait attribute access

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -852,7 +852,10 @@ has_traits_getattro(has_traits_object *obj, PyObject *name)
         return trait->getattr(trait, obj, name);
     }
 
-    if ((value = PyObject_GenericGetAttr((PyObject *)obj, name)) != NULL) {
+    /* Try normal Python attribute access, but if it fails with an
+       AttributeError then get a prefix trait. */
+    value = PyObject_GenericGetAttr((PyObject *)obj, name);
+    if (value != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError)) {
         return value;
     }
 

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -401,7 +401,7 @@ class TestHasTraits(unittest.TestCase):
 
         # Exercise the code path where the PyObject_GenericGetAttr call raises
         # AttributeError. In this case, we catch the error but the prefix trait
-        # machinery re-raises.
+        # machinery raises a new AttributeError.
         with self.assertRaises(AttributeError):
             a.veg
 

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -390,12 +390,24 @@ class TestHasTraits(unittest.TestCase):
         class A(HasTraits):
             fruit = PropertyLike()
 
+            banana_ = Int(1729)
+
         a = A()
 
         # The exception raised on the first attribute access should be
         # propagated.
         with self.assertRaises(ZeroDivisionError):
             a.fruit
+
+        # Exercise the code path where the PyObject_GenericGetAttr call raises
+        # AttributeError. In this case, we catch the error but the prefix trait
+        # machinery re-raises.
+        with self.assertRaises(AttributeError):
+            a.veg
+
+        # Exercise the case where the prefix traits machinery goes on to
+        # produce a valid result.
+        self.assertEqual(a.banananana, 1729)
 
 
 class TestObjectNotifiers(unittest.TestCase):


### PR DESCRIPTION
When doing `obj.attr_name` on a `HasTraits` object `obj`, if `attr_name` doesn't appear in either the class or instance dictionaries, Traits next tries to look it up as a regular Python attribute (via the `PyObject_GenericGetAttr` C-API function). If that lookup fails with an exception of any kind, the exception is swallowed and Traits then moves on to try the general prefix-trait machinery. In effect, there's a bare `except` here, but at C level.

This PR modifies the behaviour to replace the bare `except` with an `except AttributeError`, so that exceptions other than `AttributeError` will no longer be swallowed.

The fix itself is easy. Writing a regression test that worked was ... more interesting.

This fixes one case of #946.
