### PR TITLE
Make TraitList notify index a plain int where possible

### DIFF
--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -425,7 +425,7 @@ class TestTraitList(unittest.TestCase):
                        notifiers=[self.notification_handler])
 
         tl += [6, 7]
-        self.assertEqual(self.index, slice(2, 4, None))
+        self.assertEqual(self.index, 2)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [6, 7])
 
@@ -448,7 +448,7 @@ class TestTraitList(unittest.TestCase):
 
         tl += [True, True]
         self.assertEqual(tl, [4, 5, 1, 1])
-        self.assertEqual(self.index, slice(2, 4))
+        self.assertEqual(self.index, 2)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [1, 1])
         self.assertTrue(
@@ -478,7 +478,7 @@ class TestTraitList(unittest.TestCase):
 
         tl += (x**2 for x in range(3))
         self.assertEqual(tl, [4, 5, 0, 1, 4])
-        self.assertEqual(self.index, slice(2, 5))
+        self.assertEqual(self.index, 2)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [0, 1, 4])
 
@@ -494,7 +494,7 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.added, None)
 
         tl *= 2
-        self.assertEqual(self.index, slice(2, 4, None))
+        self.assertEqual(self.index, 2)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [1, 2])
 
@@ -505,7 +505,7 @@ class TestTraitList(unittest.TestCase):
             tl *= 2.5
 
         tl *= -1
-        self.assertEqual(self.index, slice(0, 4, None))
+        self.assertEqual(self.index, 0)
         self.assertEqual(self.removed, [1, 2, 1, 2])
         self.assertEqual(self.added, [])
 
@@ -531,13 +531,13 @@ class TestTraitList(unittest.TestCase):
 
         tl *= numpy.int64(2)
         self.assertEqual(tl, [1, 2, 1, 2])
-        self.assertEqual(self.index, slice(2, 4))
+        self.assertEqual(self.index, 2)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [1, 2])
 
         tl *= numpy.int64(-1)
         self.assertEqual(tl, [])
-        self.assertEqual(self.index, slice(0, 4))
+        self.assertEqual(self.index, 0)
         self.assertEqual(self.removed, [1, 2, 1, 2])
         self.assertEqual(self.added, [])
 
@@ -597,7 +597,7 @@ class TestTraitList(unittest.TestCase):
                        notifiers=[self.notification_handler])
 
         tl.extend([1, 2])
-        self.assertEqual(self.index, slice(1, 3, None))
+        self.assertEqual(self.index, 1)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [1, 2])
 
@@ -620,7 +620,7 @@ class TestTraitList(unittest.TestCase):
 
         tl.extend([False, True])
         self.assertEqual(tl, [4, 0, 1])
-        self.assertEqual(self.index, slice(1, 3))
+        self.assertEqual(self.index, 1)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [0, 1])
         self.assertTrue(
@@ -650,7 +650,7 @@ class TestTraitList(unittest.TestCase):
 
         tl.extend(x**2 for x in range(10, 13))
         self.assertEqual(tl, [1, 100, 121, 144])
-        self.assertEqual(self.index, slice(1, 4))
+        self.assertEqual(self.index, 1)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [100, 121, 144])
 
@@ -755,7 +755,7 @@ class TestTraitList(unittest.TestCase):
                        item_validator=int_item_validator,
                        notifiers=[self.notification_handler])
         tl.clear()
-        self.assertEqual(self.index, slice(0, 5, None))
+        self.assertEqual(self.index, 0)
         self.assertEqual(self.removed, [1, 2, 3, 4, 5])
         self.assertEqual(self.added, [])
 
@@ -778,9 +778,31 @@ class TestTraitList(unittest.TestCase):
         tl.sort()
 
         self.assertEqual(tl, [0, 1, 2, 3, 4, 5])
-        self.assertEqual(self.index, slice(0, 6, None))
+        self.assertEqual(self.index, 0)
         self.assertEqual(self.removed, [2, 3, 1, 4, 5, 0])
         self.assertEqual(self.added, [0, 1, 2, 3, 4, 5])
