### PR TITLE
Trait container documentation

### DIFF
--- a/docs/source/traits_user_manual/internals.rst
+++ b/docs/source/traits_user_manual/internals.rst
@@ -177,6 +177,121 @@ Attribute deletion
 Attribute deletion (``del obj.name``) goes through the same code path as
 attribute set operations. Most ``CTrait`` types do not permit deletion.
 
+Traits Containers
+-----------------
+
+Traits has the ability to watch for changes in standard Python containers,
+specifically lists, dictionaries and sets.  To achieve this, Traits provides
+special subclasses of the standard Python classes that can validate elements
+and can fire trait notifications when the contents change.  These classes are,
+respectively, |TraitList|, |TraitDict| and |TraitSet| (not to be confused with
+the deprecated Trait Handlers of the same names).
+
+In addition to being able to take an appropriate value to initialize the
+container (such as a sequence or mapping), these container subclasses also
+take keyword-only arguments for validators (either a single item validator for
+|TraitList| and |TraitSet|, or key and value validators for |TraitDict|) and
+notifiers.
+
+These classes were introduced in Traits 6.1 and the implementation details
+described here are provisional and may change.
+
+Backwards Compatibility
+~~~~~~~~~~~~~~~~~~~~~~~
+
+In practice, most traits containers are instances of |TraitListObject|,
+|TraitDictObject| and |TraitSetObject| which are subclasses that are
+created by the validators of |List|, |Dict| and |Set| traits respectively and
+supplied with appropriate element validators that wrap the standard trait
+validators so that constructs like ``List(Str)`` can work.
+
+These objects are designed to be API compatible with the classes of the
+same name from Traits 6.0 and before, and so have different constructors and
+may behave slightly differently from the base classes in some cases.
+
+In particular |TraitListObject| classes can have restrictions on their
+length, which is not part of the base |TraitList| API.
+
+All of these backward compatibility classes are strongly tied to a particular
+object and trait, and are not designed to operate as stand-alone entities.
+These relationships are required to support the `object.*_items`-style event
+traits, but complicate the implementation, for example by having to use
+weak references to the object, and having to take this additional structure
+into account when serializing and deserializing.
+
+It is a long-term goal to phase out the use of these backwards compatibility
+classes.
+
+Container Validators
+~~~~~~~~~~~~~~~~~~~~
+
+Container validators are callables that are expected to take a single value
+and either return a validated value or raise a TraitError.  The default
+validators simply pass the input value directly through, but validators can
+potentially do much more.   Validators are expected to be idempotent:
+``validate(validate(x)) == validate(x)`` should hold as long as
+``validate(x)`` does not raise an error.
+
+For example, the following validator casts the list items to integers,
+raising a TraitError if that fails::
+
+    def int_validator(value):
+        try:
+            return int(value)
+        except ValueError:
+            raise TraitError(
+                "List items must be castable to an int, but a value %r was specified."
+                % value
+            )
+
+So if we were to use this as the validator for a |TraitList| we would get the
+following behaviour::
+
+    >>> int_list = TraitList(item_validator=int_validator)
+    >>> int_list.append("5")
+    >>> int_list
+    [5]
+    >>> int_list.extend([3, 5, "aaaarrrghh"])
+    TraitError: List items must be castable to an int, but a value 'aaaarrrghh' was specified.
+
+In Traits 6.1 validation is not done uniformly before performing operations
+to keep behaviour the same as Traits 6.0 and earlier, so results of operations can
+sometimes be surprising::
+
+    >>> int_list.append("6")
+    >>> int_list.remove("6")
+    ValueError: list.remove(x): x not in list
+
+This is expected to be resolved in a future traits version by providing clear
+guidance to users about when validation is performed, and possibly changing the
+behaviour.
+
+Container Notifiers
+~~~~~~~~~~~~~~~~~~~
+
+Container objects also have a list of notifiers that fire when the contents of
+the container change.  Like trait notifiers, container notifiers are low-level
+callbacks that are used by the higher-level, more user-friendly observer and
+listener systems.  They have a fixed signature, which is slightly different for
+lists, dicts and sets, but in all cases starts with the container object itself.
+Notifiers are called in the order that they appear in the notifiers list and
+should not mutate the parameters that they have been passed.
+
+List notifiers must take 4 arguments: the list object, the index value or slice
+that identifies where the change occurred, a list of removed elements, and a
+list of added elements.  The |ListObject| methods make an attempt to normalize
+indices and slices to make things easier for notification writers.
+
+Dict notifiers expect 4 arguments: the dict object, a dictionary of removed
+items, a dictionary of added elements, and a dictionary of changed items,
+where the values are the old values held in the keys.
+
+Set notifiers expect 3 arguments: the set object, the set of removed elements,
+and the set of added elements.
+
+Users should not usually need to interact with the container notifiers directly,
+just as they do not usually need to interact with trait notifiers.
+
 
 ..
    # substitutions
