### PR TITLE
Deprecate Color, RBGColor and Font traits

### DIFF
--- a/docs/source/traits_api_reference/traits.rst
+++ b/docs/source/traits_api_reference/traits.rst
@@ -15,16 +15,17 @@ Classes
 
 .. autoclass:: ForwardProperty
 
-.. autoclass:: Color
-
-.. autoclass:: RGBColor
-
-.. autoclass:: Font
 
 Functions
 ---------
 
 .. autofunction:: Trait
+
+.. autofunction:: Color
+
+.. autofunction:: RGBColor
+
+.. autofunction:: Font
 
 
 Private Classes

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -235,13 +235,13 @@ trait cannot be used as a simple name, it is omitted from the Name column of
 the table.
 
 .. index:: Any(), Array(), Button(), Callable(), CArray(), Code()
-.. index:: Color(), CSet(), Constant(), Dict()
+.. index:: CSet(), Constant(), Dict()
 .. index:: Directory(), Disallow, Either(), Enum()
-.. index:: Event(), Expression(), false, File(), Font()
+.. index:: Event(), Expression(), false, File()
 .. index:: Instance(), List(), Method(), Module()
 .. index:: Password(), Property(), Python()
 .. index:: PythonValue(), Range(), ReadOnly(), Regex()
-.. index:: RGBColor(), Set() String(), This,
+.. index:: Set() String(), This,
 .. index:: ToolbarButton(), true, Tuple(), Type()
 .. index:: undefined, UUID(), ValidatedTuple(), WeakRef()
 
@@ -272,8 +272,6 @@ the table.
 | Code             | Code( [*value* = '', *minlen* = 0, *maxlen* = sys.maxint,|
 |                  | *regex* = '', \*\*\ *metadata*] )                        |
 +------------------+----------------------------------------------------------+
-| Color            | Color( [\*\ *args*, \*\*\ *metadata*] )                  |
-+------------------+----------------------------------------------------------+
 | CSet             | CSet( [*trait* = None, *value* = None, *items* = True,   |
 |                  | \*\*\ *metadata*] )                                      |
 +------------------+----------------------------------------------------------+
@@ -298,8 +296,6 @@ the table.
 +------------------+----------------------------------------------------------+
 | File             | File( [*value* = '', *filter* = None, *auto_set* = False,|
 |                  | *entries* = 10, *exists* = False,  \*\*\ *metadata* ] )  |
-+------------------+----------------------------------------------------------+
-| Font             | Font( [\*\ *args*, \*\*\ *metadata*] )                   |
 +------------------+----------------------------------------------------------+
 | Function         | Function( [*value* = None, \*\*\ *metadata*] )           |
 +------------------+----------------------------------------------------------+
@@ -344,8 +340,6 @@ the table.
 | ReadOnly         | ReadOnly( [*value* = Undefined, \*\*\ *metadata*] )      |
 +------------------+----------------------------------------------------------+
 | Regex            | Regex( [*value* = '', *regex* = '.\*', \*\*\ *metadata*])|
-+------------------+----------------------------------------------------------+
-| RGBColor         | RGBColor( [\*\ *args*, \*\*\ *metadata*] )               |
 +------------------+----------------------------------------------------------+
 | self             | n/a                                                      |
 +------------------+----------------------------------------------------------+

--- a/examples/tutorials/doc_examples/examples/event.py
+++ b/examples/tutorials/doc_examples/examples/event.py
@@ -11,7 +11,8 @@
 # event.py --- Example of a trait event
 
 # --<Imports>------------------------------------------------------------------
-from traits.api import Event, HasTraits, List, RGBColor, Tuple
+from traits.api import Event, HasTraits, List, Tuple
+from traitsui.api import RGBColor
 
 # --[Code]---------------------------------------------------------------------
 

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -1284,7 +1284,6 @@ class TestDeprecatedTraits(unittest.TestCase):
 
     def test_color_deprecated(self):
         with self.assertWarnsRegex(DeprecationWarning, "'Color' in 'traits'"):
