### PR TITLE
Implement logic for adding/removing notifiers for a given ObserverGraph

### DIFF
--- a/traits/observers/_exceptions.py
+++ b/traits/observers/_exceptions.py
@@ -1,0 +1,14 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+class NotifierNotFound(Exception):
+    """ Raised when a notifier cannot be found."""
+    pass

--- a/traits/observers/_i_notifier.py
+++ b/traits/observers/_i_notifier.py
@@ -1,0 +1,42 @@
+
+import abc
+
+
+class INotifier(abc.ABC):
+    """ Interface for all notifiers.
+
+    An instance of notifier must be a callable, i.e. ``__call__`` must be
+    implemented and cannot be None. The signature of that callable should be
+    compatible with the observables the notifier will be given to. This
+    interface does not define what that signature should be.
+    """
+
+    def __call__(self, *args, **kwargs):
+        """ Called by the observable.
+        The signature is not restricted by the interface.
+        """
+        raise NotImplementedError("__call__ must be implemented.")
+
+    def add_to(self, observable):
+        """ Add this notifier to the observable.
+
+        Parameters
+        ----------
+        observable : IObservable
+        """
+        raise NotImplementedError("add_to must be implemented.")
+
+    def remove_from(self, observable):
+        """ Remove this notifier or a notifier equivalent to this one
+        from the observable.
+
+        Parameters
+        ----------
+        observable : IObservable
+
+        Raises
+        ------
+        NotifierNotFound
+            If the notifier cannot be found.
+        """
+        raise NotImplementedError("remove_from must be implemented.")

--- a/traits/observers/_i_notifier.py
+++ b/traits/observers/_i_notifier.py
@@ -12,7 +12,7 @@ class INotifier(abc.ABC):
     """
 
     def __call__(self, *args, **kwargs):
-        """ Called by the observable.
+        """ Called by an observable.
         The signature is not restricted by the interface.
         """
         raise NotImplementedError("__call__ must be implemented.")

--- a/traits/observers/_i_notifier.py
+++ b/traits/observers/_i_notifier.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
 
 import abc
 

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -28,8 +28,7 @@ class IObserver(abc.ABC):
     to the leaf nodes. The first observer (root node) will be given the object
     the user wants to observe. It knows how to obtain observable(s) for
     attaching notifiers. It also knows what objects should be given to the
-    downstream/children observers in the same graph. Then the process repeats
-    as the ``ObserverGraph`` is walked.
+    downstream/children observers in the same graph.
 
     An observer defines the notifier that wraps the user change handler, should
     notification is enabled by the user. This allows the observer to define

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -80,11 +80,6 @@ class IObserver(abc.ABC):
         Yields
         ------
         IObservable
-
-        Raises
-        ------
-        ValueError
-            If the given object cannot be handled by this observer.
         """
         raise NotImplementedError("iter_observables must be implemented.")
 

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -20,6 +20,21 @@ class IObserver(abc.ABC):
     user. In order to support equality and hashing on the
     ``ObserverGraph``, ``IObserver`` needs to be hashable
     and it needs to support comparison for equality.
+
+    A subclass of ``IObserver`` is often context specific, e.g. for observing
+    a trait on an HasTraits instance, for observing items in a list, etc.
+
+    Given an ``ObserverGraph``, observers are visited from the root node
+    to the leaf nodes. The first observer (root node) will be given the object
+    the user wants to observe. It knows how to obtain the ``IObservable``
+    object(s) for attaching notifiers (see ``iter_observables``). It also
+    knows what objects should be given to the downstream/children observers in
+    the same graph (see ``iter_objects``). Then the process repeats as the
+    ``ObserverGraph`` is walked. See ``add_or_remove_notifiers``.
+
+    Some observers may require additional helper observers and notifiers,
+    e.g. an observer for traits will need to respond to the ``trait_added``
+    event. See ``iter_extra_graphs``.
     """
 
     def __hash__(self):
@@ -29,3 +44,95 @@ class IObserver(abc.ABC):
     def __eq__(self, other):
         """ Return true if this observer is equal to the given one."""
         raise NotImplementedError("__eq__ must be implemented.")
