### PR TITLE
Add trait_added support for observing a named trait

### DIFF
--- a/traits/observers/_named_trait_observer.py
+++ b/traits/observers/_named_trait_observer.py
@@ -16,6 +16,8 @@ from traits.observers._has_traits_helpers import (
 )
 from traits.observers._i_observer import IObserver
 from traits.observers._observer_change_notifier import ObserverChangeNotifier
+from traits.observers._observer_graph import ObserverGraph
+from traits.observers._trait_added_observer import TraitAddedObserver
 from traits.observers._trait_event_notifier import TraitEventNotifier
 from traits.trait_base import Uninitialized
 
@@ -206,7 +208,10 @@ class NamedTraitObserver:
         ------
         graph : ObserverGraph
         """
-        # This will yield a new ObserverGraph with an observer specialized in
-        # observing trait_added event.
-        # enthought/traits#977
-        yield from ()
+        yield ObserverGraph(
+            node=TraitAddedObserver(
+                match_func=lambda name, trait: name == self.name,
+                optional=self.optional,
+            ),
+            children=[graph],
+        )

--- a/traits/observers/_testing.py
+++ b/traits/observers/_testing.py
@@ -19,6 +19,10 @@ from traits.observers._observer_graph import ObserverGraph
 _DEFAULT_TARGET = mock.Mock()
 
 
+def dispatch_same(handler, event):
+    handler(event)
+
+
 def create_graph(*nodes):
     """ Create an ObserverGraph with the given nodes joined one after another.
 
@@ -47,9 +51,6 @@ def call_add_or_remove_notifiers(**kwargs):
     **kwargs
         New argument values to use instead.
     """
-    def dispatch_same(handler, event):
-        handler(event)
-
     values = dict(
         object=mock.Mock(),
         graph=ObserverGraph(node=None),

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -117,25 +117,7 @@ class TraitAddedObserver:
         # children graphs are used in the maintainer only.
         yield from ()
 
-    def get_notifier(self, handler, target, dispatcher):
-        """ Return a notifier for calling the user handler with the change
-        event. This is needed if ``notify`` is true.
-
-        Parameters
-        ----------
-        handler : callable
-            User handler.
-        target : object
-            Object seen by the user as the owner of the observer.
-        dispatcher : callable
-            Callable for dispatching the handler.
-
-        Returns
-        -------
-        notifier : INotifier
-        """
-        # notify is always false, no notifiers are needed here.
-        raise NotImplementedError("notifier is not needed for trait_added.")
+    # get_notifier is not implemented as notify is always false.
 
     def get_maintainer(self, graph, handler, target, dispatcher):
         """ Return a notifier for maintaining downstream observers when

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -32,7 +32,7 @@ class TraitAddedObserver:
     ----------
     match_func : callable(str, CTrait) -> bool
         A callable that receives the name of the trait added and the
-        corresponding trait type. The returned boolean indicates whether
+        corresponding trait. The returned boolean indicates whether
         notifiers should be added/removed for the added trait.
         This callable is used for equality check and must be hashable.
     optional : boolean

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -46,7 +46,7 @@ class TraitAddedObserver:
 
     def __hash__(self):
         """ Return a hash of this object."""
