### PR TITLE
Doc: Add mention of IObserver in add_or_remove_notifiers docstring

### DIFF
--- a/traits/observers/_observe.py
+++ b/traits/observers/_observe.py
@@ -14,12 +14,16 @@ def add_or_remove_notifiers(
     """ Add/Remove notifiers on objects following the description on an
     ObserverGraph.
 
+    All nodes in ``ObserverGraph`` are required to be instances of
+    ``IObserver``. The interface of ``IObserver`` supports this function.
+
     Parameters
     ----------
     object : object
         An object to be observed.
     graph : ObserverGraph
         A graph describing what and how extended traits are being observed.
+        All nodes must be ``IObserver``.
     handler : callable(event)
         User-defined callable to handle change events.
         ``event`` is an object representing the change.


### PR DESCRIPTION
This PR expands the docstring of `add_or_remove_notifiers` to aid code discovery.

While `add_or_remove_notifiers` was added together with the interface of `IObserver`, for anyone reading the code outside the context of a PR, they will likely start from the top-level `observe` function to this `add_or_remove_notifiers`. It is not clear the function should be understood with the interface defined in `IObserver`.

While the docstring of `ObserverGraph` does briefly mention `IObserver`, `ObserverGraph` does not actually enforce its nodes to be `IObserver` at all. `add_or_remove_notifiers` does.

**Checklist**
~Tests~
~Update API reference (`docs/source/traits_api_reference`)~
~Update User manual (`docs/source/traits_user_manual`)~
~Update type annotation hints in `traits-stubs`~
