### PR TITLE
Make TraitListObject notify even if list values stay the same

### DIFF
--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -259,9 +259,20 @@ class TestTraitList(unittest.TestCase):
 
         tl[3:] = []
         self.assertEqual(tl, [1, 2, 3])
-        self.assertIsNone(self.index)
-        self.assertIsNone(self.removed)
-        self.assertIsNone(self.added)
+        self.assertEqual(self.index, 3)
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [])
+
+    def test_setitem_nochange_element(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl[0] = 1
+        self.assertEqual(tl, [1, 2, 3])
+        self.assertEqual(self.index, 0)
+        self.assertEqual(self.removed, [1])
+        self.assertEqual(self.added, [1])
 
     def test_setitem_iterable(self):
         tl = TraitList([1, 2, 3],

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -252,18 +252,18 @@ class TestTraitList(unittest.TestCase):
             msg="Event contains non-integers for int-only list",
         )
 
-    def test_setitem_nochange(self):
+    def test_setitem_no_structural_change(self):
         tl = TraitList([1, 2, 3],
                        item_validator=int_item_validator,
                        notifiers=[self.notification_handler])
 
         tl[3:] = []
         self.assertEqual(tl, [1, 2, 3])
-        self.assertEqual(self.index, 3)
-        self.assertEqual(self.removed, [])
-        self.assertEqual(self.added, [])
+        self.assertIsNone(self.index)
+        self.assertIsNone(self.removed)
+        self.assertIsNone(self.added)
 
-    def test_setitem_nochange_element(self):
+    def test_setitem_no_item_change(self):
         tl = TraitList([1, 2, 3],
                        item_validator=int_item_validator,
                        notifiers=[self.notification_handler])
@@ -273,6 +273,28 @@ class TestTraitList(unittest.TestCase):
         self.assertEqual(self.index, 0)
         self.assertEqual(self.removed, [1])
         self.assertEqual(self.added, [1])
+
+    def test_setitem_no_removed(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl[3:] = [4, 5, 6]
+        self.assertEqual(tl, [1, 2, 3, 4, 5, 6])
+        self.assertEqual(self.index, 3)
+        self.assertEqual(self.removed, [])
+        self.assertEqual(self.added, [4, 5, 6])
+
+    def test_setitem_no_added(self):
+        tl = TraitList([1, 2, 3],
+                       item_validator=int_item_validator,
+                       notifiers=[self.notification_handler])
+
+        tl[1:2] = []
+        self.assertEqual(tl, [1, 3])
+        self.assertEqual(self.index, 1)
+        self.assertEqual(self.removed, [2])
+        self.assertEqual(self.added, [])
 
     def test_setitem_iterable(self):
         tl = TraitList([1, 2, 3],

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -1089,10 +1089,9 @@ class test_list_value(test_base2):
         self.assertLastTraitListEventEqual(0, [6, 7], [4, 5])
         self.obj.alist[0:2:1] = [8, 9]
         self.assertLastTraitListEventEqual(0, [4, 5], [8, 9])
-        old_event = self.last_event
         self.obj.alist[0:2:1] = [8, 9]
-        # If no values changed, no new TraitListEvent will be generated.
-        self.assertIs(self.last_event, old_event)
+        # Even if no values change, a new TraitListEvent will be generated.
+        self.assertLastTraitListEventEqual(0, [8, 9], [8, 9])
         self.obj.alist[0:4:2] = [10, 11]
         self.assertLastTraitListEventEqual(
             slice(0, 4, 2), [8, 4], [10, 11]

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -1090,8 +1090,12 @@ class test_list_value(test_base2):
         self.obj.alist[0:2:1] = [8, 9]
         self.assertLastTraitListEventEqual(0, [4, 5], [8, 9])
         self.obj.alist[0:2:1] = [8, 9]
-        # Even if no values change, a new TraitListEvent will be generated.
+        # If list values stay the same, a new TraitListEvent will be generated.
         self.assertLastTraitListEventEqual(0, [8, 9], [8, 9])
+        old_event = self.last_event
+        self.obj.alist[4:] = []
+        # If no structural change, NO new TraitListEvent will be generated.
+        self.assertIs(self.last_event, old_event)
         self.obj.alist[0:4:2] = [10, 11]
         self.assertLastTraitListEventEqual(
             slice(0, 4, 2), [8, 4], [10, 11]

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -285,8 +285,7 @@ class TraitList(list):
                 pass
         super().__setitem__(key, value)
 
-        if added != removed:
-            self.notify(normalized_index, removed, added)
+        self.notify(normalized_index, removed, added)
 
     def append(self, object):
         """ Append object to the end of the list.

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -285,7 +285,8 @@ class TraitList(list):
                 pass
         super().__setitem__(key, value)
 
-        self.notify(normalized_index, removed, added)
+        if added or removed:
+            self.notify(normalized_index, removed, added)
 
     def append(self, object):
         """ Append object to the end of the list.


### PR DESCRIPTION
Closes #972 

This PR changes the behaviour of TraitListObject. From now on it will notify even if the underlying list doesn't change (it didn't before). An exception - notification is still suppressed if there is no structural change.

For example, given a class:
```
>>> class Foo(HasTraits):
...     bar = List([1, 2, 3])
...     @on_trait_change('bar[]')
...     def report_bar_change(self, obj, name, old, new):
...         print(f"Some bar values changed: {old} --> {new}")
...
>>> f = Foo()
```
all of the following will notify listeners:
```
>>> f.bar[0] = 1
Some bar values changed: [1] --> [1]
>>> f.bar[:2] = [1, 2]
Some bar values changed: [1, 2] --> [1, 2]
```
The exception - no structural change:
```
>>> f.bar[3:] = []
>>>
```

**Checklist**
- [x] Tests
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~
- ~[ ] Update type annotation hints in `traits-stubs`~
