### PR TITLE
Address issues in #913 for introducing TraitDict and reworking TraitDictObject

### DIFF
--- a/traits/tests/test_dict.py
+++ b/traits/tests/test_dict.py
@@ -12,7 +12,7 @@
 
 import unittest
 
-from traits.trait_types import Dict, Event, Str, TraitDictObject
+from traits.trait_types import Any, Dict, Event, Str, TraitDictObject
 from traits.has_traits import HasTraits, on_trait_change
 from traits.trait_errors import TraitError
 
@@ -116,3 +116,33 @@ class TestDict(unittest.TestCase):
         # object is None (check for issue #71)
         result = foo.validate(object=None, name="bar", value={})
         self.assertEqual(result, {})
+
+    def test_validate_key(self):
+
+        class Foo(HasTraits):
+
+            mapping = Dict(Str)
+
+        foo = Foo(mapping={})
+
+        # This is okay
+        foo.mapping["a"] = 1
+
+        # This raises
+        with self.assertRaises(TraitError):
+            foo.mapping[1] = 1
+
+    def test_validate_value(self):
+
+        class Foo(HasTraits):
+
+            mapping = Dict(Any, Str)
+
+        foo = Foo(mapping={})
+
+        # This is okay
+        foo.mapping["a"] = "1"
+
+        # This raises
+        with self.assertRaises(TraitError):
+            foo.mapping["a"] = 1

--- a/traits/tests/test_trait_dict_object.py
+++ b/traits/tests/test_trait_dict_object.py
@@ -96,6 +96,20 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.changed, {})
         self.assertEqual(self.removed, {"a": 1})
 
+    def test_delitem_not_found(self):
+        python_dict = dict()
+        with self.assertRaises(KeyError) as python_e:
+            del python_dict["x"]
+
+        td = TraitDict()
+        with self.assertRaises(KeyError) as trait_e:
+            del td["x"]
+
+        self.assertEqual(
+            str(trait_e.exception),
+            str(python_e.exception),
+        )
+
     def test_update(self):
         td = TraitDict({"a": 1, "b": 2}, key_validator=str_validator,
                        value_validator=int_validator,

--- a/traits/tests/test_trait_dict_object.py
+++ b/traits/tests/test_trait_dict_object.py
@@ -13,8 +13,9 @@ import pickle
 import unittest
 from unittest import mock
 
-from traits.trait_dict_object import TraitDict
+from traits.trait_dict_object import TraitDict, TraitDictObject
 from traits.trait_errors import TraitError
+from traits.trait_types import Dict, Int, Str
 
 
 def str_validator(value):
@@ -242,3 +243,37 @@ class TestTraitList(unittest.TestCase):
                        value_validator=int_validator,
                        notifiers=[self.notification_handler])
         pickle.loads(pickle.dumps(td))
+
+
+class TestTraitDictObject(unittest.TestCase):
+    """ Test TraitDictObject operations."""
+
+    def test_trait_dict_object_validators(self):
+
+        trait_dict = TraitDictObject(
+            trait=Dict(Str),
+            object=mock.Mock(),
+            name="a",
+            value={},
+        )
+        # This is okay
+        trait_dict.validate_key("1")
+
+        # This fails.
+        with self.assertRaises(TraitError):
+            trait_dict.validate_key(1)
+
+    def test_trait_dict_object_validate_value(self):
+
+        trait_dict = TraitDictObject(
+            trait=Dict(Int, Str),
+            object=mock.Mock(),
+            name="a",
+            value={},
+        )
+        # This is okay
+        trait_dict.validate_value("1")
+
+        # This fails.
+        with self.assertRaises(TraitError):
+            trait_dict.validate_value(1)

--- a/traits/tests/test_trait_dict_object.py
+++ b/traits/tests/test_trait_dict_object.py
@@ -204,6 +204,20 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.removed, {"b": 2})
         self.assertEqual(res, "X")
 
