### PR TITLE
Refactor TraitList / TraitListObject

### DIFF
--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -801,6 +801,18 @@ class TestTraitListObject(unittest.TestCase):
         with self.assertRaises(TraitError):
             HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4, 5, 6])
 
+    def test_init_from_iterable(self):
+        class Foo:
+            pass
+
+        tl = TraitListObject(
+            trait=List(),
+            object=Foo(),
+            name="foo",
+            value=squares(5),
+        )
+        self.assertEqual(tl, list(squares(5)))
+
     def test_delitem_single_too_small(self):
         foo = HasLengthConstrainedLists(at_least_two=[1, 2])
         with self.assertRaises(TraitError):

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -13,6 +13,7 @@ import operator
 import pickle
 import unittest
 
+from traits.testing.optional_dependencies import numpy, requires_numpy
 from traits.trait_errors import TraitError
 from traits.trait_list_object import (
     accept_anything,
@@ -93,12 +94,39 @@ class TestTraitList(unittest.TestCase):
         self.assertIs(tl.item_validator, accept_anything)
         self.assertEqual(tl.notifiers, [])
 
+    def test_init_no_value(self):
+        tl = TraitList()
+
+        self.assertEqual(tl, [])
+        self.assertIs(tl.item_validator, accept_anything)
+        self.assertEqual(tl.notifiers, [])
+
     def test_init_iterable(self):
         tl = TraitList("abcde")
 
         self.assertListEqual(tl, ['a', 'b', 'c', 'd', 'e'])
         self.assertIs(tl.item_validator, accept_anything)
         self.assertEqual(tl.notifiers, [])
+
+    def test_init_iterable_without_length(self):
+        tl = TraitList(x**2 for x in range(5))
+
+        self.assertEqual(tl, [0, 1, 4, 9, 16])
+        self.assertIs(tl.item_validator, accept_anything)
+        self.assertEqual(tl.notifiers, [])
+
+    def test_init_validates(self):
+        with self.assertRaises(TraitError):
+            TraitList([1, 2.0, 3], item_validator=int_item_validator)
+
+    def test_init_converts(self):
+        tl = TraitList([True, False], item_validator=int_item_validator)
+
+        self.assertEqual(tl, [1, 0])
+        self.assertTrue(
+            all(type(item) is int for item in tl),
+            msg="Non-integers found in int-only list",
+        )
 
     def test_validator(self):
         tl = TraitList([1, 2, 3], item_validator=int_item_validator)
@@ -150,6 +178,155 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.removed, [1, 5, 3])
         self.assertEqual(self.added, [1, 2, 3, 4, 5])
 
