### PR TITLE
Don't run CI on Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=3.5
     - env: RUNTIME=3.6
-    - os: osx
-      env: RUNTIME=3.5
     - os: osx
       env: RUNTIME=3.6
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
     INSTALL_EDM_VERSION: "2.0.0"
 
   matrix:
-    - RUNTIME: '3.5'
     - RUNTIME: '3.6'
 
 cache:

--- a/etstool.py
+++ b/etstool.py
@@ -102,7 +102,7 @@ unix_dependencies = {
     "gnureadline",
 }
 
-supported_runtimes = ["3.5", "3.6"]
+supported_runtimes = ["3.6"]
 default_runtime = "3.6"
 
 github_url_fmt = "git+http://github.com/enthought/{0}.git#egg={0}"


### PR DESCRIPTION
This PR drops CI runs on Python 3.5. We no longer build eggs for Python 3.5, so that makes it difficult to run against the latest version of Pyface and TraitsUI using our current EDM- and buildsystem-based infrastructure.

See also #687.