### PR TITLE
Register all observables to IObservable

### DIFF
--- a/traits/ctrait.py
+++ b/traits/ctrait.py
@@ -20,6 +20,7 @@ import inspect
 
 from . import ctraits
 from .constants import ComparisonMode, DefaultValue, default_value_map
+from .observers._i_observable import IObservable
 from .trait_base import SequenceTypes, Undefined
 from .trait_dict_object import TraitDictObject
 from .trait_list_object import TraitListObject
@@ -32,6 +33,7 @@ def __newobj__(cls, *args):
     return cls.__new__(cls, *args)
 
 
+@IObservable.register
 class CTrait(ctraits.cTrait):
     """ Extends the underlying C-based cTrait type.
     """

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -11,6 +11,7 @@
 import copy
 from weakref import ref
 
+from traits.observers._i_observable import IObservable
 from traits.trait_base import Undefined, _validate_everything
 from traits.trait_errors import TraitError
 
@@ -56,6 +57,7 @@ class TraitDictEvent(object):
         )
 
 
+@IObservable.register
 class TraitDict(dict):
     """ A subclass of dict that validates keys and values and notifies
     listeners of any change.

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -12,9 +12,9 @@ import copy
 import operator
 from weakref import ref
 
+from traits.observers._i_observable import IObservable
 from traits.trait_base import class_of, Undefined, _validate_everything
 from traits.trait_errors import TraitError
-from traits.observers._i_observable import IObservable as _IObservable
 
 
 class TraitListEvent(object):
@@ -162,7 +162,7 @@ def _removed_items(items, index, return_for_invalid_index):
             return return_for_invalid_index
 
 
-@_IObservable.register
+@IObservable.register
 class TraitList(list):
     """ A subclass of list that validates and notifies listeners of changes.
 

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -13,9 +13,9 @@ import copyreg
 from itertools import chain
 from weakref import ref
 
+from traits.observers._i_observable import IObservable
 from traits.trait_base import _validate_everything
 from traits.trait_errors import TraitError
-from traits.observers._i_observable import IObservable as _IObservable
 
 
 class TraitSetEvent(object):
@@ -52,7 +52,7 @@ class TraitSetEvent(object):
         )
 
 
-@_IObservable.register
+@IObservable.register
 class TraitSet(set):
     """ A subclass of set that validates and notifies listeners of changes.
 


### PR DESCRIPTION
This PR makes sure all observables are (virtual) subclasses of `IObservable`.

So far nothing does the subclassing check e.g. `issubclass` or `isinstance`, so the registeration is arguably unused.
This is more about explicitly declaring a type as observable and making observables more discoverable (e.g. one can do a global search on `IObservable`. Unfortunately registering virtual subclass does not allow reverse lookup from the `ABC`...)

Drive-by import and naming changes to make things more consistent.

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
