### PR TITLE
Split ctraits property api to _set_property and _get_property

### DIFF
--- a/docs/source/traits_api_reference/trait_type.rst
+++ b/docs/source/traits_api_reference/trait_type.rst
@@ -15,8 +15,6 @@ Private Functions
 -----------------
 .. autofunction:: traits.trait_type._infer_default_value_type
 
-.. autofunction:: traits.trait_type._arg_count
-
 .. autofunction:: traits.trait_type._write_only
 
 .. autofunction:: traits.trait_type._read_only

--- a/traits/ctrait.py
+++ b/traits/ctrait.py
@@ -112,13 +112,13 @@ class CTrait(ctraits.cTrait):
         ctraits.cTrait.comparison_mode.__set__(self, value)
 
     @property
-    def property(self):
+    def property_fields(self):
         """ Return a tuple of callables (fget, fset, validate) for the
         property trait."""
         return self._get_property()
 
-    @property.setter
-    def property(self, value):
+    @property_fields.setter
+    def property_fields(self, value):
         """ Set the fget, fset, validate callables for the property.
 
         Parameters
@@ -130,15 +130,14 @@ class CTrait(ctraits.cTrait):
         func_arg_counts = []
 
         for arg in value:
+
             if arg is None:
-                func_arg_counts.extend([None, 0])
+                nargs = 0
             else:
-                try:
-                    sig = inspect.signature(arg)
-                except TypeError:
-                    raise TypeError("Property setter expects a callable "
-                                    "but got {} instead".format(arg))
-                func_arg_counts.extend([arg, len(sig.parameters)])
+                sig = inspect.signature(arg)
+                nargs = len(sig.parameters)
+
+            func_arg_counts.extend([arg, nargs])
 
         self._set_property(*func_arg_counts)
 

--- a/traits/ctrait.py
+++ b/traits/ctrait.py
@@ -16,6 +16,8 @@ validate as well as maintining a list of notifiers and calling them when
 values are modified.
 """
 
+import inspect
+
 from . import ctraits
 from .constants import ComparisonMode, DefaultValue, default_value_map
 from .trait_base import SequenceTypes, Undefined
@@ -108,6 +110,34 @@ class CTrait(ctraits.cTrait):
     @comparison_mode.setter
     def comparison_mode(self, value):
         ctraits.cTrait.comparison_mode.__set__(self, value)
+
+    def property(self, *args):
+        """ Gets or sets the fget, fset, and fvalidate callables
+        for the property.
+
+        Returns a tuple (fget, fset, fvalidate) if this method
+        is called with no arguments.
+
+        If the arguments fget, fset and fvalidate are provided,
+        these values are set for the property.
+        """
+
+        if len(args) == 0:
+            # Get the values
+            return self._get_property()
+
+        else:
+            # Set values
+            func_arg_counts = []
+            for arg in args:
+                if arg is None:
+                    func_arg_counts.extend([None, 0])
+                else:
+                    sig = inspect.signature(arg)
+                    pararm_count = len(sig.parameters)
+                    func_arg_counts.extend([arg, pararm_count])
+
+            self._set_property(*func_arg_counts)
 
     def is_trait_type(self, trait_type):
         """ Returns whether or not this trait is of a specified trait type.

--- a/traits/ctrait.py
+++ b/traits/ctrait.py
@@ -115,11 +115,11 @@ class CTrait(ctraits.cTrait):
         """ Gets or sets the fget, fset, and fvalidate callables
         for the property.
 
-        Returns a tuple (fget, fset, fvalidate) if this method
-        is called with no arguments.
+        If this method is called with no arguments, it returns
+        a tuple (fget, fset, fvalidate).
 
