### PR TITLE
Maint: Avoid calling observe's dispatch with named arguments

### DIFF
--- a/traits/observers/_trait_event_notifier.py
+++ b/traits/observers/_trait_event_notifier.py
@@ -119,7 +119,7 @@ class TraitEventNotifier:
         if self.prevent_event(event):
             return
         try:
-            self.dispatcher(handler, event=event)
+            self.dispatcher(handler, event)
         except Exception:
             handle_exception(event)
 

--- a/traits/observers/tests/test_trait_event_notifier.py
+++ b/traits/observers/tests/test_trait_event_notifier.py
@@ -100,7 +100,8 @@ class TestTraitEventNotifierCall(unittest.TestCase):
         # Test the dispatch is used
         events = []
 
-        def dispatcher(handler, event):
+        def dispatcher(handler, *args):
+            event, = args
             events.append(event)
 
         def event_factory(*args, **kwargs):


### PR DESCRIPTION
Related to #977

This PR removes the requirement on the event argument name for the dispatch callable, as the requirement unnecessarily forbids the use of other generic dispatch-like functions, such as `concurrent.futures.Executor.submit(callable, *args, **kwargs)`. With this, it will be possible to use something like `Executor.submit` as the dispatch callable. 
(Whether to expose this flexibility to the user API is a separate discussion though.)
 
**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
