### PR TITLE
Add notifications for the #ets-bots Slack channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,7 @@ after_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov
   - edm run -- codecov
+
+notifications:
+  slack:
+    secure: dlu0Cw3+5yx8Ho7BvaB6PJ0kcj/tKSZKOZv08e3v5B5puhFvp7EtngjvEdmYkXRcUJ/oigI88MoF5DHM8JsZ4vT3TyiXpjMUv2A3uhPosn1TX4r7eGZH8wikAErFu8GFVg52vTxbpCCAe2wlZUmyqVkac/AAngGA98S8g3SDOD0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,5 @@ after_success:
 notifications:
   slack:
     secure: dlu0Cw3+5yx8Ho7BvaB6PJ0kcj/tKSZKOZv08e3v5B5puhFvp7EtngjvEdmYkXRcUJ/oigI88MoF5DHM8JsZ4vT3TyiXpjMUv2A3uhPosn1TX4r7eGZH8wikAErFu8GFVg52vTxbpCCAe2wlZUmyqVkac/AAngGA98S8g3SDOD0=
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
This PR attempts to add Slack notifications (to the internal #ets-bots channel on Enthought's Slack) for Travis CI builds. This is mostly to support the cron jobs, so that we get alerted when a cron job fails.

Right now I'm just making this PR to see if it works. Once it's working, we'll want to fine-tune the notification settings (e.g., only notify on failure).

For the record, here are my notes on the steps I took:

```
Notes on integrating Travis with Slack

- Get the Travis CLI:  https://github.com/travis-ci/travis.rb#readme
  - With ruby (and "gem") installed, do: "gem install travis"
  - For a MacPorts install, I needed to:
    - $ port install ruby27
    - $ sudo ln -s /opt/local/bin/ruby2.7 /usr/local/bin
    - $ sudo ln -s /opt/local/bin/gem2.7 /usr/local/bin
    - $ sudo gem2.7 install travis    
    - $ sudo ln -s /opt/local/bin/travis /usr/local/bin

On Slack, set up a new Travis integration:

This gives a webpage showing:

    notifications:
      slack: enthought:<token>

Record the token and save the settings.

Now change to the Traits repository directory and encrypt the token with:

    travis encrypt "enthought:<token>" --add notifications.slack

This reformats the existing .travis.yml file, ready for commit.
```
