### PR TITLE
Refactor trait set container

### DIFF
--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -332,26 +332,22 @@ class TestTraitSet(unittest.TestCase):
         # Check the values given to the validator
         # when symmetric_difference_update is called.
 
-        validator_args = set()
-
-        def validator(added):
-            nonlocal validator_args
-            validator_args.add(added)
-
-            return str(added)
-
+        validator = mock.Mock(wraps=str)
         ts = TraitSet(
             [1, 2, 3],
             item_validator=validator,
             notifiers=[self.notification_handler],
         )
         self.assertEqual(ts, set(["1", "2", "3"]))
+        validator.reset_mock()
 
         # when
         ts ^= set(["2", 3, 4])
 
         # then
-        self.assertEqual(validator_args, set([1, 2, 3, 4]))
+        validator_inputs = set(
+            value for (value,), _ in validator.call_args_list)
+        self.assertEqual(validator_inputs, set([3, 4]))
         self.assertEqual(ts, set(["1", "3", "4"]))
         self.assertEqual(self.added, set(["4"]))
         self.assertEqual(self.removed, set(["2"]))

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -18,14 +18,17 @@ from traits.trait_types import _validate_int
 
 
 def int_validator(value):
-    return _validate_int((value))
+    try:
+        return _validate_int(value)
+    except TypeError:
+        raise TraitError("int_validator error")
 
 
 def string_validator(value):
     if isinstance(value, str):
         return value
     else:
-        raise TraitError
+        raise TraitError("string_validator error")
 
 
 class TestTraitSet(unittest.TestCase):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -70,6 +70,9 @@ class TraitSet(set):
 
             notifier(removed, added)
 
+        Where 'added' is a set containing the new values that will be added.
+        And 'removed' is a set containing the old values that will be removed.
+
         If this argument is not given, the list of notifiers is initially
         empty.
 
@@ -83,6 +86,9 @@ class TraitSet(set):
         A list of callables with the signature::
 
             notifier(removed, added)
+
+        Where 'added' is a set containing the new values that will be added.
+        And 'removed' is a set containing the old values that will be removed.
 
     """
 

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -61,17 +61,17 @@ class TraitSet(set):
     value : iterable
         Iterable providing the items for the set.
     item_validator : callable, optional
-        Called to validate and/or transform items added to the list. The
-        callable should accept a single item from the set and return
-        the transformed item, raising TraitError for invalid items. If
-        not given, no item validation is performed.
+        Called to validate and/or transform items added to the set. The
+        callable should accept a single item and return the transformed
+        item, raising TraitError for invalid items. If not given, no
+        item validation is performed.
     notifiers : list of callable
         A list of callables with the signature::
 
             notifier(removed, added)
 
-        Where 'added' is a set containing the new values that will be added.
-        And 'removed' is a set containing the old values that will be removed.
+        Where 'added' is a set containing new values that have been added.
+        And 'removed' is a set containing old values that have been removed.
 
         If this argument is not given, the list of notifiers is initially
         empty.
@@ -79,17 +79,17 @@ class TraitSet(set):
     Attributes
     ----------
     item_validator : callable
-        Called to validate and/or transform items added to the list. The
-        callable should accept a single item from the list and return
-        the transformed item, raising TraitError for invalid items.
+        Called to validate and/or transform items added to the set. The
+        callable should accept a single item and return the transformed
+        item, raising TraitError for invalid items. If not given, no
+        item validation is performed.
     notifiers : list of callable
         A list of callables with the signature::
 
             notifier(removed, added)
 
-        Where 'added' is a set containing the new values that will be added.
-        And 'removed' is a set containing the old values that will be removed.
-
+        Where 'added' is a set containing new values that have been added.
+        And 'removed' is a set containing old values that have been removed.
     """
 
     def __new__(cls, *args, **kwargs):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -117,9 +117,9 @@ class TraitSet(set):
         Parameters
         ----------
         removed : set
-            The items to be removed.
+            The items that have been removed.
         added : set
