### PR TITLE
Implement parsing logic for converting text to Expression

### DIFF
--- a/docs/source/traits_api_reference/traits.observers.rst
+++ b/docs/source/traits_api_reference/traits.observers.rst
@@ -28,3 +28,12 @@
 .. autoclass:: TraitChangeEvent
    :members:
    :inherited-members:
+
+
+:mod:`traits.observers.parsing` Module
+--------------------------------------
+
+.. automodule:: traits.observers.parsing
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -23,6 +23,9 @@ class Expression:
     Expression is an object for describing what traits are being observed
     for change notifications. It can be passed directly to
     ``HasTraits.observe`` method or the ``observe`` decorator.
+
+    An Expression is typically created using one of the top-level functions
+    provided in this module, e.g.``trait``.
     """
     def __init__(self):
         # ``_levels`` is a list of list of IObserver.

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -110,6 +110,27 @@ class Expression:
             new._prior_expression = _SeriesExpression([self, expression])
         return new
 
+    def trait(self, name, notify=True, optional=False):
+        """ Create a new expression for observing a trait with the exact
+        name given.
+
+        Events emitted (if any) will be instances of ``TraitChangeEvent``.
+
+        Parameters
+        ----------
+        name : str
+            Name of the trait to match.
+        notify : boolean, optional
+            Whether to notify for changes.
+        optional : boolean, optional
+            If true, skip this observer if the requested trait is not found.
+
+        Returns
+        -------
+        new_expression : traits.observers.expression.Expression
+        """
+        return self.then(trait(name=name, notify=notify, optional=optional))
+
     def _as_graphs(self):
         """ Return all the ObserverGraph for the observer framework to attach
         notifiers.

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -110,33 +110,6 @@ class Expression:
             new._prior_expression = _SeriesExpression([self, expression])
         return new
 
-    def trait(self, name, notify=True, optional=False):
-        """ Create a new expression for observing a trait with the exact
-        name given.
-
-        e.g. ``trait("child").trait("age")`` matches ``child.age``
-        on an object, and is equivalent to
-        ``trait("child").then(trait("age"))``
-
-        Events emitted (if any) will be instances of ``TraitChangeEvent``.
-
-        Parameters
-        ----------
-        name : str
-            Name of the trait to match.
-        notify : boolean, optional
-            Whether to notify for changes.
-        optional : boolean, optional
-            If true, skip this observer if the requested trait is not found.
-
-        Returns
-        -------
-        new_expression : traits.observers.expression.Expression
-        """
-        observer = _NamedTraitObserver(
-            name=name, notify=notify, optional=optional)
-        return self._new_with_branches(nodes=[observer])
-
     def _as_graphs(self):
         """ Return all the ObserverGraph for the observer framework to attach
         notifiers.
@@ -323,31 +296,25 @@ def join_(*expressions):
     return _functools.reduce(lambda e1, e2: e1.then(e2), expressions)
 
 
-def _as_top_level(func):
-    """ Create a top-level function that calls an instance method of
-    an empty ``Expression`` instance.
+def trait(name, notify=True, optional=False):
+    """ Create a new expression for observing a trait with the exact
+    name given.
+
+    Events emitted (if any) will be instances of ``TraitChangeEvent``.
 
     Parameters
     ----------
-    func : callable
-        Unbound method of ``Expression`` to be wrapped.
+    name : str
+        Name of the trait to match.
+    notify : boolean, optional
+        Whether to notify for changes.
+    optional : boolean, optional
+        If true, skip this observer if the requested trait is not found.
 
     Returns
     -------
-    new_func : callable
-        New callable with the associated docstring copied over.
+    new_expression : traits.observers.expression.Expression
     """
-
-    def new_func(*args, **kwargs):
-        return func(Expression(), *args, **kwargs)
-
-    # Recreate the docstring with the appropriate arguments
-    _functools.update_wrapper(
-        new_func,
-        getattr(Expression(), func.__name__)
-    )
-    new_func.__module__ = __name__
-    return new_func
-
-
-trait = _as_top_level(Expression.trait)
+    observer = _NamedTraitObserver(
+        name=name, notify=notify, optional=optional)
+    return Expression()._new_with_branches(nodes=[observer])

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -304,8 +304,6 @@ class _ParallelExpression:
         return new_graphs
 
 
