### PR TITLE
__repr__ implementation for TraitListEvent, TraitDictEvent and TraitSetEvent

### DIFF
--- a/traits/tests/test_trait_dict_list_set_event.py
+++ b/traits/tests/test_trait_dict_list_set_event.py
@@ -13,7 +13,7 @@
 import unittest
 
 from traits.api import (
-    HasTraits, List, Dict, Set, on_trait_change,
+    Dict, HasTraits, List, on_trait_change, Set,
     TraitListEvent, TraitDictEvent, TraitSetEvent
 )
 

--- a/traits/tests/test_trait_dict_list_set_event.py
+++ b/traits/tests/test_trait_dict_list_set_event.py
@@ -33,25 +33,25 @@ class TestTraitEvent(unittest.TestCase):
 
     foo = Foo()
 
-    def check_repr(self, event, event_str):
-        self.assertEqual(event.__repr__(), event_str)
-        self.assertEqual(eval(event_str).__repr__(), event_str)
-
     def test_list_repr(self):
-        self.foo.alist[0] = 2
+        self.foo.alist[::2] = [4, 5]
         event = self.foo.event
-        event_str = "TraitListEvent(index=0, removed=[1], added=[2])"
-        self.check_repr(event, event_str)
+        event_str = ("TraitListEvent(index=slice(0, 3, 2), "
+                     "removed=[1, 3], added=[4, 5])")
+        self.assertEqual(event.__repr__(), event_str)
+        self.assertIsInstance(eval(event.__repr__()), TraitListEvent)
 
     def test_dict_event_repr(self):
         self.foo.adict.update({'blue': 10, 'black': 0})
         event = self.foo.event
         event_str = ("TraitDictEvent(added={'black': 0}, "
                      "changed={'blue': 0}, removed={})")
-        self.check_repr(event, event_str)
+        self.assertEqual(event.__repr__(), event_str)
+        self.assertIsInstance(eval(event.__repr__()), TraitDictEvent)
 
     def test_set_event_repr(self):
         self.foo.aset.symmetric_difference_update({3, 4})
         event = self.foo.event
         event_str = "TraitSetEvent(removed={3}, added={4})"
-        self.check_repr(event, event_str)
+        self.assertEqual(event.__repr__(), event_str)
+        self.assertIsInstance(eval(event.__repr__()), TraitSetEvent)

--- a/traits/tests/test_trait_dict_list_set_event.py
+++ b/traits/tests/test_trait_dict_list_set_event.py
@@ -1,0 +1,57 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test cases for TraitListEvent, TraitDictEvent, TraitSetEvent. """
+
+import unittest
+
+from traits.api import (
+    HasTraits, List, Dict, Set, on_trait_change,
+    TraitListEvent, TraitDictEvent, TraitSetEvent
+)
+
+
+class Foo(HasTraits):
+
+    alist = List([1, 2, 3])
+    adict = Dict({'red': 255, 'blue': 0, 'green': 127})
+    aset = Set({1, 2, 3})
+
+    @on_trait_change(["alist_items", "adict_items", "aset_items"])
+    def _receive_events(self, event):
+        self.event = event
+
+
+class TestTraitEvent(unittest.TestCase):
+
+    foo = Foo()
+
+    def check_repr(self, event, event_str):
+        self.assertEqual(event.__repr__(), event_str)
+        self.assertEqual(eval(event_str).__repr__(), event_str)
+
+    def test_list_repr(self):
+        self.foo.alist[0] = 2
+        event = self.foo.event
+        event_str = "TraitListEvent(index=0, removed=[1], added=[2])"
+        self.check_repr(event, event_str)
+
+    def test_dict_event_repr(self):
+        self.foo.adict.update({'blue': 10, 'black': 0})
+        event = self.foo.event
+        event_str = ("TraitDictEvent(added={'black': 0}, "
+                     "changed={'blue': 0}, removed={})")
+        self.check_repr(event, event_str)
+
+    def test_set_event_repr(self):
+        self.foo.aset.symmetric_difference_update({3, 4})
+        event = self.foo.event
+        event_str = "TraitSetEvent(removed={3}, added={4})"
+        self.check_repr(event, event_str)

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -61,6 +61,12 @@ class TraitDictEvent(object):
             removed = {}
         self.removed = removed
 
+    def __repr__(self):
+        outstr = "Updated dict: {} changed, {} added, {} removed".format(
+            self.changed, self.added, self.removed
+        )
+        return outstr
+
 
 class TraitDictObject(dict):
     """ A subclass of dict that fires trait events when mutated.

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -62,7 +62,7 @@ class TraitDictEvent(object):
         self.removed = removed
 
     def __repr__(self):
