### PR TITLE
Add an observer for observing traits using an arbitrary filter

### DIFF
--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -14,7 +14,6 @@ from traits.observers._has_traits_helpers import (
 )
 from traits.observers._i_observer import IObserver
 from traits.observers._observer_change_notifier import ObserverChangeNotifier
-from traits.observers._observer_graph import ObserverGraph
 from traits.observers._trait_change_event import trait_event_factory
 from traits.observers._trait_event_notifier import TraitEventNotifier
 from traits.trait_base import Uninitialized

--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -35,8 +35,8 @@ class FilteredTraitObserver:
     """
 
     def __init__(self, notify, filter):
-        self._notify = notify
-        self._filter = filter
+        self.notify = notify
+        self.filter = filter
 
     def __hash__(self):
         """ Return a hash of this object."""
@@ -49,18 +49,6 @@ class FilteredTraitObserver:
             and self.notify == other.notify
             and self.filter == other.filter
         )
-
-    @property
-    def notify(self):
-        """ A boolean for whether this observer will notify for changes.
-        """
-        return self._notify
-
-    @property
-    def filter(self):
-        """ The callable to decide if a given trait should be observed.
-        """
-        return self._filter
 
     def iter_observables(self, object):
         """ Yield the instance traits matching the filter given. If trait

--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -66,8 +66,7 @@ class FilteredTraitObserver:
         ------
         IObservable
         """
-        name_to_ctrait = object.traits()
-        for name, ctrait in name_to_ctrait.items():
+        for name, ctrait in object.traits().items():
             if self.filter(name, ctrait):
                 yield object._trait(name, 2)
 
@@ -96,8 +95,7 @@ class FilteredTraitObserver:
         ------
         value : object
         """
-        name_to_ctrait = object.traits()
-        for name, ctrait in name_to_ctrait.items():
+        for name, ctrait in object.traits().items():
             if self.filter(name, ctrait):
                 yield from iter_objects(object, name)
 

