### PR TITLE
Deprecate TraitMap, TraitPrefixMap and TraitPrefixList

### DIFF
--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -17,12 +17,6 @@ Classes
 
 .. autoclass:: TraitEnum
 
-.. autoclass:: TraitPrefixList
-
-.. autoclass:: TraitMap
-
-.. autoclass:: TraitPrefixMap
-
 .. autoclass:: TraitCompound
 
 Private Functions
@@ -45,3 +39,10 @@ and may be removed in a future version of Traits.
 .. autodata:: TraitList
 
 .. autodata:: TraitTuple
+
+.. autoclass:: TraitPrefixList
+
+.. autoclass:: TraitMap
+
+.. autoclass:: TraitPrefixMap
+

--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -34,11 +34,11 @@ Deprecated Handlers
 The following :class:`~.TraitHandler` classes and instances are deprecated,
 and may be removed in a future version of Traits.
 
-.. autodata:: TraitDict
+.. autoclass:: TraitDict
 
-.. autodata:: TraitList
+.. autoclass:: TraitList
 
-.. autodata:: TraitTuple
+.. autoclass:: TraitTuple
 
 .. deprecated:: 6.1.0
 

--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -40,6 +40,8 @@ and may be removed in a future version of Traits.
 
 .. autodata:: TraitTuple
 
+.. deprecated:: 6.1.0
+
 .. autoclass:: TraitPrefixList
 
 .. autoclass:: TraitMap

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -28,20 +28,16 @@ class TestTraitHandlerDeprecatedWarnings(unittest.TestCase):
             "TraitDict": TraitDict,
             "TraitList": TraitList,
             "TraitTuple": TraitTuple,
-            "TraitMap": [TraitMap, {}],
-            "TraitPrefixList": [TraitPrefixList, "one", "two"],
-            "TraitPrefixMap": [TraitPrefixMap, {}],
+            "TraitMap": lambda: TraitMap({}),
+            "TraitPrefixList": lambda: TraitPrefixList("one", "two"),
+            "TraitPrefixMap": lambda: TraitPrefixMap({}),
         }
 
-        for name, handler in handlers.items():
+        for name, handler_factory in handlers.items():
             with self.subTest(handler=name):
                 with warnings.catch_warnings(record=True):
                     warnings.simplefilter("error", DeprecationWarning)
 
                     with self.assertRaises(DeprecationWarning) as cm:
-                        args = []
-                        if isinstance(handler, list) and len(handler) > 0:
-                            args = handler[1:]
-                            handler = handler[0]
-                        handler(*args)
+                        handler_factory()
                 self.assertIn(name, str(cm.exception))

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -14,6 +14,9 @@ import warnings
 from traits.api import (
     TraitDict,
     TraitList,
+    TraitMap,
+    TraitPrefixList,
+    TraitPrefixMap,
     TraitTuple,
 )
 
@@ -24,14 +27,21 @@ class TestTraitHandlerDeprecatedWarnings(unittest.TestCase):
         handlers = {
             "TraitDict": TraitDict,
             "TraitList": TraitList,
-            "TraitTuple": TraitTuple
+            "TraitTuple": TraitTuple,
+            "TraitMap": [TraitMap, {}],
+            "TraitPrefixList": [TraitPrefixList, "one", "two"],
+            "TraitPrefixMap": [TraitPrefixMap, {}],
         }
 
-        for name, handler_factory in handlers.items():
+        for name, handler in handlers.items():
             with self.subTest(handler=name):
                 with warnings.catch_warnings(record=True):
                     warnings.simplefilter("error", DeprecationWarning)
 
                     with self.assertRaises(DeprecationWarning) as cm:
-                        handler_factory()
+                        args = []
+                        if isinstance(handler, list) and len(handler) > 0:
+                            args = handler[1:]
+                            handler = handler[0]
+                        handler(*args)
                 self.assertIn(name, str(cm.exception))

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -574,6 +574,8 @@ class TraitPrefixList(TraitHandler):
         Enumeration of all legal values for a trait.
     """
 
+    @deprecated(_WARNING_FORMAT_STR.format(
+        handler="TraitPrefixList", replacement="PrefixList"))
     def __init__(self, *values):
         if (len(values) == 1) and (type(values[0]) in SequenceTypes):
             values = values[0]
@@ -671,6 +673,8 @@ class TraitMap(TraitHandler):
 
     is_mapped = True
 
+    @deprecated(_WARNING_FORMAT_STR.format(
+        handler="TraitMap", replacement="Map"))
     def __init__(self, map):
         self.map = map
         self.fast_validate = (ValidateTrait.map, map)
@@ -741,6 +745,8 @@ class TraitPrefixMap(TraitMap):
         the shadow trait attribute.
     """
 
+    @deprecated(_WARNING_FORMAT_STR.format(
+        handler="TraitPrefixMap", replacement="PrefixMap"))
     def __init__(self, map):
         self.map = map
         self._map = _map = {}


### PR DESCRIPTION
**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
~~- [ ] Update User manual (`docs/source/traits_user_manual`)~~ No changes
~~- [ ] Update type annotation hints in `traits-stubs`~~ Remains the same

PR deprecates `TraitMap`, `TraitPrefixMap` and `TraitPrefixList`
Fixes #941 