### PR TITLE
Maint: Fix correctness in Enum default traitsui editor

### DIFF
--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2055,20 +2055,23 @@ class BaseEnum(TraitType):
         from traitsui.api import EnumEditor
 
         if self.name is None:
-            values = self
+            values = self.values
             name = ""
         else:
             values = None
             name = self.name
 
-        return EnumEditor(
-            values=values,
+        editor = EnumEditor(
             name=name,
             cols=self.cols or 3,
             evaluate=self.evaluate,
             format_func=self.format_func,
             mode=self.mode if self.mode else "radio",
         )
+        # Workaround enthought/traitsui#782
+        if values is not None:
+            editor.values = values
+        return editor
 
     def _get(self, object, name, trait):
         """ Returns the current value of a dynamic enum trait.


### PR DESCRIPTION
Closes #965 

This PR:
- changes `value = self` (`self` is an instance of `Enum`) to `value = self.values`. Both works, but the latter is more correct.
- Workaround https://github.com/enthought/traitsui/issues/782 when the allowed values are defined statically and when the `format_func` is provided. I'd not recommend putting `format_func` in the definition of trait, but it needs to stay for backward compatibility.

For example, this:
```
from traits.api import HasTraits, Enum

class Foo(HasTraits):

    true_or_false = Enum([0, 1], format_func=lambda v: str(bool(v)).upper())

foo = Foo()
foo.configure_traits()
```
We'd expect to see the dropdown contains `"TRUE"` and  `"FALSE"`.  https://github.com/enthought/traitsui/issues/782 causes us to see `"0"` and `"1"` instead.

**Checklist**
- Tests
     Not testing the effect of `format_func` here to reduce test dependencies on traitsui. See previous discussion in #988. See #1004 as well.
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