--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -1,0 +1,199 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traits.observers._trait_change_event import trait_event_factory
+from traits.observers._has_traits_helpers import (
+    iter_objects,
+    observer_change_handler,
+)
+from traits.observers._i_observer import IObserver
+from traits.observers._observer_graph import ObserverGraph
+from traits.observers._observer_change_notifier import ObserverChangeNotifier
+from traits.observers._trait_event_notifier import TraitEventNotifier
+from traits.trait_base import Uninitialized
+
+
+@IObserver.register
+class FilteredTraitObserver:
+    """ An observer for observing traits using a custom filter.
+
+    Parameters
+    ----------
+    notify : boolean
+        Whether to notify for changes.
+    filter : callable(str, CTrait) -> boolean
+        A callable that receives the name of a trait and the corresponding
+        trait definition. The returned boolean indicates whether the trait is
+        observed. In order to remove an existing observer with the equivalent
+        filter, the filter callables must be equal to each other.
+    """
+
+    def __init__(self, notify, filter):
+        self._notify = notify
+        self._filter = filter
+
+    def __hash__(self):
+        """ Return a hash of this object."""
+        return hash((type(self), self.notify, self.filter))
+
+    def __eq__(self, other):
+        """ Return true if this observer is equal to the given one."""
+        return (
+            type(self) is type(other)
+            and self.notify == other.notify
+            and self.filter == other.filter
+        )
+
+    @property
+    def notify(self):
+        """ A boolean for whether this observer will notify for changes.
+        """
+        return self._notify
+
+    @property
+    def filter(self):
+        """ The callable to decide if a given trait should be observed.
+        """
+        return self._filter
+
+    def iter_observables(self, object):
+        """ Yield the instance traits matching the filter given. If trait
+        definition cannot be found on the object, raise an error.
+
+        Parameters
+        ----------
+        object: object
+            Object provided by the ``iter_objects`` methods from another
+            observers or directly by the user.
+
+        Yields
+        ------
+        IObservable
+
+        Raises
+        ------
+        ValueError
+            If the given object cannot be handled by this observer.
+        """
+        try:
+            name_to_ctrait = object.traits()
+        except AttributeError:
+            raise ValueError(
+                "Unable to obtain trait definitions from {!r}".format(object)
+            )
+
+        for name, ctrait in name_to_ctrait.items():
+            if self.filter(name, ctrait):
+                yield object._trait(name, 2)
+
+    def iter_objects(self, object):
+        """ Yield the values of the traits that match the given filter. The
+        values will be given to the next observer(s) following this one in an
+        ObserverGraph.
+
+        If a value has not been set as an instance attribute, i.e. absent in
+        ``object.__dict__``, this observer will skip it. This is to avoid
+        evaluating default initializers while adding observers. When the
+        default is defined, a change event will trigger the maintainer to
+        add/remove notifiers for the next observers.
+
+        Note that ``Undefined``, ``Uninitialized`` and ``None`` values are also
+        skipped, as they are unavoidable filled values that contain no further
+        attributes to be observed by any other observers.
+
+        Parameters
+        ----------
+        object: object
+            Object provided by the ``iter_objects`` methods from another
+            observers or directly by the user.
+
+        Yields
+        ------
+        value : object
+        """
+        try:
+            name_to_ctrait = object.traits()
+        except AttributeError:
+            raise ValueError(
+                "Unable to obtain trait definitions from {!r}".format(object)
+            )
+
+        for name, ctrait in name_to_ctrait.items():
+            if self.filter(name, ctrait):
+                yield from iter_objects(object, name)
+
+    def get_notifier(self, handler, target, dispatcher):
+        """ Return a notifier for calling the user handler with the change
+        event.
+
+        If the old value is uninitialized, then the change is caused by having
+        the default value defined. Such an event is prevented from reaching the
+        user's change handler.
+
+        Returns
+        -------
+        notifier : TraitEventNotifier
+        """
+        return TraitEventNotifier(
+            handler=handler,
+            target=target,
+            dispatcher=dispatcher,
+            event_factory=trait_event_factory,
+            prevent_event=lambda event: event.old is Uninitialized,
+        )
+
+    def get_maintainer(self, graph, handler, target, dispatcher):
+        """ Return a notifier for maintaining downstream observers when
+        a trait is changed.
+
+        All events should be allowed through, including setting default value
+        such that downstream observers can be maintained on the new value.
+
+        Parameters
+        ----------
+        graph : ObserverGraph
+            Description for the *downstream* observers, i.e. excluding self.
+        handler : callable
+            User handler.
+        target : object
+            Object seen by the user as the owner of the observer.
+        dispatcher : callable
+            Callable for dispatching the handler.
+
+        Returns
+        -------
+        notifier : ObserverChangeNotifier
+        """
+        return ObserverChangeNotifier(
+            observer_handler=observer_change_handler,
+            event_factory=trait_event_factory,
+            prevent_event=lambda event: False,
+            graph=graph,
+            handler=handler,
+            target=target,
+            dispatcher=dispatcher,
+        )
+
+    def iter_extra_graphs(self, graph):
+        """ Yield new ObserverGraph to be contributed by this observer.
+
+        Parameters
+        ----------
+        graph : ObserverGraph
+            The graph this observer is part of.
+
+        Yields
+        ------
+        ObserverGraph
+        """
+        # This will yield a new ObserverGraph with an observer specialized in
+        # observing trait_added event.
+        # enthought/traits#1077
+        yield from ()

--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -31,7 +31,8 @@ class FilteredTraitObserver:
         A callable that receives the name of a trait and the corresponding
         trait definition. The returned boolean indicates whether the trait is
         observed. In order to remove an existing observer with the equivalent