-            print("I register changes")
             Color()
 
     def test_rgb_color_deprecated(self):

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -20,13 +20,16 @@ from traits.api import (
     CFloat,
     CInt,
     ComparisonMode,
+    Color,
     Delegate,
     Float,
+    Font,
     HasTraits,
     Instance,
     Int,
     List,
     Range,
+    RGBColor,
     Str,
     This,
     Trait,
@@ -1275,3 +1278,20 @@ class ComparisonModeTests(unittest.TestCase):
         self.assertEqual(len(events), 1)
         old_compare.bar = [4, 5, 6]
         self.assertEqual(len(events), 2)
+
+
+class TestDeprecatedTraits(unittest.TestCase):
+
+    def test_color_deprecated(self):
+        with self.assertWarnsRegex(DeprecationWarning, "'Color' in 'traits'"):
+            print("I register changes")
+            Color()
+
+    def test_rgb_color_deprecated(self):
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   "'RGBColor' in 'traits'"):
+            RGBColor()
+
+    def test_font_deprecated(self):
+        with self.assertWarnsRegex(DeprecationWarning, "'Font' in 'traits'"):
+            Font()

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -73,6 +73,7 @@ from .trait_handlers import (
 from .trait_factory import (
     TraitFactory,
 )
+from .util.deprecated import deprecated
 
 # Constants
 
@@ -653,21 +654,14 @@ generic_trait = CTrait(TraitKind.generic)
 
 # User interface related color and font traits
 
+@deprecated("'Color' in 'traits' package has been deprecated. "
+            "Use 'Color' from 'traitsui' package instead.")
 def Color(*args, **metadata):
     """ Returns a trait whose value must be a GUI toolkit-specific color.
 
-    Description
-    -----------
-    For wxPython, the returned trait accepts any of the following values:
-
-    * A wx.Colour instance
-    * A wx.ColourPtr instance
-    * an integer whose hexadecimal form is 0x*RRGGBB*, where *RR* is the red
-      value, *GG* is the green value, and *BB* is the blue value
-
-    Default Value
-    -------------
-    For wxPython, 0xffffff (that is, white)
+    .. deprecated:: 6.1.0
+        ``Color`` trait in this package will be removed in the future. It is
+        replaced by ``Color`` trait in TraitsUI package.
     """
     from traitsui.toolkit_traits import ColorTrait
 
@@ -677,23 +671,15 @@ def Color(*args, **metadata):
 Color = TraitFactory(Color)
 
 
+@deprecated("'RGBColor' in 'traits' package has been deprecated. "
+            "Use 'RGBColor' from 'traitsui' package instead.")
 def RGBColor(*args, **metadata):
     """ Returns a trait whose value must be a GUI toolkit-specific RGB-based
-        color.
+    color.
 
-    Description
-    -----------
-    For wxPython, the returned trait accepts any of the following values:
-
-    * A tuple of the form (*r*, *g*, *b*), in which *r*, *g*, and *b* represent
-      red, green, and blue values, respectively, and are floats in the range
-      from 0.0 to 1.0
-    * An integer whose hexadecimal form is 0x*RRGGBB*, where *RR* is the red
-      value, *GG* is the green value, and *BB* is the blue value
-
-    Default Value
-    -------------
-    For wxPython, (1.0, 1.0, 1.0) (that is, white)
+    .. deprecated:: 6.1.0
+        ``RGBColor`` trait in this package will be removed in the future. It is
+        replaced by ``RGBColor`` trait in TraitsUI package.
     """
     from traitsui.toolkit_traits import RGBColorTrait
 
@@ -703,21 +689,14 @@ def RGBColor(*args, **metadata):
 RGBColor = TraitFactory(RGBColor)
 
 
+@deprecated("'Font' in 'traits' package has been deprecated. "
+            "Use 'Font' from 'traitsui' package instead.")
 def Font(*args, **metadata):
     """ Returns a trait whose value must be a GUI toolkit-specific font.
 
-    Description
-    -----------
-    For wxPython, the returned trait accepts any of the following:
-
-    * a wx.Font instance
-    * a wx.FontPtr instance
-    * a string describing the font, including one or more of the font family,
-      size, weight, style, and typeface name.
-
-    Default Value
-    -------------
-    For wxPython, 'Arial 10'
+    .. deprecated:: 6.1.0
+        ``Font`` trait in this package will be removed in the future. It is
+        replaced by ``Font`` trait in TraitsUI package.
     """
     from traitsui.toolkit_traits import FontTrait
 


### PR DESCRIPTION
Closes #728 

Color, RBGColor and Font traits are now deprecated with the recommendation to use `traitsui` instead. 

Updated API references and docstrings. Description and Default Value sections seemed out of date (and sphinx was complaining) so I just removed them. Removed all references to these traits from User manual as well.

Also updated one example that uses `RGBColor`.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~[ ] Update type annotation hints in `traits-stubs`~