+
+    @property
+    def notify(self):
+        """ A boolean for whether this observer will notify for changes.
+        """
+        raise NotImplementedError("notify property must be implemented.")
+
+    def iter_observables(self, object):
+        """ Yield observables for notifiers to be attached to or detached from.
+
+        Parameters
+        ----------
+        object: object
+            Object provided by the ``iter_objects`` methods from another
+            observers or directly by the user.
+            No guarantee can be made about the type of the object.
+            Concrete should do the sanity check where appropriate.
+
+        Yields
+        ------
+        IObservable
+
+        Raises
+        ------
+        ValueError
+            If the given object cannot be handled by this observer.
+        """
+        raise NotImplementedError("iter_observables must be implemented.")
+
+    def iter_objects(self, object):
+        """ Yield objects for the next observer following this observer, in an
+        ObserverGraph.
+
+        Parameters
+        ----------
+        object: object
+            Object provided by the ``iter_objects`` methods from another
+            observers or directly by the user.
+            No guarantee can be made about the type of the object.
+            Concrete should do the sanity check where appropriate.
+
+        Yields
+        ------
+        value : object
+        """
+        raise NotImplementedError("iter_objects must be implemented.")
+
+    def get_notifier(self, observable, handler, target, dispatcher):
+        """ Return a notifier for calling the user handler with the change
+        event. This is needed if ``notify`` is true.
+
+        Returns
+        -------
+        notifier : INotifier
+        """
+        raise NotImplementedError("get_notifier must be implemented.")
+
+    def get_maintainer(self, graph, handler, target, dispatcher):
+        """ Return a notifier for maintaining downstream observers in an
+        ObserverGraph, when the object observed by this observer changes.
+
+        Parameters
+        ----------
+        graph : ObserverGraph
+            Description for the *downstream* observers, i.e. excluding self.
+        handler : callable
+            User handler.
+        target : object
+            Object seen by the user as the owner of the observer.
+        dispatcher : callable
+            Callable for dispatching the handler.
+
+        Returns
+        -------
+        notifier : INotifier
+        """
+        raise NotImplementedError("get_maintainer must be implemented.")
+
+    def iter_extra_graphs(self, graph):
+        """ Yield additional ObserverGraph for adding/removing notifiers when
+        this observer is encountered in a given ObserverGraph.
+
+        Parameters
+        ----------
+        graph : ObserverGraph
+            The graph where this observer is the root node.
+
+        Yields
+        ------
+        graph : ObserverGraph
+        """
+        raise NotImplementedError("iter_extra_graphs must be implemented.")

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -26,11 +26,22 @@ class IObserver(abc.ABC):
 
     Given an ``ObserverGraph``, observers are visited from the root node
     to the leaf nodes. The first observer (root node) will be given the object
-    the user wants to observe. It knows how to obtain the ``IObservable``
-    object(s) for attaching notifiers (see ``iter_observables``). It also
-    knows what objects should be given to the downstream/children observers in
-    the same graph (see ``iter_objects``). Then the process repeats as the
-    ``ObserverGraph`` is walked. See ``add_or_remove_notifiers``.
+    the user wants to observe. It knows how to obtain observable(s) for
+    attaching notifiers. It also knows what objects should be given to the
+    downstream/children observers in the same graph. Then the process repeats
+    as the ``ObserverGraph`` is walked.
+
+    An observer defines the notifier that wraps the user change handler, should
+    notification is enabled by the user. This allows the observer to define
+    how the user should receive the change event, e.g. what type of event
+    object should be created, and whether a given event should be silenced etc.
+
+    An observer also defines a "maintainer" (which is also a notifier from the
+    point of view of an observable), for maintaining downstream observers when
+    a change happens for an observable. For example, an observerable may not
+    have a defined value yet for the children observers to handle. When the
+    value is defined, the observable is expected to notify the maintainer,
+    which will pass the new value onto the children observers.
 
     An observer can also contribute more ``ObserverGraph`` via
     ``iter_extra_graphs`` if they require support from other observers.

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -91,9 +91,18 @@ class IObserver(abc.ABC):
         """
         raise NotImplementedError("iter_objects must be implemented.")
 
-    def get_notifier(self, observable, handler, target, dispatcher):
+    def get_notifier(self, handler, target, dispatcher):
         """ Return a notifier for calling the user handler with the change
         event. This is needed if ``notify`` is true.
+
+        Parameters
+        ----------
+        handler : callable
+            User handler.
+        target : object
+            Object seen by the user as the owner of the observer.
+        dispatcher : callable
+            Callable for dispatching the handler.
 
         Returns
         -------

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -52,7 +52,22 @@ class IObserver(abc.ABC):
         raise NotImplementedError("notify property must be implemented.")
 
     def iter_observables(self, object):
-        """ Yield observables for notifiers to be attached to or detached from.
+        """ Yield observables for adding or removing notifiers.
+
+        The notifiers are contributed by this observer's ``get_notifier``
+        and ``get_maintainer`` methods.
+
+        An observer may observe many items, e.g. multiple traits for a given
+        instance of HasTraits, then the observer will yield many items here.
+
+        An observer may also observe just one thing, a single trait, then
+        the observer may yield just that.
+
+        An observer may also find nothing to be observed and does not need to
+        complain about that, and it will yield nothing here.
+
+        Observers are allowed to raise here if it is appropriate to do so,
+        e.g. to help catch usage errors.
 
         Parameters
         ----------