-        filter, the filter callables must compare equally.
+        filter, the filter callables must compare equally. The callable must
+        also be hashable.
     """
 
     def __init__(self, notify, filter):
@@ -51,8 +52,9 @@ class FilteredTraitObserver:
         )
 
     def iter_observables(self, object):
-        """ Yield the instance traits matching the filter given. If trait
-        definition cannot be found on the object, raise an error.
+        """ Yield the instance traits matching the filter given. Any error
+        occurred upon obtaining the trait definitions (e.g. the given object
+        is not an instance of HasTraits) will be propagated.
 
         Parameters
         ----------
@@ -63,19 +65,8 @@ class FilteredTraitObserver:
         Yields
         ------
         IObservable
-
-        Raises
-        ------
-        ValueError
-            If the given object cannot be handled by this observer.
         """
-        try:
-            name_to_ctrait = object.traits()
-        except AttributeError:
-            raise ValueError(
-                "Unable to obtain trait definitions from {!r}".format(object)
-            )
-
+        name_to_ctrait = object.traits()
         for name, ctrait in name_to_ctrait.items():
             if self.filter(name, ctrait):
                 yield object._trait(name, 2)

--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -96,13 +96,7 @@ class FilteredTraitObserver:
         ------
         value : object
         """
-        try:
-            name_to_ctrait = object.traits()
-        except AttributeError:
-            raise ValueError(
-                "Unable to obtain trait definitions from {!r}".format(object)
-            )
-
+        name_to_ctrait = object.traits()
         for name, ctrait in name_to_ctrait.items():
             if self.filter(name, ctrait):
                 yield from iter_objects(object, name)

--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -32,7 +32,7 @@ class FilteredTraitObserver:
         A callable that receives the name of a trait and the corresponding
         trait definition. The returned boolean indicates whether the trait is
         observed. In order to remove an existing observer with the equivalent
-        filter, the filter callables must be equal to each other.
+        filter, the filter callables must compare equally.
     """
 
     def __init__(self, notify, filter):

--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -40,7 +40,7 @@ class FilteredTraitObserver:
 
     def __hash__(self):
         """ Return a hash of this object."""
-        return hash((type(self), self.notify, self.filter))
+        return hash((type(self).__name__, self.notify, self.filter))
 
     def __eq__(self, other):
         """ Return true if this observer is equal to the given one."""

--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -8,14 +8,14 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.observers._trait_change_event import trait_event_factory
 from traits.observers._has_traits_helpers import (
     iter_objects,
     observer_change_handler,
 )
 from traits.observers._i_observer import IObserver
-from traits.observers._observer_graph import ObserverGraph
 from traits.observers._observer_change_notifier import ObserverChangeNotifier
+from traits.observers._observer_graph import ObserverGraph
+from traits.observers._trait_change_event import trait_event_factory
 from traits.observers._trait_event_notifier import TraitEventNotifier
 from traits.trait_base import Uninitialized
 

--- a/traits/observers/_testing.py
+++ b/traits/observers/_testing.py
@@ -19,6 +19,10 @@ from traits.observers._observer_graph import ObserverGraph
 _DEFAULT_TARGET = mock.Mock()
 
 
+def dispatch_same(handler, event):
+    handler(event)
+
+
 def create_graph(*nodes):
     """ Create an ObserverGraph with the given nodes joined one after another.
 
@@ -47,9 +51,6 @@ def call_add_or_remove_notifiers(**kwargs):
     **kwargs
         New argument values to use instead.
     """