-# User-facing top-level functions.
-
 def join_(*expressions):
     """ Convenient function for joining many expressions in series
     using ``Expression.then``

--- a/traits/observers/parsing.py
+++ b/traits/observers/parsing.py
@@ -1,0 +1,258 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import contextlib
+from functools import reduce
+import operator
+
+import traits.observers.expression as _expr_module
+from traits.observers._generated_parser import (
+    Lark_StandAlone as _Lark_StandAlone
+)
+
+_LARK_PARSER = _Lark_StandAlone()
+
+#: Token annotation for a name (a trait name, or a metadata name, etc.)
+_NAME_TOKEN = "NAME"
+
+
+def _handle_series(trees, default_notifies):
+    """ Handle expressions joined in series using "." or ":" connectors.
+
+    Parameters
+    ----------
+    trees : list of lark.tree.Tree
+        The children tree for the "series" rule.
+        It should contain one or more items.
+
+    Returns
+    -------
+    expression : traits.observers.expressions.Expression
+    """
+    expressions = (
+        _handle_tree(tree, default_notifies=default_notifies)
+        for tree in trees
+    )
+    return _expr_module.join_(*expressions)
+
+
+def _handle_parallel(trees, default_notifies):
+    """ Handle expressions joined in parallel using "," connectors.
+
+    Parameters
+    ----------
+    trees : list of lark.tree.Tree
+        The children tree for the "parallel" rule.
+        It should contain one or more items.
+
+    Returns
+    -------
+    expression : traits.observers.expressions.Expression
+    """
+    expressions = (
+        _handle_tree(tree, default_notifies=default_notifies) for tree in trees
+    )
+    return reduce(operator.or_, expressions)
+
+
+@contextlib.contextmanager
+def _notify_flag(default_notifies, value):
+    """ Context manager to push the notify to the given stack.
+    Upon exiting the context, pop the flag out of the stack.
+
+    Parameters
+    ----------
+    default_notifies : list of boolean
+        The notify flag stack.
+    value : boolean
+        Notify flag to push.
+    """
+    default_notifies.append(value)
+    try:
+        yield
+    finally:
+        notify = default_notifies.pop()
+        if notify is not value:
+            raise RuntimeError("Default notify flag unexpectedly changed.")
+
+
+def _handle_notify(trees, default_notifies):
+    """ Handle trees wrapped with the notify flag set to True,
+    indicated by the existence of "." suffix to an element.
+
+    Parameters
+    ----------
+    trees : list of lark.tree.Tree
+        The children tree for the "notify" rule.
+        It contains only one item.
+    default_notifies : list of boolean
+        The notify flag stack.
+
+    Returns
+    -------
+    expression : traits.observers.expressions.Expression
+    """
+    with _notify_flag(default_notifies, True):
+        return _handle_last(trees, default_notifies=default_notifies)
+
+
+def _handle_quiet(trees, default_notifies):
+    """ Handle trees wrapped with the notify flag set to True,
+    indicated by the existence of ":" suffix to an element.
+
+    Parameters
+    ----------
+    trees : list of lark.tree.Tree
+        The children tree for the "quiet" rule.
+        It contains only one item.
+    default_notifies : list of boolean
+        The notify flag stack.
+
+    Returns
+    -------
+    expression : traits.observers.expressions.Expression
+    """
+    with _notify_flag(default_notifies, False):
+        return _handle_last(trees, default_notifies=default_notifies)
+
+
+def _handle_last(trees, default_notifies):
+    """ Handle trees when the notify is not immediately specified
+    as a suffix. The last notify flag will be used.
+
+    e.g. In "a.[b,c]:.d", the element "b" should receive a notify flag
+    set to false, which is set after a parallel group is defined.
+
+    Parameters
+    ----------
+    trees : list of lark.tree.Tree
+        The children tree for the "last" rule.
+        It contains only one item.
+    default_notifies : list of boolean
+        The notify flag stack.
+
+    Returns
+    -------
+    expression : traits.observers.expressions.Expression
+    """
+    tree, = trees
+    return _handle_tree(tree, default_notifies=default_notifies)
+
+
+def _handle_trait(trees, default_notifies):
+    """ Handle an element for a named trait.
+
+    Parameters
+    ----------
+    trees : list of lark.tree.Tree
+        The children tree for the "trait" rule.
+        It contains only one item.
+    default_notifies : list of boolean
+        The notify flag stack.
+
+    Returns
+    -------
+    expression : traits.observers.expressions.Expression
+    """
+    token, = trees
+    # sanity check
+    if token.type != _NAME_TOKEN:
+        raise ValueError("Unexpected token: {!r}".format(token))
+    name = token.value
+    notify = default_notifies[-1]
+    return _expr_module.trait(name, notify=notify)
+
+
+def _handle_metadata(trees, default_notifies):
+    """ Handle an element for filtering existing metadata.
+
+    Parameters
+    ----------
+    trees : list of lark.tree.Tree
+        The children tree for the "metadata" rule.
+        It contains only one item.
+    default_notifies : list of boolean
+        The notify flag stack.
+
+    Returns
+    -------
+    expression : traits.observers.expressions.Expression
+    """
+    raise NotImplementedError("metadata is not yet implemeneted.")
+
+
+def _handle_items(trees, default_notifies):
+    """ Handle keyword "items".
+
+    Parameters
+    ----------
+    trees : list of lark.tree.Tree
+        The children tree for the "items" rule.
+        It should be empty.
+    default_notifies : list of boolean
+        The notify flag stack.
+
+    Returns
+    -------
+    expression : traits.observers.expressions.Expression
+    """
+    raise NotImplementedError("items is not yet implemeneted.")
+
+
+def _handle_tree(tree, default_notifies=None):
+    """ Handle a tree using the specified rule.
+
+    Parameters
+    ----------
+    tree : lark.tree.Tree
+        Tree to be converted to an Expression.
+    default_notifies : list of boolean
+        The notify flag stack.
+        The last item is the current notify flag.
+        See handlers for "notify" and "quiet", which
+        push and pop a notify flag to this stack.
+
+    Returns
+    -------
+    expression: traits.observers.expressions.Expression
+    """
+    if default_notifies is None:
+        default_notifies = [True]
+
+    # All handlers must be callable
+    # with the signature (list of Tree, default_notifies)
+    handlers = {
+        "series": _handle_series,
+        "parallel": _handle_parallel,
+        "notify": _handle_notify,
+        "quiet": _handle_quiet,
+        "last": _handle_last,
+        "trait": _handle_trait,
+        "metadata": _handle_metadata,
+        "items": _handle_items,
+    }
+    return handlers[tree.data](
+        tree.children, default_notifies=default_notifies)
+
+
+def parse(text):
+    """ Top-level function for parsing user's text to an Expression.
+
+    Parameters
+    ----------
+    text : str
+        Text to be parsed.
+
+    Returns
+    -------
+    expression : traits.observers.expressions.Expression
+    """
+    tree = _LARK_PARSER.parse(text)
+    return _handle_tree(tree)

--- a/traits/observers/parsing.py
+++ b/traits/observers/parsing.py
@@ -185,7 +185,7 @@ def _handle_metadata(trees, default_notifies):
     -------
     expression : traits.observers.expressions.Expression
     """