@@ -76,6 +91,21 @@ class IObserver(abc.ABC):
     def iter_objects(self, object):
         """ Yield objects for the next observer following this observer, in an
         ObserverGraph.
+
+        For example, an observer may observe many traits for a given instance
+        of HasTraits, then the observer will yield the values of those traits
+        if they are deem appropriate to be passed onto the next observer.
+
+        An observer may be observing items in a container, e.g. an instance
+        of TraitListObject, then the observer will yield the content of the
+        container for the next observer to handle.
+
+        An observer may find nothing to be passed onto the next observer, and
+        has no need to complain about that. Then the observer may yield
+        nothing.
+
+        Observers are allowed to raise here if it is appropriate to do so,
+        e.g. to help catch usage errors.
 
         Parameters
         ----------
@@ -134,6 +164,13 @@ class IObserver(abc.ABC):
     def iter_extra_graphs(self, graph):
         """ Yield additional ObserverGraph for adding/removing notifiers when
         this observer is encountered in a given ObserverGraph.
+
+        If an observer needs support from another observer(s), e.g.
+        for observing 'trait_added' event, then this method can yield any
+        number of ObserverGraph containing those additional observer(s).
+
+        If an observer does not need additional support from other observers,
+        this method can yield nothing.
 
         Parameters
         ----------

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -60,8 +60,8 @@ class IObserver(abc.ABC):
         An observer may observe many items, e.g. multiple traits for a given
         instance of HasTraits, then the observer will yield many items here.
 
-        An observer may also observe just one thing, a single trait, then
-        the observer may yield just that.
+        An observer may also observe just one thing, e.g. a single trait, or an
+        instance of TraitListObject, then the observer may yield just that.
 
         An observer may also find nothing to be observed and does not need to
         complain about that, and it will yield nothing here.

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -91,13 +91,14 @@ class IObserver(abc.ABC):
         """ Yield objects for the next observer following this observer, in an
         ObserverGraph.
 
-        For example, an observer may observe many traits for a given instance
-        of HasTraits, then the observer will yield the values of those traits
-        if they are deem appropriate to be passed onto the next observer.
+        An observer may yield many items for the next observer, e.g. the
+        observer is observing many traits on the given instance of HasTraits
+        or the observer is observing items in a container. The observer can
+        evaluate whether the value is appropriate to be passed on, or skip some
+        if the observer expected to do so.
 
-        An observer may be observing items in a container, e.g. an instance
-        of TraitListObject, then the observer will yield the content of the
-        container for the next observer to handle.
+        An observer may yield one item if that is what should be passed onto
+        the next observer.
 
         An observer may find nothing to be passed onto the next observer, and
         has no need to complain about that. Then the observer may yield

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -74,7 +74,8 @@ class IObserver(abc.ABC):
             Object provided by the ``iter_objects`` methods from another
             observers or directly by the user.
             No guarantee can be made about the type of the object.
-            Concrete should do the sanity check where appropriate.
+            Concrete implementations should do the sanity check where
+            appropriate.
 
         Yields
         ------
@@ -95,7 +96,7 @@ class IObserver(abc.ABC):
         observer is observing many traits on the given instance of HasTraits
         or the observer is observing items in a container. The observer can
         evaluate whether the value is appropriate to be passed on, or skip some
-        if the observer expected to do so.
+        if the observer is expected to do so.
 
         An observer may yield one item if that is what should be passed onto
         the next observer.
@@ -113,7 +114,8 @@ class IObserver(abc.ABC):
             Object provided by the ``iter_objects`` methods from another
             observers or directly by the user.
             No guarantee can be made about the type of the object.
-            Concrete should do the sanity check where appropriate.
+            Concrete implementations should do the sanity check where
+            appropriate.
 
         Yields
         ------

--- a/traits/observers/_i_observer.py
+++ b/traits/observers/_i_observer.py
@@ -32,9 +32,8 @@ class IObserver(abc.ABC):
     the same graph (see ``iter_objects``). Then the process repeats as the
     ``ObserverGraph`` is walked. See ``add_or_remove_notifiers``.
 
-    Some observers may require additional helper observers and notifiers,
-    e.g. an observer for traits will need to respond to the ``trait_added``
-    event. See ``iter_extra_graphs``.
+    An observer can also contribute more ``ObserverGraph`` via
+    ``iter_extra_graphs`` if they require support from other observers.
     """
 
     def __hash__(self):

