### PR TITLE
Simplify checks in TraitDictObject.notifier and add the related test

### DIFF
--- a/traits/tests/test_dict.py
+++ b/traits/tests/test_dict.py
@@ -11,6 +11,7 @@
 """ Test cases for dictionary (Dict) traits. """
 
 import unittest
+from unittest import mock
 
 from traits.trait_types import Any, Dict, Event, Str, TraitDictObject
 from traits.has_traits import HasTraits, on_trait_change
@@ -146,3 +147,21 @@ class TestDict(unittest.TestCase):
         # This raises
         with self.assertRaises(TraitError):
             foo.mapping["a"] = 1
+
+    def test_items_set_to_false(self):
+
+        class Foo(HasTraits):
+
+            mapping = Dict(items=False)
+
+        handler = mock.Mock()
+        # Setting items to false effectively switches off
+        # notifications on mapping_items
+        foo = Foo(mapping={})
+        foo.on_trait_change(lambda: handler(), name="mapping_items")
+
+        # when
+        foo.mapping["1"] = 1
+
+        # then
+        handler.assert_not_called()

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -608,13 +608,10 @@ class TraitDictObject(TraitDict):
         None
 
         """
-        trait = getattr(self, 'trait', None)
-        name_items = getattr(self, 'name_items', None)
-        object_ref = getattr(self, 'object', None)
-        if trait is None or name_items is None or object_ref is None:
+        if self.name_items is None:
             return
 
-        object = object_ref()
+        object = self.object()
 
         if object is None:
             return


### PR DESCRIPTION
This PR is targeting #913 (TraitDictObject) and is similar to #990 which was targeting TraitSetObject.

This PR simplifies the checks in `TraitDictObject.notifier` and add a test that would fail if we did not check for `if self.name_items is None`.