+    def test_setitem_converts(self):
+        tl = TraitList([9, 8, 7],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl[1] = False
+        self.assertEqual(tl, [9, 0, 7])
+        self.assertEqual(self.index, 1)
+        self.assertEqual(self.removed, [8])
+        self.assertEqual(self.added, [0])
+        self.assertTrue(
+            all(type(item) is int for item in tl),
+            msg="Non-integers found in int-only list",
+        )
+        self.assertTrue(
+            all(type(item) is int for item in self.added),
+            msg="Event contains non-integers for int-only list",
+        )
+
+        tl[::2] = [True, True]
+        self.assertEqual(tl, [1, 0, 1])
+        self.assertEqual(self.index, slice(0, 3, 2))
+        self.assertEqual(self.removed, [9, 7])
+        self.assertEqual(self.added, [1, 1])
+        self.assertTrue(
+            all(type(item) is int for item in tl),
+            msg="Non-integers found in int-only list",
+        )
+        self.assertTrue(
+            all(type(item) is int for item in self.added),
+            msg="Event contains non-integers for int-only list",
+        )
+
+    def test_setitem_nochange(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl[3:] = []
+        self.assertEqual(tl, [1, 2, 3])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_setitem_iterable(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl[:] = (x**2 for x in range(4))
+        self.assertEqual(tl, [0, 1, 4, 9])
+        self.assertEqual(self.index, slice(0, 3))
+        self.assertEqual(self.removed, [1, 2, 3])
+        self.assertEqual(self.added, [0, 1, 4, 9])
+
+    def test_setitem_indexerror(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        with self.assertRaises(IndexError):
+            tl[3] = 4
+        self.assertEqual(tl, [1, 2, 3])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_setitem_validation_error(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        with self.assertRaises(TraitError):
+            tl[0] = 4.5
+        self.assertEqual(tl, [1, 2, 3])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+        with self.assertRaises(TraitError):
+            tl[0:2] = [1, "a string"]
+        self.assertEqual(tl, [1, 2, 3])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+        with self.assertRaises(TraitError):
+            tl[2:0:-1] = [1, "a string"]
+        self.assertEqual(tl, [1, 2, 3])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_setitem_index_and_validation_error(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        # Assigning an invalid value to an invalid index: the
+        # TraitError from the invalid value wins.
+        with self.assertRaises(TraitError):
+            tl[3] = 4.5
+        self.assertEqual(tl, [1, 2, 3])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+        # Assigning to a slice with invalid r.h.s. length and
+        # invalid contents: again, the TraitError wins.
+        with self.assertRaises(TraitError):
+            tl[::2] = [1, 2, 4.5]
+        self.assertEqual(tl, [1, 2, 3])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_setitem_item_conversion(self):
+        tl = TraitList([2, 3, 4],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl[0] = True
+        self.assertEqual(tl, [1, 3, 4])
+        self.assertEqual(self.index, 0)
+        self.assertEqual(self.removed, [2])
+        self.assertEqual(self.added, [1])
+
+        # Check that the True has been converted to an int.
+        self.assertTrue(
+            all(type(item) is int for item in tl),
+            msg="Non-integers found in int-only list",
+        )
+        self.assertTrue(
+            all(type(item) is int for item in self.added),
+            msg="Event contains non-integers for int-only list",
+        )
+
+    def test_setitem_corner_case(self):
+        # A peculiar-looking corner case where it's easy to get the
+        # implementation wrong (and CPython did so in the distance past).
+        tl = TraitList(range(7), notifiers=[self.notification_handler])
+
+        # Note: new items inserted at position 5, not position 2.
+        tl[5:2] = [10, 11, 12]
+        self.assertEqual(tl, [0, 1, 2, 3, 4, 10, 11, 12, 5, 6])
+        self.assertEqual(self.index, slice(5, 2))
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [10, 11, 12])
+
     def test_delitem(self):
         tl = TraitList([1, 2, 3],
                        item_validator=int_item_validator,
@@ -168,6 +345,17 @@ class TestTraitList(unittest.TestCase):
         with self.assertRaises(IndexError):
             del tl[0]
 
+    def test_delitem_nochange(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        del tl[3:]
+        self.assertEqual(tl, [1, 2, 3])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
     def test_iadd(self):
         tl = TraitList([4, 5],
                        item_validator=int_item_validator,
@@ -177,6 +365,59 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.index, slice(2, 4, None))
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [6, 7])
+
+    def test_iadd_validates(self):
+        tl = TraitList([4, 5],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        with self.assertRaises(TraitError):
+            tl += [6, 7, 8.0]
+        self.assertEqual(tl, [4, 5])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_iadd_converts(self):
+        tl = TraitList([4, 5],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl += [True, True]
+        self.assertEqual(tl, [4, 5, 1, 1])
+        self.assertEqual(self.index, slice(2, 4))
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [1, 1])
+        self.assertTrue(
+            all(type(item) is int for item in tl),
+            msg="Non-integers found in int-only list",
+        )
+        self.assertTrue(
+            all(type(item) is int for item in self.added),
+            msg="Event contains non-integers for int-only list",
+        )
+
+    def test_iadd_empty(self):
+        tl = TraitList([4, 5],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl += []
+        self.assertEqual(tl, [4, 5])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_iadd_iterable(self):
+        tl = TraitList([4, 5],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl += (x**2 for x in range(3))
+        self.assertEqual(tl, [4, 5, 0, 1, 4])
+        self.assertEqual(self.index, slice(2, 5))
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [0, 1, 4])
 
     def test_imul(self):
         tl = TraitList([1, 2],
@@ -205,6 +446,38 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.removed, [1, 2, 1, 2])
         self.assertEqual(self.added, [])
 
+    def test_imul_no_notification_for_empty_list(self):
+        for multiplier in [-1, 0, 1, 2]:
+            with self.subTest(multiplier=multiplier):
+                tl = TraitList(
+                    [],
+                    item_validator=int_item_validator,
+                    notifiers=[self.notification_handler])
+
+                tl *= multiplier
+                self.assertEqual(tl, [])
+                self.assertIsNone(self.index)
+                self.assertIsNone(self.removed)
+                self.assertIsNone(self.added)
+
+    @requires_numpy
+    def test_imul_integer_like(self):
+        tl = TraitList([1, 2],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl *= numpy.int64(2)
+        self.assertEqual(tl, [1, 2, 1, 2])
+        self.assertEqual(self.index, slice(2, 4))
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [1, 2])
+
+        tl *= numpy.int64(-1)
+        self.assertEqual(tl, [])
+        self.assertEqual(self.index, slice(0, 4))
+        self.assertEqual(self.removed, [1, 2, 1, 2])
+        self.assertEqual(self.added, [])
+
     def test_append(self):
         tl = TraitList([1],
                        item_validator=int_item_validator,
@@ -215,6 +488,37 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [2])
 
+    def test_append_validates(self):
+        tl = TraitList([1],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        with self.assertRaises(TraitError):
+            tl.append(1.0)
+        self.assertEqual(tl, [1])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_append_converts(self):
+        tl = TraitList([2],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl.append(False)
+        self.assertEqual(tl, [2, 0])
+        self.assertEqual(self.index, 1)
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [0])
+        self.assertTrue(
+            all(type(item) is int for item in tl),
+            msg="Non-integers found in int-only list",
+        )
+        self.assertTrue(
+            all(type(item) is int for item in self.added),
+            msg="Event contains non-integers for int-only list",
+        )
+
     def test_extend(self):
         tl = TraitList([1],
                        item_validator=int_item_validator,
@@ -224,6 +528,59 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.index, slice(1, 3, None))
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [1, 2])
+
+    def test_extend_validates(self):
+        tl = TraitList([5],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        with self.assertRaises(TraitError):
+            tl.extend([2, 3, 4.0])
+        self.assertEqual(tl, [5])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_extend_converts(self):
+        tl = TraitList([4],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl.extend([False, True])
+        self.assertEqual(tl, [4, 0, 1])
+        self.assertEqual(self.index, slice(1, 3))
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [0, 1])
+        self.assertTrue(
+            all(type(item) is int for item in tl),
+            msg="Non-integers found in int-only list",
+        )
+        self.assertTrue(
+            all(type(item) is int for item in self.added),
+            msg="Event contains non-integers for int-only list",
+        )
+
+    def test_extend_empty(self):
+        tl = TraitList([1],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl.extend([])
+        self.assertEqual(tl, [1])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_extend_iterable(self):
+        tl = TraitList([1],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl.extend(x**2 for x in range(10, 13))
+        self.assertEqual(tl, [1, 100, 121, 144])
+        self.assertEqual(self.index, slice(1, 4))
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [100, 121, 144])
 
     def test_insert(self):
         tl = TraitList([2],
@@ -239,6 +596,47 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.index, 1)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [3])
+
+    def test_insert_index_matches_python_interpretation(self):
+        for insertion_index in range(-10, 10):
+            with self.subTest(insertion_index=insertion_index):
+                tl = TraitList([5, 6, 7])
+                pl = [5, 6, 7]
+
+                tl.insert(insertion_index, 1729)
+                pl.insert(insertion_index, 1729)
+                self.assertEqual(tl, pl)
+
+    def test_insert_validates(self):
+        tl = TraitList([2],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        with self.assertRaises(TraitError):
+            tl.insert(0, 1.0)
+        self.assertEqual(tl, [2])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_insert_converts(self):
+        tl = TraitList([2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl.insert(1, True)
+        self.assertEqual(tl, [2, 1, 3])
+        self.assertEqual(self.index, 1)
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [1])
+        self.assertTrue(
+            all(type(item) is int for item in tl),
+            msg="Non-integers found in int-only list",
+        )
+        self.assertTrue(
+            all(type(item) is int for item in self.added),
+            msg="Event contains non-integers for int-only list",
+        )
 
     def test_pop(self):
         tl = TraitList([1, 2, 3, 4, 5],

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -1078,7 +1078,7 @@ class TestTraitListObject(unittest.TestCase):
         with self.assertRaises(TraitError):
             foo.at_least_two.remove(1)
         with self.assertRaises(TraitError):
-            foo.at_least_two.pop(2.0)
+            foo.at_least_two.remove(2.0)
         # TraitError from the length violation takes precedence over
         # the ValueError for the vad value.
         with self.assertRaises(TraitError):

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -271,6 +271,17 @@ class TestTraitList(unittest.TestCase):
         self.assertIsNone(self.removed)
         self.assertIsNone(self.added)
 
+    def test_setitem_negative_step(self):
+        tl = TraitList([1, 2, 3, 4, 5],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl[::-2] = [10, 11, 12]
+        self.assertEqual(tl, [12, 2, 11, 4, 10])
+        self.assertEqual(self.index, slice(None, None, -2))
+        self.assertEqual(self.removed, [5, 3, 1])
+        self.assertEqual(self.added, [10, 11, 12])
+
     def test_setitem_index_and_validation_error(self):
         tl = TraitList([1, 2, 3],
                        item_validator=int_item_validator,
@@ -355,6 +366,17 @@ class TestTraitList(unittest.TestCase):
         self.assertIsNone(self.index)
         self.assertIsNone(self.removed)
         self.assertIsNone(self.added)
+
+    def test_delitem_negative_step(self):
+        tl = TraitList([1, 2, 3, 4, 5],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        del tl[::-2]
+        self.assertEqual(tl, [2, 4])
+        self.assertEqual(self.index, slice(None, None, -2))
+        self.assertEqual(self.removed, [5, 3, 1])
+        self.assertEqual(self.added, [])
 
     def test_iadd(self):
         tl = TraitList([4, 5],

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -25,16 +25,14 @@ def int_item_validator(item):
     try:
         return _validate_int(item)
     except TypeError:
-        raise TraitError(
-            "Value {} cannot be interpreted as an integer".format(item))
+        raise TraitError("Value {} is not a valid integer".format(item))
 
 
 def list_item_validator(item):
     if isinstance(item, list):
         return item
     else:
-        raise TraitError(
-            "Value {} is not a list instance".format(item))
+        raise TraitError("Value {} is not a list instance".format(item))
 
 
 class TestTraitList(unittest.TestCase):

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -170,6 +170,19 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.removed, [1])
         self.assertEqual(self.added, [5])
 
+    def test_copy(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl_copy = copy.copy(tl)
+
+        for itm, itm_cpy in zip(tl, tl_copy):
+            self.assertEqual(itm_cpy, itm)
+
+        self.assertEqual(tl_copy.notifiers, [])
+        self.assertEqual(tl_copy.item_validator, tl.item_validator)
+
     def test_deepcopy(self):
         tl = TraitList([1, 2, 3],
                        item_validator=int_item_validator,

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -26,7 +26,8 @@ from traits.trait_list_object import (
 
 def int_item_validator(item):
     """
-    An item_validator for TraitList that checks that the item is an integer.
+    An item_validator for TraitList that checks that the item is an int
+    or integer-like object (e.g., any object whose type provides __index__).
 
     Parameters
     ----------

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -687,6 +687,17 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.removed, [1, 2, 3, 4, 5])
         self.assertEqual(self.added, [])
 
+    def test_clear_empty_list(self):
+        tl = TraitList([],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl.clear()
+        self.assertEqual(tl, [])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
     def test_sort(self):
         tl = TraitList([2, 3, 1, 4, 5, 0],
                        item_validator=int_item_validator,

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -19,6 +19,7 @@ from traits.trait_errors import TraitError
 from traits.trait_list_object import (
     accept_anything,
     TraitList,
+    TraitListEvent,
     TraitListObject,
 )
 
@@ -71,6 +72,25 @@ def list_item_validator(item):
         return item
     else:
         raise TraitError("Value {} is not a list instance".format(item))
+
+
+class TestTraitListEvent(unittest.TestCase):
+    def test_creation(self):
+        event = TraitListEvent(2, [3], [4])
+        self.assertEqual(event.index, 2)
+        self.assertEqual(event.removed, [3])
+        self.assertEqual(event.added, [4])
+
+        event = TraitListEvent(index=2, removed=[3], added=[4])
+        self.assertEqual(event.index, 2)
+        self.assertEqual(event.removed, [3])
+        self.assertEqual(event.added, [4])
+
+    def test_defaults(self):
+        event = TraitListEvent()
+        self.assertEqual(event.index, 0)
+        self.assertEqual(event.removed, [])
+        self.assertEqual(event.added, [])
 
 
 class TestTraitList(unittest.TestCase):

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -974,6 +974,12 @@ class TestTraitListObject(unittest.TestCase):
             foo.at_least_two[1::2] = squares(3)
         self.assertEqual(foo.at_least_two, [1, 2, 3, 4])
 
+    def test_setitem_item_validation_failure(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
+        with self.assertRaises(TraitError):
+            foo.at_least_two[2:] = [5.0, 6.0]
+        self.assertEqual(foo.at_least_two, [1, 2, 3, 4])
+
     def test_append(self):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3])
         foo.at_most_five.append(6)

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -955,6 +955,11 @@ class TestTraitListObject(unittest.TestCase):
             foo.at_most_five *= 2
         self.assertEqual(foo.at_most_five, [1, 2, 3, 4])
 
+    def test_imul_negative_multiplier(self):
+        foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4])
+        foo.at_most_five *= -10
+        self.assertEqual(foo.at_most_five, [])
+
     def test_setitem_index(self):
         foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
         foo.at_least_two[1] = 7

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -183,6 +183,13 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(tl_copy.notifiers, [])
         self.assertEqual(tl_copy.item_validator, tl.item_validator)
 
+    def test_deepcopy_memoization(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+        trait_lists_copy = copy.deepcopy([tl, tl])
+        self.assertIs(trait_lists_copy[0], trait_lists_copy[1])
+
     def test_setitem(self):
         tl = TraitList([1, 2, 3],
                        item_validator=int_item_validator,

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -846,6 +846,11 @@ class TestTraitListObject(unittest.TestCase):
         )
         self.assertEqual(tl, list(squares(5)))
 
+    def test_delitem(self):
+        foo = HasLengthConstrainedLists(at_most_five=[1, 23])
+        del foo.at_most_five[1]
+        self.assertEqual(foo.at_most_five, [1])
+
     def test_delitem_single_too_small(self):
         foo = HasLengthConstrainedLists(at_least_two=[1, 2])
         with self.assertRaises(TraitError):
@@ -858,6 +863,11 @@ class TestTraitListObject(unittest.TestCase):
             del foo.at_least_two[:]
         self.assertEqual(foo.at_least_two, [1, 2])
 
+    def test_iadd(self):
+        foo = HasLengthConstrainedLists(at_most_five=[1, 2])
+        foo.at_most_five += [6, 7, 8]
+        self.assertEqual(foo.at_most_five, [1, 2, 6, 7, 8])
+
     def test_iadd_too_large(self):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4])
         with self.assertRaises(TraitError):
@@ -868,6 +878,11 @@ class TestTraitListObject(unittest.TestCase):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2])
         foo.at_most_five += squares(3)
         self.assertEqual(foo.at_most_five, [1, 2, 0, 1, 4])
+
+    def test_imul(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3])
+        foo.at_least_two *= 2
+        self.assertEqual(foo.at_least_two, [1, 2, 3, 1, 2, 3])
 
     def test_imul_too_small(self):
         foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
@@ -880,6 +895,21 @@ class TestTraitListObject(unittest.TestCase):
         with self.assertRaises(TraitError):
             foo.at_most_five *= 2
         self.assertEqual(foo.at_most_five, [1, 2, 3, 4])
+
+    def test_setitem_index(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
+        foo.at_least_two[1] = 7
+        self.assertEqual(foo.at_least_two, [1, 7, 3, 4])
+
+    def test_setitem_slice(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
+        foo.at_least_two[1:] = [6, 7]
+        self.assertEqual(foo.at_least_two, [1, 6, 7])
+
+    def test_setitem_extended_slice(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
+        foo.at_least_two[1::2] = [6, 7]
+        self.assertEqual(foo.at_least_two, [1, 6, 3, 7])
 
     def test_setitem_too_small(self):
         foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
@@ -898,17 +928,38 @@ class TestTraitListObject(unittest.TestCase):
         foo.at_most_five[:1] = squares(4)
         self.assertEqual(foo.at_most_five, [0, 1, 4, 9, 2])
 
+    def test_setitem_extended_slice_bad_length(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
+        with self.assertRaises(ValueError):
+            foo.at_least_two[1::2] = squares(3)
+        self.assertEqual(foo.at_least_two, [1, 2, 3, 4])
+
+    def test_append(self):
+        foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3])
+        foo.at_most_five.append(6)
+        self.assertEqual(foo.at_most_five, [1, 2, 3, 6])
+
     def test_append_too_large(self):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4, 5])
         with self.assertRaises(TraitError):
             foo.at_most_five.append(6)
         self.assertEqual(foo.at_most_five, [1, 2, 3, 4, 5])
 
+    def test_clear(self):
+        foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4])
+        foo.at_most_five.clear()
+        self.assertEqual(foo.at_most_five, [])
+
     def test_clear_too_small(self):
         foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
         with self.assertRaises(TraitError):
             foo.at_least_two.clear()
         self.assertEqual(foo.at_least_two, [1, 2, 3, 4])
+
+    def test_extend(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
+        foo.at_least_two.extend([10, 11])
+        self.assertEqual(foo.at_least_two, [1, 2, 3, 4, 10, 11])
 
     def test_extend_too_large(self):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4])
@@ -921,6 +972,11 @@ class TestTraitListObject(unittest.TestCase):
         foo.at_most_five.extend(squares(3))
         self.assertEqual(foo.at_most_five, [1, 2, 0, 1, 4])
 
+    def test_insert(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 3, 4])
+        foo.at_least_two.insert(3, 16)
+        self.assertEqual(foo.at_least_two, [1, 2, 3, 16, 4])
+
     def test_insert_too_large(self):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4, 5])
         with self.assertRaises(TraitError):
@@ -930,6 +986,11 @@ class TestTraitListObject(unittest.TestCase):
         with self.assertRaises(TraitError):
             foo.at_most_five.insert(10, 16)
         self.assertEqual(foo.at_most_five, [1, 2, 3, 4, 5])
+
+    def test_pop(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 6])
+        foo.at_least_two.pop()
+        self.assertEqual(foo.at_least_two, [1, 2])
 
     def test_pop_too_small(self):
         foo = HasLengthConstrainedLists(at_least_two=[1, 2])
@@ -941,6 +1002,11 @@ class TestTraitListObject(unittest.TestCase):
         with self.assertRaises(TraitError):
             foo.at_least_two.pop(10)
         self.assertEqual(foo.at_least_two, [1, 2])
+
+    def test_remove(self):
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2, 6, 4])
+        foo.at_least_two.remove(2)
+        self.assertEqual(foo.at_least_two, [1, 6, 4])
 
     def test_remove_too_small(self):
         foo = HasLengthConstrainedLists(at_least_two=[1, 2])
@@ -954,7 +1020,7 @@ class TestTraitListObject(unittest.TestCase):
             foo.at_least_two.remove(10)
         self.assertEqual(foo.at_least_two, [1, 2])
 
-    def test_removed_object_reference(self):
+    def test_dead_object_reference(self):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4])
         list_object = foo.at_most_five
         del foo

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -920,3 +920,13 @@ class TestTraitListObject(unittest.TestCase):
         with self.assertRaises(TraitError):
             foo.at_least_two.remove(10)
         self.assertEqual(foo.at_least_two, [1, 2])
+
+    def test_removed_object_reference(self):
+        foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4])
+        list_object = foo.at_most_five
+        del foo
+
+        list_object.append(5)
+        self.assertEqual(list_object, [1, 2, 3, 4, 5])
+        with self.assertRaises(TraitError):
+            list_object.append(4)

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 import copy
+import operator
 import pickle
 import unittest
 
@@ -18,17 +19,53 @@ from traits.trait_list_object import (
     TraitList,
     TraitListObject,
 )
-from traits.trait_types import _validate_int, List
+from traits.trait_types import List
 
 
 def int_item_validator(item):
+    """
+    An item_validator for TraitList that checks that the item is an integer.
+
+    Parameters
+    ----------
+    item : object
+        Proposed item to add to the list.
+
+    Returns
+    -------
+    validated_item : object
+        Actual item to add to the list.
+
+    Raises
+    ------
+    TraitError
+        If the item is not valid.
+    """
     try:
-        return _validate_int(item)
+        return int(operator.index(item))
     except TypeError:
         raise TraitError("Value {} is not a valid integer".format(item))
 
 
 def list_item_validator(item):
+    """
+    An item_validator for TraitList that checks that the item is a list.
+
+    Parameters
+    ----------
+    item : object
+        Proposed item to add to the list.
+
+    Returns
+    -------
+    validated_item : object
+        Actual item to add to the list.
+
+    Raises
+    ------
+    TraitError
+        If the item is not valid.
+    """
     if isinstance(item, list):
         return item
     else:

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -203,13 +203,10 @@ class TraitList(list):
         """
 
         original_length = len(self)
-        extended = super().__iadd__(
-            [self.item_validator(item) for item in value]
-        )
-        new_length = len(self)
-        if new_length > original_length:
-            index = slice(original_length, new_length)
-            self.notify(index, [], self[index])
+        added = [self.item_validator(item) for item in value]
+        extended = super().__iadd__(added)
+        if added:
+            self.notify(slice(original_length, len(self)), [], added)
         return extended
 
     def __imul__(self, value):
@@ -311,11 +308,10 @@ class TraitList(list):
         """
 
         original_length = len(self)
-        super().extend([self.item_validator(item) for item in iterable])
-        new_length = len(self)
-        if new_length > original_length:
-            index = slice(original_length, new_length)
-            self.notify(index, [], self[index])
+        added = [self.item_validator(item) for item in iterable]
+        super().extend(added)
+        if added:
+            self.notify(slice(original_length, len(self)), [], added)
 
     def insert(self, index, object):
         """ Insert object before index.

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -8,8 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-# XXX Test for "object is None" branch in _item_validator.
-
 # XXX Put notification information back into docstrings? Or not? Should be
 #     possible to interpret it without knowledge of the particular operation
 #     performed, so it doesn't belong in individual docstrings. Instead, put

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -8,11 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-# XXX Need tests for LengthConstrainedTraitList.initialization that breaks
-#     length limits.
-# XXX Make sure there are tests for clearing a list with a minimum length.
 # XXX Test for "object is None" branch in _item_validator.
-# XXX Test TraitListObject operations with iterables that don't have a length.
 
 # XXX Put notification information back into docstrings? Or not? Should be
 #     possible to interpret it without knowledge of the particular operation

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -331,16 +331,7 @@ class TraitList(list):
 
         original_length = len(self)
         super().insert(index, self.item_validator(object))
-        if index < 0:
-            if index < -original_length:
-                normalized_index = 0
-            else:
-                normalized_index = original_length + index
-        else:
-            if index < original_length:
-                normalized_index = index
-            else:
-                normalized_index = original_length
+        normalized_index = _normalize_index(index, original_length)
         self.notify(normalized_index, [], [self[normalized_index]])
 
     def pop(self, index=-1):
@@ -365,10 +356,7 @@ class TraitList(list):
 
         original_length = len(self)
         item = super().pop(index)
-        if index < 0:
-            normalized_index = index + original_length
-        else:
-            normalized_index = index
+        normalized_index = _normalize_index(index, original_length)
         self.notify(normalized_index, [item], [])
         return item
 

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -8,11 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-# XXX Put notification information back into docstrings? Or not? Should be
-#     possible to interpret it without knowledge of the particular operation
-#     performed, so it doesn't belong in individual docstrings. Instead, put
-#     information into the main docstring.
-
 import copy
 import operator
 from weakref import ref

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -10,12 +10,9 @@
 
 # XXX Need tests for LengthConstrainedTraitList.initialization that breaks
 #     length limits.
-# XXX Check coverage for all branches.
-# XXX Make sure we have a test for x = list(range(10)), x[5:2] = [1, 2, 3]
-# XXX Test LengthConstrainedTraitList.__setitem__ with iterable that doesn't
-#     have a length. Ditto append.
 # XXX Make sure there are tests for clearing a list with a minimum length.
 # XXX Test for "object is None" branch in _item_validator.
+# XXX Test TraitListObject operations with iterables that don't have a length.
 
 # XXX Put notification information back into docstrings? Or not? Should be
 #     possible to interpret it without knowledge of the particular operation
@@ -213,7 +210,8 @@ class TraitList(list):
 
         original_length = len(self)
         extended = super().__iadd__(
-            [self.item_validator(item) for item in value])
+            [self.item_validator(item) for item in value]
+        )
         new_length = len(self)
         if new_length > original_length:
             index = slice(original_length, new_length)

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -84,26 +84,11 @@ def _normalize_slice(index, length):
     if index.step is not None and index.step < 0:
         return index
 
-    if index.step is None or index.step > 0:
-        if index.start is not None:
-            start = _normalize_index(index.start, length)
-        else:
-            start = 0
-        if index.stop is not None:
-            stop = _normalize_index(index.stop, length)
-        else:
-            stop = length
-    else:
-        if index.start is not None:
-            start = _normalize_index(index.start, length)
-        else:
-            start = length
-        if index.stop is not None:
-            stop = _normalize_index(index.stop, length)
-        else:
-            stop = 0
-
-    return slice(start, stop, index.step)
+    return slice(
+        _normalize_index(0 if index.start is None else index.start, length),
+        _normalize_index(length if index.stop is None else index.stop, length),
+        index.step,
+    )
 
 
 # Default item validator for TraitList.

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -256,6 +256,15 @@ class TraitList(list):
             Index of the element(s) to be replaced.
         value : iterable
             Replacement values.
+
+        Raises
+        ------
+        IndexError
+            If key is an integer index and is out of range.
+        ValueError
+            If key is an extended slice (that is, it's a slice whose step
+            is not 1 and not None) and the number of replacement elements
+            doesn't match the number of removed elements.
         """
 
         if isinstance(key, slice):
@@ -601,6 +610,15 @@ class TraitListObject(TraitList):
             Index of the element(s) to be replaced.
         value : iterable
             Replacement values.
+
+        Raises
+        ------
+        IndexError
+            If key is an integer index and is out of range.
+        ValueError
+            If key is an extended slice (that is, it's a slice whose step
+            is not 1 and not None) and the number of replacement elements
+            doesn't match the number of removed elements.
         """
 
         if isinstance(key, slice):

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -419,14 +419,10 @@ class TraitList(list):
 
         Notifiers are transient and should not be copied.
         """
-        id_self = id(self)
-        if id_self not in memo:
-            # notifiers are transient and should not be copied
-            memo[id_self] = type(self)(
-                [copy.deepcopy(x, memo) for x in self],
-                item_validator=copy.deepcopy(self.item_validator, memo),
-            )
-        return memo[id_self]
+        return type(self)(
+            [copy.deepcopy(x, memo) for x in self],
+            item_validator=copy.deepcopy(self.item_validator, memo),
+        )
 
     def __getstate__(self):
         """ Get the state of the object for serialization.

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -443,9 +443,9 @@ class TraitList(list):
 
 
 class TraitListObject(TraitList):
-    """ A specialization of LengthConstrainedTraitList with a default
-    validator and notifier which provide bug-for-bug compatibility with the
-    TraitListObject from Traits versions before 6.0.
+    """ A specialization of TraitList with a default validator and notifier
+    which provide bug-for-bug compatibility with the TraitListObject from
+    Traits versions before 6.0.
 
     Parameters
     ----------
@@ -547,7 +547,7 @@ class TraitListObject(TraitList):
 
         Returns
         -------
-        self : LengthConstrainedTraitList
+        self : TraitList
             The modified list.
         """
 
@@ -566,7 +566,7 @@ class TraitListObject(TraitList):
 
         Returns
         -------
-        self : LengthConstrainedTraitList
+        self : TraitList
             The modified list.
         """
 

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -707,18 +707,12 @@ class TraitListObject(TraitList):
 
         Notifiers are transient and should not be copied.
         """
-        id_self = id(self)
-        if id_self in memo:
-            return memo[id_self]
-
-        memo[id_self] = result = TraitListObject(
+        return TraitListObject(
             self.trait,
             lambda: None,
             self.name,
             [copy.deepcopy(x, memo) for x in self],
         )
-
-        return result
 
     def __getstate__(self):
         """ Get the state of the object for serialization.

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -570,7 +570,7 @@ class TraitListObject(TraitList):
             The modified list.
         """
 
-        self._validate_length(len(self) * value)
+        self._validate_length(max(0, len(self) * value))
         return super().__imul__(value)
 
     def __setitem__(self, key, value):

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -26,14 +26,13 @@ class TraitListEvent(object):
 
     Parameters
     ----------
-    index : int or slice
-        An index or slice indicating the location of the changes to the list.
-    added : list or None
-        The list of values added to the list, or optionally None if nothing
-        is added.
-    removed : list or None
-        The list of values removed from the list, or optionally None if
-        nothing is removed.
+    index : int or slice, optional
+        An index or slice indicating the location of the changes to the trait
+        list. The default is 0.
+    added : list, optional
+        The list of values added to the trait list.
+    removed : list, optional
+        The list of values removed from the list.
 
     Attributes
     ----------

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -212,7 +212,8 @@ class TraitList(list):
         """
 
         original_length = len(self)
-        extended = super().__iadd__(map(self.item_validator, value))
+        extended = super().__iadd__(
+            [self.item_validator(item) for item in value])
         new_length = len(self)
         if new_length > original_length:
             index = slice(original_length, new_length)
@@ -260,7 +261,7 @@ class TraitList(list):
         """
 
         if isinstance(key, slice):
-            value = list(map(self.item_validator, value))
+            value = [self.item_validator(item) for item in value]
             normalized_index = _normalize_slice(key, len(self))
             added = value
             removed = self[key]
@@ -310,7 +311,7 @@ class TraitList(list):
         """
 
         original_length = len(self)
-        super().extend(map(self.item_validator, iterable))
+        super().extend([self.item_validator(item) for item in iterable])
         new_length = len(self)
         if new_length > original_length:
             index = slice(original_length, new_length)

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -8,48 +8,26 @@
 #
 # Thanks for using Enthought open source!
 
+# XXX Need tests for LengthConstrainedTraitList.initialization that breaks
+#     length limits.
+# XXX Check coverage for all branches.
+# XXX Make sure we have a test for x = list(range(10)), x[5:2] = [1, 2, 3]
+# XXX Test LengthConstrainedTraitList.__setitem__ with iterable that doesn't
+#     have a length. Ditto append.
+# XXX Make sure there are tests for clearing a list with a minimum length.
+# XXX Test for "object is None" branch in _item_validator.
+
+# XXX Put notification information back into docstrings? Or not? Should be
+#     possible to interpret it without knowledge of the particular operation
+#     performed, so it doesn't belong in individual docstrings. Instead, put
+#     information into the main docstring.
+
 import copy
 import operator
 from weakref import ref
 
 from traits.trait_base import class_of, Undefined
 from traits.trait_errors import TraitError
-
-
-def adapt_trait_validator(trait_validator, name="items"):
-    """ Adapt a trait validator to work as a trait list validator.
-
-    Parameters
-    ----------
-    trait_validator : callable
-        A callable validator
-    name : str
-        The name of the trait on the object.
-
-    The trait validator is expected to have the signature::
-
-        validator(object, name, value)
-
-
-    Returns
-    -------
-    list_trait_validator : callable
-        The trait validator that has been adapted for lists.
-
-    """
-
-    def validator(trait_list, index, removed, value):
-        try:
-            return [
-                trait_validator(trait_list, name, item)
-                for item in value
-            ]
-
-        except TraitError as excp:
-            excp.set_prefix("Each element of the")
-            raise excp
-
-    return validator
 
 
 class TraitListEvent(object):
@@ -90,108 +68,104 @@ class TraitListEvent(object):
         self.added = added
 
 
+def _normalize_index(index, length):
+    """ Normalize integer index to range 0 to len (inclusive). """
+    index = operator.index(index)
+    if index < 0:
+        return max(0, length + index)
+    else:
+        return min(length, index)
+
+
+def _normalize_slice(index, length):
+    """ Normalize slice start and stop to range 0 to len (inclusive). """
+
+    # Do not normalize if step is negative.
+    if index.step is not None and index.step < 0:
+        return index
+
+    if index.step is None or index.step > 0:
+        if index.start is not None:
+            start = _normalize_index(index.start, length)
+        else:
+            start = 0
+        if index.stop is not None:
+            stop = _normalize_index(index.stop, length)
+        else:
+            stop = length
+    else:
+        if index.start is not None:
+            start = _normalize_index(index.start, length)
+        else:
+            start = length
+        if index.stop is not None:
+            stop = _normalize_index(index.stop, length)
+        else:
+            stop = 0
+
+    return slice(start, stop, index.step)
+
+
+# Default item validator for TraitList.
+
+
+def accept_anything(item):
+    """
+    List item validator which accepts any item and returns it unaltered.
+    """
+    return item
+
+
 class TraitList(list):
     """ A subclass of list that validates and notifies listeners of changes.
 
     Parameters
     ----------
-    value : list
-        The value for the list
-    validator : callable, optional
-        Called to validate items in the list.
-        With the signature::
-
-            validator(current_list, index, removed, added)
-
-        If the validator is not provided, all values added to the list
-        are considered to be valid.
-
+    value : iterable
+        Iterable providing the items for the list
+    item_validator : callable, optional
+        Called to validate and/or transform items added to the list. The
+        callable should accept a single item from the list and return
+        the transformed item, raising TraitError for invalid items. If
+        not given, no item validation is performed.
     notifiers : list of callable, optional
         A list of callables with the signature::
 
             notifier(trait_list, index, removed, added)
 
-        If a notifier is not provided, an empty list of notifiers is
-        used.
+        If this argument is not given, the list of notifiers is initially
+        empty.
 
     Attributes
     ----------
-    validator : callable, optional
-        Called to validate items in the list
-        With the signature::
-
-            validator(current_list, index, removed, added)
-
-        If the validator is not provided, all values added to the list
-        are considered to be valid.
-
-    notifiers : list of callable, optional
+    item_validator : callable
+        Called to validate and/or transform items added to the list. The
+        callable should accept a single item from the list and return
+        the transformed item, raising TraitError for invalid items.
+    notifiers : list of callable
         A list of callables with the signature::
 
             notifier(trait_list, index, removed, added)
-
-        If a notifier is not provided, an empty list of notifiers is
-        used.
-
     """
 
     def __new__(cls, *args, **kwargs):
-        instance = super().__new__(cls)
-        instance.validator = None
-        instance.notifiers = []
-        return instance
+        # We need a __new__ in addition to __init__ in order to properly
+        # support unpickling: the 'append' or 'extend' methods may be
+        # called during unpickling, triggering item validation.
+        self = super().__new__(cls)
+        self.item_validator = accept_anything
+        self.notifiers = []
+        return self
 
-    def __init__(self, value=(), *, validator=None, notifiers=None):
-        self.validator = validator
-
-        if notifiers is None:
-            notifiers = []
-        self.notifiers = list(notifiers)
-
-        value = self.validate(slice(0, 0), [], list(value))
-        super().__init__(value)
-
-    # ------------------------------------------------------------------------
-    # TraitList interface
-    # ------------------------------------------------------------------------
-
-    def validate(self, index, removed, added):
-        """ Validate values for given index and removed values.
-
-        This simply calls the validator provided by the class, if any.
-        The validator is expected to have the signature::
-
-            validator(trait_list, index, removed, added)
-
-        and return a list of added values or raise a TraitError.
-
-        Parameters
-        ----------
-        index : int or slice
-            The indices being modified by the operation.
-        removed : list
-            The items to be removed.
-        added : list
-            The new items being added to the list.
-
-        Returns
-        -------
-        values : list
-            The validated values that must be added to the list.
-
-        Raises
-        ------
-        TraitError
-            If validation fails.
-        """
-
-        if self.validator is None:
-            return added
-        else:
-            return self.validator(self, index, removed, added)
+    def __init__(self, iterable=(), *, item_validator=None, notifiers=None):
+        if item_validator is not None:
+            self.item_validator = item_validator
+        super().__init__(self.item_validator(item) for item in iterable)
+        if notifiers is not None:
+            self.notifiers = list(notifiers)
 
     def notify(self, index, removed, added):
-        """ Call all notifiers
+        """ Call all notifiers.
 
         This simply calls all notifiers provided by the class, if any.
         The notifiers are expected to have the signature::
@@ -212,9 +186,264 @@ class TraitList(list):
         for notifier in self.notifiers:
             notifier(self, index, removed, added)
 
-    # ------------------------------------------------------------------------
-    # list interface
-    # ------------------------------------------------------------------------
+    # -- list interface -------------------------------------------------------
+
+    def __delitem__(self, key):
+        """ Delete self[key].
+
+        Parameters
+        ----------
+        key : integer or slice
+            Index of the element(s) to be deleted.
+        """
+
+        if isinstance(key, slice):
+            removed = self[key]
+            normalized_index = _normalize_slice(key, len(self))
+        else:
+            # Suppress IndexError. If the lookup fails, __delitem__ should also
+            # fail, and we want to allow the __delitem__ error to propagate.
+            try:
+                removed = [self[key]]
+            except IndexError:
+                pass
+            normalized_index = _normalize_index(key, len(self))
+        super().__delitem__(key)
+        if removed:
+            self.notify(normalized_index, removed, [])
+
+    def __iadd__(self, value):
+        """ Implement self += value.
+
+        Parameters
+        ----------
+        value : iterable
+            The items to be added.
+
+        Returns
+        -------
+        self : TraitList
+            The modified list.
+        """
+
+        original_length = len(self)
+        extended = super().__iadd__(map(self.item_validator, value))
+        new_length = len(self)
+        if new_length > original_length:
+            index = slice(original_length, new_length)
+            self.notify(index, [], self[index])
+        return extended
+
+    def __imul__(self, value):
+        """ Implement self *= value.
+
+        Parameters
+        ----------
+        value : integer
+            The multiplier.
+
+        Returns
+        -------
+        self : TraitList
+            The modified list.
+        """
+
+        if value < 1:
+            removed = self.copy()
+            multiplied = super().__imul__(value)
+            if removed:
+                self.notify(slice(0, len(removed)), removed, [])
+        else:
+            # Values being added.
+            original_length = len(self)
+            multiplied = super().__imul__(value)
+            new_length = len(self)
+            if new_length > original_length:
+                index = slice(original_length, new_length)
+                self.notify(index, [], self[index])
+        return multiplied
+
+    def __setitem__(self, key, value):
+        """ Set self[key] to value.
+
+        Parameters
+        ----------
+        key : integer or slice
+            Index of the element(s) to be replaced.
+        value : iterable
+            Replacement values.
+        """
+
+        if isinstance(key, slice):
+            value = list(map(self.item_validator, value))
+            normalized_index = _normalize_slice(key, len(self))
+            added = value
+            removed = self[key]
+        else:
+            value = self.item_validator(value)
+            normalized_index = _normalize_index(key, len(self))
+            added = [value]
+            # Suppress IndexError. If the lookup fails, __setitem__ should also
+            # fail, and we want to allow the __setitem__ error to propagate.
+            try:
+                removed = [self[key]]
+            except IndexError:
+                pass
+        super().__setitem__(key, value)
+
+        if added != removed:
+            self.notify(normalized_index, removed, added)
+
+    def append(self, object):
+        """ Append object to the end of the list.
+
+        Parameters
+        ----------
+        object : any
+            The object to append.
+        """
+
+        original_length = len(self)
+        super().append(self.item_validator(object))
+        self.notify(original_length, [], self[original_length:])
+
+    def clear(self):
+        """ Remove all items from list. """
+
+        removed = self.copy()
+        super().clear()
+        if removed:
+            self.notify(slice(0, len(removed)), removed, [])
+
+    def extend(self, iterable):
+        """ Extend list by appending elements from the iterable.
+
+        Parameters
+        ----------
+        iterable : iterable
+            The elements to append.
+        """
+
+        original_length = len(self)
+        super().extend(map(self.item_validator, iterable))
+        new_length = len(self)
+        if new_length > original_length:
+            index = slice(original_length, new_length)
+            self.notify(index, [], self[index])
+
+    def insert(self, index, object):
+        """ Insert object before index.
+
+        Parameters
+        ----------
+        index : integer
+            The position at which to insert.
+        object : object
+            The object to insert.
+        """
+
+        original_length = len(self)
+        super().insert(index, self.item_validator(object))
+        if index < 0:
+            if index < -original_length:
+                normalized_index = 0
+            else:
+                normalized_index = original_length + index
+        else:
+            if index < original_length:
+                normalized_index = index
+            else:
+                normalized_index = original_length
+        self.notify(normalized_index, [], [self[normalized_index]])
+
+    def pop(self, index=-1):
+        """ Remove and return item at index (default last).
+
+        Parameters
+        ----------
+        index : int, optional
+            Index at which to remove item. If not given, the
+            last item of the list is removed.
+
+        Returns
+        -------
+        item : object
+            The removed item.
+
+        Raises
+        ------
+        IndexError
+            If list is empty or index is out of range.
+        """
+
+        original_length = len(self)
+        item = super().pop(index)
+        if index < 0:
+            normalized_index = index + original_length
+        else:
+            normalized_index = index
+        self.notify(normalized_index, [item], [])
+        return item
+
+    def remove(self, value):
+        """ Remove first occurrence of value.
+
+        Notes
+        -----
+        The value is not validated or converted before removal.
+
+        Parameters
+        ----------
+        value : object
+            Value to be removed.
+
+        Raises
+        ------
+        ValueError
+            If the value is not present.
+        """
+        # Suppress ValueError. If the index call fails because the item is not
+        # in the list, remove should also fail, and we want to allow the remove
+        # error to propagate.
+        try:
+            index = self.index(value)
+        except ValueError:
+            pass
+        else:
+            removed = [self[index]]
+        super().remove(value)
+        self.notify(index, removed, [])
+
+    def reverse(self):
+        """ Reverse the items in the list in place. """
+        removed = self.copy()
+        super().reverse()
+        self.notify(slice(0, len(self)), removed, self.copy())
+
+    def sort(self, *, key=None, reverse=False):
+        """ Sort the list in ascending order and return None.
+
+        The sort is in-place (i.e. the list itself is modified) and stable
+        (i.e. the order of two equal elements is maintained).
+
+        If a key function is given, apply it once to each list item and sort
+        them, ascending or descending, according to their function values.
+
+        The reverse flag can be set to sort in descending order.
+
+        Parameters
+        ----------
+        key : callable
+            Custom function that accepts a single item from the list and
+            returns the key to be used in comparisons.
+        reverse : bool
+            If true, the resulting list will be sorted in descending order.
+        """
+        removed = self.copy()
+        super().sort(key=key, reverse=reverse)
+        self.notify(slice(0, len(self)), removed, self.copy())
+
+    # -- pickle and copy support ----------------------------------------------
 
     def __deepcopy__(self, memo):
         """ Perform a deepcopy operation.
@@ -222,17 +451,13 @@ class TraitList(list):
         Notifiers are transient and should not be copied.
         """
         id_self = id(self)
-        if id_self in memo:
-            return memo[id_self]
-
-        # notifiers are transient and should not be copied
-        memo[id_self] = result = TraitList(
-            [copy.deepcopy(x, memo) for x in self],
-            validator=copy.deepcopy(self.validator, memo),
-            notifiers=[],
-        )
-
-        return result
+        if id_self not in memo:
+            # notifiers are transient and should not be copied
+            memo[id_self] = type(self)(
+                [copy.deepcopy(x, memo) for x in self],
+                item_validator=copy.deepcopy(self.item_validator, memo),
+            )
+        return memo[id_self]
 
     def __getstate__(self):
         """ Get the state of the object for serialization.
@@ -248,436 +473,14 @@ class TraitList(list):
 
         Notifiers are transient and are restored to the empty list.
         """
-        state['notifiers'] = []
+        state["notifiers"] = []
         self.__dict__.update(state)
-
-    def __setitem__(self, index, value):
-        """ Set a value at index, implements self[index] = value
-
-        Parameters
-        ----------
-        index : int
-            Index at which the value will be set.
-        value : any
-            The value to set at the index.
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : int
-                The index at which the value is set.
-            added : list
-                The value that is set, as a list.
-            removed : list
-                The value that is removed, as a list.
-
-        """
-        removed = self._get_removed(index, default=[])
-        index_is_slice = isinstance(index, slice)
-
-        if index_is_slice:
-            if len(removed) != len(value) and index.step not in {1, None}:
-                raise ValueError("attempt to assign sequence of size {} "
-                                 "to extended slice of size "
-                                 "{}".format(len(value), len(removed)))
-        else:
-            value = [value]
-
-        norm_index = self._normalize(index)
-
-        added = item = self.validate(norm_index, removed, value)
-
-        if not index_is_slice:
-            item = added[0]
-
-        super().__setitem__(index, item)
-
-        if added != removed:
-            self.notify(norm_index, removed, added)
-
-    def __delitem__(self, index):
-        """ Delete an item from the list at index.
-
-        Parameters
-        ----------
-        index : int
-            Index of the element to be deleted.
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : int
-                The index of the value that is deleted.
-            added : list
-                The empty list [].
-            removed : list
-                The removed value, as a list.
-
-        """
-        added = []
-        removed = self._get_removed(index, default=[])
-        norm_index = self._normalize(index)
-        self.validate(norm_index, removed, added)
-
-        super().__delitem__(index)
-
-        if added != removed:
-            self.notify(norm_index, removed, added)
-
-    def append(self, object):
-        """ Append an item to the end of the list.
-
-        Parameters
-        ----------
-        object : any
-            The item to append to the list.
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : int
-                The index of the newly appended item.
-            added : list
-                The new item, as a list
-            removed : list
-                Will be []
-
-        """
-        index = len(self)
-
-        removed = []
-        added = self.validate(index, removed, [object])
-
-        super().append(added[0])
-
-        if added != removed:
-            self.notify(index, removed, added)
-
-    def extend(self, iterable):
-        """ Extend list by appending elements from the iterable.
-
-        Parameters
-        ----------
-        iterable : iterable
-            Any iterable type
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : slice
-                The slice(current_length,new_length) if successful if
-                the iterable supports len() else the slice(current_len,None,1).
-            added : list
-                The newly added items.
-            removed : list
-                Will be []
-
-        """
-        iterable = list(iterable)
-        index = slice(len(self), len(self) + len(iterable))
-        removed = []
-        added = self.validate(index, removed, iterable)
-
-        super().extend(added)
-
-        if added != removed:
-            self.notify(index, removed, added)
-
-    def insert(self, index, object):
-        """ Insert an object to the list before index.
-
-        Parameters
-        ----------
-        index : int
-            The index before which to insert the object.
-        object : any
-            The object to insert.
-
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : int
-                The index before which the item was inserted.
-            added : list
-                The newly added item(s) as a list.
-            removed : list
-                Will be []
-
-        """
-        removed = []
-        norm_index = self._normalize_index(index)
-        added = self.validate(norm_index, removed, [object])
-
-        super().insert(index, added[0])
-
-        if added != removed:
-            self.notify(norm_index, removed, added)
-
-    def clear(self):
-        """ Remove all items from the list
-
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : slice
-                The range of the slice will be 0 to len(self).
-            added : list
-                The empty list [].
-            removed : list
-                The removed items.
-
-        """
-        index = slice(0, len(self))
-        removed = self.copy()
-        added = []
-        self.validate(index, removed, added)
-        super().clear()
-
-        if added != removed:
-            self.notify(index, removed, [])
-
-    def pop(self, index=-1):
-        """ Remove and return item at index (default last).
-
-        Parameters
-        ----------
-        index: int
-            Index at which item has to be removed.
-
-        Returns
-        -------
-        item : An item in the list at given index, last item if no index given.
-
-        Raises
-        ------
-        IndexError
-            If the index is out of range.
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : int
-                The normalized index between 0 and len(self).
-            added : list
-                Will be []
-            removed : list
-                The removed item, as a list.
-
-        """
-
-        added = []
-        removed = self._get_removed(index, default=[])
-        norm_index = self._normalize_index(index)
-        self.validate(norm_index, removed, added)
-
-        removed_item = super().pop(index)
-
-        if added != removed:
-            self.notify(norm_index, removed, added)
-
-        return removed_item
-
-    def remove(self, value):
-        """ Remove first occurrence of value.
-
-        Parameters
-        ----------
-        value : any
-            A value contained in the list.
-
-        Raises
-        ------
-        ValueError
-            If the value is not present.
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : int
-                The index between 0 and len(self).
-            added : list
-                Will be [].
-            removed : list
-                The removed item, as a list.
-
-        """
-        index = self.index(value)
-        removed = self._get_removed(index)
-        added = []
-
-        self.validate(index, removed, added)
-
-        super().remove(value)
-
-        if added != removed:
-            self.notify(index, removed, added)
-
-    def sort(self, *, key=None, reverse=False):
-        """ Sort the items in the list in ascending order, *IN PLACE*.
-        A custom key function can be supplied to customize
-        the sort order, and the reverse flag can be set to request the result
-        in descending order.
-
-        Parameters
-        ----------
-        key : callable
-            Custom function.
-        reverse : bool
-            If true, the resulting list will be sorted in descending order.
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : slice
-                The slice between 0 and len(self)
-            added : list
-                A copy of the list after sorting elements.
-            removed : list
-                A copy of the list before sorting elements.
-
-        """
-
-        removed = self[:]
-        super().sort(key=key, reverse=reverse)
-        added = self[:]
-        index = slice(0, len(self))
-
-        self.notify(index, removed, added)
-
-    def reverse(self):
-        """ Reverse the order of the items in the list *IN PLACE*.
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : slice
-                The slice between 0 and len(self).
-            added : list
-                A copy of the list after reversing the order of items.
-            removed : list.
-                A copy of the list before reversing the order of items.
-
-        """
-        removed = self[:]
-        self[:] = self[::-1]
-        added = self[:]
-
-        index = slice(0, len(self))
-
-        self.notify(index, removed, added)
-
-    def __iadd__(self, other):
-        """ Implements the self += value operator.
-
-        Parameters
-        ----------
-        other : any
-            The item to add to the list.
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : slice
-                Slice ranging from current_length to new_length.
-            added : list
-                The  new values that were added.
-            removed : list
-                The empty list [].
-
-        """
-        self.extend(other)
-        return self
-
-    def __imul__(self, count):
-        """ Implements the self *= value operator.
-
-        Parameters
-        ----------
-        count : int
-            Number of times to duplicate the list.
-
-        Notes
-        -----
-        Parameters in the notification:
-            index : slice
-                Slice ranging from current_length to new_length.
-            added : list
-                The  new values that were added.
-            removed : list
-                The empty list [].
-
-        """
-        extension = self * count
-        if count <= 0:
-            self.clear()
-        else:
-            self.extend(extension[:-len(self)])
-
-        return self
-
-    # ------------------------------------------------------------------------
-    # Private interface
-    # ------------------------------------------------------------------------
-
-    def _get_removed(self, index, default=[]):
-        """ Compute removed values given index. """
-        try:
-            if not isinstance(index, slice):
-                return [self[index]]
-            else:
-                return self[index]
-        except IndexError:
-            return default
-
-    def _normalize(self, index):
-        if isinstance(index, slice):
-            return self._normalize_slice(index)
-        else:
-            return self._normalize_index(index)
-
-    def _normalize_index(self, index):
-        """ Normalize integer index to range 0 to len (inclusive). """
-        index = operator.index(index)
-        if index < 0:
-            return max(0, len(self) + index)
-        else:
-            return min(len(self), index)
-
-    def _normalize_slice(self, index):
-        """ Normalize slice start and stop to range 0 to len (inclusive). """
-
-        # Do not normalize if step is negative.
-        if index.step is not None and index.step < 0:
-            return index
-
-        if index.step is None or index.step > 0:
-            if index.start is not None:
-                start = self._normalize_index(index.start)
-            else:
-                start = 0
-            if index.stop is not None:
-                stop = self._normalize_index(index.stop)
-            else:
-                stop = len(self)
-        else:
-            if index.start is not None:
-                start = self._normalize_index(index.start)
-            else:
-                start = len(self)
-            if index.stop is not None:
-                stop = self._normalize_index(index.stop)
-            else:
-                stop = 0
-
-        return slice(start, stop, index.step)
 
 
 class TraitListObject(TraitList):
-    """ A specialization of TraitList with a default validator and notifier
-    which provide bug-for-bug compatibility with the TraitsListObject from
-    Traits versions before 6.0.
+    """ A specialization of LengthConstrainedTraitList with a default
+    validator and notifier which provide bug-for-bug compatibility with the
+    TraitListObject from Traits versions before 6.0.
 
     Parameters
     ----------
@@ -711,65 +514,15 @@ class TraitListObject(TraitList):
         if trait.has_items:
             self.name_items = name + "_items"
 
-        super().__init__(value, validator=self.trait_validator,
-                         notifiers=[self.notifier])
+        # Convert to an explicit list so that we can validate the length.
+        value = list(value)
+        self._validate_length(len(value))
 
-    def trait_validator(self, trait_list, index, removed, added):
-        """ Validates the value by calling the inner trait's validate method
-        and also ensures that the size of the list is within the specified
-        bounds.
-
-        Parameters
-        ----------
-        trait_list : list
-            The current list.
-        index : index or slice
-            Index or slice corresponding to the values added/removed.
-        removed : list
-            values that are removed.
-        added : list
-            value or list of values that are added.
-
-        Returns
-        -------
-        value : validated value or list of validated values.
-
-        Raises
-        ------
-        TraitError
-            On validation failure for the inner trait or if the size of the
-            list exceeds the specified bounds
-        """
-        object_ref = getattr(self, 'object', None)
-        trait = getattr(self, 'trait', None)
-
-        if object_ref is None or trait is None:
-            return added
-
-        object = object_ref()
-
-        # check that length is within bounds
-        new_len = len(trait_list) - len(removed) + len(added)
-        if not trait.minlen <= new_len <= trait.maxlen:
-            raise TraitError(
-                "The '%s' trait of %s instance must be %s, "
-                "but you attempted to change its length to %d element%s."
-                % (
-                    self.name,
-                    class_of(object),
-                    self.trait.full_info(object, self.name, Undefined),
-                    new_len,
-                    "s"[new_len == 1:],
-                )
-            )
-
-        # validate the new value(s)
-        validate = trait.item_trait.handler.validate
-        if validate is None or added == []:
-            return added
-
-        validate = adapt_trait_validator(validate, self.name)
-        return validate(object, index, removed, added)
+        super().__init__(
+            value,
+            item_validator=self._item_validator,
+            notifiers=[self.notifier],
+        )
 
     def notifier(self, trait_list, index, removed, added):
         """ Converts and consolidates the parameters to a TraitListEvent and
@@ -804,6 +557,176 @@ class TraitListObject(TraitList):
         event = TraitListEvent(index, removed, added)
         items_event = self.trait.items_event()
         object.trait_items_event(self.name_items, event, items_event)
+
+    # -- list interface -------------------------------------------------------
+
+    def __delitem__(self, key):
+        """ Delete self[key].
+
+        Parameters
+        ----------
+        key : integer or slice
+            Index of the element(s) to be deleted.
+        """
+        removed_count = len(self[key]) if isinstance(key, slice) else 1
+        self._validate_length(len(self) - removed_count)
+        super().__delitem__(key)
+
+    def __iadd__(self, value):
+        """ Implement self += value.
+
+        Parameters
+        ----------
+        value : iterable
+            The items to be added.
+
+        Returns
+        -------
+        self : LengthConstrainedTraitList
+            The modified list.
+        """
+
+        # Convert input to a concrete list for length-checking purposes.
+        value = list(value)
+        self._validate_length(len(self) + len(value))
+        return super().__iadd__(value)
+
+    def __imul__(self, value):
+        """ Implement self *= value.
+
+        Parameters
+        ----------
+        value : integer
+            The multiplier.
+
+        Returns
+        -------
+        self : LengthConstrainedTraitList
+            The modified list.
+        """
+
+        self._validate_length(len(self) * value)
+        return super().__imul__(value)
+
+    def __setitem__(self, key, value):
+        """ Set self[key] to value.
+
+        Parameters
+        ----------
+        key : integer or slice
+            Index of the element(s) to be replaced.
+        value : iterable
+            Replacement values.
+        """
+
+        if isinstance(key, slice):
+            value = list(value)
+            if key.step is None or key.step == 1:
+                self._validate_length(len(self) - len(self[key]) + len(value))
+            else:
+                # No length change possible, so no need to validate length. But
+                # for backwards compatibility we simulate Python's complaint
+                # about any length difference before validating items.
+                if len(value) != len(self[key]):
+                    raise ValueError(
+                        "attempt to assign sequence of size {} "
+                        "to extended slice of size {}".format(
+                            len(value), len(self[key])
+                        )
+                    )
+        super().__setitem__(key, value)
+
+    def append(self, object):
+        """ Append object to the end of the list.
+
+        Parameters
+        ----------
+        object : any
+            The object to append.
+        """
+
+        self._validate_length(len(self) + 1)
+        super().append(object)
+
+    def clear(self):
+        """ Remove all items from list. """
+
+        self._validate_length(0)
+        super().clear()
+
+    def extend(self, iterable):
+        """ Extend list by appending elements from the iterable.
+
+        Parameters
+        ----------
+        iterable : iterable
+            The elements to append.
+        """
+
+        # Convert input to a concrete list for length-checking purposes.
+        items = list(iterable)
+        self._validate_length(len(self) + len(items))
+        super().extend(items)
+
+    def insert(self, index, object):
+        """ Insert object before index.
+
+        Parameters
+        ----------
+        index : integer
+            The position at which to insert.
+        object : object
+            The object to insert.
+        """
+
+        self._validate_length(len(self) + 1)
+        super().insert(index, object)
+
+    def pop(self, index=-1):
+        """ Remove and return item at index (default last).
+
+        Parameters
+        ----------
+        index : int, optional
+            Index at which to remove item. If not given, the
+            last item of the list is removed.
+
+        Returns
+        -------
+        item : object
+            The removed item.
+
+        Raises
+        ------
+        IndexError
+            If list is empty or index is out of range.
+        """
+
+        self._validate_length(len(self) - 1)
+        return super().pop(index)
+
+    def remove(self, value):
+        """ Remove first occurrence of value.
+
+        Notes
+        -----
+        The value is not validated or converted before removal.
+
+        Parameters
+        ----------
+        value : object
+            Value to be removed.
+
+        Raises
+        ------
+        ValueError
+            If the value is not present.
+        """
+
+        self._validate_length(len(self) - 1)
+        super().remove(value)
+
+    # -- pickle and copy support ----------------------------------------------
 
     def __deepcopy__(self, memo):
         """ Perform a deepcopy operation.
@@ -843,12 +766,64 @@ class TraitListObject(TraitList):
         state["notifiers"] = [self.notifier]
         object = state.pop("object", None)
         if object is not None:
-            state['object'] = ref(object)
+            state["object"] = ref(object)
             trait = self.object()._trait(name, 0)
             if trait is not None:
-                state['trait'] = trait.handler
+                state["trait"] = trait.handler
         else:
-            state['object'] = lambda: None
-            state['trait'] = None
+            state["object"] = lambda: None
+            state["trait"] = None
 
         self.__dict__.update(state)
+
+    # -- private methods ------------------------------------------------------
+
+    def _item_validator(self, value):
+        """
+        Validate an item that's being added to the list.
+        """
+        object = self.object()
+        if object is None:
+            return value
+
+        trait_validator = self.trait.item_trait.handler.validate
+        if trait_validator is None:
+            return value
+
+        try:
+            return trait_validator(object, self.name, value)
+        except TraitError as excp:
+            excp.set_prefix("Each element of the")
+            raise
+
+    def _validate_length(self, new_length):
+        """
+        Validate the new length for a proposed operation.
+
+        Parameters
+        ----------
+        new_length : int
+            New length of the list.
+
+        Raises
+        ------
+        TraitError
+            If the proposed new length would violate the length constraints
+            of the list.
+        """
+        trait = getattr(self, "trait", None)
+        if trait is None:
+            return
+
+        if not trait.minlen <= new_length <= trait.maxlen:
+            raise TraitError(
+                "The '%s' trait of %s instance must be %s, "
+                "but you attempted to change its length to %d %s."
+                % (
+                    self.name,
+                    class_of(object),
+                    self.trait.full_info(object, self.name, Undefined),
+                    new_length,
+                    "element" if new_length == 1 else "elements",
+                )
+            )

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -232,7 +232,6 @@ class TraitList(list):
             if removed:
                 self.notify(slice(0, len(removed)), removed, [])
         else:
-            # Values being added.
             original_length = len(self)
             multiplied = super().__imul__(value)
             new_length = len(self)


### PR DESCRIPTION
Here's the promised `TraitList` / `TraitListObject` refactor that I suggested last week. The main change is that whole-list validation is gone from `TraitList`: instead of the previous `validator` argument, `TraitList` now takes an `item_validator` argument, and that argument is used to validate any items being added in a list operation.

In meetings last week we discussed the possibility of a subclass of `TraitList` implementing the length-constraint logic. It turned out to be simplest to merge that proposed subclass with `TraitListObject`.  So this PR doesn't introduce any new classes: we still have `TraitList` and `TraitListObject`, but length validation has moved into `TraitListObject`.

Rationale for the change:

- It's not obvious that the `validator` API will extend naturally to future use-cases (for example, maintaining whole-list order); this feels like a case of premature abstraction. The only common use-case we have is item validation. The uncommon use-case we have is compatibility with `minlen` and `maxlen` support for the `List` trait type.
- If we do have some form of whole-list validation in the future, that validation could involve needing to alter elements of the list other than `added`, and the current API doesn't support this.
- We're not currently calling `validator` consistently: for example, it's not called for the `sort` and `reverse` methods, and without concrete use-cases it's hard to see what it should do in those cases.
- The implementation and list operation logic in `TraitList` becomes simpler and clearer if we only need to validate new items.
- Consistency with `TraitSet` and `TraitDict`, which don't do whole-object validation.
- The `validator` API is likely to be awkward to use for _consumers_: for list length validation it works fine, but for other whole-list validation most uses would likely involve reconstructing the list from `index`, `removed` and `added`, which would be painful and bug-prone.
- Long term, it may make sense to remove the `minlen` and `maxlen` support for `List` traits altogether; at that point, `TraitListObject` would become significantly simpler.

Key points:

- TraitList now only knows about validating individual items, instead of validating the entire list.
- Min/max length-checking has moved into TraitListObject.
- TraitList operations always call the corresponding list operation, to maintain exception wording.
- Despite earlier discussions, elements being added to a list are validated _before_ the underlying list operation is called. That means that a validation error will take precedence over a Python `IndexError`: for example, given `foo = List(Int)`, if `myobj.foo` has length 3, then `myobj.foo[10] = 4.5` will raise a `TraitError` because `4.5` is not a valid int, rather than `IndexError` because `10` is out of range. This seems to be the most convenient and natural implementation-wise, and matches the current behaviour on master.
- There's an odd corner case in `TraitListObject.__setitem__`: for an assignment involving a step that's neither `1` nor `None`, Python requires that the object assigned be the same length as the items it's replacing. However, there are tests that expect that the resulting `ValueError` takes precedence over any `TraitError` arising from invalid items, so there's some extra backwards compatibility logic in `TraitListObject.__setitem__` to ensure those tests pass.

This isn't quite ready for merge: there's still some work to do in improving documentation and increasing coverage; while the `trait_list_object` module has been almost completely rewritten, I've deliberately tried to leave the tests as unchanged as possible, but I'd like to add more tests to ensure we have good coverage.

I'm making the PR now to get feedback from CI and from reviewers.
