### PR TITLE
Add trait_set to TraitSetObject notifier signature for consistency

### DIFF
--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -39,7 +39,8 @@ class TestTraitSet(unittest.TestCase):
         self.removed = None
         self.validator_args = None
 
-    def notification_handler(self, removed, added):
+    def notification_handler(self, trait_set, removed, added):
+        self.trait_set = trait_set
         self.removed = removed
         self.added = added
 
@@ -75,6 +76,13 @@ class TestTraitSet(unittest.TestCase):
         self.assertEqual(ts, {1, 2, 3})
         self.assertEqual(ts.item_validator, int_validator)
         self.assertEqual(ts.notifiers, [self.notification_handler])
+
+        ts.add(5)
+
+        self.assertEqual(ts, {1, 2, 3, 5})
+        self.assertIs(self.trait_set, ts)
+        self.assertEqual(self.removed, set())
+        self.assertEqual(self.added, {5})
 
     def test_add(self):
         ts = TraitSet({1, 2, 3}, item_validator=int_validator,
@@ -306,7 +314,7 @@ class TestTraitSet(unittest.TestCase):
         python_set = set([1, 2, 3])
         python_set.intersection_update([2], [3])
 
-        ts = TraitSet([1, 2, 3], notifiers=[notifier])
+        ts = TraitSet([1, 2, 3])
         ts.intersection_update([2], [3])
 
         self.assertEqual(ts, python_set)

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -38,6 +38,7 @@ class TestTraitSet(unittest.TestCase):
         self.added = None
         self.removed = None
         self.validator_args = None
+        self.trait_set = None
 
     def notification_handler(self, trait_set, removed, added):
         self.trait_set = trait_set

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -66,7 +66,7 @@ class TraitSet(set):
     notifiers : list of callable, optional
         A list of callables with the signature::
 
-            notifier(removed, added)
+            notifier(trait_set, removed, added)
 
         Where 'added' is a set containing new values that have been added.
         And 'removed' is a set containing old values that have been removed.
@@ -83,7 +83,7 @@ class TraitSet(set):
     notifiers : list of callable
         A list of callables with the signature::
 
-            notifier(removed, added)
+            notifier(trait_set, removed, added)
 
         where 'added' is a set containing new values that have been added
         and 'removed' is a set containing old values that have been removed.
@@ -108,7 +108,7 @@ class TraitSet(set):
         This simply calls all notifiers provided by the class, if any.
         The notifiers are expected to have the signature::
 
-            notifier(removed, added)
+            notifier(trait_set, removed, added)
 
         Any return values are ignored. Any exceptions raised are not
         handled. Notifiers are therefore expected not to raise any
@@ -122,7 +122,7 @@ class TraitSet(set):
             The new items that have been added to the set.
         """
         for notifier in self.notifiers:
-            notifier(removed, added)
+            notifier(self, removed, added)
 
     # -- set interface -------------------------------------------------------
 
@@ -502,12 +502,14 @@ class TraitSetObject(TraitSet):
             excp.set_prefix("Each element of the")
             raise excp
 
-    def notifier(self, removed, added):
+    def notifier(self, trait_set, removed, added):
         """ Converts and consolidates the parameters to a TraitSetEvent and
         then fires the event.
 
         Parameters
         ----------
+        trait_set : set
+            The complete set
         removed : set
             Set of values that were removed.
         added : set


### PR DESCRIPTION
Closes #1027 

Adds `trait_set` argument to `notifier` signature of `TraitSetObject` for consistency with `TraitDictObject` and `TraitListObject` (even thought the argument is not needed here).

**Checklist**
- [x] Tests
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~
- ~[ ] Update type annotation hints in `traits-stubs`~
