### PR TITLE
Allow tests requiring traitsui to be skipped when an environment does not have traitsui

### DIFF
--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -41,6 +41,7 @@ from traits.api import (
     pop_exception_handler,
     push_exception_handler,
 )
+from traits.testing.optional_dependencies import requires_traitsui
 
 #  Base unit test classes:
 
@@ -1271,6 +1272,7 @@ class ComparisonModeTests(unittest.TestCase):
         self.assertEqual(len(events), 2)
 
 
+@requires_traitsui
 class TestDeprecatedTraits(unittest.TestCase):
 
     def test_color_deprecated(self):


### PR DESCRIPTION
This PR wraps tests requiring traitsui with `requires_traitsui` so they can be skipped when traitsui is not importable.

The CI environment has traitsui (and a lot of other optional dependencies) so the tests are still run. However `traits` actually has no dependencies and test suite should still be expected to pass when one installs `traits` in a clean Python environment (e.g. `pip install traits` from PyPI).

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
