### PR TITLE
DOC: Clarify when default initializer is called and when handlers are registered

### DIFF
--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -43,9 +43,8 @@ The method overrides any default value specified in the trait definition. The
 initializer is called when:
 
 1. the attribute value is accessed the first time or
-2. an instance is constructed with a value different from the default, if there
-   is a change handler defined for the trait
-   (see :ref:`static-notification`).
+2. an instance is constructed with a specific value, if there is a change
+   handler defined for the trait (see :ref:`static-notification`).
 
 .. index:: get_default_value()
 

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -31,16 +31,21 @@ Dynamic Initialization
 When you define trait attributes using predefined traits, the Trait() factory
 function or trait handlers, you typically specify their default values
 statically. You can also define a method that dynamically initializes a trait
-attribute the first time that the attribute value is accessed. To do this, you
-define a method on the same class as the trait attribute, with a name based on
-the name of the trait attribute:
+attribute. To do this, you define a method on the same class as the trait
+attribute, with a name based on the name of the trait attribute:
 
 .. index:: default value; method
 
 .. method:: _name_default()
 
 This method initializes the *name* trait attribute, returning its initial value.
-The method overrides any default value specified in the trait definition.
+The method overrides any default value specified in the trait definition. The
+initializer is called when:
+
+1. the attribute value is accessed the first time or
+2. an instance is constructed with a different value provided to the instance
+   constructor, if there is a change handler defined for the trait
+   (see :ref:`trait-notification`).
 
 .. index:: get_default_value()
 

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -45,7 +45,7 @@ initializer is called when:
 1. the attribute value is accessed the first time or
 2. an instance is constructed with a different value provided to the instance
    constructor, if there is a change handler defined for the trait
-   (see :ref:`trait-notification`).
+   (see :ref:`static-notification`).
 
 .. index:: get_default_value()
 

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -44,7 +44,8 @@ initializer is called when:
 
 1. the attribute value is accessed the first time or
 2. an instance is constructed with a specific value, if there is a change
-   handler defined for the trait (see :ref:`static-notification`).
+   handler defined for the trait. This is needed so the default can be reported
+   as the old value (see :ref:`static-notification`).
 
 .. index:: get_default_value()
 

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -43,8 +43,8 @@ The method overrides any default value specified in the trait definition. The
 initializer is called when:
 
 1. the attribute value is accessed the first time or
-2. an instance is constructed with a different value provided to the instance
-   constructor, if there is a change handler defined for the trait
+2. an instance is constructed with a value different from the default, if there
+   is a change handler defined for the trait
    (see :ref:`static-notification`).
 
 .. index:: get_default_value()

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -453,8 +453,8 @@ not belong to the same object.
 
 .. _decorator-semantics:
 
-Registration time
-:::::::::::::::::
+Decorator Semantics
+:::::::::::::::::::
 
 The functionality provided by the @on_trait_change() decorator is identical to
 that of specially-named handlers, in that both result in a call to

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -1,4 +1,6 @@
 
+.. _trait-notification:
+
 ==================
 Trait Notification
 ==================
@@ -463,11 +465,6 @@ on_trait_change() to register the method as a notification handler. However,
 the two approaches differ in when the call is made. Specially-named handlers
 are registered at class construction time; decorated handlers are registered at
 instance creation time, prior to setting any object state.
-
-A consequence of this difference is that the @on_trait_change() decorator
-causes any default initializers for the traits it references to be executed at
-instance construction time. In the case of specially-named handlers, any
-default initializers are executed lazily.
 
 .. index:: notification; specially-named handlers
 

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -464,10 +464,10 @@ are registered at class construction time; decorated handlers are registered at
 instance creation time.
 
 By default, decorated handlers are registered prior to setting the object
-states. When an instance is constructed with a trait value that is different
+state. When an instance is constructed with a trait value that is different
 from the default, that is considered a change and will fire the associated
 change handlers. The ``post_init`` argument in @on_trait_change can be used
-to delay registering the handler to after the states are set.
+to delay registering the handler to after the state is set.
 
 .. literalinclude:: /../../examples/tutorials/doc_examples/examples/post_init_notification.py
    :start-after: post_init_notification

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -458,7 +458,6 @@ not belong to the same object.
 Decorator Semantics
 :::::::::::::::::::
 
-
 The functionality provided by the @on_trait_change() decorator is identical to
 that of specially-named handlers, in that both result in a call to
 on_trait_change() to register the method as a notification handler. However,

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -453,8 +453,8 @@ not belong to the same object.
 
 .. _decorator-semantics:
 
-Handler registration time
-:::::::::::::::::::::::::
+Registration time
+:::::::::::::::::
 
 The functionality provided by the @on_trait_change() decorator is identical to
 that of specially-named handlers, in that both result in a call to

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -1,6 +1,4 @@
 
-.. _trait-notification:
-
 ==================
 Trait Notification
 ==================
@@ -455,15 +453,24 @@ not belong to the same object.
 
 .. _decorator-semantics:
 
-Decorator Semantics
-:::::::::::::::::::
+Handler registration time
+:::::::::::::::::::::::::
 
 The functionality provided by the @on_trait_change() decorator is identical to
 that of specially-named handlers, in that both result in a call to
 on_trait_change() to register the method as a notification handler. However,
 the two approaches differ in when the call is made. Specially-named handlers
 are registered at class construction time; decorated handlers are registered at
-instance creation time, prior to setting any object state.
+instance creation time.
+
+By default, decorated handlers are registered prior to setting the object
+states. When an instance is constructed with a trait value that is different
+from the default, that is considered a change and will fire the associated
+change handlers. The ``post_init`` argument in @on_trait_change can be used
+to delay registering the handler to after the states are set.
+
+.. literalinclude:: /../../examples/tutorials/doc_examples/examples/post_init_notification.py
+   :start-after: post_init_notification
 
 .. index:: notification; specially-named handlers
 

--- a/examples/tutorials/doc_examples/examples/post_init_notification.py
+++ b/examples/tutorials/doc_examples/examples/post_init_notification.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-# post_init_notification.py --- Example of dynamic notification
+# post_init_notification.py --- Example of static notification
 from traits.api import Float, HasTraits, on_trait_change, Str
 
 class Part(HasTraits):

--- a/examples/tutorials/doc_examples/examples/post_init_notification.py
+++ b/examples/tutorials/doc_examples/examples/post_init_notification.py
@@ -1,0 +1,28 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+# post_init_notification.py --- Example of dynamic notification
+from traits.api import Float, HasTraits, on_trait_change, Str
+
+class Part(HasTraits):
+    cost = Float(0.0)
+
+    name = Str("Part")
+
+    @on_trait_change("cost")
+    def cost_updated(self, object, name, old, new):
+        print("{} is changed from {} to {}".format(name, old, new))
+
+    @on_trait_change("name", post_init=True)
+    def name_updated(self, object, name, old, new):
+        print("{} is changed from {} to {}".format(name, old, new))
+
+part = Part(cost=2.0, name="Nail")
+# Result: cost is changed from 0.0 to 2.0


### PR DESCRIPTION
The behaviour seen in #94 wasn't obvious to me. This PR expands the documentation to clarify:
(1) instantiation with a specific value will be considered for firing a trait change event, if there is a change handler
(2) `post_init` can be used for use cases when firing change handler for values provided to `__init__` is not desirable. This `post_init` was never mentioned in the user documentation, but often mentioned in issues when this comes up.

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