-        return hash((type(self), self.match_func, self.optional))
+        return hash((type(self).__name__, self.match_func, self.optional))
 
     def __eq__(self, other):
         """ Return true if this observer is equal to the given one."""

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -8,7 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.observers._trait_change_event import trait_event_factory
 from traits.observers._has_traits_helpers import (
     iter_objects,
     object_has_named_trait,
@@ -17,6 +16,7 @@ from traits.observers._i_observer import IObserver
 from traits.observers._observe import add_or_remove_notifiers
 from traits.observers._observer_change_notifier import ObserverChangeNotifier
 from traits.observers._observer_graph import ObserverGraph
+from traits.observers._trait_change_event import trait_event_factory
 
 
 @IObserver.register

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -215,8 +215,8 @@ class TraitAddedObserver:
 @IObserver.register
 class _RestrictedNamedTraitObserver:
     """ An observer to support TraitAddedObserver in order to add
-    notifiers for one specific named trait, and retain the notifiers from the
-    original observer.
+    notifiers for one specific named trait. The notifiers should be
+    contributed by the original observer.
 
     Parameters
     ----------

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -171,7 +171,7 @@ class TraitAddedObserver:
 
         Parameters
         ----------
-        event : TraitObserverEvent
+        event : TraitChangeEvent
             Event triggered by add_trait.
         """
         object = event.object
@@ -185,7 +185,7 @@ class TraitAddedObserver:
 
         Parameters
         ----------
-        event : TraitObserverEvent
+        event : TraitChangeEvent
             Event triggered by add_trait.
         graph : ObserverGraph
             Description for the *downstream* observers, i.e. excluding self.

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -41,8 +41,8 @@ class TraitAddedObserver:
     """
 
     def __init__(self, match_func, optional):
-        self._match_func = match_func
-        self._optional = optional
+        self.match_func = match_func
+        self.optional = optional
 
     def __hash__(self):
         """ Return a hash of this object."""
@@ -61,19 +61,6 @@ class TraitAddedObserver:
         """ A boolean for whether this observer will notify for changes.
         """
         return False
-
-    @property
-    def match_func(self):
-        """ The callable to decide if the added trait should be handled.
-        """
-        return self._match_func
-
-    @property
-    def optional(self):
-        """ Whether to skip this observer if the trait_added trait cannot be
-        found on the incoming object.
-        """
-        return self._optional
 
     def iter_observables(self, object):
         """ Yield observables for notifiers to be attached to or detached from.

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -231,7 +231,7 @@ class _RestrictedNamedTraitObserver:
         self._wrapped_observer = wrapped_observer
 
     def __hash__(self):
-        return hash(tuple(type(self), self.name, self._wrapped_observer))
+        return hash((type(self), self.name, self._wrapped_observer))
 
     def __eq__(self, other):
         return (

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -1,0 +1,286 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traits.observers._trait_change_event import trait_event_factory
+from traits.observers._has_traits_helpers import (
+    iter_objects,
+    object_has_named_trait,
+)
+from traits.observers._i_observer import IObserver
+from traits.observers._observe import add_or_remove_notifiers
+from traits.observers._observer_change_notifier import ObserverChangeNotifier
+from traits.observers._observer_graph import ObserverGraph
+
+
+@IObserver.register
+class TraitAddedObserver:
+    """ An observer for observing the trait_added event.
+
+    This observer only offers the "maintainer". When this observer is used in
+    an ObserverGraph, its subgraphs are the graphs to be hooked up when a new
+    trait is added, provided that the trait satisfies a given criterion.
+    The criterion should align with the root observer(s) in these subgraph(s).
+
+    Parameters
+    ----------
+    match_func : callable(str, TraitType) -> boolean
+        A callable that receives the name of the trait added and the
+        corresponding trait type. The returned boolean indicates whether
+        notifiers should be added/removed for the added trait.
+        This callable is used for equality check and must be hashable.
+    optional : boolean
+        Whether to skip this observer if the trait_added trait cannot be
+        found on the incoming object.
+    """
+
+    def __init__(self, match_func, optional):
+        self._match_func = match_func
+        self._optional = optional
+
+    def __hash__(self):
+        """ Return a hash of this object."""
+        return hash((type(self), self.match_func, self.optional))
+
+    def __eq__(self, other):
+        """ Return true if this observer is equal to the given one."""
+        return (
+            type(self) is type(other)
+            and self.match_func == other.match_func
+            and self.optional == other.optional
+        )
+
+    @property
+    def notify(self):
+        """ A boolean for whether this observer will notify for changes.
+        """
+        return False
+
+    @property
+    def match_func(self):
+        """ The callable to decide if the added trait should be handled.
+        """
+        return self._match_func
+
+    @property
+    def optional(self):
+        """ Whether to skip this observer if the trait_added trait cannot be
+        found on the incoming object.
+        """
+        return self._optional
+
+    def iter_observables(self, object):
+        """ Yield observables for notifiers to be attached to or detached from.
+
+        Parameters
+        ----------
+        object: object
+            Object provided by the ``iter_objects`` methods from another
+            observers or directly by the user.
+
+        Yields
+        ------
+        IObservable
+
+        Raises
+        ------
+        ValueError
+            If the given object cannot be handled by this observer.
+        """
+        if not object_has_named_trait(object, "trait_added"):
+            if self.optional:
+                return
+            raise ValueError(
+                "Unable to observe 'trait_added' event on {!r}".format(object))
+        yield object._trait("trait_added", 2)
+
+    def iter_objects(self, object):
+        """ Yield objects for the next observer following this observer, in an
+        ObserverGraph.
+
+        Parameters
+        ----------
+        object: object
+            Object provided by the ``iter_objects`` methods from another
+            observers or directly by the user.
+
+        Yields
+        ------
+        value : object
+        """
+        # children graphs are used in the maintainer only.
+        yield from ()
+
+    def get_notifier(self, handler, target, dispatcher):
+        """ Return a notifier for calling the user handler with the change
+        event. This is needed if ``notify`` is true.
+
+        Parameters
+        ----------
+        handler : callable
+            User handler.
+        target : object
+            Object seen by the user as the owner of the observer.
+        dispatcher : callable
+            Callable for dispatching the handler.
+
+        Returns
+        -------
+        notifier : INotifier
+        """
+        # notify is always false, no notifiers are needed here.
+        raise NotImplementedError("notifier is not needed for trait_added.")
+
+    def get_maintainer(self, graph, handler, target, dispatcher):
+        """ Return a notifier for maintaining downstream observers when
+        trait_added event happens.
+
+        Parameters
+        ----------
+        graph : ObserverGraph
+            Description for the *downstream* observers, i.e. excluding self.
+        handler : callable
+            User handler.
+        target : object
+            Object seen by the user as the owner of the observer.
+        dispatcher : callable
+            Callable for dispatching the handler.
+
+        Returns
+        -------
+        notifier : ObserverChangeNotifier
+        """
+        return ObserverChangeNotifier(
+            observer_handler=self.observer_change_handler,
+            event_factory=trait_event_factory,
+            prevent_event=self.prevent_event,
+            graph=graph,
+            handler=handler,
+            target=target,
+            dispatcher=dispatcher,
+        )
+
+    def prevent_event(self, event):
+        """ Return true if the added trait should not be handled.
+
+        Parameters
+        ----------
+        event : TraitObserverEvent
+            Event triggered by add_trait.
+        """
+        object = event.object
+        name = event.new
+        trait = object.trait(name=name)
+        return not self.match_func(name, trait)
+
+    @staticmethod
+    def observer_change_handler(event, graph, handler, target, dispatcher):
+        """ Handler for maintaining observers.
+
+        Parameters
+        ----------
+        event : TraitObserverEvent
+            Event triggered by add_trait.
+        graph : ObserverGraph
+            Description for the *downstream* observers, i.e. excluding self.
+        handler : callable
+            User handler.
+        target : object
+            Object seen by the user as the owner of the observer.
+        dispatcher : callable
+            Callable for dispatching the handler.
+        """
+        new_graph = ObserverGraph(
+            node=_RestrictedNamedTraitObserver(
+                name=event.new,
+                wrapped_observer=graph.node,
+            ),
+            children=graph.children
+        )
+        add_or_remove_notifiers(
+            object=event.object,
+            graph=new_graph,
+            handler=handler,
+            target=target,
+            dispatcher=dispatcher,
+            remove=False,
+        )
+
+    def iter_extra_graphs(self, graph):
+        """ Yield new ObserverGraph to be contributed by this observer.
+
+        Parameters
+        ----------
+        graph : ObserverGraph
+            The graph this observer is part of.
+
+        Yields
+        ------
+        ObserverGraph
+        """
+        yield from ()
+
+
+@IObserver.register
+class _RestrictedNamedTraitObserver:
+    """ An observer to support TraitAddedObserver in order to add
+    notifiers for one specific named trait, and retain the notifiers from the
+    original observer.
+
+    Parameters
+    ----------
+    name : str
+        Name of the trait to be observed.
+    wrapped_observer : IObserver
+        The observer from which notifers are obtained.
+    """
+
+    def __init__(self, name, wrapped_observer):
+        self._name = name
+        self._wrapped_observer = wrapped_observer
+
+    def __hash__(self):
+        return hash(tuple(type(self), self.name, self._wrapped_observer))
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self.name == other.name
+            and self._wrapped_observer == other._wrapped_observer
+        )
+
+    @property
+    def name(self):
+        """ Name of trait to observe on any given HasTraits object."""
+        return self._name
+
+    @property
+    def notify(self):
+        """ A boolean for whether this observer will notify for changes. """
+        return self._wrapped_observer.notify
+
+    def iter_observables(self, object):
+        """ Yield only the observable for the named trait."""
+        yield object._trait(self.name, 2)
+
+    def iter_objects(self, object):
+        """ Yield only the value for the named trait."""
+        yield from iter_objects(object, self.name)
+
+    def get_notifier(self, handler, target, dispatcher):
+        """ Return the notifier from the wrapped observer."""
+        return self._wrapped_observer.get_notifier(handler, target, dispatcher)
+
+    def get_maintainer(self, graph, handler, target, dispatcher):
+        """ Return the maintainer from the wrapped observer."""
+        return self._wrapped_observer.get_maintainer(
+            graph, handler, target, dispatcher)
+
+    def iter_extra_graphs(self, graph):
+        yield from ()

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -30,7 +30,7 @@ class TraitAddedObserver:
 
     Parameters
     ----------
-    match_func : callable(str, TraitType) -> boolean
+    match_func : callable(str, CTrait) -> bool
         A callable that receives the name of the trait added and the
         corresponding trait type. The returned boolean indicates whether
         notifiers should be added/removed for the added trait.

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -211,6 +211,9 @@ class TraitAddedObserver:
             dispatcher=dispatcher,
             remove=False,
         )