-        If the arguments fget, fset and fvalidate are provided,
-        these values are set for the property.
+        If this method is called with the arguments fget, fset, fvalidate,
+        these values are set and None is returned.
         """
 
         if len(args) == 0:
@@ -127,15 +127,19 @@ class CTrait(ctraits.cTrait):
             return self._get_property()
 
         else:
-            # Set values
+            # Set the values
             func_arg_counts = []
             for arg in args:
                 if arg is None:
                     func_arg_counts.extend([None, 0])
                 else:
-                    sig = inspect.signature(arg)
-                    pararm_count = len(sig.parameters)
-                    func_arg_counts.extend([arg, pararm_count])
+                    try:
+                        sig = inspect.signature(arg)
+                    except TypeError:
+                        raise ValueError("Expecting a tuple of "
+                                         "callables (fget, fset, validate)"
+                                         " but got {}".format(args))
+                    func_arg_counts.extend([arg, len(sig.parameters)])
 
             self._set_property(*func_arg_counts)
 

--- a/traits/ctrait.py
+++ b/traits/ctrait.py
@@ -16,7 +16,6 @@ validate as well as maintining a list of notifiers and calling them when
 values are modified.
 """
 
-import builtins
 import inspect
 
 from . import ctraits
@@ -56,17 +55,17 @@ class CTrait(ctraits.cTrait):
     def default(self):
         kind, value = self.default_value()
         if kind in (
-                DefaultValue.object,
-                DefaultValue.callable_and_args,
-                DefaultValue.callable,
+            DefaultValue.object,
+            DefaultValue.callable_and_args,
+            DefaultValue.callable,
         ):
             return Undefined
         elif kind in (
-                DefaultValue.dict_copy,
-                DefaultValue.trait_dict_object,
-                DefaultValue.trait_set_object,
-                DefaultValue.list_copy,
-                DefaultValue.trait_list_object,
+            DefaultValue.dict_copy,
+            DefaultValue.trait_dict_object,
+            DefaultValue.trait_set_object,
+            DefaultValue.list_copy,
+            DefaultValue.trait_list_object,
         ):
             return value.copy()
         elif kind in {DefaultValue.constant, DefaultValue.missing}:

--- a/traits/ctrait.py
+++ b/traits/ctrait.py
@@ -136,8 +136,8 @@ class CTrait(ctraits.cTrait):
                 try:
                     sig = inspect.signature(arg)
                 except TypeError:
-                    raise ValueError("Expecting a callable "
-                                     "but got {} instead".format(arg))
+                    raise TypeError("Property setter expects a callable "
+                                    "but got {} instead".format(arg))
                 func_arg_counts.extend([arg, len(sig.parameters)])
 
         self._set_property(*func_arg_counts)

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4520,6 +4520,29 @@ _get_trait_comparison_mode_int(trait_object *trait, void *closure)
 }
 
 /*-----------------------------------------------------------------------------
+|  Get the 'property' value fields of a CTrait instance:
++----------------------------------------------------------------------------*/
+
+static PyObject *
+_get_property(trait_object *trait, PyObject *args)
+{
+    if (PyTuple_GET_SIZE(args) != 0) {
+        PyErr_SetString(PyExc_ValueError, "Invalid number of arguments.");
+        return NULL;
+    }
+
+    if (trait->flags & TRAIT_PROPERTY) {
+        return PyTuple_Pack(
+            3, trait->delegate_name, trait->delegate_prefix,
+            trait->py_validate);
+    }
+    else {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+}
+
+/*-----------------------------------------------------------------------------
 |  Sets the 'property' value fields of a CTrait instance:
 +----------------------------------------------------------------------------*/
 
@@ -4529,21 +4552,14 @@ static trait_setattr setattr_property_handlers[] = {
     (trait_setattr)post_setattr_trait_python, NULL};
 
 static PyObject *
-_trait_property(trait_object *trait, PyObject *args)
+_set_property(trait_object *trait, PyObject *args)
 {
     PyObject *get, *set, *validate;
     int get_n, set_n, validate_n;
 
-    if (PyTuple_GET_SIZE(args) == 0) {
-        if (trait->flags & TRAIT_PROPERTY) {
-            return PyTuple_Pack(
-                3, trait->delegate_name, trait->delegate_prefix,
-                trait->py_validate);
-        }
-        else {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
+    if (PyTuple_GET_SIZE(args) != 6) {
+        PyErr_SetString(PyExc_ValueError, "Invalid number of arguments.");
+        return NULL;
     }
 
     if (!PyArg_ParseTuple(
@@ -5107,20 +5123,23 @@ PyDoc_STRVAR(
     "    is modified.\n");
 
 PyDoc_STRVAR(
-    property_doc,
-    "property()\n"
-    "property(get, get_n, set, set_n, validate, validate_n)\n"
+    _get_property_doc,
+    "_get_property()\n"
     "\n"
-    "Get or set property fields for this trait.\n"
+    "Get the property fields for this trait.\n"
     "\n"
     "When called with no arguments on a property trait, this method returns a\n"
     "tuple (get, set, validate) of length 3 containing the getter, setter and\n"
     "validator for this property trait.\n"
     "\n"
     "When called with no arguments on a non-property trait, this method\n"
-    "returns *None*.\n"
+    "returns *None*.\n");
+
+PyDoc_STRVAR(
+    _set_property_doc,
+    "_set_property(get, get_n, set, set_n, validate, validate_n)\n"
     "\n"
-    "Otherwise, the *property* method expects six arguments, and uses these\n"
+    "The *property* method expects six arguments, and uses these\n"
     "arguments to set the get, set and validation for the trait. It also\n"
     "sets the property flag on the trait.\n"
     "\n"
@@ -5223,8 +5242,10 @@ static PyMethodDef trait_methods[] = {
     {"validate", (PyCFunction)_trait_validate, METH_VARARGS, validate_doc},
     {"delegate", (PyCFunction)_trait_delegate, METH_VARARGS,
      delegate_doc},
-    {"property", (PyCFunction)_trait_property, METH_VARARGS,
-     property_doc},
+    {"_get_property", (PyCFunction)_get_property, METH_VARARGS,
+     _get_property_doc},
+    {"_set_property", (PyCFunction)_set_property, METH_VARARGS,
+     _set_property_doc},
     {"clone", (PyCFunction)_trait_clone, METH_VARARGS,
      clone_doc},
     {"_notifiers", (PyCFunction)_trait_notifiers, METH_VARARGS,

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4526,11 +4526,6 @@ _get_trait_comparison_mode_int(trait_object *trait, void *closure)
 static PyObject *
 _get_property(trait_object *trait, PyObject *args)
 {
-    if (PyTuple_GET_SIZE(args) != 0) {
-        PyErr_SetString(PyExc_ValueError, "Invalid number of arguments.");
-        return NULL;
-    }
-
     if (trait->flags & TRAIT_PROPERTY) {
         return PyTuple_Pack(
             3, trait->delegate_name, trait->delegate_prefix,
@@ -4557,16 +4552,13 @@ _set_property(trait_object *trait, PyObject *args)
     PyObject *get, *set, *validate;
     int get_n, set_n, validate_n;
 
-    if (PyTuple_GET_SIZE(args) != 6) {
-        PyErr_SetString(PyExc_ValueError, "Invalid number of arguments.");
-        return NULL;
-    }
-
     if (!PyArg_ParseTuple(
             args, "OiOiOi", &get, &get_n, &set, &set_n, &validate,
             &validate_n)) {
+        PyErr_SetString(PyExc_ValueError, "Invalid arguments.");
         return NULL;
     }
+
     if (!PyCallable_Check(get) || !PyCallable_Check(set)
         || ((validate != Py_None) && !PyCallable_Check(validate))
         || (get_n < 0) || (get_n > 3) || (set_n < 0) || (set_n > 3)

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -5120,12 +5120,10 @@ PyDoc_STRVAR(
     "\n"
     "Get the property fields for this trait.\n"
     "\n"
-    "When called with no arguments on a property trait, this method returns a\n"
-    "tuple (get, set, validate) of length 3 containing the getter, setter and\n"
-    "validator for this property trait.\n"
+    "This method returns a tuple (get, set, validate) of length 3 containing\n"
+    "the getter, setter and validator for this property trait.\n"
     "\n"
-    "When called with no arguments on a non-property trait, this method\n"
-    "returns *None*.\n");
+    "When called a non-property trait, this method returns *None*.\n");
 
 PyDoc_STRVAR(
     _set_property_doc,

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4532,8 +4532,7 @@ _get_property(trait_object *trait, PyObject *args)
             trait->py_validate);
     }
     else {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
 }
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -4524,7 +4524,7 @@ _get_trait_comparison_mode_int(trait_object *trait, void *closure)
 +----------------------------------------------------------------------------*/
 
 static PyObject *
-_get_property(trait_object *trait, PyObject *args)
+_trait_get_property(trait_object *trait, PyObject *Py_UNUSED(ignored))
 {
     if (trait->flags & TRAIT_PROPERTY) {
         return PyTuple_Pack(
@@ -4546,7 +4546,7 @@ static trait_setattr setattr_property_handlers[] = {
     (trait_setattr)post_setattr_trait_python, NULL};
 
 static PyObject *
-_set_property(trait_object *trait, PyObject *args)
+_trait_set_property(trait_object *trait, PyObject *args)
 {
     PyObject *get, *set, *validate;
     int get_n, set_n, validate_n;
@@ -4554,7 +4554,6 @@ _set_property(trait_object *trait, PyObject *args)
     if (!PyArg_ParseTuple(
             args, "OiOiOi", &get, &get_n, &set, &set_n, &validate,
             &validate_n)) {
-        PyErr_SetString(PyExc_ValueError, "Invalid arguments.");
         return NULL;
     }
 
@@ -5114,23 +5113,23 @@ PyDoc_STRVAR(
     "    is modified.\n");
 
 PyDoc_STRVAR(
-    _get_property_doc,
-    "_get_property()\n"
+    _trait_get_property_doc,
+    "_trait_get_property()\n"
     "\n"
     "Get the property fields for this trait.\n"
     "\n"
     "This method returns a tuple (get, set, validate) of length 3 containing\n"
     "the getter, setter and validator for this property trait.\n"
     "\n"
-    "When called a non-property trait, this method returns *None*.\n");
+    "When called on a non-property trait, this method returns *None*.\n");
 
 PyDoc_STRVAR(
-    _set_property_doc,
-    "_set_property(get, get_n, set, set_n, validate, validate_n)\n"
+    _trait_set_property_doc,
+    "_trait_set_property(get, get_n, set, set_n, validate, validate_n)\n"
     "\n"
-    "The *property* method expects six arguments, and uses these\n"
-    "arguments to set the get, set and validation for the trait. It also\n"
-    "sets the property flag on the trait.\n"
+    "This method expects six arguments, and uses these arguments to set the\n"
+    "get, set and validation for the trait. It also sets the property flag \n"
+    "on the trait.\n"
     "\n"
     "Parameters\n"
     "----------\n"
@@ -5231,10 +5230,10 @@ static PyMethodDef trait_methods[] = {
     {"validate", (PyCFunction)_trait_validate, METH_VARARGS, validate_doc},
     {"delegate", (PyCFunction)_trait_delegate, METH_VARARGS,
      delegate_doc},
-    {"_get_property", (PyCFunction)_get_property, METH_VARARGS,
-     _get_property_doc},
-    {"_set_property", (PyCFunction)_set_property, METH_VARARGS,
-     _set_property_doc},
+    {"_get_property", (PyCFunction)_trait_get_property, METH_NOARGS,
+     _trait_get_property_doc},
+    {"_set_property", (PyCFunction)_trait_set_property, METH_VARARGS,
+     _trait_set_property_doc},
     {"clone", (PyCFunction)_trait_clone, METH_VARARGS,
      clone_doc},
     {"_notifiers", (PyCFunction)_trait_notifiers, METH_VARARGS,

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -516,7 +516,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
         # Merge base traits:
         for name, value in base_dict.get(BaseTraits).items():
             if name not in base_traits:
-                property_info = value.property()
+                property_info = value.property
                 if property_info is not None:
                     key = id(value)
                     migrated_properties[key] = value = migrate_property(
@@ -527,7 +527,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
         # Merge class traits:
         for name, value in base_dict.get(ClassTraits).items():
             if name not in class_traits:
-                property_info = value.property()
+                property_info = value.property
                 if property_info is not None:
                     new_value = migrated_properties.get(id(value))
                     if new_value is not None:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -516,7 +516,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
         # Merge base traits:
         for name, value in base_dict.get(BaseTraits).items():
             if name not in base_traits:
-                property_info = value.property
+                property_info = value.property_fields
                 if property_info is not None:
                     key = id(value)
                     migrated_properties[key] = value = migrate_property(
@@ -527,7 +527,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
         # Merge class traits:
         for name, value in base_dict.get(ClassTraits).items():
             if name not in class_traits:
-                property_info = value.property
+                property_info = value.property_fields
                 if property_info is not None:
                     new_value = migrated_properties.get(id(value))
                     if new_value is not None:

--- a/traits/tests/test_copyable_trait_names.py
+++ b/traits/tests/test_copyable_trait_names.py
@@ -105,7 +105,7 @@ class TestCopyableTraitNameQueries(unittest.TestCase):
 
     def test_property_query(self):
         names = self.foo.copyable_trait_names(
-            **{"property": lambda p: p() and p()[1].__name__ == "_set_p"}
+            **{"property": lambda p: p and p[1].__name__ == "_set_p"}
         )
 
         self.assertEqual(["p"], names)

--- a/traits/tests/test_copyable_trait_names.py
+++ b/traits/tests/test_copyable_trait_names.py
@@ -105,7 +105,7 @@ class TestCopyableTraitNameQueries(unittest.TestCase):
 
     def test_property_query(self):
         names = self.foo.copyable_trait_names(
-            **{"property": lambda p: p and p[1].__name__ == "_set_p"}
+            **{"property_fields": lambda p: p and p[1].__name__ == "_set_p"}
         )
 
         self.assertEqual(["p"], names)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -85,7 +85,7 @@ class TestCTrait(unittest.TestCase):
 
         self.assertFalse(trait.is_property)
 
-        trait.property = (getter, setter, validator)
+        trait.property_fields = (getter, setter, validator)
 
         self.assertTrue(trait.is_property)
 
@@ -96,7 +96,7 @@ class TestCTrait(unittest.TestCase):
         trait = CTrait(TraitKind.trait)
 
         # Get the property, ensure None
-        self.assertIsNone(trait.property)
+        self.assertIsNone(trait.property_fields)
 
         def value_get(self):
             return self.__dict__.get("_value", 0)
@@ -108,9 +108,9 @@ class TestCTrait(unittest.TestCase):
                 self.trait_property_changed("value", old_value, value)
 
         # Set the callables
-        trait.property = (value_get, value_set, None)
+        trait.property_fields = (value_get, value_set, None)
 
-        fget, fset, validate = trait.property
+        fget, fset, validate = trait.property_fields
 
         self.assertIs(fget, value_get)
         self.assertIs(fset, value_set)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -85,7 +85,7 @@ class TestCTrait(unittest.TestCase):
 
         self.assertFalse(trait.is_property)
 
-        trait.property(getter, 0, setter, 1, validator, 1)
+        trait.property(getter, setter, validator)
 
         self.assertTrue(trait.is_property)
 

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -116,6 +116,10 @@ class TestCTrait(unittest.TestCase):
         self.assertIs(fset, value_set)
         self.assertIsNone(validate)
 
+        # Ensure that _get_property does not accept arguments.
+        with self.assertRaises(TypeError):
+            trait._get_property(fget)
+
     def test_modify_delegate(self):
         trait = CTrait(TraitKind.trait)
 

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -92,6 +92,36 @@ class TestCTrait(unittest.TestCase):
         with self.assertRaises(AttributeError):
             trait.is_property = False
 
+    def test_get_set_property(self):
+        trait = CTrait(TraitKind.trait)
+
+        # Get the property, ensure None
+        self.assertIsNone(trait.property())
+
+        def value_get(self):
+            return self.__dict__.get("_value", 0)
+
+        def value_set(self, value):
+            old_value = self.__dict__.get("_value", 0)
+            if value != old_value:
+                self._value = value
+                self.trait_property_changed("value", old_value, value)
+
+        # Set the callables
+        trait.property(value_get, value_set, None)
+
+        fget, fset, validate = trait.property()
+
+        self.assertIs(fget, value_get)
+        self.assertIs(fset, value_set)
+        self.assertIsNone(validate)
+
+        with self.assertRaises(ValueError):
+            trait.property(value_get, 0, value_set, 1, None, 0)
+
+        with self.assertRaises(ValueError):
+            trait.property(value_get)
+
     def test_modify_delegate(self):
         trait = CTrait(TraitKind.trait)
 
@@ -303,7 +333,6 @@ class TestCTraitNotifiers(unittest.TestCase):
     """ Test calling trait notifiers and object notifiers. """
 
     def test_notifiers_empty(self):
-
         class Foo(HasTraits):
             x = Int()
 
@@ -313,7 +342,6 @@ class TestCTraitNotifiers(unittest.TestCase):
         self.assertEqual(x_ctrait._notifiers(True), [])
 
     def test_notifiers_on_trait(self):
-
         class Foo(HasTraits):
             x = Int()
 

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -85,7 +85,7 @@ class TestCTrait(unittest.TestCase):
 
         self.assertFalse(trait.is_property)
 
-        trait.property(getter, setter, validator)
+        trait.property = (getter, setter, validator)
 
         self.assertTrue(trait.is_property)
 
@@ -96,7 +96,7 @@ class TestCTrait(unittest.TestCase):
         trait = CTrait(TraitKind.trait)
 
         # Get the property, ensure None
-        self.assertIsNone(trait.property())
+        self.assertIsNone(trait.property)
 
         def value_get(self):
             return self.__dict__.get("_value", 0)
@@ -108,19 +108,13 @@ class TestCTrait(unittest.TestCase):
                 self.trait_property_changed("value", old_value, value)
 
         # Set the callables
-        trait.property(value_get, value_set, None)
+        trait.property = (value_get, value_set, None)
 
-        fget, fset, validate = trait.property()
+        fget, fset, validate = trait.property
 
         self.assertIs(fget, value_get)
         self.assertIs(fset, value_set)
         self.assertIsNone(validate)
-
-        with self.assertRaises(ValueError):
-            trait.property(value_get, 0, value_set, 1, None, 0)
-
-        with self.assertRaises(ValueError):
-            trait.property(value_get)
 
     def test_modify_delegate(self):
         trait = CTrait(TraitKind.trait)

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -331,6 +331,7 @@ class TestCTraitNotifiers(unittest.TestCase):
     """ Test calling trait notifiers and object notifiers. """
 
     def test_notifiers_empty(self):
+
         class Foo(HasTraits):
             x = Int()
 
@@ -340,6 +341,7 @@ class TestCTraitNotifiers(unittest.TestCase):
         self.assertEqual(x_ctrait._notifiers(True), [])
 
     def test_notifiers_on_trait(self):
+
         class Foo(HasTraits):
             x = Int()
 

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -170,7 +170,7 @@ class TestRegression(unittest.TestCase):
             prop = Property()
 
         a = A()
-        self.assertEqual(sys.getrefcount(a.trait("prop").property), 1)
+        self.assertEqual(sys.getrefcount(a.trait("prop").property_fields), 1)
 
     def test_delegate_initializer(self):
         mess = DelegateMess()

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -170,7 +170,7 @@ class TestRegression(unittest.TestCase):
             prop = Property()
 
         a = A()
-        self.assertEqual(sys.getrefcount(a.trait("prop").property()), 1)
+        self.assertEqual(sys.getrefcount(a.trait("prop").property), 1)
 
     def test_delegate_initializer(self):
         mess = DelegateMess()

--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -373,7 +373,7 @@ class TraitType(BaseTraitHandler):
                 metadata.setdefault("transient", True)
             trait = CTrait(TraitKind.property)
             validate = getattr(self, "validate", None)
-            trait.property = (getter, setter, validate)
+            trait.property_fields = (getter, setter, validate)
             metadata.setdefault("type", "property")
         else:
             type = getattr(self, "ctrait_type", None)

--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -373,11 +373,7 @@ class TraitType(BaseTraitHandler):
                 metadata.setdefault("transient", True)
             trait = CTrait(TraitKind.property)
             validate = getattr(self, "validate", None)
-            trait.property(
-                getter,
-                setter,
-                validate,
-            )
+            trait.property = (getter, setter, validate)
             metadata.setdefault("type", "property")
         else:
             type = getattr(self, "ctrait_type", None)

--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -16,7 +16,6 @@ traits, and provides a richer API than the old-style traits derived from
 ``TraitHandler``.
 """
 
-from types import MethodType
 import warnings
 
 from .base_trait_handler import BaseTraitHandler
@@ -67,14 +66,6 @@ def _read_only(object, name, value):
         "The '%s' trait of %s instance is 'read only'."
         % (name, class_of(object))
     )
-
-
-def _arg_count(func):
-    """ Returns the correct argument count for a specified function or method.
-    """
-    if (type(func) is MethodType) and (func.__self__ is not None):
-        return func.__code__.co_argcount - 1
-    return func.__code__.co_argcount
 
 
 # Create a singleton object for use in the TraitType constructor:
@@ -381,17 +372,11 @@ class TraitType(BaseTraitHandler):
                 setter = _read_only
                 metadata.setdefault("transient", True)
             trait = CTrait(TraitKind.property)
-            n = 0
             validate = getattr(self, "validate", None)
-            if validate is not None:
-                n = _arg_count(validate)
             trait.property(
                 getter,
-                _arg_count(getter),
                 setter,
-                _arg_count(setter),
                 validate,
-                n,
             )
             metadata.setdefault("type", "property")
         else:

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -55,7 +55,6 @@ from .trait_converters import (
 
 from .trait_handler import TraitHandler
 from .trait_type import (
-    _arg_count,
     _infer_default_value_type,
     _read_only,
     _write_only,
@@ -624,15 +623,9 @@ def Property(
     ):
         metadata.setdefault("cached", True)
 
-    n = 0
     trait = CTrait(TraitKind.property)
     trait.__dict__ = metadata.copy()
-    if fvalidate is not None:
-        n = _arg_count(fvalidate)
-
-    trait.property(
-        fget, _arg_count(fget), fset, _arg_count(fset), fvalidate, n
-    )
+    trait.property(fget, fset, fvalidate)
     trait.handler = handler
 
     return trait

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -625,7 +625,7 @@ def Property(
 
     trait = CTrait(TraitKind.property)
     trait.__dict__ = metadata.copy()
-    trait.property(fget, fset, fvalidate)
+    trait.property = (fget, fset, fvalidate)
     trait.handler = handler
 
     return trait

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -625,7 +625,7 @@ def Property(
 
     trait = CTrait(TraitKind.property)
     trait.__dict__ = metadata.copy()
-    trait.property = (fget, fset, fvalidate)
+    trait.property_fields = (fget, fset, fvalidate)
     trait.handler = handler
 
     return trait


### PR DESCRIPTION
**Checklist**
- [x] Tests
- ~~[ ] Update API reference (`docs/source/traits_api_reference`)~~ Not public API
- ~~[ ] Update User manual (`docs/source/traits_user_manual`)~~ Not public API
- ~~[ ] Update type annotation hints in `traits-stubs`~~ No trait API change

Fixes #825 
PR introduces two new functions in `ctraits.c` , a `_set_property` and a `_get_property` and removes the `_trait_property` function. The new functions together achieve the same purpose as `_trait_property`.  Ref : https://github.com/enthought/traits/pull/837#issuecomment-600073352
The `_get_property` only returns a tuple of 3 arguments (fget, fset and validate), not sure if there are any merits in returning the argument counts for the `fget`, `fset` and `validate` callables also.

It also introduces a new `property` method in `ctrait.py` which rely on the above two methods for setting/getting the property values. 

Setting the values for `fget`, `fset` and `fvalidate` is made simpler by automatically counting the function arguments inside the `property` method.