### PR TITLE
BaseEnum and Enum fixes and cleanup

### DIFF
--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -260,3 +260,12 @@ class EnumTestCase(unittest.TestCase):
                 a = Enum()
 
             EmptyEnum()
+
+    def test_attributes(self):
+        static_enum = Enum(1, 2, 3)
+        self.assertEqual(static_enum.values, (1, 2, 3))
+        self.assertIsNone(static_enum.name, None)
+
+        dynamic_enum = Enum(values="values")
+        self.assertIsNone(dynamic_enum.values)
+        self.assertEqual(dynamic_enum.name, "values")

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -277,6 +277,13 @@ class EnumTestCase(unittest.TestCase):
         self.assertIsNone(dynamic_enum.values)
         self.assertEqual(dynamic_enum.name, "values")
 
+    def test_explicit_collection_with_no_elements(self):
+        class A(HasTraits):
+            enum = Enum([])
+
+        a = A()
+        self.assertIsNone(a.enum)
+
     def test_base_enum(self):
         # Minimal tests for BaseEnum, sufficient to cover the validation
         # for the static case.

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -11,7 +11,8 @@
 import enum
 import unittest
 
-from traits.api import Any, Enum, HasTraits, List, Property, TraitError
+from traits.api import (
+    Any, BaseEnum, Enum, HasTraits, List, Property, TraitError)
 
 
 class FooEnum(enum.Enum):
@@ -105,6 +106,8 @@ class EnumCollectionExample(HasTraits):
     two_digits = Enum(1, 2)
 
     single_digit = Enum(8)
+
+    slow_enum = BaseEnum("yes", "no", "maybe")
 
 
 class EnumTestCase(unittest.TestCase):
@@ -273,3 +276,16 @@ class EnumTestCase(unittest.TestCase):
         dynamic_enum = Enum(values="values")
         self.assertIsNone(dynamic_enum.values)
         self.assertEqual(dynamic_enum.name, "values")
+
+    def test_base_enum(self):
+        # Minimal tests for BaseEnum, sufficient to cover the validation
+        # for the static case.
+        obj = EnumCollectionExample()
+
+        self.assertEqual(obj.slow_enum, "yes")
+        obj.slow_enum = "no"
+        self.assertEqual(obj.slow_enum, "no")
+
+        with self.assertRaises(TraitError):
+            obj.slow_enum = "perhaps"
+        self.assertEqual(obj.slow_enum, "no")

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -279,10 +279,13 @@ class EnumTestCase(unittest.TestCase):
 
     def test_explicit_collection_with_no_elements(self):
         class A(HasTraits):
-            enum = Enum([])
+            empty_enum = Enum([])
+
+            empty_enum_with_default = Enum(3.5, [])
 
         a = A()
-        self.assertIsNone(a.enum)
+        self.assertIsNone(a.empty_enum)
+        self.assertEqual(a.empty_enum_with_default, 3.5)
 
     def test_base_enum(self):
         # Minimal tests for BaseEnum, sufficient to cover the validation

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -278,14 +278,11 @@ class EnumTestCase(unittest.TestCase):
         self.assertEqual(dynamic_enum.name, "values")
 
     def test_explicit_collection_with_no_elements(self):
-        class A(HasTraits):
-            empty_enum = Enum([])
+        with self.assertRaises(TraitError):
+            Enum([])
 
-            empty_enum_with_default = Enum(3.5, [])
-
-        a = A()
-        self.assertIsNone(a.empty_enum)
-        self.assertEqual(a.empty_enum_with_default, 3.5)
+        with self.assertRaises(TraitError):
+            Enum(3.5, [])
 
     def test_base_enum(self):
         # Minimal tests for BaseEnum, sufficient to cover the validation

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -261,6 +261,10 @@ class EnumTestCase(unittest.TestCase):
 
             EmptyEnum()
 
+    def test_too_many_arguments_for_dynamic_enum(self):
+        with self.assertRaises(TraitError):
+            Enum("red", "green", values="values")
+
     def test_attributes(self):
         static_enum = Enum(1, 2, 3)
         self.assertEqual(static_enum.values, (1, 2, 3))

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -104,6 +104,8 @@ class EnumCollectionExample(HasTraits):
 
     two_digits = Enum(1, 2)
 
