### PR TITLE
Remove conditional traitsui import (ViewElement)

### DIFF
--- a/traits/api.py
+++ b/traits/api.py
@@ -226,14 +226,3 @@ from .adaptation.adaptation_manager import (  # noqa: F401
 )
 
 from .trait_numeric import Array, ArrayOrNone, CArray  # noqa: F401
-
-try:
-    #  Patch the main traits module with the correct definition for the
-    #  ViewElement class:
-
-    from traitsui.view_element import ViewElement
-
-    if not isinstance(ViewElement, AbstractViewElement):
-        AbstractViewElement.register(ViewElement)
-except ImportError:
-    pass

--- a/traits/tests/test_view_elements.py
+++ b/traits/tests/test_view_elements.py
@@ -10,7 +10,7 @@
 
 import unittest
 
-from traits.api import HasTraits, Int, TraitError
+from traits.api import AbstractViewElement, HasTraits, Int, TraitError
 from traits.testing.optional_dependencies import requires_traitsui
 
 
@@ -125,3 +125,8 @@ class TestViewElements(unittest.TestCase):
 
         with self.assertRaises(TraitError):
             Model.class_trait_view_elements()
+
+    def test_view_element_superclass(self):
+        from traitsui.api import ViewElement
+
+        self.assertIsInstance(ViewElement(), AbstractViewElement)


### PR DESCRIPTION
Closes #932

This import is no longer needed as `traitsui` takes care of registering `ViewElement` as `AbstractViewElement` subclass, so it is removed. Also added a test to verify that `ViewElement` imported from `traitsui.api` is indeed a subclass of `AbstractViewElement`.

**Checklist**
- [x] Tests
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~
- ~[ ] Update type annotation hints in `traits-stubs`~
