### PR TITLE
Add documentation for Map, PrefixMap and PrefixList to the User manual

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -314,12 +314,18 @@ the table.
 +------------------+----------------------------------------------------------+
 | List             | List([*trait* = None, *value* = None, *minlen* = 0,      |
 +------------------+----------------------------------------------------------+
+| Map              | Map( [*map* = Undefined, \*\*\ *metadata*] )             |
++------------------+----------------------------------------------------------+
 | Method           | Method ([\*\*\ *metadata*] )                             |
 +------------------+----------------------------------------------------------+
 | Module           | Module ( [\*\*\ *metadata*] )                            |
 +------------------+----------------------------------------------------------+
 | Password         | Password( [*value* = '', *minlen* = 0, *maxlen* =        |
 |                  | sys.maxint, *regex* = '', \*\*\ *metadata*] )            |
++------------------+----------------------------------------------------------+
+| PrefixList       | PrefixList( [*values* = None, \*\*\ *metadata*] )        |
++------------------+----------------------------------------------------------+
+| PrefixMap        | PrefixMap( [*map* = Undefined, \*\*\ *metadata*] )       |
 +------------------+----------------------------------------------------------+
 | Property         | Property( [*fget* = None, *fset* = None, *fvalidate* =   |
 |                  | None, *force* = False, *handler* = None, *trait* = None, |
@@ -427,6 +433,119 @@ on the class on which it was defined. For example::
     >>> fred.manager = mary
     >>> # This is also OK, because mary's manager can be an Employee
     >>> mary.manager = fred
+
+.. index:: Map trait
+
+.. _map:
+
+Map
+:::
+The map trait ensures that the value assigned to a trait attribute
+is a key of a specified dictionary, and also assigns the dictionary
+value corresponding to that key to a shadow attribute.
+
+.. index::
+   pair: Map trait; examples
+
+The following is an example of using Map::
+
+    # map.py --- Example of Map predefined trait
+
+    from traits.api import HasTraits, Map
+
+    class Person(HasTraits):
+        married = Map({'yes': 1, 'no': 0 }, default_value="yes")
+
+This example defines a Person class which has a **married** trait
+attributute which accepts values "yes" and "no". The default value
+is set to "yes". The name of the shadow attribute is the name of
+the Map attribute followed by an underscore, i.e ``married_``
+Instantiating the class produces the following::
+
+    >>> from traits.api import HasTraits, Map
+    >>> bob = Person()
+    >>> print(bob.married)
+    yes
+    >>> print(bob.married_)
+    1
+
+.. index:: PrefixMap trait
+
+.. _prefixmap:
+
+PrefixMap
+:::::::::
+Like Map, PrefixMap is created using a dictionary, but in this
+case, the keys of the dictionary must be strings. Like PrefixList,
+a string *v* is a valid value for the trait attribute if it is a prefix of
+one and only one key *k* in the dictionary. The actual values assigned to
+the trait attribute is *k*, and its corresponding mapped attribute is map[*k*].
+
+.. index::
+   pair: PrefixMap trait; examples
+
+The following is an example of using PrefixMap::
+
+    # prefixmap.py --- Example of PrefixMap predefined trait
+
+    from traits.api import HasTraits, PrefixMap
+
+    class Person(HasTraits):
+        married = PrefixMap({'yes': 1, 'no': 0 }, default_value="yes")
+
+This example defines a Person class which has a **married** trait
+attributute which accepts values "yes" and "no" or any unique
+prefix. The default value is set to "yes". The name of the shadow attribute
+is the name of the PrefixMap attribute followed by an underscore, i.e ``married_``
+Instantiating the class produces the following::
+
+    >>> bob = Person()
+    >>> print(bob.married)
+    yes
+    >>> print(bob.married_)
+    1
+    >>> bob.married = "n" # Setting a prefix
+    >>> print(bob.married)
+    no
+    >>> print(bob.married_)
+    0
+
+.. index:: PrefixList trait
+
+.. _prefixlist:
+
+PrefixList
+::::::::::
+Ensures that a value assigned to the attribute is a member of a list of
+specified string values, or is a unique prefix of one of those values.
+The values that can be assigned to a trait attribute of type PrefixList
+type is the set of all strings supplied to the PrefixList constructor,
+as well as any unique prefix of those strings. The actual value assigned
+to the trait is limited to the set of complete strings assigned to the
+PrefixList constructor.
+
+.. index::
+   pair: PrefixList trait; examples
+
+The following is an example of using PrefixList::
+
+    # prefixlist.py --- Example of PrefixList predefined trait
+
+    from traits.api import HasTraits, PrefixList
+
+    class Person(HasTraits):
+        married = PrefixList("yes", "no")
+
+This example defines a Person class which has a **married** trait
+attributute which accepts values "yes" and "no" or any unique
+prefix. Instantiating the class produces the following::
+
+    >>> bob = Person()
+    >>> print(bob.married)
+    yes
+    >>> bob.married = "n" # Setting a prefix
+    >>> print(bob.married)
+    no
 
 .. index:: Either trait
 

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -314,7 +314,7 @@ the table.
 +------------------+----------------------------------------------------------+
 | List             | List([*trait* = None, *value* = None, *minlen* = 0,      |
 +------------------+----------------------------------------------------------+
-| Map              | Map( [*map* = Undefined, \*\*\ *metadata*] )             |
+| Map              | Map( *map*\ [, \*\*\ *metadata*] )                       |
 +------------------+----------------------------------------------------------+
 | Method           | Method ([\*\*\ *metadata*] )                             |
 +------------------+----------------------------------------------------------+
@@ -325,7 +325,7 @@ the table.
 +------------------+----------------------------------------------------------+
 | PrefixList       | PrefixList( [*values* = None, \*\*\ *metadata*] )        |
 +------------------+----------------------------------------------------------+
-| PrefixMap        | PrefixMap( [*map* = Undefined, \*\*\ *metadata*] )       |
+| PrefixMap        | PrefixMap( *map*\ [, \*\*\ *metadata*] )                 |
 +------------------+----------------------------------------------------------+
 | Property         | Property( [*fget* = None, *fset* = None, *fvalidate* =   |
 |                  | None, *force* = False, *handler* = None, *trait* = None, |
@@ -457,7 +457,7 @@ The following is an example of using Map::
         married = Map({'yes': 1, 'no': 0 }, default_value="yes")
 
 This example defines a Person class which has a **married** trait
-attributute which accepts values "yes" and "no". The default value
+attribute which accepts values "yes" and "no". The default value
 is set to "yes". The name of the shadow attribute is the name of
 the Map attribute followed by an underscore, i.e ``married_``
 Instantiating the class produces the following::
@@ -494,7 +494,7 @@ The following is an example of using PrefixMap::
         married = PrefixMap({'yes': 1, 'no': 0 }, default_value="yes")
 
 This example defines a Person class which has a **married** trait
-attributute which accepts values "yes" and "no" or any unique
+attribute which accepts values "yes" and "no" or any unique
 prefix. The default value is set to "yes". The name of the shadow attribute
 is the name of the PrefixMap attribute followed by an underscore, i.e ``married_``
 Instantiating the class produces the following::
@@ -519,9 +519,9 @@ PrefixList
 Ensures that a value assigned to the attribute is a member of a list of
 specified string values, or is a unique prefix of one of those values.
 The values that can be assigned to a trait attribute of type PrefixList
-type is the set of all strings supplied to the PrefixList constructor,
-as well as any unique prefix of those strings. The actual value assigned
-to the trait is limited to the set of complete strings assigned to the
+is the set of all strings supplied to the PrefixList constructor, as well
+as any unique prefix of those strings. The actual value assigned to the
+trait is limited to the set of complete strings assigned to the
 PrefixList constructor.
 
 .. index::
@@ -537,7 +537,7 @@ The following is an example of using PrefixList::
         married = PrefixList("yes", "no")
 
 This example defines a Person class which has a **married** trait
-attributute which accepts values "yes" and "no" or any unique
+attribute which accepts values "yes" and "no" or any unique
 prefix. Instantiating the class produces the following::
 
     >>> bob = Person()


### PR DESCRIPTION
PR documents the `Map`, `PrefixMap` and `PrefixList` in the user manual.
Fixes #954 

**Checklist**
~~- [ ] Tests~~
~~- [ ] Update API reference (`docs/source/traits_api_reference`)~~
- [x] Update User manual (`docs/source/traits_user_manual`)
~~- [ ] Update type annotation hints in `traits-stubs`~~
