### PR TITLE
Update front matter for the user manual

### DIFF
--- a/docs/source/traits_user_manual/front.rst
+++ b/docs/source/traits_user_manual/front.rst
@@ -33,9 +33,10 @@ All trademarks and registered trademarks are the property of their respective
 owners.
 
 | Enthought, Inc.
-| 515 Congress Avenue
-| Suite 2100
-| Austin TX 78701
+| 200 W Cesar Chavez
+| Suite 202
+| Austin, TX 78701
+| United States
 | 1.512.536.1057 (voice)
 | 1.512.536.1059 (fax)
 | http://www.enthought.com


### PR DESCRIPTION
**Checklist**
~~- [ ] Tests~~
~~- [ ] Update API reference (`docs/source/traits_api_reference`)~~
- [x] Update User manual (`docs/source/traits_user_manual`)
~~- [ ] Update type annotation hints in `traits-stubs`~~

Fixes #902 
Updates the office address on the traits user manual front cover.