+        # Added notifiers cannot be removed because the reverse action
+        # of ``add_trait`` does not fire a change event
+        # see enthought/traits#1047
 
     def iter_extra_graphs(self, graph):
         """ Yield new ObserverGraph to be contributed by this observer.

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -214,7 +214,7 @@ class _RestrictedNamedTraitObserver:
     """
 
     def __init__(self, name, wrapped_observer):
-        self._name = name
+        self.name = name
         self._wrapped_observer = wrapped_observer
 
     def __hash__(self):
@@ -226,11 +226,6 @@ class _RestrictedNamedTraitObserver:
             and self.name == other.name
             and self._wrapped_observer == other._wrapped_observer
         )
-
-    @property
-    def name(self):
-        """ Name of trait to observe on any given HasTraits object."""
-        return self._name
 
     @property
     def notify(self):

--- a/traits/observers/_trait_added_observer.py
+++ b/traits/observers/_trait_added_observer.py
@@ -193,8 +193,8 @@ class TraitAddedObserver:
             dispatcher=dispatcher,
             remove=False,
         )
-        # Added notifiers cannot be removed because the reverse action
-        # of ``add_trait`` does not fire a change event
+        # There is no mirrored action to this.
+        # ``remove_trait`` does not fire a change event.
         # see enthought/traits#1047
 
     def iter_extra_graphs(self, graph):

