### PR TITLE
Make TraitSetEvent arguments keyword-only

### DIFF
--- a/traits/tests/test_trait_dict_list_set_event.py
+++ b/traits/tests/test_trait_dict_list_set_event.py
@@ -41,6 +41,10 @@ class TestTraitEvent(unittest.TestCase):
         self.assertEqual(event.__repr__(), event_str)
         self.assertIsInstance(eval(event.__repr__()), TraitListEvent)
 
+    def test_dict_event_kwargs_only(self):
+        with self.assertRaises(TypeError):
+            TraitDictEvent({}, {'black': 0}, {'blue': 2})
+
     def test_dict_event_repr(self):
         self.foo.adict.update({'blue': 10, 'black': 0})
         event = self.foo.event
@@ -48,6 +52,10 @@ class TestTraitEvent(unittest.TestCase):
                      "changed={'blue': 0})")
         self.assertEqual(event.__repr__(), event_str)
         self.assertIsInstance(eval(event.__repr__()), TraitDictEvent)
+
+    def test_set_event_kwargs_only(self):
+        with self.assertRaises(TypeError):
+            TraitSetEvent({3}, {4})
 
     def test_set_event_repr(self):
         self.foo.aset.symmetric_difference_update({3, 4})

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -34,7 +34,7 @@ class TraitSetEvent(object):
         New values added to the set.
     """
 
-    def __init__(self, removed=None, added=None):
+    def __init__(self, *, removed=None, added=None):
 
         if removed is None:
             removed = set()
@@ -529,7 +529,7 @@ class TraitSetObject(TraitSet):
         if object is None:
             return
 
-        event = TraitSetEvent(removed, added)
+        event = TraitSetEvent(removed=removed, added=added)
         items_event = self.trait.items_event()
         object.trait_items_event(self.name_items, event, items_event)
 


### PR DESCRIPTION
This PR makes the `TraitSetEvent` arguments keyword-only, for safety, and for consistency with `TraitDictEvent`. I'd like to do the same for `TraitListEvent` too, but that needs changes in TraitsUI. See #1035 

**Checklist**
- [x] Tests