-    def dispatch_same(handler, event):
-        handler(event)
-
     values = dict(
         object=mock.Mock(),
         graph=ObserverGraph(node=None),

--- a/traits/observers/tests/test_filtered_trait_observer.py
+++ b/traits/observers/tests/test_filtered_trait_observer.py
@@ -97,20 +97,6 @@ class TestFilteredTraitObserverEqualHashImmutable(unittest.TestCase):
         imposter.filter = filter_func
         self.assertNotEqual(observer1, imposter)
 
-    def test_filter_not_mutable(self):
-        observer = create_observer()
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.filter = mock.Mock()
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
-
-    def test_notify_not_immutable(self):
-        observer = create_observer()
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.notify = True
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
-
 
 class Dummy(HasTraits):
 

--- a/traits/observers/tests/test_filtered_trait_observer.py
+++ b/traits/observers/tests/test_filtered_trait_observer.py
@@ -50,9 +50,8 @@ def create_observer(**kwargs):
     return FilteredTraitObserver(**values)
 
 
-class TestFilteredTraitObserverEqualHashImmutable(unittest.TestCase):
-    """ Tests for FilteredTraitObserver __eq__ and __hash__ methods, and
-    the fact it is not mutable.
+class TestFilteredTraitObserverEqualHash(unittest.TestCase):
+    """ Tests for FilteredTraitObserver __eq__ and __hash__ methods.
     """
 
     def test_not_equal_filter(self):

--- a/traits/observers/tests/test_filtered_trait_observer.py
+++ b/traits/observers/tests/test_filtered_trait_observer.py
@@ -135,16 +135,6 @@ class TestFilteredTraitObserverIterObservables(unittest.TestCase):
         ]
         self.assertCountEqual(actual, expected)
 
-    def test_iter_observable_error(self):
-        observer = create_observer()
-        with self.assertRaises(ValueError) as exception_context:
-            list(observer.iter_observables(None))
-
-        self.assertIn(
-            "Unable to obtain trait definitions from None",
-            str(exception_context.exception)
-        )
-
 
 class TestFilteredTraitObserverIterObjects(unittest.TestCase):
     """ Test FilteredTraitObserver.iter_objects """

--- a/traits/observers/tests/test_filtered_trait_observer.py
+++ b/traits/observers/tests/test_filtered_trait_observer.py
@@ -162,15 +162,6 @@ class TestFilteredTraitObserverIterObjects(unittest.TestCase):
             [instance.instance, instance.instance2]
         )
 
-    def test_iter_objects_error(self):
-        observer = create_observer()
-        with self.assertRaises(ValueError) as exception_context:
-            list(observer.iter_objects(None))
-
-        self.assertIn(
-            "Unable to obtain trait definitions from None",
-            str(exception_context.exception)
-        )
 
 # ------------------------------------
 # Integration tests with notifiers

--- a/traits/observers/tests/test_filtered_trait_observer.py
+++ b/traits/observers/tests/test_filtered_trait_observer.py
@@ -25,7 +25,7 @@ from traits.observers._testing import (
 
 
 class DummyFilter:
-    """ A callable to be used as FilteredTraitObserver
+    """ A callable to be used as the 'filter' for FilteredTraitObserver
     """
 
     def __init__(self, return_value):

--- a/traits/observers/tests/test_filtered_trait_observer.py
+++ b/traits/observers/tests/test_filtered_trait_observer.py
@@ -1,0 +1,313 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+from unittest import mock
+
+from traits.has_traits import HasTraits
+from traits.trait_base import Undefined, Uninitialized
+from traits.trait_types import Float, Instance, Int, List
+from traits.observers._filtered_trait_observer import FilteredTraitObserver
+from traits.observers._testing import (
+    call_add_or_remove_notifiers,
+    create_graph,
+    DummyNotifier,
+    DummyObservable,
+    DummyObserver,
+)
+
+
+class DummyFilter:
+    """ A callable to be used as FilteredTraitObserver
+    """
+
+    def __init__(self, return_value):
+        self.return_value = return_value
+
+    def __call__(self, name, trait):
+        return self.return_value
+
+    def __eq__(self, other):
+        return self.return_value == other.return_value
+
+    def __hash__(self):
+        return hash(self.return_value)
+
+
+def create_observer(**kwargs):
+    values = dict(
+        notify=True,
+        filter=DummyFilter(return_value=True),
+    )
+    values.update(kwargs)
+    return FilteredTraitObserver(**values)
+
+
+class TestFilteredTraitObserverEqualHashImmutable(unittest.TestCase):
+    """ Tests for FilteredTraitObserver __eq__ and __hash__ methods, and
+    the fact it is not mutable.
+    """
+
+    def test_not_equal_filter(self):
+        observer1 = FilteredTraitObserver(
+            notify=True,
+            filter=DummyFilter(return_value=True),
+        )
+        observer2 = FilteredTraitObserver(
+            notify=True,
+            filter=DummyFilter(return_value=False),
+        )
+        self.assertNotEqual(observer1, observer2)
+
+    def test_not_equal_notify(self):
+        filter_func = mock.Mock()
+        observer1 = FilteredTraitObserver(
+            notify=False, filter=filter_func)
+        observer2 = FilteredTraitObserver(
+            notify=True, filter=filter_func)
+        self.assertNotEqual(observer1, observer2)
+
+    def test_equal_filter_notify(self):
+        observer1 = FilteredTraitObserver(
+            notify=True,
+            filter=DummyFilter(return_value=True),
+        )
+        observer2 = FilteredTraitObserver(
+            notify=True,
+            filter=DummyFilter(return_value=True),
+        )
+        self.assertEqual(observer1, observer2)
+        self.assertEqual(hash(observer1), hash(observer2))
+
+    def test_not_equal_type(self):
+        filter_func = mock.Mock()
+        observer1 = FilteredTraitObserver(
+            notify=True,
+            filter=filter_func,
+        )
+        imposter = mock.Mock()
+        imposter.notify = True
+        imposter.filter = filter_func
+        self.assertNotEqual(observer1, imposter)
+
+    def test_filter_not_mutable(self):
+        observer = create_observer()
+        with self.assertRaises(AttributeError) as exception_context:
+            observer.filter = mock.Mock()
+        self.assertEqual(
+            str(exception_context.exception), "can't set attribute")
+
+    def test_notify_not_immutable(self):
+        observer = create_observer()
+        with self.assertRaises(AttributeError) as exception_context:
+            observer.notify = True
+        self.assertEqual(
+            str(exception_context.exception), "can't set attribute")
+
+
+class Dummy(HasTraits):
+
+    number = Int()
+
+
+class DummyParent(HasTraits):
+
+    number = Int()
+
+    number2 = Int()
+
+    instance = Instance(Dummy, allow_none=True)
+
+    instance2 = Instance(Dummy)
+
+    income = Float()
+
+    dummies = List(Dummy)
+
+
+class TestFilteredTraitObserverIterObservables(unittest.TestCase):
+
+    def test_iter_observables_with_filter(self):
+        instance = DummyParent()
+
+        observer = create_observer(
+            filter=lambda name, trait: type(trait.trait_type) is Int,
+        )
+
+        actual = list(observer.iter_observables(instance))
+        expected = [
+            instance._trait("number", 2),
+            instance._trait("number2", 2),
+        ]
+        self.assertCountEqual(actual, expected)
+
+    def test_iter_observable_error(self):
+        observer = create_observer()
+        with self.assertRaises(ValueError) as exception_context:
+            list(observer.iter_observables(None))
+
+        self.assertIn(
+            "Unable to obtain trait definitions from None",
+            str(exception_context.exception)
+        )
+
+
+class TestFilteredTraitObserverIterObjects(unittest.TestCase):
+
+    def test_iter_objects(self):
+        instance = DummyParent()
+        instance.instance = Dummy()
+        self.assertIsNone(instance.instance2)
+
+        observer = create_observer(
+            filter=lambda name, trait: type(trait.trait_type) is Instance,
+        )
+
+        actual = list(observer.iter_objects(instance))
+
+        # the None value is skipped here
+        self.assertEqual(actual, [instance.instance])
+
+        # when
+        instance.instance2 = Dummy()
+        actual = list(observer.iter_objects(instance))
+
+        # then
+        self.assertCountEqual(
+            actual,
+            [instance.instance, instance.instance2]
+        )
+
+    def test_iter_objects_error(self):
+        observer = create_observer()
+        with self.assertRaises(ValueError) as exception_context:
+            list(observer.iter_objects(None))
+
+        self.assertIn(
+            "Unable to obtain trait definitions from None",
+            str(exception_context.exception)
+        )
+
+# ------------------------------------
+# Integration tests with notifiers
+# ------------------------------------
+
+
+class WatchfulObserver(DummyObserver):
+    """ This is a dummy observer to be used as the next observer following
+    FilteredTraitObserver.
+    """
+    def iter_observables(self, object):
+        if object in (Undefined, Uninitialized, None):
+            raise ValueError(
+                "Child observer unexpectedly receive {}".format(object)
+            )
+        yield from self.observables
+
+
+class TestFilteredTraitObserverNotifications(unittest.TestCase):
+
+    def test_notify_filter_values_changed(self):
+        instance = DummyParent()
+
+        # Observes number and number2
+        observer = create_observer(
+            filter=lambda name, trait: type(trait.trait_type) is Int,
+        )
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance,
+            graph=create_graph(observer),
+            handler=handler,
+        )
+
+        # when
+        instance.number += 1
+
+        # then
+        self.assertEqual(handler.call_count, 1)
+        handler.reset_mock()
+
+        # when
+        instance.number2 += 1
+
+        # then
+        self.assertEqual(handler.call_count, 1)
+
+    def test_notifier_can_be_removed(self):
+
+        def filter_func(name, trait):
+            return name.startswith("num")
+
+        instance = DummyParent()
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance,
+            graph=create_graph(
+                create_observer(filter=filter_func)
+            ),
+            handler=handler,
+        )
+
+        # sanity check
+        instance.number += 1
+        self.assertEqual(handler.call_count, 1)
+        handler.reset_mock()
+
+        # when
+        call_add_or_remove_notifiers(
+            object=instance,
+            graph=create_graph(
+                create_observer(filter=filter_func)
+            ),
+            handler=handler,
+            remove=True,
+        )
+
+        # then
+        instance.number += 1
+        self.assertEqual(handler.call_count, 0)
+
+    def test_maintainer_notifier(self):
+        # Test maintaining downstream notifier
+
+        # Observes a nested instance
+        observer = create_observer(
+            filter=lambda name, trait: type(trait.trait_type) is Instance,
+        )
+        observable = DummyObservable()
+        notifier = DummyNotifier()
+        child_observer = WatchfulObserver(
+            observables=[observable],
+            notifier=notifier,
+        )
+        instance = DummyParent()
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance,
+            graph=create_graph(
+                observer,
+                child_observer,
+            ),
+            handler=handler,
+        )
+
+        # when
+        # this will trigger the maintainer
+        instance.instance = Dummy()
+
+        # then
+        self.assertEqual(observable.notifiers, [notifier])
+
+        # when
+        instance.instance = None
+
+        # then
+        self.assertEqual(observable.notifiers, [])