--- a/traits/observers/tests/test_named_trait_observer.py
+++ b/traits/observers/tests/test_named_trait_observer.py
@@ -502,10 +502,12 @@ class TestNamedTraitObserverTraitAdded(unittest.TestCase):
 
         not_an_has_traits_instance = mock.Mock()
 
-        # when
         # does not complain because optional is set to true
-        call_add_or_remove_notifiers(
-            object=not_an_has_traits_instance,
-            graph=graph,
-            handler=handler,
-        )
+        try:
+            call_add_or_remove_notifiers(
+                object=not_an_has_traits_instance,
+                graph=graph,
+                handler=handler,
+            )
+        except Exception:
+            self.fail("Optional flag should have been propagated.")

--- a/traits/observers/tests/test_trait_added_observer.py
+++ b/traits/observers/tests/test_trait_added_observer.py
@@ -1,0 +1,245 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+from unittest import mock
+
+from traits.has_traits import HasTraits
+from traits.trait_types import Str
+from traits.observers._trait_added_observer import TraitAddedObserver
+from traits.observers._testing import (
+    call_add_or_remove_notifiers,
+    create_graph,
+    DummyNotifier,
+    DummyObserver,
+)
+
+
+def create_observer(**kwargs):
+    values = dict(
+        match_func=mock.Mock(),
+        optional=False,
+    )
+    values.update(kwargs)
+    return TraitAddedObserver(**values)
+
+
+class DummyMatchFunc:
+    """ A callable to be used as TraitAddedObserver.match_func
+    """
+
+    def __init__(self, return_value):
+        self.return_value = return_value
+
+    def __call__(self, name, trait):
+        return self.return_value
+
+    def __eq__(self, other):
+        return self.return_value == other.return_value
+
+    def __hash__(self):
+        return hash(self.return_value)
+
+
+class TestTraitAddedObserverEqualHashImmutable(unittest.TestCase):
+    """ Tests for TraitAddedObserver __eq__ and __hash__ methods, and
+    the fact it is not mutable.
+    """
+
+    def test_not_equal_match_func(self):
+        observer1 = TraitAddedObserver(match_func=mock.Mock(), optional=True)
+        observer2 = TraitAddedObserver(match_func=mock.Mock(), optional=True)
+        self.assertNotEqual(observer1, observer2)
+
+    def test_not_equal_optional(self):
+        match_func = mock.Mock()
+        observer1 = TraitAddedObserver(match_func=match_func, optional=False)
+        observer2 = TraitAddedObserver(match_func=match_func, optional=True)
+        self.assertNotEqual(observer1, observer2)
+
+    def test_equal_match_func_optional(self):
+        # If two match_func compare equally and optional is the same
+        # then they are the same.
+        observer1 = TraitAddedObserver(
+            match_func=DummyMatchFunc(return_value=True),
+            optional=False,
+        )
+        observer2 = TraitAddedObserver(
+            match_func=DummyMatchFunc(return_value=True),
+            optional=False,
+        )
+        self.assertEqual(observer1, observer2)
+        self.assertEqual(hash(observer1), hash(observer2))
+
+    def test_not_equal_type(self):
+        match_func = mock.Mock()
+        observer1 = TraitAddedObserver(
+            match_func=match_func,
+            optional=False,
+        )
+        imposter = mock.Mock()
+        imposter.match_func = match_func
+        imposter.optional = False
+        self.assertNotEqual(observer1, imposter)
+
+    def test_match_func_not_mutable(self):
+        observer = TraitAddedObserver(match_func=mock.Mock(), optional=True)
+        with self.assertRaises(AttributeError) as exception_context:
+            observer.match_func = mock.Mock()
+        self.assertEqual(
+            str(exception_context.exception), "can't set attribute")
+
+    def test_optional_not_mutable(self):
+        observer = TraitAddedObserver(match_func=mock.Mock(), optional=True)
+        with self.assertRaises(AttributeError) as exception_context:
+            observer.optional = False
+        self.assertEqual(
+            str(exception_context.exception), "can't set attribute")
+
+    def test_notify_is_false_and_immutable(self):
+        observer = create_observer()
+        self.assertFalse(
+            observer.notify,
+            "TraitAddedObserver.notify should be always false.",
+        )
+        with self.assertRaises(AttributeError) as exception_context:
+            observer.notify = True
+        self.assertEqual(
+            str(exception_context.exception), "can't set attribute")
+
+
+# -----------------------------------
+# Integration tests with HasTraits
+# -----------------------------------
+
+class DummyHasTraitsClass(HasTraits):
+
+    def dummy_method(self):
+        pass
+
+
+class TestTraitAddedObserverIterObservables(unittest.TestCase):
+    """ Test sanity checks in iter_observables. """
+
+    def test_iter_observables_get_trait_added_ctrait(self):
+        observer = create_observer()
+        instance = DummyHasTraitsClass()
+
+        actual, = list(observer.iter_observables(instance))
+        self.assertEqual(actual, instance._trait("trait_added", 2))
+
+    def test_iter_observables_ignore_incompatible_object_if_optional(self):
+        observer = create_observer(optional=True)
+
+        actual = list(observer.iter_observables(None))
+        self.assertEqual(actual, [])
+
+    def test_iter_observables_error_incompatible_object_if_required(self):
+        observer = create_observer(optional=False)
+
+        with self.assertRaises(ValueError) as exception_cm:
+            list(observer.iter_observables(None))
+
+        self.assertIn(
+            "Unable to observe 'trait_added'", str(exception_cm.exception))
+
+
+class TestTraitAddedObserverIterObjects(unittest.TestCase):
+    """ Test iter_objects yields nothing. """
+
+    def test_iter_objects_yields_nothing(self):
+        observer = create_observer()
+        actual = list(observer.iter_objects(None))
+        self.assertEqual(actual, [])
+
+
+class TestTraitAddedObserverNotifications(unittest.TestCase):
+    """ Test the core logic for maintaining downstream observers
+    when a trait is added.
+    """
+
+    def setUp(self):
+
+        def match_func(name, trait):
+            return name.startswith("good_")
+
+        self.observer = TraitAddedObserver(
+            match_func=match_func,
+            optional=False,
+        )
+
+    def test_maintainer_trait_added(self):
+        # Test the maintainer is added for the trait_added event.
+        instance = DummyHasTraitsClass()
+        notifier = DummyNotifier()
+        maintainer = DummyNotifier()
+        graph = create_graph(
+            self.observer,
+            DummyObserver(
+                notify=True,
+                notifier=notifier,
+                maintainer=maintainer,
+            ),
+            DummyObserver(),  # to get maintainer in
+        )
+        call_add_or_remove_notifiers(
+            object=instance,
+            handler=instance.dummy_method,
+            target=instance,
+            graph=graph,
+            remove=False,
+        )
+
+        # when
+        instance.add_trait("good_name", Str())
+
+        # then
+        # the maintainer will have added a notifier because notify flag
+        # is set to true on the single observer being maintained.
+        notifiers = instance._trait("good_name", 2)._notifiers(True)
+        self.assertIn(notifier, notifiers)
+        self.assertIn(maintainer, notifiers)
+
+        # when
+        instance.add_trait("bad_name", Str())
+
+        # then
+        notifiers = instance._trait("bad_name", 2)._notifiers(True)
+        self.assertNotIn(notifier, notifiers)
+        self.assertNotIn(maintainer, notifiers)
+
+    def test_maintainer_keep_notify_flag(self):
+        # Test the maintainer will maintain the notify flag for the root
+        # observer in the subgraph.
+        instance = DummyHasTraitsClass()
+        notifier = DummyNotifier()
+        graph = create_graph(
+            self.observer,
+            DummyObserver(
+                notify=False,
+                notifier=notifier,
+            ),
+        )
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance,
+            handler=handler,
+            target=instance,
+            graph=graph,
+            remove=False,
+        )
+
+        # when
+        instance.add_trait("good_name", Str())
+
+        # then
+        # notify flag is set to false, so there are no notifiers added.
+        notifiers = instance._trait("good_name", 2)._notifiers(True)
+        self.assertNotIn(notifier, notifiers)