-            The new items being added to the set.
+            The new items that have been added to the set.
         """
         for notifier in self.notifiers:
             notifier(removed, added)
@@ -132,7 +132,7 @@ class TraitSet(set):
         Parameters
         ----------
         value : any
-            The value to update the set with.
+            A value.
 
         Returns
         -------
@@ -211,7 +211,7 @@ class TraitSet(set):
             self.notify(set(), {value})
 
     def remove(self, value):
-        """ Remove an element from a set; it must be a member.
+        """ Remove an element that is a member of the set.
 
         If the element is not a member, raise a KeyError.
 
@@ -230,7 +230,7 @@ class TraitSet(set):
         self.notify(set([value]), set())
 
     def update(self, value=()):
-        """ Update a set with the union of itself and others.
+        """ Update the set with the union of itself and others.
 
         Parameters
         ----------
@@ -261,7 +261,7 @@ class TraitSet(set):
             self.notify(removed, set())
 
     def intersection_update(self, value=None):
-        """  Update a set with the intersection of itself and another.
+        """  Update the set with the intersection of itself and another set.
 
         Parameters
         ----------
@@ -280,7 +280,7 @@ class TraitSet(set):
             self.notify(removed, set())
 
     def symmetric_difference_update(self, value):
-        """ Update a set with the symmetric difference of itself and another.
+        """ Update the set with the symmetric difference of itself and another.
 
         Parameters
         ----------
@@ -300,7 +300,7 @@ class TraitSet(set):
             self.notify(removed, added)
 
     def discard(self, value):
-        """ Remove an element from a set if it is a member.
+        """ Remove an element from the set if it is a member.
 
         If the element is not a member, do nothing.
 
@@ -318,12 +318,18 @@ class TraitSet(set):
 
     def pop(self):
         """ Remove and return an arbitrary set element.
+
         Raises KeyError if the set is empty.
 
         Returns
         -------
         item : any
             An element from the set.
+
+        Raises
+        ------
+        KeyError
+            If the set is empty.
         """
 
         removed = super().pop()
@@ -427,12 +433,13 @@ class TraitSetObject(TraitSet):
 
         Parameters
         ----------
-        value : set
-            set of values that need to be validated.
+        value : any
+            The value to be validated.
 
         Returns
         -------
-        value : set of validated values
+        value : any
+            The validated value.
 
         Raises
         ------
@@ -489,11 +496,7 @@ class TraitSetObject(TraitSet):
         Notifiers are transient and should not be copied.
         """
 
