### PR TITLE
Remove caching of editor factories

### DIFF
--- a/traits/editor_factories.py
+++ b/traits/editor_factories.py
@@ -16,14 +16,6 @@ import datetime
 from functools import partial
 import logging
 
-PasswordEditors = {}
-MultilineTextEditors = {}
-BytesEditors = {}
-SourceCodeEditor = None
-HTMLTextEditor = None
-PythonShellEditor = None
-DateEditor = None
-TimeEditor = None
 
 logger = logging.getLogger(__name__)
 
@@ -31,118 +23,77 @@ logger = logging.getLogger(__name__)
 def password_editor(auto_set=True, enter_set=False):
     """ Factory function that returns an editor for passwords.
     """
-    if (auto_set, enter_set) not in PasswordEditors:
-        from traitsui.api import TextEditor
-
-        PasswordEditors[auto_set, enter_set] = TextEditor(
-            password=True, auto_set=auto_set, enter_set=enter_set
-        )
-
-    return PasswordEditors[auto_set, enter_set]
+    from traitsui.api import TextEditor
+    return TextEditor(
+        password=True, auto_set=auto_set, enter_set=enter_set
+    )
 
 
 def multi_line_text_editor(auto_set=True, enter_set=False):
     """ Factory function that returns a text editor for multi-line strings.
     """
-    if (auto_set, enter_set) not in MultilineTextEditors:
-        from traitsui.api import TextEditor
-
-        MultilineTextEditors[auto_set, enter_set] = TextEditor(
-            multi_line=True, auto_set=auto_set, enter_set=enter_set
-        )
-
-    return MultilineTextEditors[auto_set, enter_set]
+    from traitsui.api import TextEditor
+    return TextEditor(
+        multi_line=True, auto_set=auto_set, enter_set=enter_set
+    )
 
 
 def bytes_editor(auto_set=True, enter_set=False, encoding=None):
     """ Factory function that returns a text editor for bytes.
     """
-    if (auto_set, enter_set, encoding) not in BytesEditors:
-        from traitsui.api import TextEditor
+    from traitsui.api import TextEditor
 
-        if encoding is None:
-            format = bytes.hex
-            evaluate = bytes.fromhex
-        else:
-            format = partial(bytes.decode, encoding=encoding)
-            evaluate = partial(str.encode, encoding=encoding)
+    if encoding is None:
+        format = bytes.hex
+        evaluate = bytes.fromhex
+    else:
+        format = partial(bytes.decode, encoding=encoding)
+        evaluate = partial(str.encode, encoding=encoding)
 
-        BytesEditors[(auto_set, enter_set, encoding)] = TextEditor(
-            multi_line=True,
-            format_func=format,
-            evaluate=evaluate,
-            auto_set=auto_set,
-            enter_set=enter_set,
-        )
-
-    return BytesEditors[(auto_set, enter_set, encoding)]
+    return TextEditor(
+        multi_line=True,
+        format_func=format,
+        evaluate=evaluate,
+        auto_set=auto_set,
+        enter_set=enter_set,
+    )
 
 
 def code_editor():
     """ Factory function that returns an editor that treats a multi-line string
     as source code.
     """
-    global SourceCodeEditor
-
-    if SourceCodeEditor is None:
-        from traitsui.api import CodeEditor
-
-        SourceCodeEditor = CodeEditor()
-
-    return SourceCodeEditor
+    from traitsui.api import CodeEditor
+    return CodeEditor()
 
 
 def html_editor():
     """ Factory function for an "editor" that displays a multi-line string as
     interpreted HTML.
     """
-    global HTMLTextEditor
-
-    if HTMLTextEditor is None:
-        from traitsui.api import HTMLEditor
-
-        HTMLTextEditor = HTMLEditor()
-
-    return HTMLTextEditor
+    from traitsui.api import HTMLEditor
+    return HTMLEditor()
 
 
 def shell_editor():
     """ Factory function that returns a Python shell for editing Python values.
     """
-    global PythonShellEditor
-
-    if PythonShellEditor is None:
-        from traitsui.api import ShellEditor
-
-        PythonShellEditor = ShellEditor()
-
-    return PythonShellEditor
+    from traitsui.api import ShellEditor
+    return ShellEditor()
 
 
 def time_editor():
     """ Factory function that returns a Time editor for editing Time values.
     """
-    global TimeEditor
-
-    if TimeEditor is None:
-        from traitsui.api import TimeEditor
-
-        TimeEditor = TimeEditor()
-
-    return TimeEditor
+    from traitsui.api import TimeEditor
+    return TimeEditor()
 
 
 def date_editor():
     """ Factory function that returns a Date editor for editing Date values.
     """
-    global DateEditor
-
-    if DateEditor is None:
-        from traitsui.api import DateEditor
-
-        DateEditor = DateEditor()
-
-    return DateEditor
+    from traitsui.api import DateEditor
+    return DateEditor()
 
 
 def _datetime_str_to_datetime(datetime_str, format="%Y-%m-%dT%H:%M:%S"):

