### PR TITLE
Fix missing 'Raises' section in TraitList.__delitem__ 

### DIFF
--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -178,6 +178,11 @@ class TraitList(list):
         ----------
         key : integer or slice
             Index of the element(s) to be deleted.
+
+        Raises
+        ------
+        IndexError
+            If key is an integer index and is out of range.
         """
 
         if isinstance(key, slice):
@@ -536,7 +541,13 @@ class TraitListObject(TraitList):
         ----------
         key : integer or slice
             Index of the element(s) to be deleted.
+
+        Raises
+        ------
+        IndexError
+            If key is an integer index and is out of range.
         """
+
         removed_count = len(self[key]) if isinstance(key, slice) else 1
         self._validate_length(len(self) - removed_count)
         super().__delitem__(key)


### PR DESCRIPTION
This is a simple documentation-only PR that adds missing "Raises" sections for `TraitList.__delitem__` and `TraitListObject.__delitem__`. Both of those operations can raise `IndexError`. We have that information for the `__setitem__` docstrings, but not for `__delitem__`.