+    single_digit = Enum(8)
+
 
 class EnumTestCase(unittest.TestCase):
     def test_valid_enum(self):
@@ -199,6 +201,7 @@ class EnumTestCase(unittest.TestCase):
         self.assertEqual(0, collection_enum.digits)
         self.assertEqual(1, collection_enum.int_set_enum)
         self.assertEqual(1, collection_enum.two_digits)
+        self.assertEqual(8, collection_enum.single_digit)
 
         # Test assigning valid values
         collection_enum.rgb = "blue"
@@ -229,6 +232,12 @@ class EnumTestCase(unittest.TestCase):
 
         with self.assertRaises(TraitError):
             collection_enum.digits = 10
+
+        with self.assertRaises(TraitError):
+            collection_enum.single_digit = 9
+
+        with self.assertRaises(TraitError):
+            collection_enum.single_digit = None
 
         # Fixing issue #835 introduces the following behaviour, which would
         # have otherwise not thrown a TraitError

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -27,8 +27,6 @@ enumerate = enumerate
 
 SequenceTypes = (list, tuple)
 
-EnumTypes = (list, tuple, enum.EnumMeta)
-
 ComplexTypes = (float, int)
 
 RangeTypes = (int, float)

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -366,12 +366,3 @@ def not_event(value):
 
 def is_str(value):
     return isinstance(value, str)
-
-
-def is_collection(value):
-    """ Returns true if the value can be iterated over. """
-    try:
-        iter(value)
-        return True
-    except TypeError:
-        return False

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1975,7 +1975,6 @@ class BaseEnum(TraitType):
         For a dynamic enumeration, this is the name of a trait holding
         the collection of valid values. For a static enumeration, this is
         None.
-
     """
 
     def __init__(self, *args, values=None, **metadata):
@@ -2091,44 +2090,79 @@ class Enum(BaseEnum):
     """ A fast-validating trait type whose value is an element of a finite
     collection.
 
-    The default value is the first positional argument, or the first item of
-    the list, tuple or enum.Enum if that is the only argument or if the valid
-    values are provided dynamically.
+    This trait type can be either *static*, with the collection of valid values
+    specified directly in the constructor, or *dynamic*, with the collection
+    provided by the value of another trait attribute.
+
+    For both static and dynamic enumerations, a default value can be provided
+    as a positional argument. If no default is provided, the default is the
+    first item (in iteration order) of the underlying collection.
+
+    Notes
+    -----
+
+    1. If the enumeration is based on an unordered collection like a
+       ``set``, and no explicit default is given, the default used will
+       effectively be arbitrary (the first element of the set in iteration
+       order). It's recommended that a default be given explicitly in this
+       case.
+
+    2. Instances of ``str``, ``bytes`` and ``bytearray`` are not treated
+       as collections for the purposes of this trait type, both for pragmatic
+       reasons (it's more likely that a user wants to use a string as an
+       element in a collection than as a collection in its own right), and
+       because the behavior of the ``in`` operator for those types does not
+       express the usual membership semantics (for example, ``"bc" in "abc"``
+       is ``True``).
 
     Parameters
     ----------
     *args
-        The enumeration of all legal values for the trait.  The expected
-        signatures are either:
+        The enumeration of all valid values for the trait. For a static
+        enumeration trait (where the *values* keyword argument is not given)
+        the supported signatures for ``args`` are as follows:
 
