### PR TITLE
Move accept_anything validator to trait_base and rename

### DIFF
--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -15,9 +15,9 @@ import unittest.mock
 
 from traits.api import HasTraits, Int, List
 from traits.testing.optional_dependencies import numpy, requires_numpy
+from traits.trait_base import validate_everything
 from traits.trait_errors import TraitError
 from traits.trait_list_object import (
-    accept_anything,
     TraitList,
     TraitListEvent,
     TraitListObject,
@@ -112,28 +112,28 @@ class TestTraitList(unittest.TestCase):
         tl = TraitList([1, 2, 3])
 
         self.assertListEqual(tl, [1, 2, 3])
-        self.assertIs(tl.item_validator, accept_anything)
+        self.assertIs(tl.item_validator, validate_everything)
         self.assertEqual(tl.notifiers, [])
 
     def test_init_no_value(self):
         tl = TraitList()
 
         self.assertEqual(tl, [])
-        self.assertIs(tl.item_validator, accept_anything)
+        self.assertIs(tl.item_validator, validate_everything)
         self.assertEqual(tl.notifiers, [])
 
     def test_init_iterable(self):
         tl = TraitList("abcde")
 
         self.assertListEqual(tl, ['a', 'b', 'c', 'd', 'e'])
-        self.assertIs(tl.item_validator, accept_anything)
+        self.assertIs(tl.item_validator, validate_everything)
         self.assertEqual(tl.notifiers, [])
 
     def test_init_iterable_without_length(self):
         tl = TraitList(x**2 for x in range(5))
 
         self.assertEqual(tl, [0, 1, 4, 9, 16])
-        self.assertIs(tl.item_validator, accept_anything)
+        self.assertIs(tl.item_validator, validate_everything)
         self.assertEqual(tl.notifiers, [])
 
     def test_init_validates(self):
@@ -160,7 +160,7 @@ class TestTraitList(unittest.TestCase):
         tl = TraitList([1, 2, 3], notifiers=[self.notification_handler])
 
         self.assertListEqual(tl, [1, 2, 3])
-        self.assertIs(tl.item_validator, accept_anything)
+        self.assertIs(tl.item_validator, validate_everything)
         self.assertEqual(tl.notifiers, [self.notification_handler])
 
         tl[0] = 5

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -15,7 +15,7 @@ import unittest.mock
 
 from traits.api import HasTraits, Int, List
 from traits.testing.optional_dependencies import numpy, requires_numpy
-from traits.trait_base import validate_everything
+from traits.trait_base import _validate_everything
 from traits.trait_errors import TraitError
 from traits.trait_list_object import (
     TraitList,
@@ -112,28 +112,28 @@ class TestTraitList(unittest.TestCase):
         tl = TraitList([1, 2, 3])
 
         self.assertListEqual(tl, [1, 2, 3])
-        self.assertIs(tl.item_validator, validate_everything)
+        self.assertIs(tl.item_validator, _validate_everything)
         self.assertEqual(tl.notifiers, [])
 
     def test_init_no_value(self):
         tl = TraitList()
 
         self.assertEqual(tl, [])
-        self.assertIs(tl.item_validator, validate_everything)
+        self.assertIs(tl.item_validator, _validate_everything)
         self.assertEqual(tl.notifiers, [])
 
     def test_init_iterable(self):
         tl = TraitList("abcde")
 
         self.assertListEqual(tl, ['a', 'b', 'c', 'd', 'e'])
-        self.assertIs(tl.item_validator, validate_everything)
+        self.assertIs(tl.item_validator, _validate_everything)
         self.assertEqual(tl.notifiers, [])
 
     def test_init_iterable_without_length(self):
         tl = TraitList(x**2 for x in range(5))
 
         self.assertEqual(tl, [0, 1, 4, 9, 16])
-        self.assertIs(tl.item_validator, validate_everything)
+        self.assertIs(tl.item_validator, _validate_everything)
         self.assertEqual(tl.notifiers, [])
 
     def test_init_validates(self):
@@ -160,7 +160,7 @@ class TestTraitList(unittest.TestCase):
         tl = TraitList([1, 2, 3], notifiers=[self.notification_handler])
 
         self.assertListEqual(tl, [1, 2, 3])
-        self.assertIs(tl.item_validator, validate_everything)
+        self.assertIs(tl.item_validator, _validate_everything)
         self.assertEqual(tl.notifiers, [self.notification_handler])
 
         tl[0] = 5

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -12,7 +12,7 @@ import unittest
 from unittest import mock
 
 from traits.api import HasTraits, Set, Str
-from traits.trait_base import validate_everything
+from traits.trait_base import _validate_everything
 from traits.trait_errors import TraitError
 from traits.trait_set_object import TraitSet
 from traits.trait_types import _validate_int
@@ -51,14 +51,14 @@ class TestTraitSet(unittest.TestCase):
         ts = TraitSet({1, 2, 3})
 
         self.assertEqual(ts, {1, 2, 3})
-        self.assertIs(ts.item_validator, validate_everything)
+        self.assertIs(ts.item_validator, _validate_everything)
         self.assertEqual(ts.notifiers, [])
 
     def test_init_with_no_input(self):
         ts = TraitSet()
 
         self.assertEqual(ts, set())
-        self.assertIs(ts.item_validator, validate_everything)
+        self.assertIs(ts.item_validator, _validate_everything)
         self.assertEqual(ts.notifiers, [])
 
     def test_validator(self):

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -12,8 +12,9 @@ import unittest
 from unittest import mock
 
 from traits.api import HasTraits, Set, Str
+from traits.trait_base import validate_everything
 from traits.trait_errors import TraitError
-from traits.trait_set_object import TraitSet, accept_anything
+from traits.trait_set_object import TraitSet
 from traits.trait_types import _validate_int
 
 
@@ -50,14 +51,14 @@ class TestTraitSet(unittest.TestCase):
         ts = TraitSet({1, 2, 3})
 
         self.assertEqual(ts, {1, 2, 3})
-        self.assertIs(ts.item_validator, accept_anything)
+        self.assertIs(ts.item_validator, validate_everything)
         self.assertEqual(ts.notifiers, [])
 
     def test_init_with_no_input(self):
         ts = TraitSet()
 
         self.assertEqual(ts, set())
-        self.assertIs(ts.item_validator, accept_anything)
+        self.assertIs(ts.item_validator, validate_everything)
         self.assertEqual(ts.notifiers, [])
 
     def test_validator(self):

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -161,6 +161,13 @@ def strx(arg):
 StringTypes = (str, int, float, complex)
 
 
+# Default item validator for TraitDict, TraitList and TraitSet.
+def validate_everything(item):
+    """ Item validator which accepts any item and returns it unaltered.
+    """
+    return item
+
+
 def safe_contains(value, container):
     """ Perform "in" containment check, allowing for TypeErrors.
 

--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -162,7 +162,7 @@ StringTypes = (str, int, float, complex)
 
 
 # Default item validator for TraitDict, TraitList and TraitSet.
-def validate_everything(item):
+def _validate_everything(item):
     """ Item validator which accepts any item and returns it unaltered.
     """
     return item

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -11,7 +11,7 @@
 import copy
 from weakref import ref
 
-from traits.trait_base import Undefined
+from traits.trait_base import Undefined, validate_everything
 from traits.trait_errors import TraitError
 
 
@@ -54,17 +54,6 @@ class TraitDictEvent(object):
         return "TraitDictEvent(removed={!r}, added={!r}, changed={!r})".format(
             self.removed, self.added, self.changed
         )
-
-
-# Default item validator for TraitDict.
-
-
-def accept_anything(item):
-    """
-    Item validator which accepts any item and returns it unaltered.
-    """
-
-    return item
 
 
 class TraitDict(dict):
@@ -118,8 +107,8 @@ class TraitDict(dict):
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
-        self.key_validator = accept_anything
-        self.value_validator = accept_anything
+        self.key_validator = validate_everything
+        self.value_validator = validate_everything
         self.notifiers = []
         return self
 

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -11,7 +11,7 @@
 import copy
 from weakref import ref
 
-from traits.trait_base import Undefined, validate_everything
+from traits.trait_base import Undefined, _validate_everything
 from traits.trait_errors import TraitError
 
 
@@ -107,8 +107,8 @@ class TraitDict(dict):
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
-        self.key_validator = validate_everything
-        self.value_validator = validate_everything
+        self.key_validator = _validate_everything
+        self.value_validator = _validate_everything
         self.notifiers = []
         return self
 

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -12,7 +12,7 @@ import copy
 import operator
 from weakref import ref
 
-from traits.trait_base import class_of, Undefined
+from traits.trait_base import class_of, Undefined, validate_everything
 from traits.trait_errors import TraitError
 
 
@@ -161,16 +161,6 @@ def _removed_items(items, index, return_for_invalid_index):
             return return_for_invalid_index
 
 
-# Default item validator for TraitList.
-
-
-def accept_anything(item):
-    """
-    List item validator which accepts any item and returns it unaltered.
-    """
-    return item
-
-
 class TraitList(list):
     """ A subclass of list that validates and notifies listeners of changes.
 
@@ -208,7 +198,7 @@ class TraitList(list):
         # support unpickling: the 'append' or 'extend' methods may be
         # called during unpickling, triggering item validation.
         self = super().__new__(cls)
-        self.item_validator = accept_anything
+        self.item_validator = validate_everything
         self.notifiers = []
         return self
 

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -12,7 +12,7 @@ import copy
 import operator
 from weakref import ref
 
-from traits.trait_base import class_of, Undefined, validate_everything
+from traits.trait_base import class_of, Undefined, _validate_everything
 from traits.trait_errors import TraitError
 
 
@@ -198,7 +198,7 @@ class TraitList(list):
         # support unpickling: the 'append' or 'extend' methods may be
         # called during unpickling, triggering item validation.
         self = super().__new__(cls)
-        self.item_validator = validate_everything
+        self.item_validator = _validate_everything
         self.notifiers = []
         return self
 

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -13,7 +13,7 @@ import copyreg
 from itertools import chain
 from weakref import ref
 
-from traits.trait_base import validate_everything
+from traits.trait_base import _validate_everything
 from traits.trait_errors import TraitError
 
 
@@ -91,7 +91,7 @@ class TraitSet(set):
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
-        self.item_validator = validate_everything
+        self.item_validator = _validate_everything
         self.notifiers = []
         return self
 

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -13,6 +13,7 @@ import copyreg
 from itertools import chain
 from weakref import ref
 
+from traits.trait_base import validate_everything
 from traits.trait_errors import TraitError
 
 
@@ -48,15 +49,6 @@ class TraitSetEvent(object):
         return "TraitSetEvent(removed={!r}, added={!r})".format(
             self.removed, self.added
         )
-
-
-# Default item validator for TraitSet.
-
-def accept_anything(item):
-    """
-    Item validator which accepts any item and returns it unaltered.
-    """
-    return item
 
 
 class TraitSet(set):
@@ -99,7 +91,7 @@ class TraitSet(set):
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
-        self.item_validator = accept_anything
+        self.item_validator = validate_everything
         self.notifiers = []
         return self
 


### PR DESCRIPTION
Closes #1014 

`accept_anything` validator was defined for each `TraitList`, `TraitSet` and `TraitDict` separately. This PR moves the validator to `trait_base` to be used by all three and renames it to `validate_everything` which hopefully is a more informative name of what the function does.

**Checklist**
- [x] Tests
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~
- ~[ ] Update type annotation hints in `traits-stubs`~
