### PR TITLE
Fix example class OddInt

### DIFF
--- a/examples/tutorials/traits_4.0/trait_types/new_types.py
+++ b/examples/tutorials/traits_4.0/trait_types/new_types.py
@@ -57,7 +57,7 @@ post_setattr(self, object, name, value)
 The subclass can also define a constant default value by setting the class-
 level *default_value* attribute to the desired constant value. For example::
 
-    class OddInt(Int):
+    class OddInt(BaseInt):
 
         default_value = 1
 
@@ -71,7 +71,7 @@ If you have a constant string that can be used as the type's *info* value, you
 can provide it by simple setting the string as the value of the class-level
 *info_text* attribute::
 
-    class OddInt(Int):
+    class OddInt(BaseInt):
 
         info_text = 'an odd integer'
 

--- a/examples/tutorials/traits_4.0/trait_types/trait_types.py
+++ b/examples/tutorials/traits_4.0/trait_types/trait_types.py
@@ -58,7 +58,7 @@ OddInt Redux
 Using the new style of defining traits, we can rewrite our previous **OddInt**
 example as follows::
 
-    class OddInt(Int):
+    class OddInt(BaseInt):
 
         # Define the default value:
         default_value = 1
@@ -76,16 +76,16 @@ example as follows::
 This provides the exact same functionality as the previous definition of
 **OddInt**. There are several points to make about the new definition however:
 
-- The **OddInt** class derives from **Int** (not **TraitHandler**). This
+- The **OddInt** class derives from **BaseInt** (not **TraitHandler**). This
   has several important side effects:
 
-  * **OddInt** can re-use and change any part of the **Int** class behavior
-    that it needs to. Note in this case the re-use of the **Int** class's
+  * **OddInt** can re-use and change any part of the **BaseInt** class behavior
+    that it needs to. Note in this case the re-use of the **BaseInt** class's
     *validate* method via the *super* call in **OddInt's** *validate* method.
 
-  * As a subclass of **Int**, it is related to **Int**, which can be
+  * As a subclass of **BaseInt**, it is related to **BaseInt**, which can be
     important both from a documentation and programming point of view. The
-    original definition of **OddInt** was related to **Int** only in that their
+    original definition of **OddInt** was related to **BaseInt** only in that their
     names were similar.
 
 - The default value and trait description information are declared as class
@@ -103,7 +103,7 @@ from traits.api import *
 
 
 # --[OddInt Definition]--------------------------------------------------------
-class OddInt(Int):
+class OddInt(BaseInt):
 
     # Define the default value:
     default_value = 1

--- a/examples/tutorials/traits_4.0/trait_types/trait_types.py
+++ b/examples/tutorials/traits_4.0/trait_types/trait_types.py
@@ -122,7 +122,7 @@ class OddInt(BaseInt):
 # --[Test Class]---------------------------------------------------------------
 class Test(HasTraits):
 
-    any_int = Int
+    any_int = BaseInt
     odd_int = OddInt
 
 

--- a/examples/tutorials/traits_4.0/trait_types/trait_types.py
+++ b/examples/tutorials/traits_4.0/trait_types/trait_types.py
@@ -85,8 +85,8 @@ This provides the exact same functionality as the previous definition of
 
   * As a subclass of **BaseInt**, it is related to **BaseInt**, which can be
     important both from a documentation and programming point of view. The
-    original definition of **OddInt** was related to **BaseInt** only in that their
-    names were similar.
+    original definition of **OddInt** was related to **BaseInt** only in that
+    their names were similar.
 
 - The default value and trait description information are declared as class
   constants. Although there are more dynamic techniques that allow computing


### PR DESCRIPTION
**Checklist**
~~- [ ] Tests~~
~~- [ ] Update API reference (`docs/source/traits_api_reference`)~~
- [x] Update User manual (`docs/source/traits_user_manual`)
~~- [ ] Update type annotation hints in `traits-stubs`~~

PR fixes #486 
Make the `OddInt` example class inherit from `BaseInt` which does not have a fast validator.