-        - a single list, enum.Enum, tuple or a collection.  The default value
-          is the first item in the collection. The collection should conform to
-          the collections.abc.Collection interface. That is, it at least
-          provides the __contains__, __len__ and __iter__ methods.
-          Note that although the types str, bytes, and bytearray
-          conform to the collection interface, these are handled
-          as discrete units.
-        - a single default value, combined with the values keyword
-          argument.
-        - a default value, followed by a single list enum.Enum, tuple or
-          collection conforming to collections.abc.Collection
-        - arbitrary positional arguments each giving a valid value.
+        (collection,)
+            The collection of valid values. The default is the first item
+            of the collection, in iteration order.
+        (default, collection)
+            The default value, followed by the collection of valid values.
+        (item1, item2, ..., itemn)
+            One or more items giving the valid values for the collection.
+            The default is *item1*.
+
+        For a dynamic enumeration trait, where the *values* keyword argument
+        is given, the supported signatures for ``args`` are:
+
+        ()
+            No arguments given. In this case the default is the first item
+            of the collection, in iteration order.
+        (default,)
+            The default value for the collection.
+
+        For the static case, the ambiguity in the signatures is resolved
+        as follows: if ``args`` has length ``1`` or ``2``, ``arg[-1]`` can be
+        iterated over, and ``arg[-1]`` is not an instance of ``str``, ``bytes``
+        or ``bytearray``, then ``arg[-1]`` is assumed to give the collection
+        of values. Otherwise, all elements of ``args`` are assumed to be
+        items in the collection. Thus the first two signatures are safe
+        from ambiguity, and it's recommended to use one of these two signatures
+        in preference to the third form.
     values : str, optional
-        The name of a trait holding the legal values.  A default value may
-        be provided via a positional argument, otherwise the first item in
-        the collection is used as the default value. Note that if the
-        collection does not have a notion of order like a set, the default
-        value will be an arbitrary element from the set.
+        The name of a trait holding the valid values. If given, this is
+        a dynamic enumeration, otherwise it's a static numeration.
     **metadata
-        Trait metadata for the trait.
+        Metadata for the trait.
 
     Attributes
     ----------
