### PR TITLE
Address issues on PR #922 for TraitSet

### DIFF
--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -304,18 +304,29 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(self.removed, {3})
         self.assertEqual(self.added, set())
 
-    def test_iand_with_validation_transform(self):
-        ts = TraitSet({1, 2, 3}, validator=validator_to_instance)
+    def test_iand_does_not_call_validator(self):
+        # Nothing are added, validator should not be called.
+
+        validator_args = None
+
+        def validator(set_, added):
+            nonlocal validator_args
+            validator_args = (set_, added)
+            return added
+
+        ts = TraitSet({1, 2, 3}, validator=validator)
         values = list(ts)
 
         python_set = set(ts)
         python_set &= set(values[:2])
 
         # when
+        validator_args = None
         ts &= set(values[:2])
 
         # then
         self.assertEqual(ts, python_set)
+        self.assertIsNone(validator_args)
 
     def test_intersection_update_with_no_arguments(self):
         python_set = set([1, 2, 3])
@@ -402,13 +413,26 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(self.added, set())
         self.assertSetEqual(ts, {1})
 
-    def test_isub_with_validation_transform(self):
-        ts = TraitSet({1, 2, 3}, validator=validator_to_instance)
+    def test_isub_validator_not_called(self):
+        # isub never needs to add items, validator should not
+        # be called.
+        validator_args = None
+
+        def validator(set_, added):
+            nonlocal validator_args
+            validator_args = (set_, added)
+            return added
+
+        ts = TraitSet({1, 2, 3}, validator=validator)
         values = list(ts)
 
+        # when
+        validator_args = None
         ts -= values
 
-        self.assertEqual(ts, set())
+        # then
+        # Validator should not be called
+        self.assertIsNone(validator_args)
 
     def test_isub_with_no_intersection(self):
         python_set = set([3, 4, 5])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -259,6 +259,14 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(self.removed, {1, 2, 3})
         self.assertEqual(self.added, set())
 
