### PR TITLE
Whitelist names with trait prefix as being safe for subclass to redefine

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -83,8 +83,8 @@ from very simple to very sophisticated. The following section presents some of
 the simpler, more commonly used forms.
 
 .. warning:: Unless otherwise stated as safe to do so, avoid naming
-   attributes with the prefix 'trait' or '_trait'. This is to prevent
-   existing methods on ``HasTraits`` from being overshadowed.
+   attributes with the prefix 'trait' or '_trait'. This avoids overshadowing
+   existing methods on HasTraits.
 
 .. index:: predefined traits
 

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -82,6 +82,10 @@ The Traits package allows creation of a wide variety of trait types, ranging
 from very simple to very sophisticated. The following section presents some of
 the simpler, more commonly used forms.
 
+.. warning:: Unless otherwise stated as safe to do so, avoid naming
+   attributes with the prefix 'trait' or '_trait'. This is to prevent
+   existing methods on ``HasTraits`` from being overshadowed.
+
 .. index:: predefined traits
 
 .. _predefined-traits:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -928,6 +928,10 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     attribute is an explicit trait event defined on the HasTraits class.)
     The wildcard attribute *temp_lunch* and the dynamically-added trait
     attribute *favorite_sport* are not listed.
+
+    Subclass should avoid defining new traits and/or methods with names
+    starting with "trait" or "_trait" to avoid overshadowing existing methods,
+    unless it has been documented as being safe to do so.
     """
 
     # -- Trait Prefix Rules ---------------------------------------------------

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -124,11 +124,22 @@ DisallowedNamePrefixes = (
     "_trait"
 )
 
+# But whitelist these because they have been sanctioned to be okay
+# prior to the prefix check is put in-place
+WhitelistedNames = (
+    "trait_context",
+    "traits_view",
+    "traits_init",
+)
+
 
 def _is_disallowed_prefix(name):
     """ Returns True if name has a prefix which is in DisallowedNamePrefixes
     """
-    return name.startswith(DisallowedNamePrefixes)
+    return (
+        name not in WhitelistedNames
+        and name.startswith(DisallowedNamePrefixes)
+    )
 
 
 def _clone_trait(clone, metadata=None):

--- a/traits/tests/test_warnings.py
+++ b/traits/tests/test_warnings.py
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import contextlib
 
 from unittest import mock, TestCase

--- a/traits/tests/test_warnings.py
+++ b/traits/tests/test_warnings.py
@@ -79,7 +79,7 @@ class TestTraitWarning(TestCase):
 
     @contextlib.contextmanager
     def _assert_no_warnings(self, category):
-        # There could be an assertNoWarns from uniitest in the future
+        # There may be an assertNoWarns from unittest in the future
         # see https://bugs.python.org/issue39385
         try:
             with self.assertWarns(category) as cm:

--- a/traits/tests/test_warnings.py
+++ b/traits/tests/test_warnings.py
@@ -7,14 +7,21 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+import contextlib
 
 from unittest import mock, TestCase
 
 from traits.api import Any, HasTraits
+from traits.has_traits import AbstractViewElement
 
 
 def mock_module_name(name):
     return mock.patch(__name__ + ".__name__", name)
+
+
+class DummyViewElement(AbstractViewElement):
+    """ Dummy view for testing purposes."""
+    pass
 
 
 class TestTraitWarning(TestCase):
@@ -47,3 +54,38 @@ class TestTraitWarning(TestCase):
             obj.add_trait("trait_invalid", Any())
         with self.assertWarns(UserWarning):
             obj.add_trait("_trait_invalid2", Any())
+
+    def test_traits_view_whitelisted(self):
+        with mock_module_name("usermodule"):
+            with self._assert_no_warnings(UserWarning):
+                class UserDefinedClass(HasTraits):
+                    traits_view = DummyViewElement()
+
+    def test_traits_init_whitelisted(self):
+        with mock_module_name("usermodule"):
+            with self._assert_no_warnings(UserWarning):
+                class UserDefinedClass(HasTraits):
+
+                    def traits_init(self):
+                        pass
+
+    def test_trait_context_whitelisted(self):
+        with mock_module_name("usermodule"):
+            with self._assert_no_warnings(UserWarning):
+                class UserDefinedClass(HasTraits):
+
+                    def trait_context(self):
+                        return {}
+
+    @contextlib.contextmanager
+    def _assert_no_warnings(self, category):
+        # There could be an assertNoWarns from uniitest in the future
+        # see https://bugs.python.org/issue39385
+        try:
+            with self.assertWarns(category) as cm:
+                yield
+        except AssertionError as e:
+            # This may silence other, unexpected assertion errors.
+            pass
+        else:
+            self.fail("Expected no warnings, got {!r}".format(cm.warning))

--- a/traits/tests/test_warnings.py
+++ b/traits/tests/test_warnings.py
@@ -84,7 +84,7 @@ class TestTraitWarning(TestCase):
         try:
             with self.assertWarns(category) as cm:
                 yield
-        except AssertionError as e:
+        except AssertionError:
             # This may silence other, unexpected assertion errors.
             pass
         else:


### PR DESCRIPTION
Closes #705 

A few existing attribute/methods with the prefix "trait" have been advertised by traits for subclasses to redefine/override.
This PR whitelists those names and updates the documentation.  

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~
