### PR TITLE
Fix a missing import that prevented a test module from being run standalone

### DIFF
--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 import sys
-import unittest
+import unittest.mock
 import warnings
 import weakref
 


### PR DESCRIPTION
There's a test in `test_ctraits` that uses `unittest.mock`, but `unittest.mock` isn't imported. That means that running `unittest` on just this module fails with a `NameError` (see test output below). This PR fixes that missing import.

Note that the CI runs weren't affected, presumably because some other module earlier in the test run does an `import unittest.mock`.

I haven't yet checked that there aren't other cases of this in the codebase. I'll do that.

```
(traits) mirzakhani:traits mdickinson$ python -m unittest traits.tests.test_ctraits
......E..............
======================================================================
ERROR: test_default_initialization (traits.tests.test_ctraits.TestCTrait)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/mdickinson/Enthought/ETS/traits/traits/tests/test_ctraits.py", line 260, in test_default_initialization
    validate = unittest.mock.MagicMock(return_value="baz")
AttributeError: module 'unittest' has no attribute 'mock'

----------------------------------------------------------------------
Ran 21 tests in 0.001s

FAILED (errors=1)
```