--- a/traits/observers/_observe.py
+++ b/traits/observers/_observe.py
@@ -33,51 +33,136 @@ def add_or_remove_notifiers(
         callback on a different thread.
     remove : boolean
         If true, notifiers are being removed.
+
+    Raises
+    ------
+    NotiferNotFound
+        Raised when notifier cannot be found for removal.
+    """
+    callable_ = _AddOrRemoveNotifier(
+        object=object,
+        graph=graph,
+        handler=handler,
+        target=target,
+        dispatcher=dispatcher,
+        remove=remove,
+    )
+    callable_()
+
+
+class _AddOrRemoveNotifier:
+    """ Callable for adding or removing notifiers.
+
+    See ``add_or_remove_notifiers`` for the input parameters.
     """
 
-    observer = graph.node
-    for observable in observer.iter_observables(object):
-        if observer.notify:
-            notifier = observer.get_notifier(
-                handler=handler,
-                target=target,
-                dispatcher=dispatcher,
+    def __init__(self, *, object, graph, handler, target, dispatcher, remove):
+        self.object = object
+        self.graph = graph
+        self.handler = handler
+        self.target = target
+        self.dispatcher = dispatcher
+        self.remove = remove
+
+        # list of (notifier, observable)
+        self._processed = []
+
+    def __call__(self):
+        """ Main function for adding/removing notifiers."""
+
+        steps = [
+            self._add_or_remove_notifiers,
+            self._add_or_remove_maintainers,
+            self._add_or_remove_children_notifiers,
+            self._add_or_remove_extra_graphs,
+        ]
+
+        # Not quite the complete reversal, as trees are still walked from
+        # root to leaves.
+        if self.remove:
+            steps = steps[::-1]
+
+        try:
+            for step in steps:
+                step()
+        except Exception:
+            # Undo and then reraise
+            while self._processed:
+                notifier, observable = self._processed.pop()
+                if self.remove:
+                    notifier.add_to(observable)
+                else:
+                    notifier.remove_from(observable)
+            raise
+        else:
+            self._processed.clear()
+
+    def _add_or_remove_extra_graphs(self):
+        """ Add or remove additional ObserverGraph contributed by the root
+        observer. e.g. for handing trait_added event.
+        """
+        for extra_graph in self.graph.node.iter_extra_graphs(self.graph):
+            add_or_remove_notifiers(
+                object=self.object,
+                graph=extra_graph,
+                handler=self.handler,
+                target=self.target,
+                dispatcher=self.dispatcher,
+                remove=self.remove,
             )
-            if remove:
+
+    def _add_or_remove_children_notifiers(self):
+        """ Recursively add or remove notifiers for the children ObserverGraph.
+        """
+        for child_graph in self.graph.children:
+            for next_object in self.graph.node.iter_objects(self.object):
+                add_or_remove_notifiers(
+                    object=next_object,
+                    graph=child_graph,
+                    handler=self.handler,
+                    target=self.target,
+                    dispatcher=self.dispatcher,
+                    remove=self.remove,
+                )
+
+    def _add_or_remove_maintainers(self):
+        """ Add or remove notifiers for maintaining children notifiers when
+        the objects being observed by the root observer change.
+        """
+        for observable in self.graph.node.iter_observables(self.object):
+
+            for child_graph in self.graph.children:
+
+                change_notifier = self.graph.node.get_maintainer(
+                    graph=child_graph,
+                    handler=self.handler,
+                    target=self.target,
+                    dispatcher=self.dispatcher,
+                )
+                if self.remove:
+                    change_notifier.remove_from(observable)
+                else:
+                    change_notifier.add_to(observable)
+
+                self._processed.append((change_notifier, observable))
+
+    def _add_or_remove_notifiers(self):
+        """ Add or remove user notifiers for the objects observed by the root
+        observer.
+        """
+        if not self.graph.node.notify:
+            return
+
+        for observable in self.graph.node.iter_observables(self.object):
+
+            notifier = self.graph.node.get_notifier(
+                handler=self.handler,
+                target=self.target,
+                dispatcher=self.dispatcher,
+            )
+            if self.remove:
                 notifier.remove_from(observable)
             else:
                 notifier.add_to(observable)
 
-        for child_graph in graph.children:
-
-            change_notifier = observer.get_maintainer(
-                graph=child_graph,
-                handler=handler,
-                target=target,
-                dispatcher=dispatcher,
-            )
-            if remove:
-                change_notifier.remove_from(observable)
-            else:
-                change_notifier.add_to(observable)
-
-    for child_graph in graph.children:
-        for next_object in observer.iter_objects(object):
-            add_or_remove_notifiers(
-                object=next_object,
-                graph=child_graph,
-                handler=handler,
-                target=target,
-                dispatcher=dispatcher,
-                remove=remove,
-            )
-
-    for extra_graph in observer.iter_extra_graphs(graph):
-        add_or_remove_notifiers(
-            object=object,
-            graph=extra_graph,
-            handler=handler,
-            target=target,
-            dispatcher=dispatcher,
-            remove=remove,
-        )
+            self._processed.append((notifier, observable))

--- a/traits/observers/_observe.py
+++ b/traits/observers/_observe.py
@@ -68,8 +68,11 @@ class _AddOrRemoveNotifier:
         self._processed = []
 
     def __call__(self):
-        """ Main function for adding/removing notifiers."""
+        """ Main function for adding/removing notifiers.
+        """
 
+        # The order of events does not matter as they are independent of each
+        # other.
         steps = [
             self._add_or_remove_notifiers,
             self._add_or_remove_maintainers,

--- a/traits/observers/_observe.py
+++ b/traits/observers/_observe.py
@@ -39,7 +39,6 @@ def add_or_remove_notifiers(
     for observable in observer.iter_observables(object):
         if observer.notify:
             notifier = observer.get_notifier(
-                observable=observable,
                 handler=handler,
                 target=target,
                 dispatcher=dispatcher,

--- a/traits/observers/_observe.py
+++ b/traits/observers/_observe.py
@@ -66,8 +66,8 @@ def add_or_remove_notifiers(
         for next_object in observer.iter_objects(object):
             add_or_remove_notifiers(
                 object=next_object,
-                handler=handler,
                 graph=child_graph,
+                handler=handler,
                 target=target,
                 dispatcher=dispatcher,
                 remove=remove,
@@ -76,8 +76,8 @@ def add_or_remove_notifiers(
     for extra_graph in observer.iter_extra_graphs(graph):
         add_or_remove_notifiers(
             object=object,
-            handler=handler,
             graph=extra_graph,
+            handler=handler,
             target=target,
             dispatcher=dispatcher,
             remove=remove,

--- a/traits/observers/_observe.py
+++ b/traits/observers/_observe.py
@@ -25,10 +25,9 @@ def add_or_remove_notifiers(
         ``event`` is an object representing the change.
         Its type and content depends on the change.
     target : Any
-        Sets the context for the handler. In practice, it is
-        the HasTrait instance on which the observer graph is defined and
-        will be seen by users as the "owner" of the observer.
-        Strictly speaking, this object does not have to be an observable.
+        An object for defining the context of the user's handler notifier.
+        This is typically an instance of HasTraits seen by the user as the
+        "owner" of the observer.
     dispatcher : callable(callable, event)
         Callable for dispatching the user-defined handler, i.e. dispatching
         callback on a different thread.

--- a/traits/observers/_observe.py
+++ b/traits/observers/_observe.py
@@ -1,0 +1,85 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+def add_or_remove_notifiers(
+        *, object, graph, handler, target, dispatcher, remove):
+    """ Add/Remove notifiers on objects following the description on an
+    ObserverGraph.
+
+    Parameters
+    ----------
+    object : IObservable
+        An object to be observed.
+    graph : ObserverGraph
+        A graph describing what and how extended traits are being observed.
+    handler : callable(event)
+        User-defined callable to handle change events.
+        ``event`` is an object representing the change.
+        Its type and content depends on the change.
+    target : Any
+        Sets the context for the handler. In practice, it is
+        the HasTrait instance on which the observer graph is defined and
+        will be seen by users as the "owner" of the observer.
+        Strictly speaking, this object does not have to be an observable.
+    dispatcher : callable(callable, event)
+        Callable for dispatching the user-defined handler, i.e. dispatching
+        callback on a different thread.
+    remove : boolean
+        If true, notifiers are being removed.
+    """
+
+    observer = graph.node
+    for observable in observer.iter_observables(object):
+        if observer.notify:
+            notifier = observer.get_notifier(
+                observable=observable,
+                handler=handler,
+                target=target,
+                dispatcher=dispatcher,
+            )
+            if remove:
+                notifier.remove_from(observable)
+            else:
+                notifier.add_to(observable)
+
+        for child_graph in graph.children:
+
+            change_notifier = observer.get_maintainer(
+                graph=child_graph,
+                handler=handler,
+                target=target,
+                dispatcher=dispatcher,
+            )
+            if remove:
+                change_notifier.remove_from(observable)
+            else:
+                change_notifier.add_to(observable)
+
+    for child_graph in graph.children:
+        for next_object in observer.iter_objects(object):
+            add_or_remove_notifiers(
+                object=next_object,
+                handler=handler,
+                graph=child_graph,
+                target=target,
+                dispatcher=dispatcher,
+                remove=remove,
+            )
+
+    for extra_graph in observer.iter_extra_graphs(graph):
+        add_or_remove_notifiers(
+            object=object,
+            handler=handler,
+            graph=extra_graph,
+            target=target,
+            dispatcher=dispatcher,
+            remove=remove,
+        )

--- a/traits/observers/_observe.py
+++ b/traits/observers/_observe.py
@@ -16,7 +16,7 @@ def add_or_remove_notifiers(
 
     Parameters
     ----------
-    object : IObservable
+    object : object
         An object to be observed.
     graph : ObserverGraph
         A graph describing what and how extended traits are being observed.

--- a/traits/observers/_testing.py
+++ b/traits/observers/_testing.py
@@ -1,0 +1,151 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+from unittest import mock
+
+from traits.observers._exceptions import NotifierNotFound
+from traits.observers._observe import add_or_remove_notifiers
+from traits.observers._observer_graph import ObserverGraph
+
+
+#: An object that does not get garbage collected until the very end
+_DEFAULT_TARGET = mock.Mock()
+
+
+def create_graph(*nodes):
+    """ Create an ObserverGraph with the given nodes joined one after another.
+
+    Parameters
+    ----------
+    *nodes : hashable
+        Items to be attached as nodes
+
+    Returns
+    -------
+    ObserverGraph
+    """
+    node = nodes[-1]
+    graph = ObserverGraph(node=node)
+    for node in nodes[:-1][::-1]:
+        graph = ObserverGraph(node=node, children=[graph])
+    return graph
+
+
+def call_add_or_remove_notifiers(**kwargs):
+    """ Convenience function for calling add_or_remove_notifiers with default
+    values.
+
+    Parameters
+    ----------
+    **kwargs
+        New argument values to use instead.
+    """
+    def dispatch_same(handler, event):
+        handler(event)
+
+    values = dict(
+        object=mock.Mock(),
+        graph=ObserverGraph(node=None),
+        handler=mock.Mock(),
+        target=_DEFAULT_TARGET,
+        dispatcher=dispatch_same,
+        remove=False,
+    )
+    values.update(kwargs)
+    add_or_remove_notifiers(**values)
+
+
+class DummyObservable:
+    """ A dummy implementation of IObservable for testing purposes."""
+
+    def __init__(self):
+        self.notifiers = []
+
+    def _notifiers(self, force_create):
+        return self.notifiers
+
+
+class DummyNotifier:
+    """ A dummy implementation of INotifier for testing purposes."""
+
+    def add_to(self, observable):
+        observable._notifiers(True).append(self)
+
+    def remove_from(self, observable):
+        notifiers = observable._notifiers(True)
+        try:
+            notifiers.remove(self)
+        except ValueError:
+            raise NotifierNotFound("Notifier not found.")
+
+
+class DummyObserver:
+    """ A dummy implementation of IObserver for testing purposes.
+
+    Parameters
+    ----------
+    notify : boolean, optional
+        The mocked return value from IObserver.notify
+    observables : iterable of IObservable, optional
+        The mocked yielded values from IObserver.iter_observables
+    next_objects : iterable of object, optional
+        The mocked yielded values from IObserver.iter_objects
+    notifier : INotifier, optional
+        The mocked returned value from IObserver.get_notifier
+        If not provided, a dummy notifier is created.
+    maintainer : INotifier, optional
+        The mocked returned value from IObserver.get_maintainer
+        if not provided, a dummy notifier is created.
+    extra_graphs : iterable of ObserverGraph, optional
+        The mocked yielded values from IObserver.iter_extra_graphs
+    """
+
+    def __init__(
+            self,
+            notify=True,
+            observables=(),
+            next_objects=(),
+            notifier=None,
+            maintainer=None,
+            extra_graphs=()):
+
+        if notifier is None:
+            notifier = DummyNotifier()
+        if maintainer is None:
+            maintainer = DummyNotifier()
+
+        self.notify = notify
+        self.observables = observables
+        self.next_objects = next_objects
+        self.notifier = notifier
+        self.maintainer = maintainer
+        self.extra_graphs = extra_graphs
+
+    def __eq__(self, other):
+        return other is self
+
+    def __hash__(self):
+        return 1
+
+    def iter_observables(self, object):
+        yield from self.observables
+
+    def iter_objects(self, object):
+        yield from self.next_objects
+
+    def get_notifier(
+            self, handler, target, dispatcher):
+        return self.notifier
+
+    def get_maintainer(
+            self, graph, handler, target, dispatcher):
+        return self.maintainer
+
+    def iter_extra_graphs(self, graph):
+        yield from self.extra_graphs

--- a/traits/observers/_testing.py
+++ b/traits/observers/_testing.py
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 from unittest import mock
 
 from traits.observers._exceptions import NotifierNotFound

--- a/traits/observers/tests/test_observe.py
+++ b/traits/observers/tests/test_observe.py
@@ -62,7 +62,7 @@ class DummyObserver:
         yield from self.next_objects
 
     def get_notifier(
-            self, observable, handler, target, dispatcher):
+            self, handler, target, dispatcher):
         return self.notifier
 
     def get_maintainer(

--- a/traits/observers/tests/test_observe.py
+++ b/traits/observers/tests/test_observe.py
@@ -1,0 +1,438 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+from unittest import mock
+
+from traits.observers._observe import add_or_remove_notifiers
+from traits.observers._observer_graph import ObserverGraph
+
+
+class DummyObservable:
+    """ A dummy implementation of IObservable for testing purposes."""
+
+    def __init__(self):
+        self.notifiers = []
+
+    def _notifiers(self, force_create):
+        return self.notifiers
+
+
+class DummyNotifier:
+    """ A dummy implementation of INotifier for testing purposes."""
+
+    def add_to(self, observable):
+        observable._notifiers(True).append(self)
+
+    def remove_from(self, observable):
+        observable._notifiers(True).remove(self)
+
+
+class DummyObserver:
+    """ A dummy implementation of IObserver for testing purposes.
+    """
+
+    def __init__(
+            self, notify, observables, next_objects,
+            notifier, maintainer, extra_graphs):
+        self.notify = notify
+        self.observables = observables
+        self.next_objects = next_objects
+        self.notifier = notifier
+        self.maintainer = maintainer
+        self.extra_graphs = extra_graphs
+
+    def __eq__(self, other):
+        return other is self
+
+    def __hash__(self):
+        return 1
+
+    def iter_observables(self, object):
+        yield from self.observables
+
+    def iter_objects(self, object):
+        yield from self.next_objects
+
+    def get_notifier(
+            self, observable, handler, target, dispatcher):
+        return self.notifier
+
+    def get_maintainer(
+            self, graph, handler, target, dispatcher):
+        return self.maintainer
+
+    def iter_extra_graphs(self, graph):
+        yield from self.extra_graphs
+
+
+def create_observer(**kwargs):
+    """ Convenient function for creating a DummyObserver.
+
+    Parameters
+    ----------
+    notify : boolean
+        The mocked return value from IObserver.notify
+    observables : iterable of IObservable
+        The mocked yielded values from IObserver.iter_observables
+    next_objects : iterable of object
+        The mocked yielded values from IObserver.iter_objects
+    notifier : INotifier
+        The mocked returned value from IObserver.get_notifier
+    maintainer : INotifier
+        The mocked returned value from IObserver.get_maintainer
+    extra_graphs : iterable of ObserverGraph
+        The mocked yielded values from IObserver.iter_extra_graphs
+    """
+    values = dict(
+        notify=True,
+        observables=[],
+        next_objects=[],
+        notifier=DummyNotifier(),
+        maintainer=DummyNotifier(),
+        extra_graphs=[],
+    )
+    values.update(kwargs)
+    return DummyObserver(**values)
+
+
+def call_add_or_remove_notifiers(**kwargs):
+    """ Convenient function for calling add_or_remove_notifiers
+    with some default inputs.
+
+    Parameters
+    ----------
+    **kwargs
+        New values to use instead of the defaults
+    """
+    values = dict(
+        object=mock.Mock(),
+        graph=ObserverGraph(node=None),
+        handler=mock.Mock(),
+        target=mock.Mock(),
+        dispatcher=mock.Mock(),
+        remove=False,
+    )
+    values.update(kwargs)
+    add_or_remove_notifiers(**values)
+
+
+class TestObserveAddNotifier(unittest.TestCase):
+    """ Test the add_notifiers action."""
+
+    def test_add_trait_notifiers(self):
+        observable = DummyObservable()
+        notifier = DummyNotifier()
+        observer = create_observer(
+            notify=True,
+            observables=[observable],
+            notifier=notifier,
+        )
+        graph = ObserverGraph(node=observer)
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=False,
+        )
+
+        # then
+        self.assertEqual(observable.notifiers, [notifier])
+
+    def test_add_trait_notifiers_notify_flag_is_false(self):
+        # Test when the notify flag is false, the notifier is not
+        # added.
+        observable = DummyObservable()
+        notifier = DummyNotifier()
+        observer = create_observer(
+            notify=False,
+            observables=[observable],
+            notifier=notifier,
+        )
+        graph = ObserverGraph(node=observer)
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=False,
+        )
+
+        # then
+        self.assertEqual(observable.notifiers, [])
+
+    def test_add_maintainers(self):
+        # Test adding maintainers for children graphs
+        observable = DummyObservable()
+        maintainer = DummyNotifier()
+        root_observer = create_observer(
+            notify=False,
+            observables=[observable],
+            maintainer=maintainer,
+        )
+        # two children, each will have a maintainer
+        graph = ObserverGraph(
+            node=root_observer,
+            children=[
+                ObserverGraph(node=create_observer()),
+                ObserverGraph(node=create_observer()),
+            ],
+        )
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=False,
+        )
+
+        # then
+        # the dummy observer always return the same maintainer object.
+        self.assertEqual(
+            observable.notifiers, [maintainer, maintainer])
+
+    def test_add_notifiers_for_children_graphs(self):
+        # Test adding notifiers using children graphs
+        observable1 = DummyObservable()
+        child_observer1 = create_observer(
+            observables=[observable1],
+        )
+        observable2 = DummyObservable()
+        child_observer2 = create_observer(
+            observables=[observable2],
+        )
+        parent_observer = create_observer(
+            next_objects=[mock.Mock()],
+        )
+        graph = ObserverGraph(
+            node=parent_observer,
+            children=[
+                ObserverGraph(
+                    node=child_observer1,
+                ),
+                ObserverGraph(
+                    node=child_observer2,
+                )
+            ],
+        )
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=False,
+        )
+
+        # then
+        self.assertCountEqual(
+            observable1.notifiers,
+            [
+                # For child1 observer
+                child_observer1.notifier,
+            ]
+        )
+        self.assertCountEqual(
+            observable2.notifiers,
+            [
+                # For child2 observer
+                child_observer2.notifier,
+            ]
+        )
+
+    def test_add_notifiers_for_extra_graph(self):
+        observable = DummyObservable()
+        extra_notifier = DummyNotifier()
+        extra_observer = create_observer(
+            observables=[observable],
+            notifier=extra_notifier,
+        )
+        extra_graph = ObserverGraph(
+            node=extra_observer,
+        )
+        observer = create_observer(
+            extra_graphs=[extra_graph],
+        )
+        graph = ObserverGraph(node=observer)
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=False,
+        )
+
+        # then
+        self.assertEqual(
+            observable.notifiers, [extra_notifier]
+        )
+
+
+class TestObserveRemoveNotifier(unittest.TestCase):
+    """ Test the remove action."""
+
+    def test_remove_trait_notifiers(self):
+        observable = DummyObservable()
+        notifier = DummyNotifier()
+        observable.notifiers = [notifier]
+
+        observer = create_observer(
+            observables=[observable],
+            notifier=notifier,
+        )
+        graph = ObserverGraph(
+            node=observer,
+        )
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=True,
+        )
+
+        # then
+        self.assertEqual(observable.notifiers, [])
+
+    def test_remove_notifiers_skip_if_notify_flag_is_false(self):
+        observable = DummyObservable()
+        notifier = DummyNotifier()
+        observable.notifiers = [notifier]
+
+        observer = create_observer(
+            notify=False,
+            observables=[observable],
+            notifier=notifier,
+        )
+        graph = ObserverGraph(
+            node=observer,
+        )
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=True,
+        )
+
+        # then
+        # notify is false, remove does nothing.
+        self.assertEqual(
+            observable.notifiers, [notifier]
+        )
+
+    def test_remove_maintainers(self):
+        observable = DummyObservable()
+        maintainer = DummyNotifier()
+        observable.notifiers = [maintainer, maintainer]
+
+        root_observer = create_observer(
+            notify=False,
+            observables=[observable],
+            maintainer=maintainer,
+        )
+
+        # for there are two children graphs
+        # two maintainers will be removed.
+        graph = ObserverGraph(
+            node=root_observer,
+            children=[
+                ObserverGraph(node=create_observer()),
+                ObserverGraph(node=create_observer()),
+            ],
+        )
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=True,
+        )
+
+        # then
+        self.assertEqual(observable.notifiers, [])
+
+    def test_remove_notifiers_for_children_graphs(self):
+        observable1 = DummyObservable()
+        notifier1 = DummyNotifier()
+        child_observer1 = create_observer(
+            observables=[observable1],
+            notifier=notifier1,
+        )
+        observable2 = DummyObservable()
+        notifier2 = DummyNotifier()
+        child_observer2 = create_observer(
+            observables=[observable2],
+            notifier=notifier2,
+        )
+        parent_observer = create_observer(
+            next_objects=[mock.Mock()],
+        )
+
+        graph = ObserverGraph(
+            node=parent_observer,
+            children=[
+                ObserverGraph(
+                    node=child_observer1,
+                ),
+                ObserverGraph(
+                    node=child_observer2,
+                )
+            ],
+        )
+
+        # suppose notifiers were added
+        observable1.notifiers = [notifier1]
+        observable2.notifiers = [notifier2]
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=True,
+        )
+
+        # then
+        self.assertEqual(observable1.notifiers, [])
+        self.assertEqual(observable2.notifiers, [])
+
+    def test_remove_notifiers_for_extra_graph(self):
+        observable = DummyObservable()
+        extra_notifier = DummyNotifier()
+        extra_observer = create_observer(
+            observables=[observable],
+            notifier=extra_notifier,
+        )
+        extra_graph = ObserverGraph(
+            node=extra_observer,
+        )
+        observer = create_observer(
+            extra_graphs=[extra_graph],
+        )
+        graph = ObserverGraph(node=observer)
+
+        # suppose the notifier was added before
+        observable.notifiers = [extra_notifier]
+
+        # when
+        call_add_or_remove_notifiers(
+            graph=graph,
+            remove=True,
+        )
+
+        # then
+        self.assertEqual(observable.notifiers, [])
+
+    def test_remove_notifier_raises_let_error_propagate(self):
+        # Test if the notifier remove_from raises, the error will
+        # be propagated.
+
+        # DummyNotifier.remove_from raises if the notifier is not found.
+        observer = create_observer(
+            observables=[DummyObservable()],
+            notifier=DummyNotifier(),
+        )
+
+        with self.assertRaises(ValueError):
+            call_add_or_remove_notifiers(
+                graph=ObserverGraph(node=observer),
+                remove=True,
+            )


### PR DESCRIPTION
Closes #1021
Item 6 of #977

This PR adds a function `add_or_remove_notifiers` for adding/removing notifiers for a given `ObserverGraph`.

- The `IObserver` interface is expanded to support `add_or_remove_notifiers`.
- Added a `INotifier` interface to support `add_or_remove_notifiers`. The `TraitEventNotifier` (in #1000) and `ObserverChangeNotifier` (in #1007) implement the `INotifier` interface introduced here. It is possible that this PR might need changes per review outcome of #1000 and #1007. The formal registration can happen later... or not happen at all.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~: Things here are still private. Module names are preceded with an underscore.
- ~Update User manual (`docs/source/traits_user_manual`)~: Things here are still private. 
- ~Update type annotation hints in `traits-stubs`~: Nothing here are trait-ed