-    values : tuple
-        A tuple holding the legal values.
-    name : str
-        The name of a trait holding the legal values, or the empty string if
-        unused.
+    values : tuple or None
+        For a static enumeration, this is a tuple holding the valid values.
+        For a dynamic enumeration, this is None.
+    name : str or None
+        For a dynamic enumeration, this is the name of a trait holding
+        the collection of valid values. For a static enumeration, this is
+        None.
     """
 
     def init_fast_validate(self, *args):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -11,6 +11,7 @@
 """ Core Trait definitions.
 """
 
+import collections.abc
 import datetime
 from importlib import import_module
 import operator
@@ -37,7 +38,6 @@ from .trait_base import (
     Undefined,
     TraitsCache,
     xgetattr,
-    is_collection,
 )
 from .trait_converters import trait_from, trait_cast
 from .trait_dict_object import TraitDictEvent, TraitDictObject
@@ -2006,8 +2006,8 @@ class BaseEnum(TraitType):
             # enumeration. Otherwise, args itself is the collection.
             have_collection_arg = (
                 nargs <= 2
-                and is_collection(args[-1])
                 and not isinstance(args[-1], (str, bytes, bytearray))
+                and isinstance(args[-1], collections.abc.Iterable)
             )
             self.values = tuple(args[-1]) if have_collection_arg else args
             if not self.values:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1899,67 +1899,92 @@ class Range(BaseRange):
         self.fast_validate = args
 
 
-# XXX Need test for case of Enum(3); if Enum("bob") is
-# allowed, then Enum(3) should be.
-
-# XXX identify safe/recommended signatures in docstring:
-# those are the ones where the collection is given
-# explicitly.
-
-# XXX Consider not turning collections into tuples
-# unnecessarily.
-
-
 class BaseEnum(TraitType):
-    """ A trait type whose value is one of a set of values.
+    """ A trait type whose value is an element of a finite collection.
 
-    The default value is the first positional argument, or the first item of
-    the list, tuple or enum.Enum if that is the only argument or if the valid
-    values are provided dynamically.
+    This trait type can be either *static*, with the collection of valid values
+    specified directly in the constructor, or *dynamic*, with the collection
+    provided by the value of another trait attribute.
+
+    For both static and dynamic enumerations, a default value can be provided
+    as a positional argument. If no default is provided, the default is the
+    first item (in iteration order) of the underlying collection.
+
+    Notes
+    -----
+
+    1. If the enumeration is based on an unordered collection like a
+       ``set``, and no explicit default is given, the default used will
+       effectively be arbitrary (the first element of the set in iteration
+       order). It's recommended that a default be given explicitly in this
+       case.
+
+    2. Instances of ``str``, ``bytes`` and ``bytearray`` are not treated
+       as collections for the purposes of this trait type, both for pragmatic
+       reasons (it's more likely that a user wants to use a string as an
+       element in a collection than as a collection in its own right), and
+       because the behavior of the ``in`` operator for those types does not
+       express the usual membership semantics (for example, ``"bc" in "abc"``
+       is ``True``).
 
     Parameters
     ----------
     *args
-        The enumeration of all legal values for the trait.  The expected
-        signatures are either:
+        The enumeration of all valid values for the trait. For a static
+        enumeration trait (where the *values* keyword argument is not given)
+        the supported signatures for ``args`` are as follows:
 
-        - a collection.  The default value is the first item in the
-          collection. The collection should conform to the
-          collections.abc.Collection interface. That is, it at least
-          provides the __contains__, __len__ and __iter__ methods.
-          Note that although the types str, bytes, and bytearray
-          conform to the collection interface, these are handled
-          as discrete units.
-        - a single default value, combined with the values keyword
-          argument.
-        - a default value, followed by a single list enum.Enum, tuple or
-          collection conforming to collections.abc.Collection
-        - arbitrary positional arguments each giving a valid value.
+        (collection,)
+            The collection of valid values. The default is the first item
+            of the collection, in iteration order.
+        (default, collection)
+            The default value, followed by the collection of valid values.
+        (item1, item2, ..., itemn)
+            One or more items giving the valid values for the collection.
+            The default is *item1*.
+
+        For a dynamic enumeration trait, where the *values* keyword argument
+        is given, the supported signatures for ``args`` are:
+
+        ()
+            No arguments given. In this case the default is the first item
+            of the collection, in iteration order.
+        (default,)
+            The default value for the collection.
+
+        For the static case, the ambiguity in the signatures is resolved
+        as follows: if ``args`` has length ``1`` or ``2``, ``arg[-1]`` can be
+        iterated over, and ``arg[-1]`` is not an instance of ``str``, ``bytes``
+        or ``bytearray``, then ``arg[-1]`` is assumed to give the collection
+        of values. Otherwise, all elements of ``args`` are assumed to be
+        items in the collection. Thus the first two signatures are safe
+        from ambiguity, and it's recommended to use one of these two signatures
+        in preference to the third form.
     values : str, optional
-        The name of a trait holding the legal values.  A default value may
-        be provided via a positional argument, otherwise the first item in
-        the collection is used as the default value. Note that if the
-        collection does not have a notion of order like a set, the default
-        value will be an arbitrary element from the set.
+        The name of a trait holding the valid values. If given, this is
+        a dynamic enumeration, otherwise it's a static numeration.
     **metadata
-        Trait metadata for the trait.
+        Metadata for the trait.
 
     Attributes
     ----------
     values : tuple or None
-        For a static enumeration, this is a tuple holding the legal values.
-        For a dynamic enumeration, it's None.
-
-    name : str
+        For a static enumeration, this is a tuple holding the valid values.
+        For a dynamic enumeration, this is None.
+    name : str or None
         For a dynamic enumeration, this is the name of a trait holding
-        the collection of legal values. For a static enumeration, this is
+        the collection of valid values. For a static enumeration, this is
         None.
+
     """
 
     def __init__(self, *args, values=None, **metadata):
+        self.name = values
+
         nargs = len(args)
-        if values is not None:
-            self.name = values
+        if self.name is not None:
+            # Dynamic enumeration
+            self.values = None
             self.get, self.set, self.validate = self._get, self._set, None
             if nargs == 0:
                 super(BaseEnum, self).__init__(**metadata)
@@ -1972,6 +1997,7 @@ class BaseEnum(TraitType):
                     "when using the 'values' keyword"
                 )
         else:
+            # Static enumeration
             if nargs == 0:
                 raise TraitError("Enum trait requires at "
                                  "least 1 argument.")
@@ -2062,7 +2088,8 @@ class BaseEnum(TraitType):
 
 
 class Enum(BaseEnum):
-    """ A fast-validating trait type whose value is one of a set of values.
+    """ A fast-validating trait type whose value is an element of a finite
+    collection.
 
     The default value is the first positional argument, or the first item of
     the list, tuple or enum.Enum if that is the only argument or if the valid
@@ -2099,7 +2126,6 @@ class Enum(BaseEnum):
     ----------
     values : tuple
         A tuple holding the legal values.
