### PR TITLE
Implement DictItemObserver for observing mutations to a dict

### DIFF
--- a/docs/source/traits_api_reference/index.rst
+++ b/docs/source/traits_api_reference/index.rst
@@ -40,6 +40,7 @@ Subpackages
 
     traits.adaptation
     traits.etsconfig
+    traits.observers
     traits.testing
     traits.util
 

--- a/docs/source/traits_api_reference/traits.observers.rst
+++ b/docs/source/traits_api_reference/traits.observers.rst
@@ -1,0 +1,20 @@
+:mod:`traits.observers` Package
+===============================
+
+.. automodule:: traits.observers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+:mod:`traits.observers.events` Module
+-------------------------------------
+
+.. automodule:: traits.observers.events
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: DictChangeEvent
+   :members:
+   :inherited-members:

--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -38,16 +38,11 @@ class DictChangeEvent:
 
     def __repr__(self):
         return (
-            "<{class_name}("
-            "trait_dict={trait_dict!r}, "
-            "removed={removed!r}, "
-            "added={added!r}"
-            ")>".format(
-                class_name=type(self).__name__,
-                trait_dict=self.trait_dict,
-                added=self.added,
-                removed=self.removed,
-            )
+            "{event.__class__.__name__}("
+            "trait_dict={event.trait_dict!r}, "
+            "removed={event.removed!r}, "
+            "added={event.added!r}"
+            ")".format(event=self)
         )
 
 

--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -13,7 +13,7 @@
 
 
 class DictChangeEvent:
-    """ Event object to represent mutation on a dict.
+    """ Event object to represent mutations on a dict.
 
     Attributes
     ----------
@@ -21,11 +21,11 @@ class DictChangeEvent:
         The dict being mutated.
     added : dict
         Keys and values for added or updated items.
-        If keys are found in removed as well, they refer to updated items
+        If keys are found in ``removed`` as well, they refer to updated items
         and the values are new.
     removed : dict
         Keys and values for removed or updated items.
-        If keys are found in added as well, they refer to updated items
+        If keys are found in ``added`` as well, they refer to updated items
         and the values are old.
     """
 

--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -19,27 +19,27 @@ class DictChangeEvent:
     ----------
     trait_dict : dict
         The dict being mutated.
-    added : dict
-        Keys and values for added or updated items.
-        If keys are found in ``removed`` as well, they refer to updated items
-        and the values are new.
     removed : dict
         Keys and values for removed or updated items.
         If keys are found in ``added`` as well, they refer to updated items
         and the values are old.
+    added : dict
+        Keys and values for added or updated items.
+        If keys are found in ``removed`` as well, they refer to updated items
+        and the values are new.
     """
 
-    def __init__(self, *, trait_dict, added, removed):
+    def __init__(self, *, trait_dict, removed, added):
         self.trait_dict = trait_dict
-        self.added = added
         self.removed = removed
