### PR TITLE
Catch TypeError in int_validator & raise TraitError

### DIFF
--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -22,7 +22,10 @@ from traits.trait_types import _validate_int, List
 
 
 def int_validator(trait_list, index, removed, added):
-    return [_validate_int(item) for item in added]
+    try:
+        return [_validate_int(item) for item in added]
+    except TypeError:
+        raise TraitError
 
 
 def list_validator(trait_list, index, removed, added):
@@ -286,7 +289,7 @@ class TestTraitList(unittest.TestCase):
                        validator=int_validator,
                        notifiers=[self.notification_handler])
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(TraitError):
             tl.append("A")
 
     def test_adapt_trait_validator(self):


### PR DESCRIPTION
PR Fixes #982 , catch `TypeError` and raise `TraitError` on validation fail for `int_validator`
**Checklist**
- [x] Tests
~~- [ ] Update API reference (`docs/source/traits_api_reference`)~~
~~- [ ] Update User manual (`docs/source/traits_user_manual`)~~
~~- [ ] Update type annotation hints in `traits-stubs`~~