-
     name : str
         The name of a trait holding the legal values, or the empty string if
         unused.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1925,7 +1925,7 @@ class BaseEnum(TraitType):
         - a default value, followed by a single list enum.Enum, tuple or
           collection conforming to collections.abc.Collection
         - arbitrary positional arguments each giving a valid value.
-    values : str
+    values : str, optional
         The name of a trait holding the legal values.  A default value may
         be provided via a positional argument, otherwise the first item in
         the collection is used as the default value. Note that if the
@@ -1944,9 +1944,8 @@ class BaseEnum(TraitType):
         unused.
     """
 
-    def __init__(self, *args, **metadata):
-        values = metadata.pop("values", None)
-        if isinstance(values, str):
+    def __init__(self, *args, values=None, **metadata):
+        if values is not None:
             self.name = values
             self.get, self.set, self.validate = self._get, self._set, None
             n = len(args)
@@ -2096,7 +2095,7 @@ class Enum(BaseEnum):
         - a default value, followed by a single list enum.Enum, tuple or
           collection conforming to collections.abc.Collection
         - arbitrary positional arguments each giving a valid value.
-    values : str
+    values : str, optional
         The name of a trait holding the legal values.  A default value may
         be provided via a positional argument, otherwise the first item in
         the collection is used as the default value. Note that if the

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -12,7 +12,6 @@
 """
 
 import datetime
-import enum
 from importlib import import_module
 import operator
 import re

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1997,7 +1997,7 @@ class BaseEnum(TraitType):
         else:
             # Static enumeration
             if nargs == 0:
-                raise TraitError("Enum trait requires at least 1 argument.")
+                raise TraitError("Enum trait requires at least 1 argument")
 
             # If we have either 1 or 2 arguments and the last argument is a
             # collection, then that collection provides the values of the
@@ -2009,7 +2009,7 @@ class BaseEnum(TraitType):
             )
             self.values = tuple(args[-1]) if have_collection_arg else args
             if not self.values:
-                raise TraitError("Enum collection should be nonempty.")
+                raise TraitError("Enum collection should be nonempty")
 
             # In the two-argument collection case, the first argument is
             # the default. Otherwise, we take the first element of self.values.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -31,7 +31,6 @@ from .trait_base import (
     get_module_name,
     HandleWeakRef,
     class_of,
-    EnumTypes,
     RangeTypes,
     safe_contains,
     SequenceTypes,
@@ -1966,20 +1965,15 @@ class BaseEnum(TraitType):
 
             elif nargs == 1:
                 arg = args[0]
-                if isinstance(arg, EnumTypes):
-                    default_value = next(iter(arg), None)
-                    self.values = tuple(arg)
 
                 # Treat str, bytes and bytearray as discrete units,
                 # and not as a collection.
-                elif isinstance(arg, (str, bytes, bytearray)):
-                    default_value = arg
-                    self.values = (arg,)
-
-                # Handle a collection
-                else:
+                if is_collection(arg) and not isinstance(arg, (str, bytes, bytearray)):
+                    self.values = tuple(arg)
                     default_value = next(iter(arg), None)
-                    self.values = arg
+                else:
+                    self.values = args
+                    default_value = arg
 
             elif nargs == 2:
                 # If 2 args, the first is default, second is allowed values.
@@ -1988,17 +1982,16 @@ class BaseEnum(TraitType):
 
                 # Treat str, bytes and bytearray as discrete units,
                 # and not as a collection.
-                if isinstance(allowed_vals, (str, bytes, bytearray)):
-                    self.values = tuple(args)
-
-                elif is_collection(allowed_vals):
+                if is_collection(allowed_vals) and not isinstance(allowed_vals, (str, bytes, bytearray)):
                     self.values = tuple(allowed_vals)
-
+                    default_value = args[0]
                 else:
-                    self.values = tuple(args)
+                    self.values = args
+                    default_value = next(iter(args), None)
+
             else:
-                default_value = args[0]
-                self.values = tuple(args)
+                self.values = args
+                default_value = next(iter(args), None)
 
             if isinstance(args, enum.EnumMeta):
                 metadata.setdefault('format_func', operator.attrgetter('name'))

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2008,15 +2008,15 @@ class BaseEnum(TraitType):
                 and not isinstance(args[-1], (str, bytes, bytearray))
             )
             self.values = tuple(args[-1]) if have_collection_arg else args