@@ -188,3 +303,12 @@ attribute set operations. Most ``CTrait`` types do not permit deletion.
 .. |ctraits| replace:: :mod:`~traits.ctraits`
 .. |CHasTraits| replace:: :class:`~traits.ctraits.CHasTraits`
 .. |HasTraits| replace:: :class:`~traits.has_traits.HasTraits`
+.. |TraitList| replace:: :class:`~traits.trait_list_object.TraitList`
+.. |TraitDict| replace:: :class:`~traits.trait_dict_object.TraitDict`
+.. |TraitSet| replace:: :class:`~traits.trait_dict_object.TraitSet`
+.. |TraitListObject| replace:: :class:`~traits.trait_list_object.TraitListObject`
+.. |TraitDictObject| replace:: :class:`~traits.trait_dict_object.TraitDictObject`
+.. |TraitSetObject| replace:: :class:`~traits.trait_dict_object.TraitSetObject`
+.. |List| replace:: :class:`~traits.trait_types.List`
+.. |Dict| replace:: :class:`~traits.trait_types.Dict`
+.. |Set| replace:: :class:`~traits.trait_types.Set`

--- a/docs/source/traits_user_manual/internals.rst
+++ b/docs/source/traits_user_manual/internals.rst
@@ -180,10 +180,10 @@ attribute set operations. Most ``CTrait`` types do not permit deletion.
 Traits Containers
 -----------------
 
-Traits has the ability to watch for changes in standard Python containers,
-specifically lists, dictionaries and sets.  To achieve this, Traits provides
-special subclasses of the standard Python classes that can validate elements
-and can fire trait notifications when the contents change.  These classes are,
+Traits has the ability to watch for changes in standard Python containers:
+lists, dictionaries and sets.  To achieve this Traits provides special
+subclasses of the standard Python classes that can validate elements and can
+fire trait notifications when the contents change.  These classes are,
 respectively, |TraitList|, |TraitDict| and |TraitSet| (not to be confused with
 the deprecated Trait Handlers of the same names).
 
@@ -277,17 +277,18 @@ lists, dicts and sets, but in all cases starts with the container object itself.
 Notifiers are called in the order that they appear in the notifiers list and
 should not mutate the parameters that they have been passed.
 
-List notifiers must take 4 arguments: the list object, the index value or slice
-that identifies where the change occurred, a list of removed elements, and a
-list of added elements.  The |ListObject| methods make an attempt to normalize
-indices and slices to make things easier for notification writers.
+List notifiers must take 4 arguments: the **trait_list** object, the **index**
+value or slice that identifies where the change occurred, a list of
+**removed** elements, and a list of **added** elements.  The |TraitList|
+methods make an attempt to normalize indices and slices to make things easier
+for notification writers.
 
-Dict notifiers expect 4 arguments: the dict object, a dictionary of removed
-items, a dictionary of added elements, and a dictionary of changed items,
-where the values are the old values held in the keys.
+Dict notifiers expect 4 arguments: the **trait_dict** object, a dictionary of
+**removed** items, a dictionary of **added** elements, and a dictionary of
+**changed** items, where the values are the old values held in the keys.
 
-Set notifiers expect 3 arguments: the set object, the set of removed elements,
-and the set of added elements.
+Set notifiers expect 3 arguments: the **trait_set** object, the set of
+**removed** elements, and the set of **added** elements.
 
 Users should not usually need to interact with the container notifiers directly,
 just as they do not usually need to interact with trait notifiers.

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -717,12 +717,16 @@ respectively.
 
 The TraitListEvent has an additional **index** attribute that holds either
 the index of the first item changed, or for changes involving slices with
-steps other than 1, **index** holds the _slice_ that was changed.
+steps other than 1, **index** holds the _slice_ that was changed.  For
+slice values you can always recover the actual values which were changed or
+removed via ``range(index.start, index.stop, index.end)``.
 
 The TraitDictEvent has an additional **changed** attribute which holds the
 keys that were modified and the _old_ values that those keys held.  The new
-values can be queried from directly from the trait value, if needed).
+values can be queried from directly from the trait value, if needed.
 
+Handlers for these events should not mutate the attributes of the event
+objects, including avoiding in-place changes to **added**, **removed**, etc.
 
 .. _on-trait-change-dos-n-donts:
 


### PR DESCRIPTION
Added documentation about the new Trait container classes to the internals section, plus some minor clarifications to the section on TraitEvents

Fixes #997.

**Checklist**
- ~[ ] Tests~
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~
- [X] Update User manual (`docs/source/traits_user_manual`)
- ~[ ] Update type annotation hints in `traits-stubs`~
