### PR TITLE
Fix the Instance init stub

### DIFF
--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -22,7 +22,6 @@ from typing import (
     Type as _Type,
     TypeVar,
     Union as _Union,
-    overload,
 )
 from uuid import UUID as _UUID
 

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -22,6 +22,7 @@ from typing import (
     Type as _Type,
     TypeVar,
     Union as _Union,
+    overload,
 )
 from uuid import UUID as _UUID
 
@@ -487,14 +488,13 @@ class BaseClass(_BaseClass[_Type]):
 
 
 class _BaseInstance(_BaseClass[_T]):
+
+    # simplified signature
     def __init__(
             self,
-            klass: _T = ...,
-            factory: _OptionalCallable = ...,
-            args: tuple = ...,
-            kw: _Dict[_Any, _Any] = ...,
-            allow_none: bool = ...,
-            adapt: str = ...,
+            klass: _T,
+            *args,
+            **metadata: _Any,
     ) -> None:
         ...
 
@@ -611,15 +611,36 @@ class WeakRef(Instance):
 
 
 class Date(_BaseInstance[datetime.date]):
-    ...
+
+    # simplified signature
+    def __init__(
+            self,
+            default_value: datetime.date = ...,
+            **metadata: _Any,
+    ) -> None:
+        ...
 
 
 class Datetime(_BaseInstance[datetime.datetime]):
-    ...
+
+    # simplified signature
+    def __init__(
+            self,
+            default_value: datetime.datetime = ...,
+            **metadata: _Any,
+    ) -> None:
+        ...
 
 
 class Time(_BaseInstance[datetime.time]):
-    ...
+
+    # simplified signature
+    def __init__(
+            self,
+            default_value: datetime.time = ...,
+            **metadata: _Any,
+    ) -> None:
+        ...
 
 
 class AdaptedTo(Supports):

--- a/traits-stubs/traits_stubs_tests/examples/Instance.py
+++ b/traits-stubs/traits_stubs_tests/examples/Instance.py
@@ -1,8 +1,11 @@
-from traits.api import HasTraits, Instance
+from traits.api import HasTraits, Instance, Str
 
 
 class Fruit:
-    info = "good for you"
+    info = Str("good for you")
+
+    def __init__(self, info="good for you", **traits):
+        super().__init__(info=info, **traits)
 
 
 class Orange(Fruit):
@@ -13,8 +16,30 @@ class Pizza:
     pass
 
 
+def fruit_factory(info, other_stuff):
+    return Fruit(info=info)
+
+
 class TestClass(HasTraits):
     itm = Instance(Fruit)
+
+    itm_args_kw = Instance(Fruit, ('different info',), {'another_trait': 3})
+    itm_args = Instance(Fruit, ('different info',))
+    itm_kw = Instance(Fruit, {'info': 'different info'})
+    itm_factory = Instance(Fruit, fruit_factory)
+    itm_factory = Instance(Fruit, fruit_factory, ('different info',), )
+    itm_factory = Instance(
+        Fruit,
+        fruit_factory,
+        ('different info',),
+        {'other_stuff': 3},
+    )
+    itm_factory = Instance(
+        Fruit,
+        fruit_factory,
+        ('different info',),
+        {'other_stuff': 3},
+    )
 
 
 obj = TestClass()

--- a/traits-stubs/traits_stubs_tests/examples/Instance.py
+++ b/traits-stubs/traits_stubs_tests/examples/Instance.py
@@ -27,17 +27,16 @@ class TestClass(HasTraits):
     itm_args = Instance(Fruit, ('different info',))
     itm_kw = Instance(Fruit, {'info': 'different info'})
     itm_factory = Instance(Fruit, fruit_factory)
-    itm_factory = Instance(Fruit, fruit_factory, ('different info',), )
-    itm_factory = Instance(
+    itm_factory_args = Instance(Fruit, fruit_factory, ('different info',), )
+    itm_factory_args_kw = Instance(
         Fruit,
         fruit_factory,
         ('different info',),
         {'other_stuff': 3},
     )
-    itm_factory = Instance(
+    itm_factory_kw = Instance(
         Fruit,
         fruit_factory,
-        ('different info',),
         {'other_stuff': 3},
     )
 


### PR DESCRIPTION
The fix was to use generic *args and **kwargs after the first argument since the `__init__` method potentially shuffles them.  This broke `Date`, `Datetime` and `Time`, so specific `__init__` methods were added for them.

Fixes #1062.

**Checklist**
- [x] Tests
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~
- [x] Update type annotation hints in `traits-stubs`