--- a/traits/tests/test_editor_factories.py
+++ b/traits/tests/test_editor_factories.py
@@ -21,9 +21,6 @@ from traits.trait_types import Instance, List, Str
 from traits.editor_factories import (
     _datetime_to_datetime_str,
     _datetime_str_to_datetime,
-    BytesEditors,
-    MultilineTextEditors,
-    PasswordEditors,
     bytes_editor,
     multi_line_text_editor,
     list_editor,
@@ -56,21 +53,8 @@ class SimpleEditorTestMixin:
             self.assertIsInstance(editor, self.traitsui_factory)
 
 
-class SimpleEditorWithCachingTestMixin(SimpleEditorTestMixin):
-
-    def tearDown(self):
-        import traits.editor_factories
-        setattr(traits.editor_factories, self.cache_name, None)
-
-    def test_editor_caching(self):
-        editor_1 = self.factory()
-        editor_2 = self.factory()
-
-        self.assertIs(editor_1, editor_2)
-
-
 @requires_traitsui
-class TestDateEditor(SimpleEditorWithCachingTestMixin, unittest.TestCase):
+class TestDateEditor(SimpleEditorTestMixin, unittest.TestCase):
     cache_name = "DateEditor"
     traitsui_name = "DateEditor"
     factory_name = "date_editor"
@@ -108,28 +92,28 @@ class TestDatetimeEditor(SimpleEditorTestMixin, unittest.TestCase):
 
 
 @requires_traitsui
-class TestCodeEditor(SimpleEditorWithCachingTestMixin, unittest.TestCase):
+class TestCodeEditor(SimpleEditorTestMixin, unittest.TestCase):
     cache_name = "SourceCodeEditor"
     traitsui_name = "CodeEditor"
     factory_name = "code_editor"
 
 
 @requires_traitsui
-class TestHTMLEditor(SimpleEditorWithCachingTestMixin, unittest.TestCase):
+class TestHTMLEditor(SimpleEditorTestMixin, unittest.TestCase):
     cache_name = "HTMLTextEditor"
     traitsui_name = "HTMLEditor"
     factory_name = "html_editor"
 
 
 @requires_traitsui
-class TestShellEditor(SimpleEditorWithCachingTestMixin, unittest.TestCase):
+class TestShellEditor(SimpleEditorTestMixin, unittest.TestCase):
     cache_name = "PythonShellEditor"
     traitsui_name = "ShellEditor"
     factory_name = "shell_editor"
 
 
 @requires_traitsui
-class TestTimeEditor(SimpleEditorWithCachingTestMixin, unittest.TestCase):
+class TestTimeEditor(SimpleEditorTestMixin, unittest.TestCase):
     cache_name = "TimeEditor"
     traitsui_name = "TimeEditor"
     factory_name = "time_editor"
@@ -137,9 +121,6 @@ class TestTimeEditor(SimpleEditorWithCachingTestMixin, unittest.TestCase):
 
 @requires_traitsui
 class TestBytesEditor(unittest.TestCase):
-
-    def tearDown(self):
-        BytesEditors.clear()
 
     def test_bytes_editor_default(self):
         editor = bytes_editor()
@@ -171,27 +152,9 @@ class TestBytesEditor(unittest.TestCase):
         evaluated = editor.evaluate("deadbeef")
         self.assertEqual(evaluated, b"deadbeef")
 
-    def test_bytes_editor_caching(self):
-        editor_1 = bytes_editor()
-        editor_2 = bytes_editor()
-
-        self.assertIs(editor_1, editor_2)
-
-        editor_3 = bytes_editor(
-            auto_set=False, enter_set=True, encoding='ascii'
-        )
-        editor_4 = bytes_editor(
-            auto_set=False, enter_set=True, encoding='ascii'
-        )
-
-        self.assertIs(editor_3, editor_4)
-
 
 @requires_traitsui
 class TestMultiLineEditor(unittest.TestCase):
-
-    def tearDown(self):
-        MultilineTextEditors.clear()
 
     def test_multi_line_text_editor_default(self):
         editor = multi_line_text_editor()
@@ -209,23 +172,9 @@ class TestMultiLineEditor(unittest.TestCase):
         self.assertFalse(editor.auto_set)
         self.assertTrue(editor.enter_set)
 
-    def test_multi_line_text_editor_caching(self):
-        editor_1 = multi_line_text_editor()
-        editor_2 = multi_line_text_editor()
-
-        self.assertIs(editor_1, editor_2)
-
-        editor_3 = multi_line_text_editor(auto_set=False, enter_set=True)
-        editor_4 = multi_line_text_editor(auto_set=False, enter_set=True)
-
-        self.assertIs(editor_3, editor_4)
-
 
 @requires_traitsui
 class TestPasswordEditor(unittest.TestCase):
-
-    def tearDown(self):
-        PasswordEditors.clear()
 
     def test_password_editor_default(self):
         editor = password_editor()
@@ -242,17 +191,6 @@ class TestPasswordEditor(unittest.TestCase):
         self.assertTrue(editor.password)
         self.assertFalse(editor.auto_set)
         self.assertTrue(editor.enter_set)
-
-    def test_password_editor_caching(self):
-        editor_1 = password_editor()
-        editor_2 = password_editor()
-
-        self.assertIs(editor_1, editor_2)
-
-        editor_3 = password_editor(auto_set=False, enter_set=True)
-        editor_4 = password_editor(auto_set=False, enter_set=True)
-
-        self.assertIs(editor_3, editor_4)
 
 
 @requires_traitsui


### PR DESCRIPTION
Removes caching of editor factories. Fixes #1030 and helps with https://github.com/enthought/traitsui/issues/790

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`) (Not needed)
- [x] Update User manual (`docs/source/traits_user_manual`) (Not needed)
- [x] Update type annotation hints in `traits-stubs` (Not needed)
