### PR TITLE
Differentiate order in Expression equality function

### DIFF
--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -43,21 +43,13 @@ class Expression:
         """ Return true if the other value is an Expression with equivalent
         content.
 
-        e.g. ``(trait("a") | trait("b")) == (trait("b") | trait("a"))`` will
-        return true.
-
         Returns
         -------
         boolean
         """
         if type(other) is not type(self):
             return False
-        self_graphs = self._as_graphs()
-        other_graphs = other._as_graphs()
-        return (
-            len(self_graphs) == len(other_graphs)
-            and set(self_graphs) == set(other_graphs)
-        )
+        return self._as_graphs() == other._as_graphs()
 
     def __or__(self, expression):
         """ Create a new expression that matches this expression OR

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -219,15 +219,6 @@ class TestExpressionEquality(unittest.TestCase):
 
         self.assertEqual(combined1, combined2)
 
-    def test_or_equality(self):
-        expr1 = create_expression(1)
-        expr2 = create_expression(2)
-
-        combined1 = expr1 | expr2
-        combined2 = expr2 | expr1
-        # order is ignored.
-        self.assertEqual(combined1, combined2)
-
     def test_equality_different_type(self):
         expr = create_expression(1)
         self.assertNotEqual(expr, "1")


### PR DESCRIPTION
This PR makes `trait("a") | trait("b")` to be considered as NOT equivalent to `trait("b") | trait("a")`.  Strictly speaking, this is true because the given change handler will be registered to "a" first and then to "b" when `observe(handler, trait("a") | trait("b"))` is called. When `observe(handler, trait("b") | trait("a"))` is called, the change handler will be registered to "b" first and then to "a".

The `__eq__` is not used by the internal machinery, it is there to help users learning the expression. Internal observe machinery uses `_as_graphs` instead. So if the users want to see these two being considered equal, we can change this back without affecting anything.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`): autodoc handled this.
- ~Update User manual (`docs/source/traits_user_manual`)~: Does not exist yet.
- ~Update type annotation hints in `traits-stubs`~