+
+    def test_sort_empty_list(self):
+        tl = TraitList([],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl.sort()
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
+
+    def test_sort_already_sorted(self):
+        tl = TraitList([10, 11, 12, 13, 14],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl.sort()
+
+        self.assertEqual(tl, [10, 11, 12, 13, 14])
+        self.assertEqual(self.index, 0)
+        self.assertEqual(self.removed, [10, 11, 12, 13, 14])
+        self.assertEqual(self.added, [10, 11, 12, 13, 14])
 
     def test_reverse(self):
         tl = TraitList([1, 2, 3, 4, 5],
@@ -789,9 +811,19 @@ class TestTraitList(unittest.TestCase):
 
         tl.reverse()
         self.assertEqual(tl, [5, 4, 3, 2, 1])
-        self.assertEqual(self.index, slice(0, 5, None))
+        self.assertEqual(self.index, 0)
         self.assertEqual(self.removed, [1, 2, 3, 4, 5])
         self.assertEqual(self.added, [5, 4, 3, 2, 1])
+
+    def test_reverse_empty_list(self):
+        tl = TraitList([],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl.reverse()
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
 
     def test_reverse_single_notification(self):
         # Regression test for double notification.

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -215,7 +215,7 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.added, [5])
 
         tl[:] = [1, 2, 3, 4, 5]
-        self.assertEqual(self.index, slice(0, 3, None))
+        self.assertEqual(self.index, 0)
         self.assertEqual(self.removed, [1, 5, 3])
         self.assertEqual(self.added, [1, 2, 3, 4, 5])
 
@@ -270,7 +270,7 @@ class TestTraitList(unittest.TestCase):
 
         tl[:] = (x**2 for x in range(4))
         self.assertEqual(tl, [0, 1, 4, 9])
-        self.assertEqual(self.index, slice(0, 3))
+        self.assertEqual(self.index, 0)
         self.assertEqual(self.removed, [1, 2, 3])
         self.assertEqual(self.added, [0, 1, 4, 9])
 
@@ -375,7 +375,7 @@ class TestTraitList(unittest.TestCase):
         # Note: new items inserted at position 5, not position 2.
         tl[5:2] = [10, 11, 12]
         self.assertEqual(tl, [0, 1, 2, 3, 4, 10, 11, 12, 5, 6])
-        self.assertEqual(self.index, slice(5, 2))
+        self.assertEqual(self.index, 5)
         self.assertEqual(self.removed, [])
         self.assertEqual(self.added, [10, 11, 12])
 
@@ -390,7 +390,7 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.added, [])
 
         del tl[:]
-        self.assertEqual(self.index, slice(0, 2, None))
+        self.assertEqual(self.index, 0)
         self.assertEqual(self.removed, [1, 2])
         self.assertEqual(self.added, [])
 

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -65,10 +65,18 @@ def _normalize_index(index, length):
 def _normalize_slice(index, length):
     """ Normalize slice start and stop to range 0 to len (inclusive). """
 
-    # Do not normalize if step is negative.
+    # Non-extended slice (step = 1): return only need the start index.
+    if index.step is None or index.step == 1:
+        if index.start is None:
+            return 0
+        else:
+            return _normalize_index(index.start, length)
+
+    # Extended slice with negative step: do not normalize.
     if index.step is not None and index.step < 0:
         return index
 
+    # Extended slice with positive step: normalize the start and stop.
     return slice(
         _normalize_index(0 if index.start is None else index.start, length),
         _normalize_index(length if index.stop is None else index.stop, length),

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -200,7 +200,7 @@ class TraitList(list):
         added = [self.item_validator(item) for item in value]
         extended = super().__iadd__(added)
         if added:
-            self.notify(slice(original_length, len(self)), [], added)
+            self.notify(original_length, [], added)
         return extended
 
     def __imul__(self, value):
@@ -221,14 +221,13 @@ class TraitList(list):
             removed = self.copy()
             multiplied = super().__imul__(value)
             if removed:
-                self.notify(slice(0, len(removed)), removed, [])
+                self.notify(0, removed, [])
         else:
             original_length = len(self)
             multiplied = super().__imul__(value)
-            new_length = len(self)
-            if new_length > original_length:
-                index = slice(original_length, new_length)
-                self.notify(index, [], self[index])
+            added = self[original_length:]
+            if added:
+                self.notify(original_length, [], added)
         return multiplied
 
     def __setitem__(self, key, value):
@@ -290,7 +289,7 @@ class TraitList(list):
         removed = self.copy()
         super().clear()
         if removed:
-            self.notify(slice(0, len(removed)), removed, [])
+            self.notify(0, removed, [])
 
     def extend(self, iterable):
         """ Extend list by appending elements from the iterable.
@@ -305,7 +304,7 @@ class TraitList(list):
         added = [self.item_validator(item) for item in iterable]
         super().extend(added)
         if added:
-            self.notify(slice(original_length, len(self)), [], added)
+            self.notify(original_length, [], added)
 
     def insert(self, index, object):
         """ Insert object before index.
@@ -382,7 +381,8 @@ class TraitList(list):
         """ Reverse the items in the list in place. """
         removed = self.copy()
         super().reverse()
-        self.notify(slice(0, len(self)), removed, self.copy())
+        if removed:
+            self.notify(0, removed, self.copy())
 
     def sort(self, *, key=None, reverse=False):
         """ Sort the list in ascending order and return None.
@@ -405,7 +405,8 @@ class TraitList(list):
         """
         removed = self.copy()
         super().sort(key=key, reverse=reverse)
-        self.notify(slice(0, len(self)), removed, self.copy())
+        if removed:
+            self.notify(0, removed, self.copy())
 
     # -- pickle and copy support ----------------------------------------------
 

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -518,11 +518,6 @@ class TraitListObject(TraitList):
         if object is None:
             return
 
-        # bug-for-bug conversion of parameters to TraitListEvent
-        if isinstance(index, slice):
-            if index.step is None or index.step == 1:
-                index = index.start
-
         event = TraitListEvent(index, removed, added)
         items_event = self.trait.items_event()
         object.trait_items_event(self.name_items, event, items_event)


### PR DESCRIPTION
Motivated by #997: this PR changes the `index` used in `TraitList.notify` calls to be a plain int, where that makes sense (i.e., everywhere except `__delitem__` and `__setitem__` operations with an _extended_ slice). I believe that this makes the events more consistent with each other, easier to explain, and easier to interpret for consumers.

As a bonus, there's no longer a difference between the `index`, `added` and `removed` in the `TraitList.notify` calls and the attributes of the corresponding `TraitListEvent`s.

One other minor change (semi-bugfix) in this PR: `sort` and `reverse` no longer notify for zero-element lists. These were the only cases that could produce a `TraitListEvent` where both `removed` and `added` were empty.