-    raise NotImplementedError("metadata is not yet implemeneted.")
+    raise NotImplementedError("metadata is not yet implemented.")
 
 
 def _handle_items(trees, default_notifies):
@@ -203,7 +203,7 @@ def _handle_items(trees, default_notifies):
     -------
     expression : traits.observers.expressions.Expression
     """
-    raise NotImplementedError("items is not yet implemeneted.")
+    raise NotImplementedError("items is not yet implemented.")
 
 
 def _handle_tree(tree, default_notifies=None):

--- a/traits/observers/parsing.py
+++ b/traits/observers/parsing.py
@@ -131,7 +131,7 @@ def _handle_last(trees, default_notifies):
     """ Handle trees when the notify is not immediately specified
     as a suffix. The last notify flag will be used.
 
-    e.g. In "a.[b,c]:.d", the element "b" should receive a notify flag
+    e.g. In "a.[b,c]:d", the element "b" should receive a notify flag
     set to false, which is set after a parallel group is defined.
 
     Parameters

--- a/traits/observers/parsing.py
+++ b/traits/observers/parsing.py
@@ -19,9 +19,6 @@ from traits.observers._generated_parser import (
 
 _LARK_PARSER = _Lark_StandAlone()
 
-#: Token annotation for a name (a trait name, or a metadata name, etc.)
-_NAME_TOKEN = "NAME"
-
 
 def _handle_series(trees, default_notifies):
     """ Handle expressions joined in series using "." or ":" connectors.
@@ -166,9 +163,6 @@ def _handle_trait(trees, default_notifies):
     expression : traits.observers.expression.Expression
     """
     token, = trees
-    # sanity check
-    if token.type != _NAME_TOKEN:
-        raise ValueError("Unexpected token: {!r}".format(token))
     name = token.value
     notify = default_notifies[-1]
     return _expr_module.trait(name, notify=notify)

--- a/traits/observers/parsing.py
+++ b/traits/observers/parsing.py
@@ -36,7 +36,7 @@ def _handle_series(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expressions.Expression
+    expression : traits.observers.expression.Expression
     """
     expressions = (
         _handle_tree(tree, default_notifies=default_notifies)
@@ -58,7 +58,7 @@ def _handle_parallel(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expressions.Expression
+    expression : traits.observers.expression.Expression
     """
     expressions = (
         _handle_tree(tree, default_notifies=default_notifies) for tree in trees
@@ -101,7 +101,7 @@ def _handle_notify(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expressions.Expression
+    expression : traits.observers.expression.Expression
     """
     with _notify_flag(default_notifies, True):
         return _handle_last(trees, default_notifies=default_notifies)
@@ -121,7 +121,7 @@ def _handle_quiet(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expressions.Expression
+    expression : traits.observers.expression.Expression
     """
     with _notify_flag(default_notifies, False):
         return _handle_last(trees, default_notifies=default_notifies)
@@ -144,7 +144,7 @@ def _handle_last(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expressions.Expression
+    expression : traits.observers.expression.Expression
     """
     tree, = trees
     return _handle_tree(tree, default_notifies=default_notifies)
@@ -163,7 +163,7 @@ def _handle_trait(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expressions.Expression
+    expression : traits.observers.expression.Expression
     """
     token, = trees
     # sanity check
@@ -187,7 +187,7 @@ def _handle_metadata(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expressions.Expression
+    expression : traits.observers.expression.Expression
     """
     raise NotImplementedError("metadata is not yet implemented.")
 
@@ -205,7 +205,7 @@ def _handle_items(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expressions.Expression
+    expression : traits.observers.expression.Expression
     """
     raise NotImplementedError("items is not yet implemented.")
 
@@ -225,7 +225,7 @@ def _handle_tree(tree, default_notifies=None):
 
     Returns
     -------
-    expression: traits.observers.expressions.Expression
+    expression: traits.observers.expression.Expression
     """
     if default_notifies is None:
         default_notifies = [True]
@@ -256,7 +256,7 @@ def parse(text):
 
     Returns
     -------
-    expression : traits.observers.expressions.Expression
+    expression : traits.observers.expression.Expression
     """
     tree = _LARK_PARSER.parse(text)
     return _handle_tree(tree)

--- a/traits/observers/parsing.py
+++ b/traits/observers/parsing.py
@@ -31,6 +31,8 @@ def _handle_series(trees, default_notifies):
     trees : list of lark.tree.Tree
         The children tree for the "series" rule.
         It should contain one or more items.
+    default_notifies : list of boolean
+        The notify flag stack.
 
     Returns
     -------
@@ -51,6 +53,8 @@ def _handle_parallel(trees, default_notifies):
     trees : list of lark.tree.Tree
         The children tree for the "parallel" rule.
         It should contain one or more items.
+    default_notifies : list of boolean
+        The notify flag stack.
 
     Returns
     -------

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -8,6 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
+import inspect
 import unittest
 
 from traits.observers import expression
@@ -273,6 +274,15 @@ class TestExpressionTrait(unittest.TestCase):
         ]
         actual = expr._as_graphs()
         self.assertEqual(actual, expected)
+
+    def test_call_signatures(self):
+        # Test to help developers keeping the two functions in-sync.
+        # Remove this if this becomes irrelevant.
+        top_level_trait = expression.trait
+        method_trait = create_expression(1).trait
+        self.assertEqual(
+            inspect.signature(top_level_trait), inspect.signature(method_trait)
+        )
 
 
 class TestExpressionEquality(unittest.TestCase):

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -206,6 +206,7 @@ class TestExpressionTrait(unittest.TestCase):
     """ Test Expression.trait """
 
     def test_trait_name(self):
+        # Test the top-level function
         expr = expression.trait("name")
         expected = [
             create_graph(
@@ -216,6 +217,7 @@ class TestExpressionTrait(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_trait_name_notify_false(self):
+        # Test the top-level function
         expr = expression.trait("name", notify=False)
         expected = [
             create_graph(
@@ -226,10 +228,47 @@ class TestExpressionTrait(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_trait_name_optional_true(self):
+        # Test the top-level function
         expr = expression.trait("name", optional=True)
         expected = [
             create_graph(
                 NamedTraitObserver(name="name", notify=True, optional=True)
+            ),
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+    def test_trait_method(self):
+        # Test the instance method calls the top-level function correctly.
+        expr = expression.trait("name").trait("attr")
+        expected = [
+            create_graph(
+                NamedTraitObserver(name="name", notify=True, optional=False),
+                NamedTraitObserver(name="attr", notify=True, optional=False),
+            ),
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+    def test_trait_method_notify_false(self):
+        # Test the instance method calls the top-level function correctly.
+        expr = expression.trait("name").trait("attr", notify=False)
+        expected = [
+            create_graph(
+                NamedTraitObserver(name="name", notify=True, optional=False),
+                NamedTraitObserver(name="attr", notify=False, optional=False),
+            ),
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+    def test_trait_method_optional_true(self):
+        # Test the instance method calls the top-level function correctly.
+        expr = expression.trait("name").trait("attr", optional=True)
+        expected = [
+            create_graph(
+                NamedTraitObserver(name="name", notify=True, optional=False),
+                NamedTraitObserver(name="attr", notify=True, optional=True),
             ),
         ]
         actual = expr._as_graphs()

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -11,6 +11,7 @@
 import unittest
 
 from traits.observers import expression
+from traits.observers._named_trait_observer import NamedTraitObserver
 from traits.observers._observer_graph import ObserverGraph
 
 
@@ -196,6 +197,40 @@ class TestExpressionComposition(unittest.TestCase):
                 observer1,
                 observer2,
             )
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+
+class TestExpressionTrait(unittest.TestCase):
+    """ Test Expression.trait """
+
+    def test_trait_name(self):
+        expr = expression.trait("name")
+        expected = [
+            create_graph(
+                NamedTraitObserver(name="name", notify=True, optional=False)
+            ),
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+    def test_trait_name_notify_false(self):
+        expr = expression.trait("name", notify=False)
+        expected = [
+            create_graph(
+                NamedTraitObserver(name="name", notify=False, optional=False)
+            ),
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+    def test_trait_name_optional_true(self):
+        expr = expression.trait("name", optional=True)
+        expected = [
+            create_graph(
+                NamedTraitObserver(name="name", notify=True, optional=True)
+            ),
         ]
         actual = expr._as_graphs()
         self.assertEqual(actual, expected)

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 import inspect
+import textwrap
 import unittest
 
 from traits.observers import expression
@@ -276,10 +277,10 @@ class TestExpressionTrait(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_call_signatures(self):
-        # Test to help developers keeping the two functions in-sync.
-        # Remove this if this becomes irrelevant.
+        # Test to help developers keeping the two function signatures in-sync.
+        # Remove this if the two need to divert in the future.
         top_level_trait = expression.trait
-        method_trait = create_expression(1).trait
+        method_trait = expression.Expression().trait
         self.assertEqual(
             inspect.signature(top_level_trait), inspect.signature(method_trait)
         )

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -9,7 +9,6 @@
 # Thanks for using Enthought open source!
 
 import inspect
-import textwrap
 import unittest
 
 from traits.observers import expression

--- a/traits/observers/tests/test_parsing.py
+++ b/traits/observers/tests/test_parsing.py
@@ -20,12 +20,12 @@ class TestParsingSeriesJoin(unittest.TestCase):
 
     def test_join(self):
         actual = parse("a.b.c")
-        expected = trait("a").then(trait("b")).then(trait("c"))
+        expected = trait("a").trait("b").trait("c")
         self.assertEqual(actual, expected)
 
     def test_join_with_colon(self):
         actual = parse("a:b:c")
-        expected = trait("a", False).then(trait("b", False).then(trait("c")))
+        expected = trait("a", False).trait("b", False).trait("c")
         self.assertEqual(actual, expected)
 
 
@@ -39,8 +39,8 @@ class TestParsingOr(unittest.TestCase):
     def test_or_with_join_nested(self):
         actual = parse("a.b.c,d.e")
         expected = (
-            trait("a").then(trait("b").then(trait("c")))
-            | trait("d").then(trait("e"))
+            trait("a").trait("b").trait("c")
+            | trait("d").trait("e")
         )
         self.assertEqual(actual, expected)
 
@@ -57,7 +57,7 @@ class TestParsingGroup(unittest.TestCase):
         actual = parse("root.[left,right].value")
         expected = (
             trait("root").then(
-                trait("left") | trait("right")).then(trait("value"))
+                trait("left") | trait("right")).trait("value")
         )
         self.assertEqual(actual, expected)
 
@@ -65,10 +65,9 @@ class TestParsingGroup(unittest.TestCase):
         actual = parse("root.[a.b.c.d,value]:g")
         expected = (
             trait("root").then(
-                trait("a").then(
-                    trait("b").then(trait("c").then(trait("d", False))))
+                trait("a").trait("b").trait("c").trait("d", False)
                 | trait("value", False)
-            ).then(trait("g"))
+            ).trait("g")
         )
         self.assertEqual(actual, expected)
 
@@ -82,5 +81,5 @@ class TestParsingTrait(unittest.TestCase):
 
     def test_trait_not_notifiy(self):
         actual = parse("a:b")
-        expected = trait("a", notify=False).then(trait("b"))
+        expected = trait("a", notify=False).trait("b")
         self.assertEqual(actual, expected)

--- a/traits/observers/tests/test_parsing.py
+++ b/traits/observers/tests/test_parsing.py
@@ -1,0 +1,109 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+from traits.observers._generated_parser import (
+    UnexpectedCharacters,
+    UnexpectedToken,
+)
+
+from traits.observers.parsing import parse
+from traits.observers.expression import (
+    trait,
+)
+
+
+class TestParsingSeriesJoin(unittest.TestCase):
+
+    def test_join(self):
+        actual = parse("a.b.c")
+        expected = trait("a").trait("b").trait("c")
+        self.assertEqual(actual, expected)
+
+    def test_join_with_colon(self):
+        actual = parse("a:b:c")
+        expected = trait("a", False).trait("b", False).trait("c")
+        self.assertEqual(actual, expected)
+
+
+class TestParsingOr(unittest.TestCase):
+
+    def test_or_with_commas(self):
+        actual = parse("a,b,c")
+        expected = trait("a") | trait("b") | trait("c")
+        self.assertEqual(actual, expected)
+
+    def test_or_with_join_nested(self):
+        actual = parse("a.b.c,d.e")
+        expected = (
+            trait("a").trait("b").trait("c")
+            | trait("d").trait("e")
+        )
+        self.assertEqual(actual, expected)
+
+
+class TestParsingGroup(unittest.TestCase):
+
+    def test_grouped_or(self):
+        actual = parse("root.[left,right]")
+        expected = trait("root").then(trait("left") | trait("right"))
+
+        self.assertEqual(actual, expected)
+
+    def test_grouped_or_extended(self):
+        actual = parse("root.[left,right].value")
+        expected = (
+            trait("root").then(
+                trait("left") | trait("right")).trait("value")
+        )
+        self.assertEqual(actual, expected)
+
+    def test_multi_branch_then_or_apply_notify_flag_to_last_item(self):
+        actual = parse("root.[a.b.c.d,value]:g")
+        expected = (
+            trait("root").then(
+                trait("a").trait("b").trait("c").trait("d", False)
+                | trait("value", False)
+            ).trait("g")
+        )
+        self.assertEqual(actual, expected)
+
+
+class TestParsingTrait(unittest.TestCase):
+
+    def test_simple_trait(self):
+        actual = parse("a")
+        expected = trait("a")
+        self.assertEqual(actual, expected)
+
+    def test_trait_not_notifiy(self):
+        actual = parse("a:b")
+        expected = trait("a", notify=False).trait("b")
+        self.assertEqual(actual, expected)
+
+
+class TestParsingError(unittest.TestCase):
+
+    def test_unparse_content(self):
+        with self.assertRaises(UnexpectedCharacters):
+            parse("a.b.c^abc")
+
+    def test_error_empty_string(self):
+        with self.assertRaises(UnexpectedToken):
+            parse("")
+
+    def test_error_unconnected_expressions(self):
+        with self.assertRaises(UnexpectedToken):
+            parse("[a.b]c")
+
+    def test_error_recursion_not_supported(self):
+        with self.assertRaises(UnexpectedCharacters):
+            parse("a*.c")

--- a/traits/observers/tests/test_parsing.py
+++ b/traits/observers/tests/test_parsing.py
@@ -10,11 +10,6 @@
 
 import unittest
 
-from traits.observers._generated_parser import (
-    UnexpectedCharacters,
-    UnexpectedToken,
-)
-
 from traits.observers.parsing import parse
 from traits.observers.expression import (
     trait,
@@ -88,22 +83,3 @@ class TestParsingTrait(unittest.TestCase):
         actual = parse("a:b")
         expected = trait("a", notify=False).trait("b")
         self.assertEqual(actual, expected)
-
-
-class TestParsingError(unittest.TestCase):
-
-    def test_unparse_content(self):
-        with self.assertRaises(UnexpectedCharacters):
-            parse("a.b.c^abc")
-
-    def test_error_empty_string(self):
-        with self.assertRaises(UnexpectedToken):
-            parse("")
-
-    def test_error_unconnected_expressions(self):
-        with self.assertRaises(UnexpectedToken):
-            parse("[a.b]c")
-
-    def test_error_recursion_not_supported(self):
-        with self.assertRaises(UnexpectedCharacters):
-            parse("a*.c")

--- a/traits/observers/tests/test_parsing.py
+++ b/traits/observers/tests/test_parsing.py
@@ -20,12 +20,12 @@ class TestParsingSeriesJoin(unittest.TestCase):
 
     def test_join(self):
         actual = parse("a.b.c")
-        expected = trait("a").trait("b").trait("c")
+        expected = trait("a").then(trait("b")).then(trait("c"))
         self.assertEqual(actual, expected)
 
     def test_join_with_colon(self):
         actual = parse("a:b:c")
-        expected = trait("a", False).trait("b", False).trait("c")
+        expected = trait("a", False).then(trait("b", False).then(trait("c")))
         self.assertEqual(actual, expected)
 
 
@@ -39,8 +39,8 @@ class TestParsingOr(unittest.TestCase):
     def test_or_with_join_nested(self):
         actual = parse("a.b.c,d.e")
         expected = (
-            trait("a").trait("b").trait("c")
-            | trait("d").trait("e")
+            trait("a").then(trait("b").then(trait("c")))
+            | trait("d").then(trait("e"))
         )
         self.assertEqual(actual, expected)
 
@@ -57,7 +57,7 @@ class TestParsingGroup(unittest.TestCase):
         actual = parse("root.[left,right].value")
         expected = (
             trait("root").then(
-                trait("left") | trait("right")).trait("value")
+                trait("left") | trait("right")).then(trait("value"))
         )
         self.assertEqual(actual, expected)
 
@@ -65,9 +65,10 @@ class TestParsingGroup(unittest.TestCase):
         actual = parse("root.[a.b.c.d,value]:g")
         expected = (
             trait("root").then(
-                trait("a").trait("b").trait("c").trait("d", False)
+                trait("a").then(
+                    trait("b").then(trait("c").then(trait("d", False))))
                 | trait("value", False)
-            ).trait("g")
+            ).then(trait("g"))
         )
         self.assertEqual(actual, expected)
 
@@ -81,5 +82,5 @@ class TestParsingTrait(unittest.TestCase):
 
     def test_trait_not_notifiy(self):
         actual = parse("a:b")
-        expected = trait("a", notify=False).trait("b")
+        expected = trait("a", notify=False).then(trait("b"))
         self.assertEqual(actual, expected)


### PR DESCRIPTION
This PR works towards finishing item 4 in #977

> Text parser for parsing traits domain specific language to an instance of Expression

- Add conversion logic from a syntax tree to an instance of Expression
- Add `parse` function to convert text to Expression. This function is exposed in the public API
- Add `trait` as a method on `Expression` for extending an expression for observing a trait with a given name.
- Add `trait` top-level function for creating an expression for a given trait name (this just wraps the method on an empty expression).

Note that parsing `"+metadata"` and `"items"` currently raise NotImplementedError as the observers required for these two are still being reviewed. This PR therefore adds some placeholders for them.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