+            if not self.values:
+                raise TraitError("Enum collection should be nonempty.")
 
             # In the two-argument collection case, the first argument is
             # the default. Otherwise, we take the first element of self.values.
             if have_collection_arg and nargs == 2:
                 default_value = args[0]
-            elif self.values:
-                default_value = self.values[0]
             else:
-                default_value = None
+                default_value = self.values[0]
 
             self.init_fast_validate(ValidateTrait.enum, self.values)
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1946,12 +1946,14 @@ class BaseEnum(TraitType):
 
     Attributes
     ----------
-    values : tuple
-        A tuple holding the legal values.
+    values : tuple or None
+        For a static enumeration, this is a tuple holding the legal values.
+        For a dynamic enumeration, it's None.
 
     name : str
-        The name of a trait holding the legal values, or the empty string if
-        unused.
+        For a dynamic enumeration, this is the name of a trait holding
+        the collection of legal values. For a static enumeration, this is
+        None.
     """
 
     def __init__(self, *args, values=None, **metadata):
@@ -1991,7 +1993,6 @@ class BaseEnum(TraitType):
             else:
                 default_value = next(iter(self.values), None)
 
-            self.name = ""
             self.init_fast_validate(ValidateTrait.enum, self.values)
 
             super(BaseEnum, self).__init__(default_value, **metadata)
@@ -2014,7 +2015,7 @@ class BaseEnum(TraitType):
     def full_info(self, object, name, value):
         """ Returns a description of the trait.
         """
-        if self.name == "":
+        if self.name is None:
             values = self.values
         else:
             values = xgetattr(object, self.name)
@@ -2026,13 +2027,16 @@ class BaseEnum(TraitType):
         """
         from traitsui.api import EnumEditor
 
-        values = self
-        if self.name != "":
+        if self.name is None:
+            values = self
+            name = ""
+        else:
             values = None
