### PR TITLE
Add TraitChangeEvent object for wrapping CTrait change

### DIFF
--- a/docs/source/traits_api_reference/index.rst
+++ b/docs/source/traits_api_reference/index.rst
@@ -40,6 +40,7 @@ Subpackages
 
     traits.adaptation
     traits.etsconfig
+    traits.observers
     traits.testing
     traits.util
 

--- a/docs/source/traits_api_reference/traits.observers.rst
+++ b/docs/source/traits_api_reference/traits.observers.rst
@@ -1,0 +1,20 @@
+:mod:`traits.observers` Package
+===============================
+
+.. automodule:: traits.observers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+:mod:`traits.observers.events` Module
+-------------------------------------
+
+.. automodule:: traits.observers.events
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: TraitChangeEvent
+   :members:
+   :inherited-members:

--- a/traits/observers/_trait_change_event.py
+++ b/traits/observers/_trait_change_event.py
@@ -1,0 +1,70 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Event object and factory for CTrait change event.
+"""
+
+
+# TraitChangeEvent is exposed in the public API.
+
+class TraitChangeEvent:
+    """ Emitted when a trait on a HasTraits object is changed.
+
+    Attributes
+    ----------
+    object : HasTraits
+        Object on which a trait is changed.
+    name : str
+        Name of the trait.
+    old : any
+        The old value.
+    new : any
+        The new value.
+    """
+
+    def __init__(self, *, object, name, old, new):
+        self.object = object
+        self.name = name
+        self.old = old
+        self.new = new
+
+    def __repr__(self):
+        return (
+            "<{class_name}("
+            "object={object!r}, name={name!r}, old={old!r}, new={new!r}"
+            ")>".format(
+                class_name=type(self).__name__,
+                object=self.object,
+                name=self.name,
+                old=self.old,
+                new=self.new,
+            )
+        )
+
+
+def trait_event_factory(object, name, old, new):
+    """ Adapt the call signature of ctraits call_notifiers to create an event.
+
+    Parameters
+    ----------
+    object : HasTraits
+        Object on which a trait is changed.
+    name : str
+        Name of the trait.
+    old : any
+        The old value.
+    new : any
+        The new value.
+
+    Returns
+    -------
+    TraitChangeEvent
+    """
+    return TraitChangeEvent(object=object, name=name, old=old, new=new)

--- a/traits/observers/events.py
+++ b/traits/observers/events.py
@@ -1,0 +1,16 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Event objects received by change handlers added using observe.
+"""
+
+from traits.observers._trait_change_event import (   # noqa: F401
+    TraitChangeEvent,
+)

--- a/traits/observers/tests/test_trait_change_event.py
+++ b/traits/observers/tests/test_trait_change_event.py
@@ -1,0 +1,66 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+from traits.has_traits import HasTraits
+from traits.trait_types import Int
+from traits.observers._trait_change_event import (
+    trait_event_factory,
+    TraitChangeEvent,
+)
+
+
+class TestTraitChangeEvent(unittest.TestCase):
+    """ Test initialization and repr of TraitChangeEvent. """
+
+    def test_trait_change_event_repr(self):
+        event = TraitChangeEvent(
+            object=None,
+            name="name",
+            old=1,
+            new=2,
+        )
+        actual = repr(event)
+        self.assertEqual(
+            actual,
+            "<TraitChangeEvent(object=None, name='name', old=1, new=2)>"
+        )
+
+
+class TestTraitEventFactory(unittest.TestCase):
+    """ Test event factory compatibility with CTrait."""
+
+    def test_trait_change_notification_compat(self):
+
+        class Foo(HasTraits):
+            number = Int()
+
+        events = []
+
+        def notifier(*args, **kwargs):
+            event = trait_event_factory(*args, **kwargs)
+            events.append(event)
+
+        foo = Foo(number=0)
+        trait = foo.trait("number")
+
+        trait._notifiers(True).append(notifier)
+
+        # when
+        foo.number += 1
+
+        # then
+        event, = events
+
+        self.assertIs(event.object, foo)
+        self.assertEqual(event.name, "number")
+        self.assertEqual(event.old, 0)
+        self.assertEqual(event.new, 1)


### PR DESCRIPTION
This PR adds the `TraitChangeEvent` object for wrapping CTrait change events.

This event object will be given to the user's handler registered using `observe`.

This event object will also be used by the `NamedTraitObserver` in #1069, the "FilteredTraitObserver" for observing traits using a filter, and the (internal-use-only) observer for `trait_added` events.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- ~Update User manual (`docs/source/traits_user_manual`)~ WIP in #1060 
- ~Update type annotation hints in `traits-stubs`~
