### PR TITLE
Fix overcomplicated __deepcopy__ implementation

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1497,17 +1497,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     def __deepcopy__(self, memo):
         """ Creates a deep copy of the object.
         """
-        id_self = id(self)
-        if id_self in memo:
-            return memo[id_self]
-
-        result = self.clone_traits(
+        return self.clone_traits(
             memo=memo,
             traits=memo.get("traits_to_copy"),
             copy=memo.get("traits_copy_mode"),
         )
-
-        return result
 
     def edit_traits(
         self,

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -26,7 +26,7 @@ from traits.has_traits import (
 )
 from traits.ctrait import CTrait
 from traits.traits import ForwardProperty, generic_trait
-from traits.trait_types import Event, Float, Instance, Int
+from traits.trait_types import Event, Float, Instance, Int, Str
 
 
 def _dummy_getter(self):

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -8,6 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
+import copy
 import unittest
 
 from traits.has_traits import (
@@ -408,6 +409,17 @@ class TestHasTraits(unittest.TestCase):
         # Exercise the case where the prefix traits machinery goes on to
         # produce a valid result.
         self.assertEqual(a.banananana, 1729)
+
+    def test_deepcopy_memoization(self):
+        class A(HasTraits):
+            x = Int()
+            y = Str()
+
+        a = A()
+        objs = [a, a]
+        objs_copy = copy.deepcopy(objs)
+        self.assertIsNot(objs_copy[0], objs[0])
+        self.assertIs(objs_copy[0], objs_copy[1])
 
 
 class TestObjectNotifiers(unittest.TestCase):


### PR DESCRIPTION
The `HasTraits.__deepcopy__` method is unnecessarily complicated: Python's `deepcopy` machinery already takes care of memoization, so there's no need to do it ourselves.

I've added a test to double check that things are still memoized properly.

**Checklist**
- [x] Tests