+    def test_clear_no_notifications_if_already_empty(self):
+        # test no notifications are emitted if the set is already
+        # empty.
+        notifier = mock.Mock()
+        ts = TraitSet(notifiers=[notifier])
+        ts.clear()
+        notifier.assert_not_called()
+
     def test_ior(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -303,6 +303,17 @@ class TestTraitSet(unittest.TestCase):
         # then
         self.assertEqual(ts, python_set)
 
+    def test_intersection_update_with_no_arguments(self):
+        python_set = set([1, 2, 3])
+        python_set.intersection_update()
+
+        notifier = mock.Mock()
+        ts = TraitSet([1, 2, 3], notifiers=[notifier])
+        ts.intersection_update()
+
+        self.assertEqual(ts, python_set)
+        notifier.assert_not_called
+
     def test_ixor(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -44,7 +44,11 @@ class ValueWrapper:
 
 
 def validator_to_instance(current_set, removed, value):
-    return set(ValueWrapper(val) for val in value)
+    return set(
+        ValueWrapper(val) if not isinstance(val, ValueWrapper)
+        else val
+        for val in value
+    )
 
 
 class TestTraitSet(unittest.TestCase):
@@ -329,6 +333,20 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(self.removed, {1, 2, 3})
         self.assertEqual(self.added, {5})
         self.assertSetEqual(ts, {5})
+
+    def test_ixor_with_transformed_values(self):
+        ts_1 = TraitSet([1, 2, 3], validator=validator_to_instance)
+        ts_2 = TraitSet([2, 3, 4], validator=validator_to_instance)
+
+        python_set1 = set(ts_1)
+        python_set2 = set(ts_2)
+        python_set1.symmetric_difference_update(python_set2)
+
+        # when
+        ts_1.symmetric_difference_update(ts_2)
+
+        # then
+        self.assertEqual(ts_1, python_set1)
 
     def test_isub(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 import unittest
+from unittest import mock
 
 from traits.trait_errors import TraitError
 from traits.trait_set_object import TraitSet, adapt_trait_validator
@@ -204,6 +205,21 @@ class TestTraitSet(unittest.TestCase):
             str(trait_exc.exception),
             str(python_exc.exception),
         )
+
+    def test_update_with_nothing(self):
+        notifier = mock.Mock()
+
+        python_set = set()
+        python_set.update()
+
+        ts = TraitSet(notifiers=[notifier])
+
+        # when
+        ts.update()
+
+        # then
+        notifier.assert_not_called()
+        self.assertEqual(ts, python_set)
 
     def test_discard(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -292,6 +292,16 @@ class TestTraitSet(unittest.TestCase):
         # then
         self.assertEqual(ts, python_set)
 
+    def test_iand_no_notify_if_no_intersection(self):
+        notifier = mock.Mock()
+        ts = TraitSet({1, 2, 3}, notifiers=[notifier])
+
+        # when
+        ts &= ts
+
+        # then
+        notifier.assert_not_called()
+
     def test_ixor(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -79,7 +79,7 @@ class TestTraitSet(unittest.TestCase):
                 raise TraitError
 
         # Fail without adaptor
-        with self.assertRaises(TypeError):
+        with self.assertRaises(TraitError):
             TraitSet({}, validator=bool_validator)
 
         # Attach the adaptor

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -356,10 +356,7 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(ts, set())
 
         # No values are being added.
-        self.assertEqual(
-            self.validator_args,
-            (ts, set()),
-        )
+        self.assertIsNone(self.validator_args)
 
     def test_ixor_validator_args_with_added(self):
         # Check the values given to the validator

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -153,6 +153,17 @@ class TestTraitSet(unittest.TestCase):
             str(python_e.exception),
         )
 
+    def test_add_no_notification_for_no_op(self):
+        # Test adding an existing item triggers no notifications
+        notifier = mock.Mock()
+        ts = TraitSet({1, 2}, notifiers=[notifier])
+
+        # when
+        ts.add(1)
+
+        # then
+        notifier.assert_not_called()
+
     def test_remove(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -292,16 +292,6 @@ class TestTraitSet(unittest.TestCase):
         # then
         self.assertEqual(ts, python_set)
 
-    def test_iand_no_notify_if_no_intersection(self):
-        notifier = mock.Mock()
-        ts = TraitSet({1, 2, 3}, notifiers=[notifier])
-
-        # when
-        ts &= ts
-
-        # then
-        notifier.assert_not_called()
-
     def test_ixor(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -337,20 +337,6 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(self.added, {5})
         self.assertSetEqual(ts, {5})
 
-    def test_ixor_with_transformed_values(self):
-        ts_1 = TraitSet([1, 2, 3], validator=validator_to_instance)
-        ts_2 = TraitSet([2, 3, 4], validator=validator_to_instance)
-
-        python_set1 = set(ts_1)
-        python_set2 = set(ts_2)
-        python_set1.symmetric_difference_update(python_set2)
-
-        # when
-        ts_1.symmetric_difference_update(ts_2)
-
-        # then
-        self.assertEqual(ts_1, python_set1)
-
     def test_ixor_no_nofications_for_no_change(self):
         notifier = mock.Mock()
         ts_1 = TraitSet([1, 2], notifiers=[notifier])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -118,6 +118,28 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(self.removed, set())
         self.assertEqual(self.added, {"four"})
 
+    def test_add_iterable(self):
+        python_set = set()
+        iterable = (i for i in range(4))
+        python_set.add(iterable)
+
+        ts = TraitSet()
+        ts.add(iterable)
+
+        self.assertEqual(ts, python_set)
+
+    def test_add_unhashable(self):
+        with self.assertRaises(TypeError) as python_e:
+            set().add([])
+
+        with self.assertRaises(TypeError) as trait_e:
+            TraitSet().add([])
+
+        self.assertEqual(
+            str(trait_e.exception),
+            str(python_e.exception),
+        )
+
     def test_remove(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -375,6 +375,28 @@ class TestTraitSet(unittest.TestCase):
             (ts, set()),
         )
 
+    def test_ixor_validator_args_with_added(self):
+        # Check the values given to the validator
+        # when symmetric_difference_update is called.
+
+        validator_args = None
+
+        def validator(set_, added):
+            nonlocal validator_args
+            validator_args = (set_, added)
+
+            return set(str(value) for value in added)
+
+        ts = TraitSet([1, 2, 3], validator=validator)
+        self.assertEqual(ts, set(["1", "2", "3"]))
+
+        # when
+        ts ^= set(["2", 3, 4])
+
+        # then
+        self.assertEqual(validator_args, (ts, set([3, 4])))
+        self.assertEqual(ts, set(["1", "4"]))
+
     def test_isub(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -429,6 +429,18 @@ class TestTraitSet(unittest.TestCase):
 
         self.assertEqual(ts, python_set)
 
+    def test_get_state(self):
+        ts = TraitSet(notifiers=[self.notification_handler])
+
+        states = ts.__getstate__()
+        self.assertNotIn("notifiers", states)
+
+    def test_set_state_exclude_notifiers(self):
+        ts = TraitSet(notifiers=[])
+        ts.__setstate__({"notifiers": [self.notification_handler]})
+
+        self.assertEqual(ts.notifiers, [])
+
 
 class Foo(HasTraits):
 

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -49,15 +49,10 @@ class TestTraitSet(unittest.TestCase):
     def setUp(self):
         self.added = None
         self.removed = None
-        self.validator_args = None
 
     def notification_handler(self, removed, added):
         self.removed = removed
         self.added = added
-
-    def validator(self, set_, added):
-        self.validator_args = (set_, added)
-        return added
 
     def test_init(self):
         ts = TraitSet({1, 2, 3})
@@ -363,13 +358,20 @@ class TestTraitSet(unittest.TestCase):
         python_set ^= set([iterable])
         self.assertEqual(python_set, set())
 
-        ts = TraitSet([iterable], validator=self.validator)
+        validator_args = None
+
+        def validator(set_, added):
+            nonlocal validator_args
+            validator_args = (set_, added)
+            return added
+
+        ts = TraitSet([iterable], validator=validator)
         ts ^= [iterable]
         self.assertEqual(ts, set())
 
         # No values are being added.
         self.assertEqual(
-            self.validator_args,
+            validator_args,
             (ts, set()),
         )
 

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -16,11 +16,11 @@ from traits.trait_set_object import TraitSet, adapt_trait_validator
 from traits.trait_types import _validate_int
 
 
-def int_validator(current_set, removed, value):
+def int_validator(current_set, value):
     return {_validate_int(v) for v in value}
 
 
-def string_validator(current_set, removed, value):
+def string_validator(current_set, value):
     ret = set()
     for v in value:
         if isinstance(v, str):
@@ -30,20 +30,13 @@ def string_validator(current_set, removed, value):
     return ret
 
 
-def length_validator(current_set, removed, value):
-    new_len = len(current_set) - len(removed) + len(value)
-    if new_len <= 0:
-        raise TraitError("This set cannot be made empty.")
-    return value
-
-
 class ValueWrapper:
 
     def __init__(self, value):
         self.value = value
 
 
-def validator_to_instance(current_set, removed, value):
+def validator_to_instance(current_set, value):
     return set(
         ValueWrapper(val) if not isinstance(val, ValueWrapper)
         else val
@@ -91,7 +84,7 @@ class TestTraitSet(unittest.TestCase):
                 raise TraitError
 
         # Fail without adaptor
-        with self.assertRaises(TraitError):
+        with self.assertRaises(TypeError):
             TraitSet({}, validator=bool_validator)
 
         # Attach the adaptor
@@ -387,12 +380,3 @@ class TestTraitSet(unittest.TestCase):
         ts.difference_update()
 
         self.assertEqual(ts, python_set)
-
-    def test_difference_update_with_length_validator(self):
-        ts = TraitSet([1], validator=length_validator)
-        with self.assertRaises(TraitError) as exception_context:
-            ts.difference_update([1, 2])
-        self.assertEqual(
-            str(exception_context.exception),
-            "This set cannot be made empty."
-        )

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -449,3 +449,20 @@ class TestTraitSetObject(unittest.TestCase):
         states = foo.values.__getstate__()
         self.assertNotIn("notifiers", states)
 
+    def test_pickle_with_notifier(self):
+        foo = Foo(values={1, 2, 3})
+        foo.values.notifiers.append(notifier)
+
+        protocols = range(pickle.HIGHEST_PROTOCOL + 1)
+
+        for protocol in protocols:
+            with self.subTest(protocol=protocol):
+                serialized = pickle.dumps(
+                    foo.values, protocol=protocol)
+                deserialized = pickle.loads(serialized)
+
+                # Transient notifiers are gone.
+                self.assertEqual(
+                    deserialized.notifiers,
+                    [deserialized.notifier],
+                )

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -46,6 +46,13 @@ class TestTraitSet(unittest.TestCase):
         self.assertIsNone(ts.validator)
         self.assertEqual(ts.notifiers, [])
 
+    def test_init_with_no_input(self):
+        ts = TraitSet()
+
+        self.assertSetEqual(ts, set())
+        self.assertIsNone(ts.validator)
+        self.assertEqual(ts.notifiers, [])
+
     def test_validator(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator)
 

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -30,6 +30,13 @@ def string_validator(current_set, removed, value):
     return ret
 
 
+def length_validator(current_set, removed, value):
+    new_len = len(current_set) - len(removed) + len(value)
+    if new_len <= 0:
+        raise TraitError("This set cannot be made empty.")
+    return value
+
+
 class ValueWrapper:
 
     def __init__(self, value):
@@ -362,3 +369,12 @@ class TestTraitSet(unittest.TestCase):
         ts.difference_update()
 
         self.assertEqual(ts, python_set)
+
+    def test_difference_update_with_length_validator(self):
+        ts = TraitSet([1], validator=length_validator)
+        with self.assertRaises(TraitError) as exception_context:
+            ts.difference_update([1, 2])
+        self.assertEqual(
+            str(exception_context.exception),
+            "This set cannot be made empty."
+        )

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -49,10 +49,15 @@ class TestTraitSet(unittest.TestCase):
     def setUp(self):
         self.added = None
         self.removed = None
+        self.validator_args = None
 
     def notification_handler(self, removed, added):
         self.removed = removed
         self.added = added
+
+    def validator(self, set_, added):
+        self.validator_args = (set_, added)
+        return added
 
     def test_init(self):
         ts = TraitSet({1, 2, 3})
@@ -350,6 +355,23 @@ class TestTraitSet(unittest.TestCase):
 
         # then
         notifier.assert_not_called()
+
+    def test_ixor_with_iterable_items(self):
+        iterable = range(2)
+
+        python_set = set([iterable])
+        python_set ^= set([iterable])
+        self.assertEqual(python_set, set())
+
+        ts = TraitSet([iterable], validator=self.validator)
+        ts ^= [iterable]
+        self.assertEqual(ts, set())
+
+        # No values are being added.
+        self.assertEqual(
+            self.validator_args,
+            (ts, set()),
+        )
 
     def test_isub(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -7,10 +7,11 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-
+import pickle
 import unittest
 from unittest import mock
 
+from traits.api import HasTraits, Set
 from traits.trait_errors import TraitError
 from traits.trait_set_object import TraitSet, adapt_trait_validator
 from traits.trait_types import _validate_int
@@ -427,3 +428,24 @@ class TestTraitSet(unittest.TestCase):
         ts.difference_update()
 
         self.assertEqual(ts, python_set)
+
+
+class Foo(HasTraits):
+
+    values = Set()
+
+
+def notifier(removed, added):
+    pass
+
+
+class TestTraitSetObject(unittest.TestCase):
+
+    def test_get_state(self):
+        foo = Foo(values={1, 2, 3})
+        self.assertEqual(
+            foo.values.notifiers, [foo.values.notifier])
+
+        states = foo.values.__getstate__()
+        self.assertNotIn("notifiers", states)
+

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -341,6 +341,16 @@ class TestTraitSet(unittest.TestCase):
         # then
         self.assertEqual(ts_1, python_set1)
 
+    def test_ixor_no_nofications_for_no_change(self):
+        notifier = mock.Mock()
+        ts_1 = TraitSet([1, 2], notifiers=[notifier])
+
+        # when
+        ts_1 ^= set()
+
+        # then
+        notifier.assert_not_called()
+
     def test_isub(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -193,18 +193,28 @@ class TestTraitSet(unittest.TestCase):
         # then
         self.assertEqual(ts, set())
 
-    def test_remove_with_validator_transform(self):
-        # Test when the validator also transform the value
-        ts = TraitSet(validator=validator_to_instance)
+    def test_remove_does_not_call_validator(self):
+        # Test validator should not be called with removed
+        # items
+        validator_args = None
+
+        def validator(set_, added):
+            nonlocal validator_args
+            validator_args = (set_, added)
+            return added
+
+        ts = TraitSet(validator=validator)
         ts.add("123")
 
         value, = ts
 
         # when
+        validator_args = None
         ts.remove(value)
 
         # then
-        self.assertEqual(ts, set())
+        # validator is not called.
+        self.assertIsNone(validator_args)
 
     def test_update_with_non_iterable(self):
 

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -296,3 +296,11 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(self.removed, {2, 3})
         self.assertEqual(self.added, set())
         self.assertSetEqual(ts, {1})
+
+    def test_isub_with_validation_transform(self):
+        ts = TraitSet({1, 2, 3}, validator=validator_to_instance)
+        values = list(ts)
+
+        ts -= values
+
+        self.assertEqual(ts, set())

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -342,3 +342,12 @@ class TestTraitSet(unittest.TestCase):
         # then
         self.assertEqual(ts, python_set)
         notifier.assert_not_called()
+
+    def test_difference_update_with_no_arguments(self):
+        python_set = set([1, 2, 3])
+        python_set.difference_update()
+
+        ts = TraitSet([1, 2, 3])
+        ts.difference_update()
+
+        self.assertEqual(ts, python_set)

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -126,6 +126,8 @@ class TestTraitSet(unittest.TestCase):
         ts = TraitSet()
         ts.add(iterable)
 
+        # iterable has not been exhausted
+        next(iterable)
         self.assertEqual(ts, python_set)
 
     def test_add_unhashable(self):

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -30,20 +30,6 @@ def string_validator(current_set, value):
     return ret
 
 
-class ValueWrapper:
-
-    def __init__(self, value):
-        self.value = value
-
-
-def validator_to_instance(current_set, value):
-    return set(
-        ValueWrapper(val) if not isinstance(val, ValueWrapper)
-        else val
-        for val in value
-    )
-
-
 class TestTraitSet(unittest.TestCase):
 
     def setUp(self):

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -190,6 +190,21 @@ class TestTraitSet(unittest.TestCase):
         # then
         self.assertEqual(ts, set())
 
+    def test_update_with_non_iterable(self):
+
+        python_set = set()
+        with self.assertRaises(TypeError) as python_exc:
+            python_set.update(None)
+
+        ts = TraitSet()
+        with self.assertRaises(TypeError) as trait_exc:
+            ts.update(None)
+
+        self.assertEqual(
+            str(trait_exc.exception),
+            str(python_exc.exception),
+        )
+
     def test_discard(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -304,3 +304,17 @@ class TestTraitSet(unittest.TestCase):
         ts -= values
 
         self.assertEqual(ts, set())
+
+    def test_isub_with_no_intersection(self):
+        python_set = set([3, 4, 5])
+        python_set -= set(i for i in range(2))
+
+        notifier = mock.Mock()
+        ts = TraitSet((3, 4, 5), notifiers=[notifier])
+
+        # when
+        ts -= set(i for i in range(2))
+
+        # then
+        self.assertEqual(ts, python_set)
+        notifier.assert_not_called()

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -370,7 +370,11 @@ class TestTraitSet(unittest.TestCase):
 
             return set(str(value) for value in added)
 
-        ts = TraitSet([1, 2, 3], validator=validator)
+        ts = TraitSet(
+            [1, 2, 3],
+            validator=validator,
+            notifiers=[self.notification_handler],
+        )
         self.assertEqual(ts, set(["1", "2", "3"]))
 
         # when
@@ -378,7 +382,9 @@ class TestTraitSet(unittest.TestCase):
 
         # then
         self.assertEqual(validator_args, (ts, set([3, 4])))
-        self.assertEqual(ts, set(["1", "4"]))
+        self.assertEqual(ts, set(["1", "3", "4"]))
+        self.assertEqual(self.added, set(["4"]))
+        self.assertEqual(self.removed, set(["2"]))
 
     def test_isub(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -15,11 +15,11 @@ from traits.trait_set_object import TraitSet, adapt_trait_validator
 from traits.trait_types import _validate_int
 
 
-def int_validator(current_set, value):
+def int_validator(current_set, removed, value):
     return {_validate_int(v) for v in value}
 
 
-def string_validator(current_set, value):
+def string_validator(current_set, removed, value):
     ret = set()
     for v in value:
         if isinstance(v, str):
@@ -27,6 +27,16 @@ def string_validator(current_set, value):
         else:
             raise TraitError
     return ret
+
+
+class ValueWrapper:
+
+    def __init__(self, value):
+        self.value = value
+
+
+def validator_to_instance(current_set, removed, value):
+    return set(ValueWrapper(val) for val in value)
 
 
 class TestTraitSet(unittest.TestCase):
@@ -163,6 +173,19 @@ class TestTraitSet(unittest.TestCase):
 
         # when
         ts.remove(iterable)
+
+        # then
+        self.assertEqual(ts, set())
+
+    def test_remove_with_validator_transform(self):
+        # Test when the validator also transform the value
+        ts = TraitSet(validator=validator_to_instance)
+        ts.add("123")
+
+        value, = ts
+
+        # when
+        ts.remove(value)
 
         # then
         self.assertEqual(ts, set())

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -154,6 +154,19 @@ class TestTraitSet(unittest.TestCase):
         with self.assertRaises(KeyError):
             ts.remove(3)
 
+    def test_remove_iterable(self):
+        iterable = (i for i in range(4))
+
+        ts = TraitSet()
+        ts.add(iterable)
+        self.assertIn(iterable, ts)
+
+        # when
+        ts.remove(iterable)
+
+        # then
+        self.assertEqual(ts, set())
+
     def test_discard(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -279,6 +279,19 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(self.removed, {3})
         self.assertEqual(self.added, set())
 
+    def test_iand_with_validation_transform(self):
+        ts = TraitSet({1, 2, 3}, validator=validator_to_instance)
+        values = list(ts)
+
+        python_set = set(ts)
+        python_set &= set(values[:2])
+
+        # when
+        ts &= set(values[:2])
+
+        # then
+        self.assertEqual(ts, python_set)
+
     def test_ixor(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -324,6 +324,14 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(ts, python_set)
         notifier.assert_not_called
 
+    def test_intersection_update_with_iterable(self):
+        python_set = set([1, 2, 3])
+        python_set.intersection_update(i for i in [1, 2])
+
+        ts = TraitSet([1, 2, 3])
+        ts.intersection_update(i for i in [1, 2])
+        self.assertEqual(ts, python_set)
+
     def test_ixor(self):
         ts = TraitSet({1, 2, 3}, validator=int_validator,
                       notifiers=[self.notification_handler])

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -677,7 +677,7 @@ class TraitSetObject(TraitSet):
 
         Notifiers are transient and should not be serialized.
         """
-        result = self.__dict__.copy()
+        result = super().__getstate__()
         result.pop("object", None)
         result.pop("trait", None)
 

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -325,11 +325,10 @@ class TraitSet(set):
                 An empty set.
 
         """
-        validated_values = self.validate(set(), value)
         removed = self.intersection(value)
 
         if len(removed) > 0:
-            super().difference_update(validated_values)
+            super().difference_update(removed)
             self.notify(removed, set())
 
     def intersection_update(self, value):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -147,19 +147,6 @@ class TraitSet(set):
             If validation fails.
         """
 
-        if not isinstance(value, set):
-
-            # Treat str, bytes, bytearray as a single unit.
-            is_iterable = (
-                isinstance(value, collections.abc.Iterable)
-                and not isinstance(value, (str, bytes, bytearray))
-            )
-
-            if is_iterable:
-                value = set(value)
-            else:
-                value = {value}
-
         if self.validator is None:
             return value
         else:

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -349,7 +349,7 @@ class TraitSet(set):
 
 
         """
-        removed = self.difference(self.intersection(value))
+        removed = self.difference(value)
         if len(removed) > 0:
             super().intersection_update(value)
             self.notify(removed, set())

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -424,6 +424,8 @@ class TraitSet(set):
                 An empty set.
 
         """
+        if not self:
+            return
         removed = set(self)
         super().clear()
         self.notify(removed, set())

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -244,7 +244,7 @@ class TraitSet(set):
                 A set containing the added value.
 
         """
-        validated_values = self.validate(value)
+        validated_values = self.validate(set([value]))
         if len(validated_values) > 1:
             raise ValueError("Validator returned {} values "
                              "where 1 value is "

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -308,7 +308,7 @@ class TraitSet(set):
             super().update(added)
             self.notify(set(), added)
 
-    def difference_update(self, value):
+    def difference_update(self, value=()):
         """  Remove all elements of another set from this set.
 
         Parameters

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -326,6 +326,7 @@ class TraitSet(set):
 
         """
         removed = self.intersection(value)
+        self.validate(removed, set())
 
         if len(removed) > 0:
             super().difference_update(removed)

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -688,15 +688,8 @@ class TraitSetObject(TraitSet):
 
         Notifiers are transient and are restored to the empty list.
         """
-        name = state.setdefault("name", "")
-        object = state.pop("object", None)
-        if object is not None:
-            state['object'] = ref(object)
-            trait = self.object()._trait(name, 0)
-            if trait is not None:
-                state['trait'] = trait.handler
-        else:
-            state['object'] = lambda: None
-            state['trait'] = None
-
+        state.setdefault("name", "")
+        state["notifiers"] = [self.notifier]
+        state["object"] = lambda: None
+        state["trait"] = None
         self.__dict__.update(state)

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -284,7 +284,7 @@ class TraitSet(set):
         super().remove(value)
         self.notify(removed, set())
 
-    def update(self, value):
+    def update(self, value=()):
         """ Update a set with the union of itself and others.
 
         Parameters

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -357,9 +357,7 @@ class TraitSet(set):
             self.notify(removed, set())
 
     def symmetric_difference_update(self, value):
-        """ Return the symmetric difference of two sets as a new set.
-
-        (i.e. all elements that are in exactly one of the sets.)
+        """ Update a set with the symmetric difference of itself and another.
 
         Parameters
         ----------

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -349,10 +349,9 @@ class TraitSet(set):
 
 
         """
-        validated_values = self.validate(set(), value)
-        removed = self.difference(self.intersection(validated_values))
+        removed = self.difference(self.intersection(value))
         if len(removed) > 0:
-            super().intersection_update(validated_values)
+            super().intersection_update(value)
             self.notify(removed, set())
 
     def symmetric_difference_update(self, value):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -301,7 +301,7 @@ class TraitSet(set):
                 A set containing the added values.
 
         """
-        validated_values = self.validate(set(), value)
+        validated_values = self.validate(set(), set(value))
         added = validated_values.difference(self)
 
         if len(added) > 0:

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -332,7 +332,7 @@ class TraitSet(set):
             self.notify(removed, set())
 
     def intersection_update(self, value):
-        """  Remove all elements of set which are not common to another set.
+        """  Update a set with the intersection of itself and another.
 
         Parameters
         ----------

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -370,13 +370,13 @@ class TraitSet(set):
                 A set containing the added values.
 
         """
-        validated_values = self.validate(value)
-
-        removed = self.intersection(validated_values)
-        added = validated_values.difference(self)
+        values = set(value)
+        removed = self.intersection(values)
+        to_be_added = values.difference(removed)
+        added = self.validate(to_be_added)
 
         if removed or added:
-            super().symmetric_difference_update(validated_values)
+            super().symmetric_difference_update(removed | added)
             self.notify(removed, added)
 
     def discard(self, value):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -279,9 +279,10 @@ class TraitSet(set):
                 An empty set.
 
         """
-        self.validate(set([value]), set())
+        removed = set([value])
+        self.validate(removed, set())
         super().remove(value)
-        self.notify(set([value]), set())
+        self.notify(removed, set())
 
     def update(self, value):
         """ Update a set with the union of itself and others.

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -358,8 +358,9 @@ class TraitSet(set):
         """
         values = set(value)
         removed = self.intersection(values)
-        to_be_added = values.difference(removed)
-        added = self.validate(to_be_added)
+        added = values.difference(removed)
+        if added:
+            added = self.validate(added)
 
         if removed or added:
             super().symmetric_difference_update(removed | added)

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -38,7 +38,7 @@ def adapt_trait_validator(trait_validator, name="items"):
 
     """
 
-    def validator(obj, removed, value):
+    def validator(obj, value):
         try:
             return {
                 trait_validator(obj, name, item)
@@ -114,20 +114,20 @@ class TraitSet(set):
             notifiers = []
         self.notifiers = list(notifiers)
 
-        value = self.validate(set(), set(value))
+        value = self.validate(set(value))
         super().__init__(value)
 
     # ------------------------------------------------------------------------
     # TraitSet interface
     # ------------------------------------------------------------------------
 
-    def validate(self, removed, value):
+    def validate(self, value):
         """ Validate the set of values.
 
         This simply calls the validator provided by the class, if any.
         The validator is expected to have the signature::
 
-            validator(original_set, removed, added)
+            validator(original_set, added)
 
         and return a set of validated values or raise TraitError.
 
@@ -163,7 +163,7 @@ class TraitSet(set):
         if self.validator is None:
             return value
         else:
-            return self.validator(self, removed, value)
+            return self.validator(self, value)
 
     def notify(self, removed, added):
         """ Call all notifiers.
@@ -244,7 +244,7 @@ class TraitSet(set):
                 A set containing the added value.
 
         """
-        validated_values = self.validate(set(), set([value]))
+        validated_values = self.validate(set([value]))
         if len(validated_values) > 1:
             raise ValueError("Validator returned {} values "
                              "where 1 value is "
@@ -279,10 +279,8 @@ class TraitSet(set):
                 An empty set.
 
         """
-        removed = set([value])
-        self.validate(removed, set())
         super().remove(value)
-        self.notify(removed, set())
+        self.notify(set([value]), set())
 
     def update(self, value=()):
         """ Update a set with the union of itself and others.
@@ -301,7 +299,7 @@ class TraitSet(set):
                 A set containing the added values.
 
         """
-        validated_values = self.validate(set(), set(value))
+        validated_values = self.validate(set(value))
         added = validated_values.difference(self)
 
         if len(added) > 0:
@@ -326,7 +324,6 @@ class TraitSet(set):
 
         """
         removed = self.intersection(value)
-        self.validate(removed, set())
 
         if len(removed) > 0:
             super().difference_update(removed)
@@ -373,7 +370,7 @@ class TraitSet(set):
                 A set containing the added values.
 
         """
-        validated_values = self.validate(set(), value)
+        validated_values = self.validate(value)
 
         removed = self.intersection(validated_values)
         added = validated_values.difference(self)

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -126,7 +126,7 @@ class TraitSet(set):
         This simply calls the validator provided by the class, if any.
         The validator is expected to have the signature::
 
-            validator(original_set, added)
+            validator(original_set, value_set)
 
         and return a set of validated values or raise TraitError.
 

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -331,7 +331,7 @@ class TraitSet(set):
             super().difference_update(removed)
             self.notify(removed, set())
 
-    def intersection_update(self, value):
+    def intersection_update(self, value=None):
         """  Update a set with the intersection of itself and another.
 
         Parameters
@@ -349,6 +349,8 @@ class TraitSet(set):
 
 
         """
+        if value is None:
+            return
         removed = self.difference(value)
         if len(removed) > 0:
             super().intersection_update(value)

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -8,7 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-import collections.abc
 import copy
 import copyreg
 from weakref import ref

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -361,9 +361,11 @@ class TraitSet(set):
         added = values.difference(removed)
         if added:
             added = self.validate(added)
+        added = added.difference(self)
 
         if removed or added:
-            super().symmetric_difference_update(removed | added)
+            super().difference_update(removed)
+            super().update(added)
             self.notify(removed, added)
 
     def discard(self, value):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -279,7 +279,7 @@ class TraitSet(set):
                 An empty set.
 
         """
-        validated_values = self.validate(value)
+        validated_values = self.validate(set([value]))
         if len(validated_values) > 1:
             raise ValueError("Validator returned {} values "
                              "where 1 value is "

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -335,6 +335,7 @@ class TraitSet(set):
         """
         if value is None:
             return
+        value = set(value)
         removed = self.difference(value)
         if len(removed) > 0:
             super().intersection_update(value)


### PR DESCRIPTION
This PR targets #922 (not master!):
- Adds a few tests that fail with this [commit](https://github.com/enthought/traits/pull/922/commits/e67b08529315775d1ea99d6fcebc198be00a02fe) of #922 
- Add a few tests to extend test coverage (i.e. they are already passing with the said commit)
- Address a few minor docstring issues

Running the tests against this [commit](https://github.com/enthought/traits/pull/922/commits/e67b08529315775d1ea99d6fcebc198be00a02fe) results in the following failures:
<details>
   <summary> python -m unittest discover -t . traits </summary>

```
======================================================================
ERROR: test_add_iterable (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 134, in test_add_iterable
    ts.add(iterable)
  File "/Users/kchoi/Work/ETS/traits/traits/trait_set_object.py", line 251, in add
    "expected".format(len(validated_values)))
ValueError: Validator returned 4 values where 1 value is expected

======================================================================
ERROR: test_add_unhashable (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 145, in test_add_unhashable
    TraitSet().add([])
  File "/Users/kchoi/Work/ETS/traits/traits/trait_set_object.py", line 253, in add
    value = next(iter(validated_values))
StopIteration

======================================================================
ERROR: test_difference_update_with_no_arguments (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 425, in test_difference_update_with_no_arguments
    ts.difference_update()
TypeError: difference_update() missing 1 required positional argument: 'value'

======================================================================
ERROR: test_intersection_update_with_no_arguments (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 322, in test_intersection_update_with_no_arguments
    ts.intersection_update()
TypeError: intersection_update() missing 1 required positional argument: 'value'

======================================================================
ERROR: test_remove_iterable (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 179, in test_remove_iterable
    ts.add(iterable)
  File "/Users/kchoi/Work/ETS/traits/traits/trait_set_object.py", line 251, in add
    "expected".format(len(validated_values)))
ValueError: Validator returned 4 values where 1 value is expected

======================================================================
ERROR: test_update_with_nothing (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 228, in test_update_with_nothing
    ts.update()
TypeError: update() missing 1 required positional argument: 'value'

======================================================================
FAIL: test_clear_no_notifications_if_already_empty (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 269, in test_clear_no_notifications_if_already_empty
    notifier.assert_not_called()
  File "/Users/kchoi/.edm/envs/traits/lib/python3.6/unittest/mock.py", line 777, in assert_not_called
    raise AssertionError(msg)
AssertionError: Expected 'mock' to not have been called. Called 1 times.

======================================================================
FAIL: test_iand_does_not_call_validator (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 314, in test_iand_does_not_call_validator
    self.assertIsNone(self.validator_args)
AssertionError: (TraitSet({1, 2}), {1, 2}) is not None

======================================================================
FAIL: test_isub_validator_not_called (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 404, in test_isub_validator_not_called
    self.assertIsNone(self.validator_args)
AssertionError: (TraitSet(), {1, 2, 3}) is not None

======================================================================
FAIL: test_ixor_skip_validator_if_nothing_added (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 359, in test_ixor_skip_validator_if_nothing_added
    self.assertIsNone(self.validator_args)
AssertionError: (TraitSet(), {1, 2}) is not None

======================================================================
FAIL: test_ixor_validator_args_with_added (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 380, in test_ixor_validator_args_with_added
    self.assertEqual(validator_args, (ts, set([3, 4])))
AssertionError: Tuples differ: (TraitSet({'4', '1'}), {'2', 3, 4}) != (TraitSet({'4', '1'}), {3, 4})

First differing element 1:
{'2', 3, 4}
{3, 4}

- (TraitSet({'4', '1'}), {'2', 3, 4})
?                         -----

+ (TraitSet({'4', '1'}), {3, 4})

======================================================================
FAIL: test_remove_does_not_call_validator (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 202, in test_remove_does_not_call_validator
    self.assertIsNone(self.validator_args)
AssertionError: (TraitSet(), {'123'}) is not None

======================================================================
FAIL: test_update_with_non_iterable (traits.tests.test_trait_set_object.TestTraitSet)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 212, in test_update_with_non_iterable
    ts.update(None)
AssertionError: TypeError not raised

======================================================================
FAIL: test_get_state (traits.tests.test_trait_set_object.TestTraitSetObject)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 459, in test_get_state
    self.assertNotIn("notifiers", states)
AssertionError: 'notifiers' unexpectedly found in {'validator': None, 'notifiers': [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>], 'name': 'values', 'name_items': 'values_items'}

======================================================================
FAIL: test_pickle_with_notifier (traits.tests.test_trait_set_object.TestTraitSetObject) (protocol=0)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 476, in test_pickle_with_notifier
    [deserialized.notifier],
AssertionError: Lists differ: [<bou[37 chars]TraitSetObject({1, 2, 3})>, <function notifier at 0x12c3e8d08>] != [<bou[37 chars]TraitSetObject({1, 2, 3})>]

First list contains 1 additional elements.
First extra element 1:
<function notifier at 0x12c3e8d08>

- [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>,
?                                                                     ^

+ [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>]
?                                                                     ^

-  <function notifier at 0x12c3e8d08>]

======================================================================
FAIL: test_pickle_with_notifier (traits.tests.test_trait_set_object.TestTraitSetObject) (protocol=1)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 476, in test_pickle_with_notifier
    [deserialized.notifier],
AssertionError: Lists differ: [<bou[37 chars]TraitSetObject({1, 2, 3})>, <function notifier at 0x12c3e8d08>] != [<bou[37 chars]TraitSetObject({1, 2, 3})>]

First list contains 1 additional elements.
First extra element 1:
<function notifier at 0x12c3e8d08>

- [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>,
?                                                                     ^

+ [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>]
?                                                                     ^

-  <function notifier at 0x12c3e8d08>]

======================================================================
FAIL: test_pickle_with_notifier (traits.tests.test_trait_set_object.TestTraitSetObject) (protocol=2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 476, in test_pickle_with_notifier
    [deserialized.notifier],
AssertionError: Lists differ: [<bou[37 chars]TraitSetObject({1, 2, 3})>, <function notifier at 0x12c3e8d08>] != [<bou[37 chars]TraitSetObject({1, 2, 3})>]

First list contains 1 additional elements.
First extra element 1:
<function notifier at 0x12c3e8d08>

- [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>,
?                                                                     ^

+ [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>]
?                                                                     ^

-  <function notifier at 0x12c3e8d08>]

======================================================================
FAIL: test_pickle_with_notifier (traits.tests.test_trait_set_object.TestTraitSetObject) (protocol=3)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 476, in test_pickle_with_notifier
    [deserialized.notifier],
AssertionError: Lists differ: [<bou[37 chars]TraitSetObject({1, 2, 3})>, <function notifier at 0x12c3e8d08>] != [<bou[37 chars]TraitSetObject({1, 2, 3})>]

First list contains 1 additional elements.
First extra element 1:
<function notifier at 0x12c3e8d08>

- [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>,
?                                                                     ^

+ [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>]
?                                                                     ^

-  <function notifier at 0x12c3e8d08>]

======================================================================
FAIL: test_pickle_with_notifier (traits.tests.test_trait_set_object.TestTraitSetObject) (protocol=4)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_set_object.py", line 476, in test_pickle_with_notifier
    [deserialized.notifier],
AssertionError: Lists differ: [<bou[37 chars]TraitSetObject({1, 2, 3})>, <function notifier at 0x12c3e8d08>] != [<bou[37 chars]TraitSetObject({1, 2, 3})>]

First list contains 1 additional elements.
First extra element 1:
<function notifier at 0x12c3e8d08>

- [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>,
?                                                                     ^

+ [<bound method TraitSetObject.notifier of TraitSetObject({1, 2, 3})>]
?                                                                     ^

-  <function notifier at 0x12c3e8d08>]
```

</details>

All tests should pass here.