### PR TITLE
Drive-by simplification

### DIFF
--- a/traits/ctrait.py
+++ b/traits/ctrait.py
@@ -62,13 +62,10 @@ class CTrait(ctraits.cTrait):
             DefaultValue.dict_copy,
             DefaultValue.trait_dict_object,
             DefaultValue.trait_set_object,
-        ):
-            return value.copy()
-        elif kind in (
             DefaultValue.list_copy,
             DefaultValue.trait_list_object,
         ):
-            return value[:]
+            return value.copy()
         elif kind in {DefaultValue.constant, DefaultValue.missing}:
             return value
         else:


### PR DESCRIPTION
A simple consistency fix: now that we've dropped compatibility with Python 2, it's safe to copy our collections using the copy method in all cases.

No behaviour changes.