### PR TITLE
DOC: Clarify when dynamic default values are considered to have existed

### DIFF
--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -53,9 +53,9 @@ initialization. For performance purposes, a default initializer is called when:
 While it is possible to use default initializers to lazily initialize
 attributes based on the object state post-instantiation, this relies on not
 having to observe for changes on the trait. This is often difficult in
-practice, since trait notifications can be setup by external objects, and are
+practice, since trait notifications can be set up by external objects, and are
 often needed for Property traits, delegation and GUI applications. These use
-cases will cause the default initializers to be evaluated eagerly prior to
+cases may cause the default initializers to be evaluated eagerly prior to
 instantiation, instead of lazily after instantiation.
 
 .. index:: get_default_value()

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -38,14 +38,22 @@ attribute, with a name based on the name of the trait attribute:
 
 .. method:: _name_default()
 
-This method initializes the *name* trait attribute, returning its initial value.
-The method overrides any default value specified in the trait definition. The
-initializer is called when:
+This method returns the default value for the *name* trait attribute and it
+overrides any default value specified in the trait definition.
+
+Similar to static default values, default values defined dynamically are
+considered to have existed **prior to** setting object state during
+initialization. For performance purposes, a default initializer is called when:
 
 1. the attribute value is accessed the first time or
 2. an instance is constructed with a specific value, if there is a change
    handler defined for the trait. This is needed so the default can be reported
    as the old value (see :ref:`static-notification`).
+
+Without any trait change notification definitions, it is possible to use
+default initializers to initialize attributes using object states after
+instantiation. However such usage will often leads to unexpected behavior when
+notifications for trait changes are defined.
 
 .. index:: get_default_value()
 

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -43,19 +43,20 @@ overrides any default value specified in the trait definition.
 
 Similar to static default values, default values defined dynamically should be
 thought of as existing **prior to** setting object state during
-initialization. For performance purposes, a default initializer is called when:
+initialization. For performance purposes, a default initializer method is
+called when:
 
 1. the attribute value is accessed the first time or
 2. an instance is constructed with a specific value, if there is a change
    handler defined for the trait. This is needed so the default can be reported
    as the old value (see :ref:`static-notification`).
 
-While it is possible to use default initializers to lazily initialize
+While it is possible to use a default initializer method to lazily initialize
 attributes based on the object state post-instantiation, this relies on not
 having to observe for changes on the trait. This is often difficult in
 practice, since trait notifications can be set up by external objects, and are
 often needed for Property traits, delegation and GUI applications. These use
-cases may cause the default initializers to be evaluated eagerly prior to
+cases may cause the default values to be computed eagerly prior to
 instantiation, instead of lazily after instantiation.
 
 .. index:: get_default_value()

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -41,8 +41,8 @@ attribute, with a name based on the name of the trait attribute:
 This method returns the default value for the *name* trait attribute and it
 overrides any default value specified in the trait definition.
 
-Similar to static default values, default values defined dynamically are
-considered to have existed **prior to** setting object state during
+Similar to static default values, default values defined dynamically should be
+thought of as existing **prior to** setting object state during
 initialization. For performance purposes, a default initializer is called when:
 
 1. the attribute value is accessed the first time or
@@ -50,10 +50,13 @@ initialization. For performance purposes, a default initializer is called when:
    handler defined for the trait. This is needed so the default can be reported
    as the old value (see :ref:`static-notification`).
 
-Without any trait change notification definitions, it is possible to use
-default initializers to initialize attributes using object states after
-instantiation. However such usage will often leads to unexpected behavior when
-notifications for trait changes are defined.
+While it is possible to use default initializers to lazily initialize an
+attribute based on the object state after instantiation, this relies on not
+having to observe for changes on the trait. This is often difficult in
+practice, since trait notifications can be setup by external objects, and are
+often needed for Property traits, delegation and GUI applications. These use
+cases will cause the default initializers to be evaluated eagerly prior to
+instantiation, instead of lazily after instantiation.
 
 .. index:: get_default_value()
 

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -50,8 +50,8 @@ initialization. For performance purposes, a default initializer is called when:
    handler defined for the trait. This is needed so the default can be reported
    as the old value (see :ref:`static-notification`).
 
-While it is possible to use default initializers to lazily initialize an
-attribute based on the object state after instantiation, this relies on not
+While it is possible to use default initializers to lazily initialize
+attributes based on the object state post-instantiation, this relies on not
 having to observe for changes on the trait. This is often difficult in
 practice, since trait notifications can be setup by external objects, and are
 often needed for Property traits, delegation and GUI applications. These use


### PR DESCRIPTION
Starting from a very basic HasTraits subclass without any notifications, defaults defined via a method with name `_name_default` are called when the trait is accessed the first time. This allows the method to be use as a lazy initializer post-instantiation, and allow the default to depend on post-instantiation attributes.  This works until the model grows and notifications are added, because the mental model of traits actually considers the default to have been defined pre-instantiation, and default initializers end up getting called early when notifications need to fire.

A couple of examples can be seen in https://github.com/enthought/traits/issues/94 and https://github.com/enthought/traits/issues/709

This PR attempts to clarify this concept in the user manual.

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~