-        id_self = id(self)
-        if id_self in memo:
-            return memo[id_self]
-
-        memo[id_self] = result = TraitSetObject(
+        result = TraitSetObject(
             self.trait,
             lambda: None,
             self.name,
@@ -509,9 +512,8 @@ class TraitSetObject(TraitSet):
         """
 
         result = super().__getstate__()
-        result.pop("object", None)
-        result.pop("trait", None)
-
+        del result["object"]
+        del result["trait"]
         return result
 
     def __setstate__(self, state):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -44,7 +44,7 @@ class TraitSetEvent(object):
         self.added = added
 
 
-# Default item validator for TraitList.
+# Default item validator for TraitSet.
 
 def accept_anything(item):
     """
@@ -62,7 +62,7 @@ class TraitSet(set):
         Iterable providing the items for the set.
     item_validator : callable, optional
         Called to validate and/or transform items added to the list. The
-        callable should accept a single item from the list and return
+        callable should accept a single item from the set and return
         the transformed item, raising TraitError for invalid items. If
         not given, no item validation is performed.
     notifiers : list of callable
@@ -87,9 +87,6 @@ class TraitSet(set):
     """
 
     def __new__(cls, *args, **kwargs):
-        # We need a __new__ in addition to __init__ in order to properly
-        # support unpickling: the 'append' or 'extend' methods may be
-        # called during unpickling, triggering item validation.
         self = super().__new__(cls)
         self.item_validator = accept_anything
         self.notifiers = []
@@ -290,8 +287,7 @@ class TraitSet(set):
         values = set(value)
         removed = self.intersection(values)
         added = values.difference(removed)
-        if added:
-            added = {self.item_validator(item) for item in added}
+        added = {self.item_validator(item) for item in added}
         added = added.difference(self)
 
         if removed or added:

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -288,6 +288,7 @@ class TraitSet(set):
         Parameters
         ----------
         value : iterable
+            An iterable
         """
 
         values = set(value)
@@ -296,9 +297,8 @@ class TraitSet(set):
         added = {self.item_validator(item) for item in added}
         added = added.difference(self)
 
+        super().symmetric_difference_update(removed | added)
         if removed or added:
-            super().difference_update(removed)
-            super().update(added)
             self.notify(removed, added)
 
     def discard(self, value):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -46,7 +46,6 @@ class TraitSetEvent(object):
 
 # Default item validator for TraitList.
 
-
 def accept_anything(item):
     """
     Item validator which accepts any item and returns it unaltered.
@@ -139,8 +138,8 @@ class TraitSet(set):
         -------
         self : set
             The updated set.
-
         """
+
         self.update(value)
         return self
 
@@ -156,8 +155,8 @@ class TraitSet(set):
         -------
         self : set
             The updated set.
-
         """
+
         self.intersection_update(value)
         return self
 
@@ -173,8 +172,8 @@ class TraitSet(set):
         -------
         self : set
             The updated set.
-
         """
+
         self.symmetric_difference_update(value)
         return self
 
@@ -190,8 +189,8 @@ class TraitSet(set):
         -------
         self : set
             The updated set.
-
         """
+
         self.difference_update(value)
         return self
 
@@ -204,8 +203,8 @@ class TraitSet(set):
         ----------
         value : any
             The value to add to the set.
-
         """
+
         value = self.item_validator(value)
         if value not in self:
             super().add(value)
@@ -225,8 +224,8 @@ class TraitSet(set):
         ------
         KeyError
             If the value is not found in the set.
-
         """
+
         super().remove(value)
         self.notify(set([value]), set())
 
@@ -237,8 +236,8 @@ class TraitSet(set):
         ----------
         value : iterable
             The other iterable.
-
         """
+
         validated_values = {self.item_validator(item) for item in value}
         added = validated_values.difference(self)
 
@@ -256,9 +255,9 @@ class TraitSet(set):
         """
 
         removed = self.intersection(value)
+        super().difference_update(value)
 
         if len(removed) > 0:
-            super().difference_update(removed)
             self.notify(removed, set())
 
     def intersection_update(self, value=None):
@@ -272,10 +271,12 @@ class TraitSet(set):
 
         if value is None:
             return
+
         value = set(value)
         removed = self.difference(value)
+        super().intersection_update(value)
+
         if len(removed) > 0:
-            super().intersection_update(value)
             self.notify(removed, set())
 
     def symmetric_difference_update(self, value):
@@ -284,16 +285,8 @@ class TraitSet(set):
         Parameters
         ----------
         value : iterable
-
-        Notes
-        -----
-        Parameters in the notification:
-            removed : set
-                A set containing the removed values.
-            added : set
-                A set containing the added values.
-
         """
+
         values = set(value)
         removed = self.intersection(values)
         added = values.difference(removed)
@@ -317,8 +310,10 @@ class TraitSet(set):
             An item in the set
         """
 
-        if value in self:
-            self.remove(value)
+        value_in_self = value in self
+        super().discard(value)
+
+        if value_in_self:
             self.notify({value}, set())
 
     def pop(self):
@@ -329,7 +324,6 @@ class TraitSet(set):
         -------
         item : any
             An element from the set.
-
         """
 
         removed = super().pop()


### PR DESCRIPTION

This PR refactors the new `TraitSet` implementation to try and match the refactored `TraitList` implementation. 

Some unresolved comments in PR #922 have been addressed here.