+        self.added = added
 
     def __repr__(self):
         return (
             "<{class_name}("
             "trait_dict={trait_dict!r}, "
-            "added={added!r}, "
             "removed={removed!r}"
+            "added={added!r}, "
             ")>".format(
                 class_name=type(self).__name__,
                 trait_dict=self.trait_dict,

--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -1,0 +1,77 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Event object for representing mutations to a dict.
+"""
+
+
+class DictChangeEvent:
+    """ Event object to represent mutation on a dict.
+
+    Attributes
+    ----------
+    trait_dict : dict
+        The dict being mutated.
+    added : dict
+        Keys and values for added or updated items.
+        If keys are found in removed as well, they refer to updated items
+        and the values are new.
+    removed : dict
+        Keys and values for removed or updated items.
+        If keys are found in added as well, they refer to updated items
+        and the values are old.
+    """
+
+    def __init__(self, *, trait_dict, added, removed):
+        self.trait_dict = trait_dict
+        self.added = added
+        self.removed = removed
+
+    def __repr__(self):
+        return (
+            "<{class_name}("
+            "trait_dict={trait_dict!r}, "
+            "added={added!r}, "
+            "removed={removed!r}"
+            ")>".format(
+                class_name=type(self).__name__,
+                trait_dict=self.trait_dict,
+                added=self.added,
+                removed=self.removed,
+            )
+        )
+
+
+def dict_event_factory(trait_dict, removed, added, changed):
+    """ Adapt the call signature of TraitDict.notify to create an event.
+
+    Parameters
+    ----------
+    trait_dict : TraitDict
+    removed : dict
+        Items removed from the dict
+    added : dict
+        Items added to the dict
+    changed : dict
+        Old values for items updated on the dict.
+
+    Returns
+    -------
+    DictChangeEvent
+    """
+    # See enthought/traits#1031 for changing the signature of TraitDict.notify
+    # instead.
+    removed = removed.copy()
+    removed.update(changed)
+    for key in changed:
+        added[key] = trait_dict[key]
+    return DictChangeEvent(
+        trait_dict=trait_dict, added=added, removed=removed,
+    )

--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -19,7 +19,7 @@ class DictChangeEvent:
 
     Attributes
     ----------
-    trait_dict : dict
+    trait_dict : traits.trait_dict_object.TraitDict
         The dict being mutated.
     removed : dict
         Keys and values for removed or updated items.
@@ -51,7 +51,8 @@ def dict_event_factory(trait_dict, removed, added, changed):
 
     Parameters
     ----------
-    trait_dict : TraitDict
+    trait_dict : traits.trait_dict_object.TraitDict
+        The dict being mutated.
     removed : dict
         Items removed from the dict
     added : dict

--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -18,7 +18,7 @@ class DictChangeEvent:
     """ Event object to represent mutations on a dict.
 
     Note that the API is different from the ``TraitDictEvent`` emitted via the
-    "*name*\_items" trait. In particular, the attribute ``changed`` is not
+    "*name* _items" trait. In particular, the attribute ``changed`` is not
     defined here.
 
     Attributes

--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -17,6 +17,10 @@
 class DictChangeEvent:
     """ Event object to represent mutations on a dict.
 
+    Note that the API is different from the ``TraitDictEvent`` emitted via the
+    "*name*\_items" trait. In particular, the attribute ``changed`` is not
+    defined here.
+
     Attributes
     ----------
     trait_dict : traits.trait_dict_object.TraitDict

--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -11,6 +11,8 @@
 """ Event object for representing mutations to a dict.
 """
 
+# DictChangeEvent is exposed in the public API
+
 
 class DictChangeEvent:
     """ Event object to represent mutations on a dict.

--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -38,8 +38,8 @@ class DictChangeEvent:
         return (
             "<{class_name}("
             "trait_dict={trait_dict!r}, "
-            "removed={removed!r}"
-            "added={added!r}, "
+            "removed={removed!r}, "
+            "added={added!r}"
             ")>".format(
                 class_name=type(self).__name__,
                 trait_dict=self.trait_dict,

--- a/traits/observers/_dict_item_observer.py
+++ b/traits/observers/_dict_item_observer.py
@@ -37,7 +37,7 @@ class DictItemObserver:
 
     def __hash__(self):
         """ Return a hash of this object."""
-        return hash((type(self), self.notify))
+        return hash((type(self), self.notify, self.optional))
 
     def __eq__(self, other):
         """ Return true if this observer is equal to the given one."""

--- a/traits/observers/_dict_item_observer.py
+++ b/traits/observers/_dict_item_observer.py
@@ -61,8 +61,8 @@ class DictItemObserver:
         return self._optional
 
     def iter_observables(self, object):
-        """ If the given object is a dict, yield that dict. Otherwise, raise
-        an error.
+        """ If the given object is an observable dict, yield that dict.
+        Otherwise, raise an error unless this observer is optional.
 
         Parameters
         ----------
@@ -76,7 +76,8 @@ class DictItemObserver:
         Raises
         ------
         ValueError
-            If the given object is not an observable dict.
+            If the given object is not an observable dict and optional is
+            false.
         """
         if not isinstance(object, TraitDict):
             if self.optional:
@@ -88,8 +89,11 @@ class DictItemObserver:
         yield object
 
     def iter_objects(self, object):
-        """ Yield object for the children observers following this one,
-        in an ObserverGraph.
+        """ Yield the values if the given object is an observable dict.
+        Otherwise, raise an error, unless the observer is optional.
+
+        The values of the dict will be passed onto the children observer(s)
+        following this one in an ObserverGraph.
 
         Parameters
         ----------
@@ -103,7 +107,8 @@ class DictItemObserver:
         Raises
         ------
         ValueError
-            If the given object is not an observable dict.
+            If the given object is not an observable dict and optional is
+            false.
         """
         if not isinstance(object, TraitDict):
             if self.optional:
@@ -122,6 +127,8 @@ class DictItemObserver:
         -------
         notifier : TraitEventNotifier
         """
+        # Unlike CTrait, when default dict is created, there isn't a change
+        # event where the old value is Uninitialized.
         return TraitEventNotifier(
             handler=handler,
             target=target,

--- a/traits/observers/_dict_item_observer.py
+++ b/traits/observers/_dict_item_observer.py
@@ -37,7 +37,7 @@ class DictItemObserver:
 
     def __hash__(self):
         """ Return a hash of this object."""
-        return hash((type(self), self.notify, self.optional))
+        return hash((type(self).__name__, self.notify, self.optional))
 
     def __eq__(self, other):
         """ Return true if this observer is equal to the given one."""

--- a/traits/observers/_dict_item_observer.py
+++ b/traits/observers/_dict_item_observer.py
@@ -32,8 +32,8 @@ class DictItemObserver:
     """
 
     def __init__(self, *, notify, optional):
-        self._notify = notify
-        self._optional = optional
+        self.notify = notify
+        self.optional = optional
 
     def __hash__(self):
         """ Return a hash of this object."""
@@ -46,19 +46,6 @@ class DictItemObserver:
             and self.notify == other.notify
             and self.optional == other.optional
         )
-
-    @property
-    def notify(self):
-        """ A boolean for whether this observer will notify for changes.
-        """
-        return self._notify
-
-    @property
-    def optional(self):
-        """ A boolean for whether this observer is optional when the incoming
-        object is not a dict.
-        """
-        return self._optional
 
     def iter_observables(self, object):
         """ If the given object is an observable dict, yield that dict.

--- a/traits/observers/_dict_item_observer.py
+++ b/traits/observers/_dict_item_observer.py
@@ -1,0 +1,211 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traits.observers._dict_change_event import dict_event_factory
+from traits.observers._i_observer import IObserver
+from traits.observers._observe import add_or_remove_notifiers
+from traits.observers._observer_change_notifier import ObserverChangeNotifier
+from traits.observers._trait_event_notifier import TraitEventNotifier
+from traits.trait_dict_object import TraitDict
+
+
+@IObserver.register
+class DictItemObserver:
+    """ Observer for observing mutations on a dict.
+
+    Parameters
+    ----------
+    notify : boolean
+        Whether to notify for changes.
+    optional : boolean
+        If False, this observer will complain if the incoming object is not
+        an observable dict. If True and the incoming object is not a dict, this
+        observer will do nothing. Useful for the 'items' keyword in the text
+        parser, where the source container type is ambiguous.
+    """
+
+    def __init__(self, *, notify, optional):
+        self._notify = notify
+        self._optional = optional
+
+    def __hash__(self):
+        """ Return a hash of this object."""
+        return hash((type(self), self.notify))
+
+    def __eq__(self, other):
+        """ Return true if this observer is equal to the given one."""
+        return (
+            type(self) is type(other)
+            and self.notify == other.notify
+            and self.optional == other.optional
+        )
+
+    @property
+    def notify(self):
+        """ A boolean for whether this observer will notify for changes.
+        """
+        return self._notify
+
+    @property
+    def optional(self):
+        """ A boolean for whether this observer is optional when the incoming
+        object is not a dict.
+        """
+        return self._optional
+
+    def iter_observables(self, object):
+        """ If the given object is a dict, yield that dict. Otherwise, raise
+        an error.
+
+        Parameters
+        ----------
+        object: object
+            Object provided by another observers or by the user.
+
+        Yields
+        ------
+        IObservable
+
+        Raises
+        ------
+        ValueError
+            If the given object is not an observable dict.
+        """
+        if not isinstance(object, TraitDict):
+            if self.optional:
+                return
+            raise ValueError(
+                "Expected a TraitDict to be observed, "
+                "got {!r} (type: {!r})".format(object, type(object))
+            )
+        yield object
+
+    def iter_objects(self, object):
+        """ Yield object for the children observers following this one,
+        in an ObserverGraph.
+
+        Parameters
+        ----------
+        object: object
+            Object provided by another observers or by the user.
+
+        Yields
+        ------
+        value : object
+
+        Raises
+        ------
+        ValueError
+            If the given object is not an observable dict.
+        """
+        if not isinstance(object, TraitDict):
+            if self.optional:
+                return
+            raise ValueError(
+                "Expected a TraitDict to be observed, "
+                "got {!r} (type: {!r})".format(object, type(object))
+            )
+        yield from object.values()
+
+    def get_notifier(self, handler, target, dispatcher):
+        """ Return a notifier for calling the user handler with the change
+        event.
+
+        Returns
+        -------
+        notifier : TraitEventNotifier
+        """
+        return TraitEventNotifier(
+            handler=handler,
+            target=target,
+            dispatcher=dispatcher,
+            event_factory=dict_event_factory,
+            prevent_event=lambda event: False,
+        )
+
+    def get_maintainer(self, graph, handler, target, dispatcher):
+        """ Return a notifier for maintaining downstream observers when
+        a dict is mutated.
+
+        Parameters
+        ----------
+        graph : ObserverGraph
+            Description for the *downstream* observers, i.e. excluding self.
+        handler : callable
+            User handler.
+        target : object
+            Object seen by the user as the owner of the observer.
+        dispatcher : callable
+            Callable for dispatching the handler.
+
+        Returns
+        -------
+        notifier : ObserverChangeNotifier
+        """
+        return ObserverChangeNotifier(
+            observer_handler=_observer_change_handler,
+            event_factory=dict_event_factory,
+            prevent_event=lambda event: False,
+            graph=graph,
+            handler=handler,
+            target=target,
+            dispatcher=dispatcher,
+        )
+
+    def iter_extra_graphs(self, graph):
+        """ Yield new ObserverGraph to be contributed by this observer.
+
+        Parameters
+        ----------
+        graph : ObserverGraph
+            The graph this observer is part of.
+
+        Yields
+        ------
+        ObserverGraph
+        """
+        # Unlike CTrait, no need to handle trait_added
+        yield from ()
+
+
+def _observer_change_handler(event, graph, handler, target, dispatcher):
+    """ Handler for maintaining observers. Used by ObserverChangeNotifier.
+
+    Parameters
+    ----------
+    event : DictChangeEvent
+        Change event that triggers the maintainer.
+    graph : ObserverGraph
+        Description for the *downstream* observers, i.e. excluding self.
+    handler : callable
+        User handler.
+    target : object
+        Object seen by the user as the owner of the observer.
+    dispatcher : callable
+        Callable for dispatching the handler.
+    """
+    for removed_item in event.removed.values():
+        add_or_remove_notifiers(
+            object=removed_item,
+            graph=graph,
+            handler=handler,
+            target=target,
+            dispatcher=dispatcher,
+            remove=True,
+        )
+    for added_item in event.added.values():
+        add_or_remove_notifiers(
+            object=added_item,
+            graph=graph,
+            handler=handler,
+            target=target,
+            dispatcher=dispatcher,
+            remove=False,
+        )

--- a/traits/observers/events.py
+++ b/traits/observers/events.py
@@ -1,0 +1,16 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Event objects received by change handlers added using observe.
+"""
+
+from traits.observers._dict_change_event import (   # noqa: F401
+    DictChangeEvent,
+)

--- a/traits/observers/tests/test_dict_change_event.py
+++ b/traits/observers/tests/test_dict_change_event.py
@@ -28,7 +28,7 @@ class TestDictChangeEvent(unittest.TestCase):
         actual = repr(event)
         self.assertEqual(
             actual,
-            "<DictChangeEvent(trait_dict={}, removed={'2': 2}, added={1: 1})>"
+            "DictChangeEvent(trait_dict={}, removed={'2': 2}, added={1: 1})"
         )
 
 

--- a/traits/observers/tests/test_dict_change_event.py
+++ b/traits/observers/tests/test_dict_change_event.py
@@ -23,20 +23,12 @@ class TestDictChangeEvent(unittest.TestCase):
         event = DictChangeEvent(
             trait_dict=dict(),
             added={1: 1},
-            removed={"key": 2},
+            removed={"2": 2},
         )
         actual = repr(event)
         self.assertEqual(
             actual,
-            "<DictChangeEvent("
-            "trait_dict={trait_dict!r}, "
-            "removed={removed!r}"
-            "added={added!r}, "
-            ")>".format(
-                trait_dict=dict(),
-                added={1: 1},
-                removed={"key": 2},
-            )
+            "<DictChangeEvent(trait_dict={}, removed={'2': 2}, added={1: 1})>"
         )
 
 

--- a/traits/observers/tests/test_dict_change_event.py
+++ b/traits/observers/tests/test_dict_change_event.py
@@ -1,0 +1,73 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+from traits.observers._dict_change_event import (
+    DictChangeEvent,
+    dict_event_factory,
+)
+from traits.trait_dict_object import TraitDict
+
+
+class TestDictChangeEvent(unittest.TestCase):
+
+    def test_dict_change_event_repr(self):
+        event = DictChangeEvent(
+            trait_dict=dict(),
+            added={1: 1},
+            removed={"key": 2},
+        )
+        actual = repr(event)
+        self.assertEqual(
+            actual,
+            "<DictChangeEvent("
+            "trait_dict={trait_dict!r}, "
+            "added={added!r}, "
+            "removed={removed!r}"
+            ")>".format(
+                trait_dict=dict(),
+                added={1: 1},
+                removed={"key": 2},
+            )
+        )
+
+
+class TestDictEventFactory(unittest.TestCase):
+    """ Test event factory compatibility with TraitDict.notify """
+
+    def test_trait_dict_notification_compat(self):
+
+        events = []
+
+        def notifier(*args, **kwargs):
+            event = dict_event_factory(*args, **kwargs)
+            events.append(event)
+
+        trait_dict = TraitDict(
+            {"3": 3, "4": 4},
+            notifiers=[notifier],
+        )
+
+        # when
+        del trait_dict["4"]
+
+        # then
+        event, = events
+        self.assertEqual(event.removed, {"4": 4})
+
+        # when
+        events.clear()
+        trait_dict.update({"3": None, "1": 1})
+
+        # then
+        event, = events
+        self.assertEqual(event.removed, {"3": 3})
+        self.assertEqual(event.added, {"3": None, "1": 1})

--- a/traits/observers/tests/test_dict_change_event.py
+++ b/traits/observers/tests/test_dict_change_event.py
@@ -30,8 +30,8 @@ class TestDictChangeEvent(unittest.TestCase):
             actual,
             "<DictChangeEvent("
             "trait_dict={trait_dict!r}, "
-            "added={added!r}, "
             "removed={removed!r}"
+            "added={added!r}, "
             ")>".format(
                 trait_dict=dict(),
                 added={1: 1},

--- a/traits/observers/tests/test_dict_item_observer.py
+++ b/traits/observers/tests/test_dict_item_observer.py
@@ -49,6 +49,7 @@ class TestDictItemObserverEqualHash(unittest.TestCase):
         observer1 = DictItemObserver(notify=False, optional=False)
         imposter = mock.Mock()
         imposter.notify = False
+        imposter.optional = False
         self.assertNotEqual(observer1, imposter)
 
     def test_equal_observers(self):

--- a/traits/observers/tests/test_dict_item_observer.py
+++ b/traits/observers/tests/test_dict_item_observer.py
@@ -270,11 +270,11 @@ class TestDictItemObserverNotifications(unittest.TestCase):
         ((event, ), _), = handler.call_args_list
         self.assertEqual(event.added, {"3": 3})
         self.assertEqual(event.removed, {})
+        handler.reset_mock()
 
         # when
         # Change the content to something else
         instance.dict_of_dict["1"] = {}
-        handler.reset_mock()
 
         # the inner dict is not inside the instance.dict_of_dict any more
         inner_dict["4"] = 4

--- a/traits/observers/tests/test_dict_item_observer.py
+++ b/traits/observers/tests/test_dict_item_observer.py
@@ -1,0 +1,252 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+from unittest import mock
+
+from traits.has_traits import HasTraits
+from traits.observers._dict_item_observer import DictItemObserver
+from traits.observers._testing import (
+    call_add_or_remove_notifiers,
+    create_graph,
+    DummyObservable,
+    DummyObserver,
+    DummyNotifier,
+)
+from traits.trait_dict_object import TraitDict
+from traits.trait_types import Dict
+
+
+def create_observer(**kwargs):
+    """ Convenient function for creating DictItemObserver with default values.
+    """
+    values = dict(
+        notify=True,
+        optional=False,
+    )
+    values.update(kwargs)
+    return DictItemObserver(**values)
+
+
+class TestDictItemObserverEqualHash(unittest.TestCase):
+    """ Test DictItemObserver __eq__, __hash__ and immutability. """
+
+    def test_not_equal_notify(self):
+        observer1 = DictItemObserver(notify=False, optional=False)
+        observer2 = DictItemObserver(notify=True, optional=False)
+        self.assertNotEqual(observer1, observer2)
+
+    def test_not_equal_optional(self):
+        observer1 = DictItemObserver(notify=True, optional=True)
+        observer2 = DictItemObserver(notify=True, optional=False)
+        self.assertNotEqual(observer1, observer2)
+
+    def test_not_equal_different_type(self):
+        observer1 = DictItemObserver(notify=False, optional=False)
+        imposter = mock.Mock()
+        imposter.notify = False
+        self.assertNotEqual(observer1, imposter)
+
+    def test_equal_observers(self):
+        observer1 = DictItemObserver(notify=False, optional=False)
+        observer2 = DictItemObserver(notify=False, optional=False)
+        self.assertEqual(observer1, observer2)
+        self.assertEqual(hash(observer1), hash(observer2))
+
+    def test_notify_not_mutable(self):
+        observer = DictItemObserver(notify=True, optional=False)
+        with self.assertRaises(AttributeError) as exception_context:
+            observer.notify = False
+        self.assertEqual(
+            str(exception_context.exception), "can't set attribute")
+
+    def test_optional_not_mutable(self):
+        observer = DictItemObserver(notify=True, optional=False)
+        with self.assertRaises(AttributeError) as exception_context:
+            observer.optional = False
+        self.assertEqual(
+            str(exception_context.exception), "can't set attribute")
+
+
+class CustomDict(dict):
+    # This is a dict, but not an observable
+    pass
+
+
+class CustomTraitDict(TraitDict):
+    # This can be observed using DictItemObserver
+    pass
+
+
+class ClassWithDict(HasTraits):
+    values = Dict()
+
+
+class TestDictItemObserverIterObservable(unittest.TestCase):
+    """ Test DictItemObserver.iter_observables """
+
+    def test_trait_dict_iter_observables(self):
+        instance = ClassWithDict()
+        observer = create_observer(optional=False)
+        actual_item, = list(observer.iter_observables(instance.values))
+
+        self.assertIs(actual_item, instance.values)
+
+    def test_dict_but_not_a_trait_dict(self):
+        observer = create_observer(optional=False)
+        with self.assertRaises(ValueError) as exception_context:
+            list(observer.iter_observables(CustomDict()))
+
+        self.assertIn(
+            "Expected a TraitDict to be observed, got",
+            str(exception_context.exception)
+        )
+
+    def test_custom_trait_dict_is_observable(self):
+        observer = create_observer(optional=False)
+        custom_trait_dict = CustomTraitDict()
+        actual_item, = list(observer.iter_observables(custom_trait_dict))
+        self.assertIs(actual_item, custom_trait_dict)
+
+    def test_not_a_dict(self):
+        observer = create_observer(optional=False)
+        with self.assertRaises(ValueError) as exception_context:
+            list(observer.iter_observables(None))
+
+        self.assertIn(
+            "Expected a TraitDict to be observed, got",
+            str(exception_context.exception)
+        )
+
+    def test_optional_flag_not_a_dict(self):
+        observer = create_observer(optional=True)
+        actual = list(observer.iter_observables(None))
+        self.assertEqual(actual, [])
+
+    def test_optional_flag_not_an_observable(self):
+        observer = create_observer(optional=True)
+        actual = list(observer.iter_observables(CustomDict()))
+        self.assertEqual(actual, [])
+
+
+class TestDictItemObserverIterObjects(unittest.TestCase):
+    """ Test DictItemObserver.iter_objects """
+
+    def test_iter_objects_from_dict(self):
+        instance = ClassWithDict()
+        instance.values = {"1": 1, "2": 2}
+        observer = create_observer()
+        actual = list(observer.iter_objects(instance.values))
+        self.assertCountEqual(actual, [1, 2])
+
+    def test_iter_objects_from_custom_trait_dict(self):
+        observer = create_observer(optional=False)
+        custom_trait_dict = CustomTraitDict({"1": 1, "2": 2})
+        actual = list(observer.iter_objects(custom_trait_dict))
+        self.assertCountEqual(actual, [1, 2])
+
+    def test_iter_objects_sanity_check(self):
+        # sanity check if the given object is a dict
+        observer = create_observer(optional=False)
+        with self.assertRaises(ValueError) as exception_context:
+            list(observer.iter_objects(None))
+
+        self.assertIn(
+            "Expected a TraitDict to be observed",
+            str(exception_context.exception),
+        )
+
+    def test_iter_objects_optional(self):
+        observer = create_observer(optional=True)
+        actual = list(observer.iter_objects(None))
+        self.assertEqual(actual, [])
+
+
+class TestDictItemObserverNotifications(unittest.TestCase):
+    """ Integration tests with notifiers (including maintainers). """
+
+    def test_notify_dict_change(self):
+        instance = ClassWithDict(values=dict())
+        graph = create_graph(
+            create_observer(notify=True),
+        )
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance.values,
+            graph=graph,
+            handler=handler,
+        )
+
+        # when
+        instance.values.update({"1": 1})
+
+        # then
+        ((event, ), _), = handler.call_args_list
+        self.assertEqual(event.added, {"1": 1})
+        self.assertEqual(event.removed, {})
+
+    def test_notify_custom_trait_dict_change(self):
+        # Test using DictItemObserver for changes on a subclass of TraitDict
+        # that isn't TraitDictObject
+        instance = ClassWithDict(custom_trait_dict=CustomTraitDict())
+        graph = create_graph(
+            create_observer(notify=True),
+        )
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance.custom_trait_dict,
+            graph=graph,
+            handler=handler,
+        )
+
+        # when
+        instance.custom_trait_dict.update({"1": 1})
+
+        # then
+        ((event, ), _), = handler.call_args_list
+        self.assertEqual(event.added, {"1": 1})
+        self.assertEqual(event.removed, {})
+
+    def test_maintain_notifier(self):
+        # Test maintaining downstream notifier
+
+        class ChildObserver(DummyObserver):
+
+            def iter_observables(self, object):
+                yield object
+
+        instance = ClassWithDict()
+
+        notifier = DummyNotifier()
+        child_observer = ChildObserver(notifier=notifier)
+        graph = create_graph(
+            create_observer(notify=False, optional=False),
+            child_observer,
+        )
+
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance.values,
+            graph=graph,
+            handler=handler,
+        )
+
+        # when
+        observable = DummyObservable()
+        instance.values.update({"1": observable})
+
+        # then
+        self.assertEqual(observable.notifiers, [notifier])
+
+        # when
+        del instance.values["1"]
+
+        # then
+        self.assertEqual(observable.notifiers, [])

--- a/traits/observers/tests/test_dict_item_observer.py
+++ b/traits/observers/tests/test_dict_item_observer.py
@@ -33,7 +33,7 @@ def create_observer(**kwargs):
 
 
 class TestDictItemObserverEqualHash(unittest.TestCase):
-    """ Test DictItemObserver __eq__, __hash__ and immutability. """
+    """ Test DictItemObserver __eq__, __hash__. """
 
     def test_not_equal_notify(self):
         observer1 = DictItemObserver(notify=False, optional=False)
@@ -57,20 +57,6 @@ class TestDictItemObserverEqualHash(unittest.TestCase):
         observer2 = DictItemObserver(notify=False, optional=False)
         self.assertEqual(observer1, observer2)
         self.assertEqual(hash(observer1), hash(observer2))
-
-    def test_notify_not_mutable(self):
-        observer = DictItemObserver(notify=True, optional=False)
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.notify = False
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
-
-    def test_optional_not_mutable(self):
-        observer = DictItemObserver(notify=True, optional=False)
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.optional = False
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
 
 
 class CustomDict(dict):

--- a/traits/observers/tests/test_dict_item_observer.py
+++ b/traits/observers/tests/test_dict_item_observer.py
@@ -22,7 +22,7 @@ from traits.trait_types import Dict, Str
 
 
 def create_observer(**kwargs):
-    """ Convenient function for creating DictItemObserver with default values.
+    """ Convenience function for creating DictItemObserver with default values.
     """
     values = dict(
         notify=True,

--- a/traits/observers/tests/test_dict_item_observer.py
+++ b/traits/observers/tests/test_dict_item_observer.py
@@ -272,7 +272,8 @@ class TestDictItemObserverNotifications(unittest.TestCase):
         self.assertEqual(event.removed, {})
 
         # when
-        del instance.dict_of_dict["1"]
+        # Change the content to something else
+        instance.dict_of_dict["1"] = {}
         handler.reset_mock()
 
         # the inner dict is not inside the instance.dict_of_dict any more

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -344,6 +344,20 @@ class TraitDict(dict):
         )
         return result
 
+    # -- Implement IObservable ------------------------------------------------
+
+    def _notifiers(self, force_create):
+        """ Return a list of callables where each callable is a notifier.
+        The list is expected to be mutated for contributing or removing
+        notifiers from the object.
+
+        Parameters
+        ----------
+        force_create: boolean
+            Not used here.
+        """
+        return self.notifiers
+
 
 class TraitDictObject(TraitDict):
     """ A subclass of TraitDict that fires trait events when mutated.


### PR DESCRIPTION
This PR implements item 9 of #977:

> Implement the logic for attaching notifiers when the items of a dict changes

- Add `DictChangeEvent`. Note that the definition of `DictChangeEvent` is not the same as `TraitDict.notify`, see discussion in #1031
- Add `DictItemObserver` that implements the interface of `IObserver`:
          - return the object for adding/removing notifiers. In this case, the observable is simply an instance of TraitDict.
          - yield the **values** of the dict for the next observer(s) in an ObserverGraph. **values** is an obvious choice here because mutables should not be used as keys in dict.
          - Like `ListItemObserver`, no filtering is done while yielding values for the next observer(s) on the observer graph. If the values are incompatible with the next observers, the latter can complain.
- Implement IObservable interface in TraitDict. With this, any subclass of TraitDict, e.g. TraitDictObject, can be observed with DictItemObserver (see tests).


**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
