### PR TITLE
Fix another case of exception swallowing from PyObject_GenericGetAttr

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2972,7 +2972,7 @@ static PyObject *
 trait_getattro(trait_object *obj, PyObject *name)
 {
     PyObject *value = PyObject_GenericGetAttr((PyObject *)obj, name);
-    if (value != NULL) {
+    if (value != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError)) {
         return value;
     }
 

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -286,7 +286,8 @@ class TestCTrait(unittest.TestCase):
     def test_exception_from_attribute_access(self):
         # Regression test for enthought/traits#946.
 
-        # Check that we're not touching an attribute that actually exists.
+        # Danger: we're (temporarily) mutating global state here! Check that
+        # we're not touching an attribute that actually exists.
         self.assertFalse(hasattr(CTrait, "badattr_test"))
 
         CTrait.badattr_test = property(lambda self: 1 / 0)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 import sys
-import unittest.mock
+import unittest
 import warnings
 import weakref
 
@@ -35,7 +35,6 @@ def setter(value):
 def validator(value):
     """ Trivial validator. """
     return value
-
 
 
 class TestCTrait(unittest.TestCase):


### PR DESCRIPTION
When an attribute is looked up on a `CTrait` object, `None` is returned on failed lookup, regardless of the actual exception that was raised. This means that (for example) logic errors from a `CTrait` method will be silenced.

This PR changes the behaviour to only return `None` if the attribute lookup raises `AttributeError`, and to propagate any other exception.

This is the `cTrait` analog to #959 for `CHasTraits`.

Along with #959, this fixes #946.
