### PR TITLE
Relax immutability in NamedTraitObserver for consistency

### DIFF
--- a/traits/observers/_named_trait_observer.py
+++ b/traits/observers/_named_trait_observer.py
@@ -44,28 +44,9 @@ class NamedTraitObserver:
             added after a handler is registered, or when the context is
             ambiguous (e.g. "items" in the domain specific language).
         """
-        self._name = name
-        self._notify = notify
-        self._optional = optional
-
-    @property
-    def name(self):
-        """ Name of trait to observe on any given HasTraits object."""
-        return self._name
-
-    @property
-    def notify(self):
-        """ A boolean for whether this observer will notify
-        for changes.
-        """
-        return self._notify
-
-    @property
-    def optional(self):
-        """ A boolean for whether to silent error if the incoming object
-        does not have the requested trait.
-        """
-        return self._optional
+        self.name = name
+        self.notify = notify
+        self.optional = optional
 
     def __hash__(self):
         return hash((type(self), self.name, self.notify, self.optional))

--- a/traits/observers/tests/test_named_trait_observer.py
+++ b/traits/observers/tests/test_named_trait_observer.py
@@ -67,27 +67,6 @@ class TestNamedTraitObserverEqualHash(unittest.TestCase):
         imposter.optional = True
         self.assertNotEqual(observer, imposter)
 
-    def test_name_not_mutable(self):
-        observer = NamedTraitObserver(name="foo", notify=True, optional=True)
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.name = "bar"
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
-
-    def test_notify_not_mutable(self):
-        observer = NamedTraitObserver(name="foo", notify=True, optional=True)
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.notify = False
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
-
-    def test_optional_not_mutable(self):
-        observer = NamedTraitObserver(name="foo", notify=True, optional=True)
-        with self.assertRaises(AttributeError) as exception_context:
-            observer.optional = False
-        self.assertEqual(
-            str(exception_context.exception), "can't set attribute")
-
 
 class TestObserverGraphIntegrateNamedTraitObserver(unittest.TestCase):
     """ Test integrating ObserverGraph with NamedTraitObserver as nodes.


### PR DESCRIPTION
`ListItemObserver` does not prevent its attributes to be mutated (see #1071). For consistency, this PR relaxes the protection on `NamedTraitObserver` too. 

These attributes should not be mutated despite this change.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