+    def test_pop_key_error(self):
+        python_dict = {}
+        with self.assertRaises(KeyError) as python_e:
+            python_dict.pop("a")
+
+        td = TraitDict()
+        with self.assertRaises(KeyError) as trait_e:
+            td.pop("a")
+
+        self.assertEqual(
+            str(trait_e.exception),
+            str(python_e.exception),
+        )
+
     def test_popitem(self):
         td = TraitDict({"a": 1, "b": 2}, key_validator=str_validator,
                        value_validator=int_validator,

--- a/traits/tests/test_trait_dict_object.py
+++ b/traits/tests/test_trait_dict_object.py
@@ -160,13 +160,14 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(td.setdefault("a", 5), 1)
 
     def test_setdefault_with_casting(self):
-        # If the validator does transformation, it is ambiguous
-        # whether the key should be transformed first before
-        # containment is checked. This test tests one of the two
-        # options, where the tranformation happens after the
-        # containment is changed.
-        # Regardless of the convention, the notification
-        # should be factual about the actual mutation on the dict.
+        # If the validator does transformation, the containment
+        # is checked before the transformation. This is more
+        # consistent with the description of setdefault, which is
+        # effectively a short-hand for ``__getitem__``,
+        # followed by ``__setitem__`` (if get fails), followed by
+        # another ``__getitem__``.
+        # The notification should be factual about the actual
+        # mutation on the dict.
         notifier = mock.Mock()
         td = TraitDict(
             key_validator=str,

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -324,19 +324,24 @@ class TraitDict(dict):
                 Will be an empty dict.
 
         """
+        if key in self:
+            return self[key]
 
-        added = None
-        if key not in self:
-            key = self.validate_key(key)
-            value = self.validate_value(value)
+        key = self.validate_key(key)
+        value = self.validate_value(value)
+
+        if key in self:
+            changed = {key: self[key]}
+            added = {}
+        else:
+            changed = {}
             added = {key: value}
 
-        result = super().setdefault(key, value)
+        super().__setitem__(key, value)
 
-        if added is not None:
-            self.notifiy(added)
+        self.notifiy(added=added, changed=changed, removed={})
 
-        return result
+        return value
 
     def pop(self, key, default_value=None):
         """ Remove the key from the dict if present and return the key-value

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -256,10 +256,9 @@ class TraitDict(dict):
                 The dict of the item that was removed.
 
         """
-        if key in self:
-            removed = {key: self[key]}
-            super().__delitem__(key)
-            self.notifiy(removed=removed)
+        removed = {key: self[key]}
+        super().__delitem__(key)
+        self.notifiy(added={}, changed={}, removed=removed)
 
     def clear(self):
         """ Remove all items from the dict.

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -519,7 +519,7 @@ class TraitDictObject(TraitDict):
         mutated.
     """
 
-    def key_validator(self, key):
+    def _key_validator(self, key):
         """ Calls the trait's key_trait.handler.validate.
 
         Parameters
@@ -551,7 +551,7 @@ class TraitDictObject(TraitDict):
 
         return validate(object, self.name, key)
 
-    def value_validator(self, value):
+    def _value_validator(self, value):
         """ Calls the trait's value_handler.validate
 
         Parameters
@@ -625,8 +625,8 @@ class TraitDictObject(TraitDict):
         if trait.has_items:
             self.name_items = name + "_items"
 
-        super().__init__(value, key_validator=self.key_validator,
-                         value_validator=self.value_validator,
+        super().__init__(value, key_validator=self._key_validator,
+                         value_validator=self._value_validator,
                          notifiers=[self.notifier])
 
     def __deepcopy__(self, memo):

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -345,9 +345,9 @@ class TraitDict(dict):
         return value
 
     def pop(self, key, value=Undefined):
-        """ Remove the key from the dict if present and return the key-value
-        pair. If key is absent, the default value is returned and the dict
-        is left unmodified.
+        """ Remove specified key and return the corresponding
+        value. If key is not found, the default value is returned
+        if given, otherwise KeyError is raised.
 
         Parameters
         ----------

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -12,6 +12,7 @@ import copy
 import logging
 from weakref import ref
 
+from traits.trait_base import Undefined
 from traits.trait_errors import TraitError
 
 # Set up a logger:
@@ -343,7 +344,7 @@ class TraitDict(dict):
 
         return value
 
-    def pop(self, key, default_value=None):
+    def pop(self, key, value=Undefined):
         """ Remove the key from the dict if present and return the key-value
         pair. If key is absent, the default value is returned and the dict
         is left unmodified.
@@ -353,7 +354,7 @@ class TraitDict(dict):
         key : A hashable type.
             Key to the dict item.
 
-        default_value : any
+        value : any
             Value to return if key is absent.
 
         Notes
@@ -368,13 +369,15 @@ class TraitDict(dict):
                 if the key was present.
 
         """
-        if key in self:
-            removed = {key: self[key]}
-            result = super().pop(key)
-            self.notifiy(removed=removed)
-            return result
-        else:
-            return default_value
+        if value is Undefined or key in self:
+            removed = super().pop(key)
+            self.notifiy(
+                added={},
+                changed={},
+                removed={key: removed}
+            )
+            return removed
+        return value
 
     def popitem(self):
         """ Remove and return some(key, value) pair as a tuple. Raise KeyError

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -246,6 +246,11 @@ class TraitDict(dict):
         key : A hashable type.
             The key to be deleted.
 
+        Raises
+        ------
+        KeyError
+            If the key is not found.
+
         Notes
         -----
         Parameters in the notification:


### PR DESCRIPTION
This PR is targeting #913

This PR adds a few tests that fail with commit b18feec652a6d949af8333ea49a8ee6631146b21 of #913, and then proceeds to fix them.

The tests that failed:

<details>
    <summary> python -m unittest discover -t . -v traits</summary>

```
======================================================================
FAIL: test_validate_key (traits.tests.test_dict.TestDict)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_dict.py", line 133, in test_validate_key
    foo.mapping[1] = 1
AssertionError: TraitError not raised

======================================================================
FAIL: test_validate_value (traits.tests.test_dict.TestDict)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_dict.py", line 148, in test_validate_value
    foo.mapping["a"] = 1
AssertionError: TraitError not raised

======================================================================
FAIL: test_trait_dict_object_validate_value (traits.tests.test_trait_dict_object.TestTraitDictObject)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_dict_object.py", line 279, in test_trait_dict_object_validate_value
    trait_dict.validate_value(1)
AssertionError: TraitError not raised

======================================================================
FAIL: test_trait_dict_object_validators (traits.tests.test_trait_dict_object.TestTraitDictObject)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_dict_object.py", line 264, in test_trait_dict_object_validators
    trait_dict.validate_key(1)
AssertionError: TraitError not raised

======================================================================
FAIL: test_delitem_not_found (traits.tests.test_trait_dict_object.TestTraitList)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_dict_object.py", line 108, in test_delitem_not_found
    del td["x"]
AssertionError: KeyError not raised

======================================================================
FAIL: test_pop_key_error (traits.tests.test_trait_dict_object.TestTraitList)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_dict_object.py", line 215, in test_pop_key_error
    td.pop("a")
AssertionError: KeyError not raised

======================================================================
FAIL: test_setdefault_with_casting (traits.tests.test_trait_dict_object.TestTraitList)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_trait_dict_object.py", line 188, in test_setdefault_with_casting
    self.assertEqual(td, {"1": "4"})
AssertionError: {'1': '2'} != {'1': '4'}

----------------------------------------------------------------------
```

</details>

Please note that I did not address all of my review comments, e.g. I did not rename `notifiy` to `notify` and there are changes here reusing the misspelt method.