-        outstr = "Updated dict: {} changed, {} added, {} removed".format(
+        outstr = "TraitDictEvent(added={}, changed={}, removed={})".format(
             self.changed, self.added, self.removed
         )
         return outstr

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -63,7 +63,7 @@ class TraitDictEvent(object):
 
     def __repr__(self):
         outstr = "TraitDictEvent(added={}, changed={}, removed={})".format(
-            self.changed, self.added, self.removed
+            self.added, self.changed, self.removed
         )
         return outstr
 

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -62,10 +62,9 @@ class TraitDictEvent(object):
         self.removed = removed
 
     def __repr__(self):
-        outstr = "TraitDictEvent(added={}, changed={}, removed={})".format(
+        return "TraitDictEvent(added={!r}, changed={!r}, removed={!r})".format(
             self.added, self.changed, self.removed
         )
-        return outstr
 
 
 class TraitDictObject(dict):

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -52,6 +52,12 @@ class TraitListEvent(object):
             added = []
         self.added = added
 
+    def __repr__(self):
+        outstr = "Changed list at {}: was {}, now {}".format(
+            self.index, self.removed, self.added
+        )
+        return outstr
+
 
 def _normalize_index(index, length):
     """ Normalize integer index to range 0 to len (inclusive). """

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -53,7 +53,7 @@ class TraitListEvent(object):
         self.added = added
 
     def __repr__(self):
-        outstr = "Changed list at {}: was {}, now {}".format(
+        outstr = "TraitListEvent(index={}, removed={}, added={})".format(
             self.index, self.removed, self.added
         )
         return outstr

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -53,10 +53,9 @@ class TraitListEvent(object):
         self.added = added
 
     def __repr__(self):
-        outstr = "TraitListEvent(index={}, removed={}, added={})".format(
+        return "TraitListEvent(index={!r}, removed={!r}, added={!r})".format(
             self.index, self.removed, self.added
         )
-        return outstr
 
 
 def _normalize_index(index, length):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -46,10 +46,9 @@ class TraitSetEvent(object):
         self.added = added
 
     def __repr__(self):
-        outstr = "TraitSetEvent(removed={}, added={})".format(
+        return "TraitSetEvent(removed={!r}, added={!r})".format(
             self.removed, self.added
         )
-        return outstr
 
 
 class TraitSetObject(set):

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -45,6 +45,12 @@ class TraitSetEvent(object):
             added = set()
         self.added = added
 
+    def __repr__(self):
+        outstr = "Updated set: {} added, {} removed".format(
+            self.added, self.removed
+        )
+        return outstr
+
 
 class TraitSetObject(set):
     """ A subclass of set that fires trait events when mutated.

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -46,8 +46,8 @@ class TraitSetEvent(object):
         self.added = added
 
     def __repr__(self):
-        outstr = "Updated set: {} added, {} removed".format(
-            self.added, self.removed
+        outstr = "TraitSetEvent(removed={}, added={})".format(
+            self.removed, self.added
         )
         return outstr
 


### PR DESCRIPTION
Added `__repr__` to class TraitListEvent, TraitDictEvent and TraitSetEvent. 

The string returned by `__repr__` indicates only the modifications on the object (to keep it small), not the full modified object.

Fixes #993.
