### PR TITLE
Minor cosmetic changes to the warning message for reserved prefixes

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -419,11 +419,14 @@ def update_traits_class_dict(class_name, bases, class_dict):
 
         # Warn name collisions.
         if check_name_collision and _is_disallowed_prefix(name):
-            warnings.warn("The attribute named '{}' of class {} uses one of "
-                          "the reserved prefixes: {}. Consider renaming it."
-                          .format(name, class_name,
-                                  ",".join(DisallowedNamePrefixes)),
-                          UserWarning, 3)
+            warnings.warn(
+                "The attribute named {!r} of class {} uses one of "
+                "the reserved prefixes: {}. Consider renaming it.".format(
+                    name, class_name,
+                    ", ".join(
+                        repr(prefix) for prefix in DisallowedNamePrefixes)
+                ),
+                UserWarning, 3)
 
         value = check_trait(value)
         rc = isinstance(value, CTrait)
@@ -2548,10 +2551,13 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         """
         if _is_disallowed_prefix(name):
-            warnings.warn("The attribute named '{}' uses one of the reserved "
-                          "prefixes: {}. Consider renaming it."
-                          .format(name, ",".join(DisallowedNamePrefixes)),
-                          UserWarning, 3)
+            warnings.warn(
+                "The attribute named {!r} uses one of the reserved "
+                "prefixes: {}. Consider renaming it.".format(
+                    name,
+                    ", ".join(repr(word) for word in DisallowedNamePrefixes)),
+                UserWarning, 3,
+            )
 
         # Make sure a trait argument was specified:
         if len(trait) == 0:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -426,7 +426,8 @@ def update_traits_class_dict(class_name, bases, class_dict):
                     ", ".join(
                         repr(prefix) for prefix in DisallowedNamePrefixes)
                 ),
-                UserWarning, 3)
+                UserWarning, stacklevel=3,
+            )
 
         value = check_trait(value)
         rc = isinstance(value, CTrait)
@@ -2556,7 +2557,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 "prefixes: {}. Consider renaming it.".format(
                     name,
                     ", ".join(repr(word) for word in DisallowedNamePrefixes)),
-                UserWarning, 3,
+                UserWarning, stacklevel=3,
             )
 
         # Make sure a trait argument was specified:


### PR DESCRIPTION
This PR makes pure cosmetic changes to the warning message when the attribute name uses one of the reserved prefixes.

Previously it looks like this:
```
The attribute named 'trait_view' of class HasDynamicViews uses one of the reserved prefixes: trait,_trait. Consider renaming it.
```

Now it looks like this:
```
The attribute named 'trait_view' of class HasDynamicViews uses one of the reserved prefixes: 'trait', '_trait'. Consider renaming it.
```

There are more line diffs than necessary because of flake8: the line got too long.