+            name = self.name
 
         return EnumEditor(
             values=values,
-            name=self.name,
+            name=name,
             cols=self.cols or 3,
             evaluate=self.evaluate,
             format_func=self.format_func,

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1976,14 +1976,16 @@ class BaseEnum(TraitType):
 
             # If we have either 1 or 2 arguments and the last argument is a
             # collection, then that collection provides the values of the
-            # enumeration.
+            # enumeration. Otherwise, args itself is the collection.
             have_collection_arg = (
                 nargs <= 2
                 and is_collection(args[-1])
                 and not isinstance(args[-1], (str, bytes, bytearray))
             )
-
             self.values = tuple(args[-1]) if have_collection_arg else args
+
+            # In the two-argument collection case, the first argument is
+            # the default. Otherwise, we take the first element of self.values.
             if have_collection_arg and nargs == 2:
                 default_value = args[0]
             else:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1955,10 +1955,10 @@ class BaseEnum(TraitType):
 
         For the static case, the ambiguity in the signatures is resolved
         as follows: if ``args`` has length ``1`` or ``2``, ``args[-1]`` can be
-        iterated over, and ``args[-1]`` is not an instance of ``str``, ``bytes``
-        or ``bytearray``, then ``args[-1]`` is assumed to give the collection
-        of values. Otherwise, all elements of ``args`` are assumed to be
-        items in the collection. Thus the first two signatures are safe
+        iterated over, and ``args[-1]`` is not an instance of ``str``,
+        ``bytes`` or ``bytearray``, then ``args[-1]`` is assumed to give the
+        collection of values. Otherwise, all elements of ``args`` are assumed
+        to be items in the collection. Thus the first two signatures are safe
         from ambiguity, and it's recommended to use one of these two signatures
         in preference to the third form.
     values : str, optional
@@ -2146,10 +2146,10 @@ class Enum(BaseEnum):
 
         For the static case, the ambiguity in the signatures is resolved
         as follows: if ``args`` has length ``1`` or ``2``, ``args[-1]`` can be
-        iterated over, and ``args[-1]`` is not an instance of ``str``, ``bytes``
-        or ``bytearray``, then ``args[-1]`` is assumed to give the collection
-        of values. Otherwise, all elements of ``args`` are assumed to be
-        items in the collection. Thus the first two signatures are safe
+        iterated over, and ``args[-1]`` is not an instance of ``str``,
+        ``bytes`` or ``bytearray``, then ``args[-1]`` is assumed to give the
+        collection of values. Otherwise, all elements of ``args`` are assumed
+        to be items in the collection. Thus the first two signatures are safe
         from ambiguity, and it's recommended to use one of these two signatures
         in preference to the third form.
     values : str, optional

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1989,10 +1989,6 @@ class BaseEnum(TraitType):
             else:
                 default_value = next(iter(self.values), None)
 
-            if isinstance(args, enum.EnumMeta):
-                metadata.setdefault('format_func', operator.attrgetter('name'))
-                metadata.setdefault('evaluate', args)
-
             self.name = ""
             self.init_fast_validate(ValidateTrait.enum, self.values)
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1954,9 +1954,9 @@ class BaseEnum(TraitType):
             The default value for the collection.
 
         For the static case, the ambiguity in the signatures is resolved
-        as follows: if ``args`` has length ``1`` or ``2``, ``arg[-1]`` can be
-        iterated over, and ``arg[-1]`` is not an instance of ``str``, ``bytes``
-        or ``bytearray``, then ``arg[-1]`` is assumed to give the collection
+        as follows: if ``args`` has length ``1`` or ``2``, ``args[-1]`` can be
+        iterated over, and ``args[-1]`` is not an instance of ``str``, ``bytes``
+        or ``bytearray``, then ``args[-1]`` is assumed to give the collection
         of values. Otherwise, all elements of ``args`` are assumed to be
         items in the collection. Thus the first two signatures are safe
         from ambiguity, and it's recommended to use one of these two signatures
@@ -2145,9 +2145,9 @@ class Enum(BaseEnum):
             The default value for the collection.
 
         For the static case, the ambiguity in the signatures is resolved
-        as follows: if ``args`` has length ``1`` or ``2``, ``arg[-1]`` can be
-        iterated over, and ``arg[-1]`` is not an instance of ``str``, ``bytes``
-        or ``bytearray``, then ``arg[-1]`` is assumed to give the collection
+        as follows: if ``args`` has length ``1`` or ``2``, ``args[-1]`` can be
+        iterated over, and ``args[-1]`` is not an instance of ``str``, ``bytes``
+        or ``bytearray``, then ``args[-1]`` is assumed to give the collection
         of values. Otherwise, all elements of ``args`` are assumed to be
         items in the collection. Thus the first two signatures are safe
         from ambiguity, and it's recommended to use one of these two signatures

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2031,7 +2031,7 @@ class BaseEnum(TraitType):
         """ Validates that the value is one of the enumerated set of valid
         values.
         """
-        if safe_contains(value, self.values):
+        if value in self.values:
             return value
 
         self.error(object, name, value)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2107,10 +2107,6 @@ class Enum(BaseEnum):
 
     def init_fast_validate(self, *args):
         """ Set up C-level fast validation. """
-        # Don't use fast validation if second arg is not a tuple.
-        if len(args) == 2 and not isinstance(args[1], tuple):
-            return
-
         self.fast_validate = args
 
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2013,8 +2013,10 @@ class BaseEnum(TraitType):
             # the default. Otherwise, we take the first element of self.values.
             if have_collection_arg and nargs == 2:
                 default_value = args[0]
+            elif self.values:
+                default_value = self.values[0]
             else:
-                default_value = next(iter(self.values), None)
+                default_value = None
 
             self.init_fast_validate(ValidateTrait.enum, self.values)
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1934,10 +1934,12 @@ class BaseEnum(TraitType):
         the supported signatures for ``args`` are as follows:
 
         (collection,)
-            The collection of valid values. The default is the first item
-            of the collection, in iteration order.
+            A nonempty collection of valid values. The default is the first
+            element of the collection, in iteration order.
         (default, collection)
-            The default value, followed by the collection of valid values.
+            The default value, followed by a nonempty collection of valid
+            values. The default should be an element of the collection, but
+            this is not checked.
         (item1, item2, ..., itemn)
             One or more items giving the valid values for the collection.
             The default is *item1*.
@@ -2123,10 +2125,12 @@ class Enum(BaseEnum):
         the supported signatures for ``args`` are as follows:
 
         (collection,)
-            The collection of valid values. The default is the first item
-            of the collection, in iteration order.
+            A nonempty collection of valid values. The default is the first
+            element of the collection, in iteration order.
         (default, collection)
-            The default value, followed by the collection of valid values.
+            The default value, followed by a nonempty collection of valid
+            values. The default should be an element of the collection, but
+            this is not checked.
         (item1, item2, ..., itemn)
             One or more items giving the valid values for the collection.
             The default is *item1*.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1945,13 +1945,13 @@ class BaseEnum(TraitType):
     """
 
     def __init__(self, *args, values=None, **metadata):
+        nargs = len(args)
         if values is not None:
             self.name = values
             self.get, self.set, self.validate = self._get, self._set, None
-            n = len(args)
-            if n == 0:
+            if nargs == 0:
                 super(BaseEnum, self).__init__(**metadata)
-            elif n == 1:
+            elif nargs == 1:
                 default_value = args[0]
                 super(BaseEnum, self).__init__(default_value, **metadata)
             else:
@@ -1960,11 +1960,11 @@ class BaseEnum(TraitType):
                     "when using the 'values' keyword"
                 )
         else:
-            if len(args) < 1:
+            if nargs == 0:
                 raise TraitError("Enum trait requires at "
                                  "least 1 argument.")
 
-            elif len(args) == 1:
+            elif nargs == 1:
                 arg = args[0]
                 if isinstance(arg, EnumTypes):
                     default_value = next(iter(arg), None)
@@ -1981,7 +1981,7 @@ class BaseEnum(TraitType):
                     default_value = next(iter(arg), None)
                     self.values = arg
 
-            elif len(args) == 2:
+            elif nargs == 2:
                 # If 2 args, the first is default, second is allowed values.
                 default_value = args[0]
                 allowed_vals = args[1]

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1998,8 +1998,7 @@ class BaseEnum(TraitType):
         else:
             # Static enumeration
             if nargs == 0:
-                raise TraitError("Enum trait requires at "
-                                 "least 1 argument.")
+                raise TraitError("Enum trait requires at least 1 argument.")
 
             # If we have either 1 or 2 arguments and the last argument is a
             # collection, then that collection provides the values of the


### PR DESCRIPTION
This PR:

- refactors some of the `BaseEnum` and `Enum` code to remove duplication and unify semantics
- changes the signature of `BaseEnum` to make the `values` argument explicit
- replaces the `is_collection` check (which is now a bit misleadingly named) with the essentially equivalent `isinstance(..., collections.abc.Iterable)` check
- removes `is_collection`, which is now unused
- removes `EnumTypes`, which we no longer need
- for static enumerations, **changes** the `name` attribute from the empty string to ``None``
- **fixes** a regression with the behaviour of ``Enum(3)``: in Traits 6.0 this is legal, while on master it raises
- adds some extra tests to improve coverage
- adds tests for the documented attributes
- reworks the ``BaseEnum`` and ``Enum`` docstrings, and ensures that they match
- **changes** behavior for static enumerations with an empty collection: before, these were accepted when a collection was explicitly given (e.g., `Enum([])`), but not where individual items were given (`Enum()`). For consistency, a `TraitError` is now raised both for `Enum([])` and for `Enum()`, to maintain the parallel between `Enum(list_of_strings)` and `Enum(*list_of_strings)`. This is technically a backwards incompatible change, but it seems unlikely to break real code. It also allows us to guarantee that an implicit default for a static enumeration will always be a valid element of the collection.

One note: for static enumerations, the `values` attribute is now always a `tuple` (as promised by the original docstring). We _could_ conceivably try to make `values` identical to the original collection instead, but that might break other pieces of code that rely on `values` being a tuple. And for mutable collections, there's some value in making a copy at `Enum` creation time.

(For dynamic enumerations, no type checking or conversion of the values collection is performed.)

Another fun note: despite all the talk of collections, the only collection-like check we're doing is to check whether a putative collection is iterable or not. That means that things like `squares = Enum(x**2 for x in range(10))` will work (both on current master, and in this PR).

I _think_ that's fine, but if we decide we don't want to allow this for some reason, we should kill it now rather than after it's released.
