### PR TITLE
Fix documentation rendering issues

### DIFF
--- a/docs/source/traits_api_reference/traits.rst
+++ b/docs/source/traits_api_reference/traits.rst
@@ -11,8 +11,6 @@ Classes
 
 .. autoclass:: Default
 
-.. autoclass:: Property
-
 .. autoclass:: ForwardProperty
 
 
@@ -20,6 +18,8 @@ Functions
 ---------
 
 .. autofunction:: Trait
+
+.. autofunction:: Property
 
 .. autofunction:: Color
 

--- a/traits/base_trait_handler.py
+++ b/traits/base_trait_handler.py
@@ -57,6 +57,11 @@ class BaseTraitHandler(object):
     def error(self, object, name, value):
         """Raises a TraitError exception.
 
+        This method is called by the validate() method when an assigned value
+        is not valid. Raising a TraitError exception either notifies the user
+        of the problem, or, in the case of compound traits, provides a chance
+        for another trait handler to handle to validate the value.
+
         Parameters
         ----------
         object : object
@@ -65,13 +70,6 @@ class BaseTraitHandler(object):
             The name of the attribute being assigned.
         value : object
             The proposed new value for the attribute.
-
-        Description
-        -----------
-        This method is called by the validate() method when an assigned value
-        is not valid. Raising a TraitError exception either notifies the user
-        of the problem, or, in the case of compound traits, provides a chance
-        for another trait handler to handle to validate the value.
         """
         raise TraitError(
             object, name, self.full_info(object, name, value), value
@@ -81,17 +79,6 @@ class BaseTraitHandler(object):
         """Returns a string describing the type of value accepted by the
         trait handler.
 
-        Parameters
-        ----------
-        object : object
-            The object whose attribute is being assigned.
-        name : str
-            The name of the attribute being assigned.
-        value :
-            The proposed new value for the attribute.
-
-        Description
-        -----------
         The string should be a phrase describing the type defined by the
         TraitHandler subclass, rather than a complete sentence. For example,
         use the phrase, "a square sprocket" instead of the sentence, "The value
@@ -104,6 +91,15 @@ class BaseTraitHandler(object):
         Note that the result can include information specific to the particular
         trait handler instance. If the full_info() method is not overridden,
         the default method returns the value of calling the info() method.
+
+        Parameters
+        ----------
+        object : object
+            The object whose attribute is being assigned.
+        name : str
+            The name of the attribute being assigned.
+        value :
+            The proposed new value for the attribute.
         """
         return self.info()
 

--- a/traits/ctrait.py
+++ b/traits/ctrait.py
@@ -193,17 +193,15 @@ class CTrait(ctraits.cTrait):
     def get_help(self, full=True):
         """ Returns the help text for a trait.
 
+        If *full* is False or the trait does not have a **help** string,
+        the returned string is constructed from the **desc** attribute on the
+        trait and the **info** string on the trait's handler.
+
         Parameters
         ----------
         full : bool
             Indicates whether to return the value of the *help* attribute of
             the trait itself.
-
-        Description
-        -----------
-        If *full* is False or the trait does not have a **help** string,
-        the returned string is constructed from the **desc** attribute on the
-        trait and the **info** string on the trait's handler.
         """
         if full:
             help = self.help

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1116,16 +1116,14 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     def has_traits_interface(self, *interfaces):
         """Returns whether the object implements a specified traits interface.
 
-           Parameters
-           ----------
-           *interfaces :
-                One or more traits Interface (sub)classes.
+        Tests whether the object implements one or more of the interfaces
+        specified by *interfaces*. Return **True** if it does, and **False**
+        otherwise.
 
-           Description
-           -----------
-           Tests whether the object implements one or more of the interfaces
-           specified by *interfaces*. Return **True** if it does, and **False**
-           otherwise.
+        Parameters
+        ----------
+        *interfaces :
+            One or more traits Interface (sub)classes.
         """
         return isinstance(self, interfaces)
 
@@ -1211,6 +1209,14 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     def trait_get(self, *names, **metadata):
         """ Shortcut for getting object trait attributes.
 
+        Looks up the value of each trait whose name is passed as an argument
+        and returns a dictionary containing the resulting name/value pairs.
+        If any name does not correspond to a defined trait, it is not included
+        in the result.
+
+        If no names are specified, the result is a dictionary containing
+        name/value pairs for *all* traits defined on the object.
+
         Parameters
         ----------
         names : list of strings
@@ -1221,16 +1227,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         result : dict
             A dictionary whose keys are the names passed as arguments and whose
             values are the corresponding trait values.
-
-        Description
-        -----------
-        Looks up the value of each trait whose name is passed as an argument
-        and returns a dictionary containing the resulting name/value pairs.
-        If any name does not correspond to a defined trait, it is not included
-        in the result.
-
-        If no names are specified, the result is a dictionary containing
-        name/value pairs for *all* traits defined on the object.
         """
 
         result = {}
@@ -1259,6 +1255,19 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     def trait_set(self, trait_change_notify=True, **traits):
         """ Shortcut for setting object trait attributes.
 
+        Treats each keyword argument to the method as the name of a trait
+        attribute and sets the corresponding trait attribute to the value
+        specified. This is a useful shorthand when a number of trait attributes
+        need to be set on an object, or a trait attribute value needs to be set
+        in a lambda function. For example, you can write::
+
+            person.trait_set(name='Bill', age=27)
+
+        instead of::
+
+            person.name = 'Bill'
+            person.age = 27
+
         Parameters
         ----------
         trait_change_notify : bool
@@ -1273,22 +1282,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         -------
         self :
             The method returns this object, after setting attributes.
-
-        Description
-        -----------
-        Treats each keyword argument to the method as the name of a trait
-        attribute and sets the corresponding trait attribute to the value
-        specified. This is a useful shorthand when a number of trait attributes
-        need to be set on an object, or a trait attribute value needs to be set
-        in a lambda function. For example, you can write::
-
-            person.trait_set(name='Bill', age=27)
-
-        instead of::
-
-            person.name = 'Bill'
-            person.age = 27
-
         """
         if not trait_change_notify:
             self._trait_change_notify(False)
@@ -1315,20 +1308,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     def trait_setq(self, **traits):
         """ Shortcut for setting object trait attributes.
 
-        Parameters
-        ----------
-        **traits :
-            Key/value pairs, the trait attributes and their values to be set.
-            No trait change notifications will be generated for any values
-            assigned (see also: trait_set).
-
-        Returns
-        -------
-        self :
-            The method returns this object, after setting attributes.
-
-        Description
-        -----------
         Treats each keyword argument to the method as the name of a trait
         attribute and sets the corresponding trait attribute to the value
         specified. This is a useful shorthand when a number of trait attributes
@@ -1342,12 +1321,30 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             person.name = 'Bill'
             person.age = 27
 
+        Parameters
+        ----------
+        **traits :
+            Key/value pairs, the trait attributes and their values to be set.
+            No trait change notifications will be generated for any values
+            assigned (see also: trait_set).
+
+        Returns
+        -------
+        self :
+            The method returns this object, after setting attributes.
         """
         return self.trait_set(trait_change_notify=False, **traits)
 
     def reset_traits(self, traits=None, **metadata):
         """ Resets some or all of an object's trait attributes to their default
         values.
+
+        Resets each of the traits whose names are specified in the *traits*
+        list to their default values. If *traits* is None or omitted, the
+        method resets all explicitly-defined object trait attributes to their
+        default values. Note that this does not affect wildcard trait
+        attributes or trait attributes added via add_trait(), unless they are
+        explicitly named in *traits*.
 
         Parameters
         ----------
@@ -1359,16 +1356,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         unresetable : list of strings
             A list of attributes that the method was unable to reset, which is
             empty if all the attributes were successfully reset.
-
-        Description
-        -----------
-        Resets each of the traits whose names are specified in the *traits*
-        list to their default values. If *traits* is None or omitted, the
-        method resets all explicitly-defined object trait attributes to their
-        default values. Note that this does not affect wildcard trait
-        attributes or trait attributes added via add_trait(), unless they are
-        explicitly named in *traits*.
-
         """
         unresetable = []
 
@@ -1497,6 +1484,13 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """ Clones a new object from this one, optionally copying only a
         specified set of traits.
 
+        Creates a new object that is a clone of the current object. If *traits*
+        is None (the default), then all explicit trait attributes defined
+        for this object are cloned. If *traits* is 'all' or an empty list, the
+        list of traits returned by all_trait_names() is used; otherwise,
+        *traits* must be a list of the names of the trait attributes to be
+        cloned.
+
         Parameters
         ----------
         traits : list of strings
@@ -1512,15 +1506,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         -------
         new :
             The newly cloned object.
-
-        Description
-        -----------
-        Creates a new object that is a clone of the current object. If *traits*
-        is None (the default), then all explicit trait attributes defined
-        for this object are cloned. If *traits* is 'all' or an empty list, the
-        list of traits returned by all_trait_names() is used; otherwise,
-        *traits* must be a list of the names of the trait attributes to be
-        cloned.
         """
         if memo is None:
             memo = {}
@@ -1627,19 +1612,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     def trait_view(self, name=None, view_element=None):
         """ Gets or sets a ViewElement associated with an object's class.
 
-        Parameters
-        ----------
-        name : str
-            Name of a view element
-        view_element : ViewElement
-            View element to associate
-
-        Returns
-        -------
-        A view element.
-
-        Description
-        -----------
         If both *name* and *view_element* are specified, the view element is
         associated with *name* for the current object's class. (That is,
         *view_element* is added to the ViewElements object associated with
@@ -1661,6 +1633,16 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         3. Otherwise, it returns a View object containing items for all the
            non-event trait attributes on the current object.
 
+        Parameters
+        ----------
+        name : str
+            Name of a view element
+        view_element : ViewElement
+            View element to associate
+
+        Returns
+        -------
+        A view element.
         """
         return self.__class__._trait_view(
             name,
@@ -1770,6 +1752,9 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """ Returns a list of the names of all view elements associated with
         the current object's class.
 
+        If *klass* is specified, the list of names is filtered such that only
+        objects that are instances of the specified class are returned.
+
         Parameters
         ----------
         klass : class
@@ -1781,11 +1766,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             * View
             * ViewElement
             * ViewSubElement
-
-        Description
-        -----------
-        If *klass* is specified, the list of names is filtered such that only
-        objects that are instances of the specified class are returned.
         """
         view_elements = self.__class__.__dict__[ViewTraits]
         if isinstance(view_elements, dict):
@@ -1867,6 +1847,23 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """Creates and displays a dialog box for editing values of trait
         attributes, as if it were a complete, self-contained GUI application.
 
+        This method is intended for use in applications that do not normally
+        have a GUI. Control does not resume in the calling application until
+        the user closes the dialog box.
+
+        The method attempts to open and unpickle the contents of *filename*
+        before displaying the dialog box. When editing is complete, the method
+        attempts to pickle the updated contents of the object back to
+        *filename*. If the file referenced by *filename* does not exist, the
+        object is not modified before displaying the dialog box. If *filename*
+        is unspecified or None, no pickling or unpickling occurs.
+
+        If *edit* is True (the default), a dialog box for editing the
+        current object is displayed. If *edit* is False or None, no
+        dialog box is displayed. You can use ``edit=False`` if you want the
+        object to be restored from the contents of *filename*, without being
+        modified by the user.
+
         Parameters
         ----------
         filename : str
@@ -1915,25 +1912,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         Returns
         -------
         True on success.
-
-        Description
-        -----------
-        This method is intended for use in applications that do not normally
-        have a GUI. Control does not resume in the calling application until
-        the user closes the dialog box.
-
-        The method attempts to open and unpickle the contents of *filename*
-        before displaying the dialog box. When editing is complete, the method
-        attempts to pickle the updated contents of the object back to
-        *filename*. If the file referenced by *filename* does not exist, the
-        object is not modified before displaying the dialog box. If *filename*
-        is unspecified or None, no pickling or unpickling occurs.
-
-        If *edit* is True (the default), a dialog box for editing the
-        current object is displayed. If *edit* is False or None, no
-        dialog box is displayed. You can use ``edit=False`` if you want the
-        object to be restored from the contents of *filename*, without being
-        modified by the user.
         """
         if filename is not None:
             message = ('Restoring from pickle will not be supported starting '
@@ -2053,6 +2031,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """Causes the object to invoke a handler whenever a trait attribute
         is modified, or removes the association.
 
+        Multiple handlers can be defined for the same object, or even for the
+        same trait attribute on the same object. If *name* is not specified or
+        is None, *handler* is invoked when any trait attribute on the
+        object is changed.
+
         Parameters
         ----------
         handler : function
@@ -2065,13 +2048,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             If True, removes the previously-set association between
             *handler* and *name*; if False (the default), creates the
             association.
-
-        Description
-        -----------
-        Multiple handlers can be defined for the same object, or even for the
-        same trait attribute on the same object. If *name* is not specified or
-        is None, *handler* is invoked when any trait attribute on the
-        object is changed.
         """
 
         if type(name) is list:
@@ -2415,6 +2391,13 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """Synchronizes the value of a trait attribute on this object with a
         trait attribute on another object.
 
+        In mutual synchronization, any change to the value of the specified
+        trait attribute of either object results in the same value being
+        assigned to the corresponding trait attribute of the other object.
+        In one-way synchronization, any change to the value of the attribute
+        on this object causes the corresponding trait attribute of *object* to
+        be updated, but not vice versa.
+
         Parameters
         ----------
         name : str
@@ -2430,15 +2413,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         remove : bool or int
             Indicates whether synchronization is being added (False or zero)
             or removed (True or non-zero)
-
-        Description
-        -----------
-        In mutual synchronization, any change to the value of the specified
-        trait attribute of either object results in the same value being
-        assigned to the corresponding trait attribute of the other object.
-        In one-way synchronization, any change to the value of the attribute
-        on this object causes the corresponding trait attribute of *object* to
-        be updated, but not vice versa.
         """
         if alias is None:
             alias = trait_name
@@ -2676,6 +2650,16 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     def trait(self, name, force=False, copy=False):
         """Returns the trait definition for the *name* trait attribute.
 
+        If *force* is False (the default) and *name* is the name of an
+        implicitly defined trait attribute that has never been referenced
+        explicitly (i.e., has not yet been defined), the result is None. In
+        all other cases, the result is the trait definition object associated
+        with *name*.
+
+        If *copy* is True, and a valid trait definition is found for *name*,
+        a copy of the trait found is returned. In all other cases, the trait
+        definition found is returned unmodified (the default).
+
         Parameters
         ----------
         name : str
@@ -2686,18 +2670,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         copy : bool
             Indicates whether to return the original trait definition or a
             copy.
-
-        Description
-        -----------
-        If *force* is False (the default) and *name* is the name of an
-        implicitly defined trait attribute that has never been referenced
-        explicitly (i.e., has not yet been defined), the result is None. In
-        all other cases, the result is the trait definition object associated
-        with *name*.
-
-        If *copy* is True, and a valid trait definition is found for *name*,
-        a copy of the trait found is returned. In all other cases, the trait
-        definition found is returned unmodified (the default).
         """
         mode = 0
         if force:
@@ -2711,18 +2683,16 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     def base_trait(self, name):
         """Returns the base trait definition for a trait attribute.
 
-        Parameters
-        ----------
-        name : str
-            Name of the attribute whose trait definition is returned.
-
-        Description
-        -----------
         This method is similar to the trait() method, and returns a
         different result only in the case where the trait attribute defined by
         *name* is a delegate. In this case, the base_trait() method follows the
         delegation chain until a non-delegated trait attribute is reached, and
         returns the definition of that attribute's trait as the result.
+
+        Parameters
+        ----------
+        name : str
+            Name of the attribute whose trait definition is returned.
         """
         return self._trait(name, -2)
 
@@ -2737,13 +2707,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """Returns a dictionary containing the definitions of all of the trait
         attributes of this object that match the set of *metadata* criteria.
 
-        Parameters
-        ----------
-        **metadata :
-            Criteria for selecting trait attributes.
-
-        Description
-        -----------
         The keys of the returned dictionary are the trait attribute names, and
         the values are their corresponding trait definition objects.
 
@@ -2764,6 +2727,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         value of the trait metadata attribute being tested. If more than one
         metadata keyword is specified, a trait attribute must match the
         metadata values of all keywords to be included in the result.
+
+        Parameters
+        ----------
+        **metadata :
+            Criteria for selecting trait attributes.
         """
         traits = self.__base_traits__.copy()
 
@@ -2800,13 +2768,6 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """Returns a dictionary containing the definitions of all of the trait
         attributes of the class that match the set of *metadata* criteria.
 
-        Parameters
-        ----------
-        **metadata :
-            Criteria for selecting trait attributes.
-
-        Description
-        -----------
         The keys of the returned dictionary are the trait attribute names, and
         the values are their corresponding trait definition objects.
 
@@ -2827,6 +2788,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         the value of the trait metadata attribute being tested. If more than
         one metadata keyword is specified, a trait attribute must match the
         metadata values of all keywords to be included in the result.
+
+        Parameters
+        ----------
+        **metadata :
+            Criteria for selecting trait attributes.
         """
         if len(metadata) == 0:
             return cls.__base_traits__.copy()
@@ -2850,15 +2816,13 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """Returns a list of the names of all trait attributes whose
         definitions match the set of *metadata* criteria specified.
 
+        This method is similar to the traits() method, but returns only the
+        names of the matching trait attributes, not the trait definitions.
+
         Parameters
         ----------
         **metadata :
             Criteria for selecting trait attributes.
-
-        Description
-        -----------
-        This method is similar to the traits() method, but returns only the
-        names of the matching trait attributes, not the trait definitions.
         """
         return list(self.traits(**metadata).keys())
 
@@ -2867,15 +2831,13 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         """Returns a list of the names of all trait attributes whose
         definitions match the set of *metadata* criteria specified.
 
+        This method is similar to the traits() method, but returns only the
+        names of the matching trait attributes, not the trait definitions.
+
         Parameters
         ----------
         **metadata :
             Criteria for selecting trait attributes.
-
-        Description
-        -----------
-        This method is similar to the traits() method, but returns only the
-        names of the matching trait attributes, not the trait definitions.
         """
         return list(cls.class_traits(**metadata).keys())
 

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3224,8 +3224,8 @@ class HasRequiredTraits(HasStrictTraits):
     TraitError
         If a required trait is not passed as an argument.
 
-    Usage
-    -----
+    Examples
+    --------
     A class with required traits:
 
     >>> class RequiredTest(HasRequiredTraits):

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -511,26 +511,6 @@ def Property(
 ):
     """ Returns a trait whose value is a Python property.
 
-    Parameters
-    ----------
-    fget : function
-        The "getter" function for the property.
-    fset : function
-        The "setter" function for the property.
-    fvalidate : function
-        The validation function for the property. The method should return the
-        value to set or raise TraitError if the new value is not valid.
-    force : bool
-        Indicates whether to use only the function definitions specified by
-        **fget** and **fset**, and not look elsewhere on the class.
-    handler : function
-        A trait handler function for the trait.
-    trait : Trait or value
-        A trait definition or a value that can be converted to a trait that
-        constrains the values of the property trait.
-
-    Description
-    -----------
     If no getter, setter or validate functions are specified (and **force** is
     not True), it is assumed that they are defined elsewhere on the class whose
     attribute this trait is assigned to. For example::
@@ -567,6 +547,24 @@ def Property(
 
     For details of the extended trait name syntax, refer to the
     on_trait_change() method of the HasTraits class.
+
+    Parameters
+    ----------
+    fget : function
+        The "getter" function for the property.
+    fset : function
+        The "setter" function for the property.
+    fvalidate : function
+        The validation function for the property. The method should return the
+        value to set or raise TraitError if the new value is not valid.
+    force : bool
+        Indicates whether to use only the function definitions specified by
+        **fget** and **fset**, and not look elsewhere on the class.
+    handler : function
+        A trait handler function for the trait.
+    trait : Trait or value
+        A trait definition or a value that can be converted to a trait that
+        constrains the values of the property trait.
     """
     metadata["type"] = "property"
 

--- a/traits/util/resource.py
+++ b/traits/util/resource.py
@@ -83,6 +83,14 @@ def create_unique_name(prefix, names, separator="_"):
 def find_resource(project, resource_path, alt_path=None, return_path=False):
     """ Returns a file object or file path pointing to the desired resource.
 
+    This function will find a desired resource file and return an opened file
+    object. The main method of finding the resource uses the pkg_resources
+    resource_stream method, which searches your working set for the installed
+    project specified and appends the resource_path given to the project
+    path, leading it to the file. If setuptools is not installed or it cannot
+    find/open the resource, find_resource will use the sys.path[0] to find the
+    resource if alt_path is defined.
+
     Parameters
     ----------
     project : str
@@ -108,16 +116,6 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
         A file object containing the resource. If return_path is True, 'file'
         will be the full path to the resource. If the file is not found or
         cannot be opened, None is returned.
-
-    Description
-    -----------
-    This function will find a desired resource file and return an opened file
-    object. The main method of finding the resource uses the pkg_resources
-    resource_stream method, which searches your working set for the installed
-    project specified and appends the resource_path given to the project
-    path, leading it to the file. If setuptools is not installed or it cannot
-    find/open the resource, find_resource will use the sys.path[0] to find the
-    resource if alt_path is defined.
     """
 
     try:


### PR DESCRIPTION
Closes #1005 

Fixes following rendering issues:
- Unsupported `Usage` section in `HasRequiredTraits`. Replaced by `Examples` section.
- Incorrect placement of `Description` - removed section headers and moved descriptions to under the "one-line description"
- `Property` was referred to as `autoclass` when it should be `autofunction`

**Checklist**
- ~[ ] Tests~
- [x] Update API reference (`docs/source/traits_api_reference`)
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~
- ~[ ] Update type annotation hints in `traits-stubs`~
