### PR TITLE
Simplify checks in TraitSetObject.notifier and add the related test

### DIFF
--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -496,3 +496,20 @@ class TestTraitSetObject(unittest.TestCase):
         TestSet(letters={"4"})
         with self.assertRaises(TraitError):
             TestSet(letters={4})
+
+    def test_notification_silenced_if_has_items_if_false(self):
+
+        class Foo(HasTraits):
+            values = Set(items=False)
+
+        foo = Foo(values=set())
+        # name_items is a on_trait_change feature
+        # Setting items to False effectively switches it off
+        notifier = mock.Mock()
+        foo.on_trait_change(lambda: notifier(), "values_items")
+
+        # when
+        foo.values.add(1)
+
+        # then
+        notifier.assert_not_called()

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -640,10 +640,7 @@ class TraitSetObject(TraitSet):
         None
 
         """
-        is_trait_none = getattr(self, 'trait', None) is None
-        is_name_items_none = getattr(self, 'name_items', None) is None
-        is_object_ref_none = getattr(self, 'object', None) is None
-        if is_trait_none or is_name_items_none or is_object_ref_none:
+        if self.name_items is None:
             return
 
         object = self.object()


### PR DESCRIPTION
This PR is targeting #922 

It simplifies attribute checks in the `TraitSetObject.notifier` method to what we actually need, and add a test that would fail if we did not check `if self.name_items is None`.