--- a/traits/observers/tests/test_trait_added_observer.py
+++ b/traits/observers/tests/test_trait_added_observer.py
@@ -51,9 +51,8 @@ class DummyMatchFunc:
         return hash(self.return_value)
 
 
-class TestTraitAddedObserverEqualHashImmutable(unittest.TestCase):
-    """ Tests for TraitAddedObserver __eq__ and __hash__ methods, and
-    the fact it is not mutable.
+class TestTraitAddedObserverEqualHash(unittest.TestCase):
+    """ Tests for TraitAddedObserver __eq__ and __hash__ methods.
     """
 
     def test_not_equal_match_func(self):

--- a/traits/observers/tests/test_trait_added_observer.py
+++ b/traits/observers/tests/test_trait_added_observer.py
@@ -92,30 +92,12 @@ class TestTraitAddedObserverEqualHashImmutable(unittest.TestCase):
         imposter.optional = False
         self.assertNotEqual(observer1, imposter)
 
-    def test_match_func_not_mutable(self):
-        observer = TraitAddedObserver(match_func=mock.Mock(), optional=True)
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.match_func = mock.Mock()
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
-
-    def test_optional_not_mutable(self):
-        observer = TraitAddedObserver(match_func=mock.Mock(), optional=True)
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.optional = False
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
-
-    def test_notify_is_false_and_immutable(self):
+    def test_notify_is_false(self):
         observer = create_observer()
         self.assertFalse(
             observer.notify,
             "TraitAddedObserver.notify should be always false.",
         )
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.notify = True
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
 
 
 class TestRestrictedNamedTraitObserverEqualityHash(unittest.TestCase):

--- a/traits/observers/tests/test_trait_added_observer.py
+++ b/traits/observers/tests/test_trait_added_observer.py
@@ -12,17 +12,17 @@ import unittest
 from unittest import mock
 
 from traits.has_traits import HasTraits
-from traits.trait_types import Str
-from traits.observers._trait_added_observer import (
-    TraitAddedObserver,
-    _RestrictedNamedTraitObserver,
-)
 from traits.observers._testing import (
     call_add_or_remove_notifiers,
     create_graph,
     DummyNotifier,
     DummyObserver,
 )
+from traits.observers._trait_added_observer import (
+    _RestrictedNamedTraitObserver,
+    TraitAddedObserver,
+)
+from traits.trait_types import Str
 
 
 def create_observer(**kwargs):


### PR DESCRIPTION
This PR implements item 11 of #977

- Add an `TraitAddedObserver` for supporting other observers that need to handle `trait_added`. - Use `TraitAddedObserver` in `NamedTraitObserver`.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~ this observer is for internal use.
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
