### PR TITLE
Add a GUI test for Enum.create_editor

### DIFF
--- a/traits/testing/optional_dependencies.py
+++ b/traits/testing/optional_dependencies.py
@@ -42,6 +42,9 @@ requires_cython = unittest.skipIf(cython is None, "Cython not available")
 numpy = optional_import("numpy")
 requires_numpy = unittest.skipIf(numpy is None, "NumPy not available")
 
+pyface = optional_import("pyface")
+requires_pyface = unittest.skipIf(pyface is None, "Pyface not available")
+
 sphinx = optional_import("sphinx")
 requires_sphinx = unittest.skipIf(sphinx is None, "Sphinx not available")
 

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -11,10 +11,17 @@
 import enum
 import unittest
 
-from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
-
 from traits.api import (
     Any, BaseEnum, Enum, HasTraits, List, Property, TraitError)
+
+from traits.testing.optional_dependencies import pyface, requires_traitsui
+
+if pyface is not None:
+    GuiTestAssistant = pyface.toolkit.toolkit_object(
+        "util.gui_test_assistant:GuiTestAssistant")
+else:
+    class GuiTestAssistant:
+        pass
 
 
 class FooEnum(enum.Enum):
@@ -307,6 +314,7 @@ class EnumTestCase(unittest.TestCase):
         self.assertEqual(obj.slow_enum, "no")
 
 
+@requires_traitsui
 class TestGui(GuiTestAssistant, unittest.TestCase):
 
     def test_create_editor(self):

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -11,6 +11,8 @@
 import enum
 import unittest
 
+from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
+
 from traits.api import (
     Any, BaseEnum, Enum, HasTraits, List, Property, TraitError)
 
@@ -108,6 +110,10 @@ class EnumCollectionExample(HasTraits):
     single_digit = Enum(8)
 
     slow_enum = BaseEnum("yes", "no", "maybe")
+
+
+class EnumCollectionGUIExample(EnumCollectionExample):
+    correct_int_set_enum = int_set_enum = Enum("int", "set")
 
 
 class EnumTestCase(unittest.TestCase):
@@ -296,3 +302,25 @@ class EnumTestCase(unittest.TestCase):
         with self.assertRaises(TraitError):
             obj.slow_enum = "perhaps"
         self.assertEqual(obj.slow_enum, "no")
+
+
+class TestGui(GuiTestAssistant, unittest.TestCase):
+
+    def test_create_editor(self):
+        obj = EnumCollectionGUIExample()
+        traits = obj.class_trait_names()
+        traits.remove("trait_added")
+        traits.remove("trait_modified")
+
+        ui = obj.edit_traits()
+        for t in traits:
+
+            with self.subTest(t=t):
+                editor = getattr(ui.info, t)
+
+                # Try setting all valid values for the Enum trait
+                for value in obj.trait(t).trait_type.values:
+                    with self.assertTraitChangesInEventLoop(
+                            obj, t, lambda instance: getattr(
+                                instance, t) == value, 0, 3):
+                        self.gui.set_trait_later(editor, 'value', value)

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -13,7 +13,6 @@ import unittest
 
 from traits.api import (
     Any, BaseEnum, Enum, HasTraits, List, Property, TraitError)
-
 from traits.testing.optional_dependencies import pyface, requires_traitsui
 
 if pyface is not None:
@@ -319,20 +318,11 @@ class TestGui(GuiTestAssistant, unittest.TestCase):
 
     def test_create_editor(self):
         obj = EnumCollectionGUIExample()
-        user_editable_traits = obj.class_editable_traits()
 
         # Create a UI window
         ui = obj.edit_traits()
-
-        for t in user_editable_traits:
-
-            with self.subTest(t=t):
-                editor = getattr(ui.info, t)
-                values = obj.trait(t).trait_type.values
-
-                # Try setting all valid values for the Enum trait
-                for value in values:
-                    with self.assertTraitChangesInEventLoop(
-                            obj, t, lambda instance: getattr(
-                                instance, t) == value, 0, 3):
-                        self.gui.set_trait_later(editor, 'value', value)
+        try:
+            self.gui.process_events()
+        finally:
+            with self.delete_widget(ui.control):
+                ui.dispose()

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -113,7 +113,10 @@ class EnumCollectionExample(HasTraits):
 
 
 class EnumCollectionGUIExample(EnumCollectionExample):
-    correct_int_set_enum = int_set_enum = Enum("int", "set")
+    # Override attributes that may fail GUI test
+    # until traitsui #781 is fixed.
+    int_set_enum = Enum("int", "set")
+    correct_int_set_enum = Enum("int", "set")
 
 
 class EnumTestCase(unittest.TestCase):

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -311,18 +311,19 @@ class TestGui(GuiTestAssistant, unittest.TestCase):
 
     def test_create_editor(self):
         obj = EnumCollectionGUIExample()
-        traits = obj.class_trait_names()
-        traits.remove("trait_added")
-        traits.remove("trait_modified")
+        user_editable_traits = obj.class_editable_traits()
 
+        # Create a UI window
         ui = obj.edit_traits()
-        for t in traits:
+
+        for t in user_editable_traits:
 
             with self.subTest(t=t):
                 editor = getattr(ui.info, t)
+                values = obj.trait(t).trait_type.values
 
                 # Try setting all valid values for the Enum trait
-                for value in obj.trait(t).trait_type.values:
+                for value in values:
                     with self.assertTraitChangesInEventLoop(
                             obj, t, lambda instance: getattr(
                                 instance, t) == value, 0, 3):


### PR DESCRIPTION
Related to #965 

Adds a GUI test for the `create_editor` method for the `Enum` trait.

**Checklist**
- [x] Tests
~~- [ ] Update API reference (`docs/source/traits_api_reference`)~~
~~- [ ] Update User manual (`docs/source/traits_user_manual`)~~
~~- [ ] Update type annotation hints in `traits-stubs`~~