--- a/traits/observers/tests/test_filtered_trait_observer.py
+++ b/traits/observers/tests/test_filtered_trait_observer.py
@@ -133,6 +133,7 @@ class DummyParent(HasTraits):
 
 
 class TestFilteredTraitObserverIterObservables(unittest.TestCase):
+    """ Test FilteredTraitObserver.iter_observables """
 
     def test_iter_observables_with_filter(self):
         instance = DummyParent()
@@ -160,6 +161,7 @@ class TestFilteredTraitObserverIterObservables(unittest.TestCase):
 
 
 class TestFilteredTraitObserverIterObjects(unittest.TestCase):
+    """ Test FilteredTraitObserver.iter_objects """
 
     def test_iter_objects(self):
         instance = DummyParent()
@@ -213,6 +215,7 @@ class WatchfulObserver(DummyObserver):
 
 
 class TestFilteredTraitObserverNotifications(unittest.TestCase):
+    """ Integration tests with HasTraits and notifiers."""
 
     def test_notify_filter_values_changed(self):
         instance = DummyParent()


### PR DESCRIPTION
This PR implements item 12 for #977

- Add `FilteredTraitObserver` for observing traits using a filter function `callable(name, trait) -> boolean`.  This observer can then be used for filtering traits with a metadata, and more.
- A lot of the logic is very similar to `NamedTraitObserver`, except no errors will be raised if the filter finds no traits to be observed.
- Support for `trait_added` is missing here. It can be added once #1077 is merged and the usage is going to be ~identical~ similar to that in `NamedTraitObserver`.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~ Users will not instantiate this observer directly.
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
