### PR TITLE
Wrap single observer to a separate expression

### DIFF
--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -18,8 +18,6 @@ from traits.observers._observer_graph import (
 )
 
 # Expression is a public user interface for constructing ObserverGraph.
-# It wraps an instance of _IExpression which is hidden from the user.
-# Despite the name, Expression itself is not an instance of _IExpression.
 
 
 class Expression:

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -32,6 +32,16 @@ class Expression:
     provided in this module, e.g.``trait``.
     """
     def __init__(self, _expression=None):
+        """ Create an user-facing Expression wrapping an _IExpression for
+        internal use.
+
+        Parameters
+        ----------
+        _expression: _IExpression, or None
+            Internal object for constructing a graph of observers.
+            If not provided, the internal object represents an empty
+            expression.
+        """
         if _expression is None:
             _expression = _EmptyExpression()
         self._expression = _expression

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -17,6 +17,10 @@ from traits.observers._observer_graph import (
     ObserverGraph as _ObserverGraph,
 )
 
+# Expression is a public user interface for constructing ObserverGraph.
+# It wraps an instance of _IExpression which is hidden from the user.
+# Despite the name, Expression itself is not an instance of _IExpression.
+
 
 class Expression:
     """
@@ -27,23 +31,10 @@ class Expression:
     An Expression is typically created using one of the top-level functions
     provided in this module, e.g.``trait``.
     """
-    def __init__(self):
-        # ``_levels`` is a list of list of IObserver.
-        # Each item corresponds to a layer of branches in the ObserverGraph.
-        # The last item is the most nested level.
-        # e.g. _levels = [[observer1, observer2], [observer3, observer4]]
-        # observer3 and observer4 are both leaf nodes of a tree, and they are
-        # "siblings" of each other. Each of observer3 and observer4 has two
-        # parents: observer1 and observer2.
-        # When ObserverGraph(s) are constructured from this expression, one
-        # starts from the end of this list, to the top, and then continues to
-        # the prior_expressions
-        self._levels = []
-
-        # Represent prior expressions to be combined in series (JOIN)
-        # or in parallel (OR). This is either an instance of _SeriesExpression
-        # or an instance of _ParallelExpression.
-        self._prior_expression = None
+    def __init__(self, _expression=None):
+        if _expression is None:
+            _expression = _EmptyExpression()
+        self._expression = _expression
 
     def __eq__(self, other):
         """ Return true if the other value is an Expression with equivalent
@@ -73,10 +64,10 @@ class Expression:
         new_expression : traits.observers.expression.Expression
         """
         if self == expression:
-            return self._copy()
-        new = Expression()
-        new._prior_expression = _ParallelExpression([self, expression])
-        return new
+            return self
+        return Expression(
+            _ParallelExpression(self._expression, expression._expression)
+        )
 
     def then(self, expression):
         """ Create a new expression by extending this expression with
@@ -93,14 +84,9 @@ class Expression:
         -------
         new_expression : traits.observers.expression.Expression
         """
-
-        if self._prior_expression is None and not self._levels:
-            # this expression is empty...
-            new = expression._copy()
-        else:
-            new = Expression()
-            new._prior_expression = _SeriesExpression([self, expression])
-        return new
+        return Expression(
+            _SeriesExpression(self._expression, expression._expression)
+        )
 
     def trait(self, name, notify=True, optional=False):
         """ Create a new expression for observing a trait with the exact
@@ -135,69 +121,48 @@ class Expression:
         -------
         graphs : list of ObserverGraph
         """
-        return _create_graphs(self)
+        return self._expression.create_graphs(branches=[])
 
-    def _new_with_branches(self, nodes):
-        """ Create a new Expression with a new leaf nodes.
+
+class _IExpression:
+    """ Interface to be implemented for objects to be wrapped in
+    Expression. Such objects are responsible for constructing an ObserverGraph
+    with the given information and context.
+
+    All these objects are used internally.
+    """
+
+    def create_graphs(self, branches):
+        """ Return a list of ObserverGraph with the given branches.
 
         Parameters
         ----------
-        nodes : list of IObserver
-
-        Returns
-        -------
-        new_expression : traits.observers.expression.Expression
+        branches : list of ObserverGraph
+            Graphs to be used as branches.
         """
-        expression = self._copy()
-        expression._levels.append(nodes)
-        return expression
-
-    def _copy(self):
-        """ Return a copy of this expression.
-
-        Returns
-        -------
-        new_expression : traits.observers.expression.Expression
-        """
-        expression = Expression()
-        expression._levels = self._levels.copy()
-        if self._prior_expression is not None:
-            expression._prior_expression = self._prior_expression._copy()
-        return expression
+        raise NotImplementedError("'create_graphs' must be implemented.")
 
 
-def _create_graphs(expression, graphs=None):
-    """ Create ObserverGraphs from a given expression.
+class _EmptyExpression:
+    """ Empty expression as a placeholder."""
 
-    Parameters
-    ----------
-    expression : traits.observers.expression.Expression
-    graphs : collection of ObserverGraph
-        Leaf graphs to be added.
-        Needed when this function is called recursively.
+    def create_graphs(self, branches):
+        return []
 
-    Returns
-    -------
-    graphs : list of ObserverGraph
-        New graphs
+
+class _SingleObserverExpression:
+    """ Container of Expression for wrapping a single observer.
+    Used internally in this module.
     """
-    if graphs is None:
-        graphs = []
 
-    for nodes in expression._levels[::-1]:
-        graphs = [
-            _ObserverGraph(node=node, children=graphs) for node in nodes
+    def __init__(self, observer):
+        self.observer = observer
+
+    def create_graphs(self, branches):
+        return [
+            _ObserverGraph(node=self.observer, children=branches),
         ]
 
-    if expression._prior_expression is not None:
-        graphs = expression._prior_expression._create_graphs(
-            graphs=graphs,
-        )
-    return graphs
-
-
-# _SeriesExpression and _ParallelExpression share an undeclared interface
-# which require the classes to have implemented ``copy`` and ``_create_graphs``
 
 class _SeriesExpression:
     """ Container of Expression for joining expressions in series.
@@ -205,44 +170,19 @@ class _SeriesExpression:
 
     Parameters
     ----------
-    expressions : list of Expression
-        List of Expression to be combined in series.
+    first : _IExpression
+        Left expression to be joined in series.
+    second : _IExpression
+        Right expression to be joined in series.
     """
 
-    def __init__(self, expressions):
-        self.expressions = expressions.copy()
+    def __init__(self, first, second):
+        self._first = first
+        self._second = second
 
-    def _copy(self):
-        """ Return a copy of this instance.
-        The internal ``expressions`` list is copied so it can be mutated.
-
-        Returns
-        -------
-        series_expression : _SeriesExpression
-        """
-        return _SeriesExpression(self.expressions)
-
-    def _create_graphs(self, graphs):
-        """
-        Create new ObserverGraph(s) from the joined expressions.
-
-        Parameters
-        ----------
-        graphs : collection of ObserverGraph
-            Leaf graphs to be added.
-            Needed when this function is called recursively.
-
-        Returns
-        -------
-        graphs : list of ObserverGraph
-            New graphs
-        """
-        for expr in self.expressions[::-1]:
-            graphs = _create_graphs(
-                expr,
-                graphs=graphs,
-            )
-        return graphs
+    def create_graphs(self, branches):
+        branches = self._second.create_graphs(branches=branches)
+        return self._first.create_graphs(branches=branches)
 
 
 class _ParallelExpression:
@@ -251,46 +191,20 @@ class _ParallelExpression:
 
     Parameters
     ----------
-    expressions : list of Expression
-        List of Expression to be combined in parallel.
+    left : _IExpression
+        Left expression to be joined in parallel.
+    right : _IExpression
+        Right expression to be joined in parallel.
     """
 
-    def __init__(self, expressions):
-        self.expressions = expressions.copy()
+    def __init__(self, left, right):
+        self._left = left
+        self._right = right
 
-    def _copy(self):
-        """ Return a copy of this instance.
-        The internal ``expressions`` list is copied so it can be mutated.
-
-        Returns
-        -------
-        parallel_expression : _ParallelExpression
-        """
-        return _ParallelExpression(self.expressions)
-
-    def _create_graphs(self, graphs):
-        """
-        Create new ObserverGraph(s) from the joined expressions.
-
-        Parameters
-        ----------
-        graphs : collection of ObserverGraph
-            Leaf graphs to be added.
-            Needed when this function is called recursively.
-
-        Returns
-        -------
-        graphs : list of ObserverGraph
-            New graphs
-        """
-        new_graphs = []
-        for expr in self.expressions:
-            or_graphs = _create_graphs(
-                expr,
-                graphs=graphs,
-            )
-            new_graphs.extend(or_graphs)
-        return new_graphs
+    def create_graphs(self, branches):
+        left_graphs = self._left.create_graphs(branches=branches)
+        right_graphs = self._right.create_graphs(branches=branches)
+        return left_graphs + right_graphs
 
 
 def join_(*expressions):
@@ -330,4 +244,4 @@ def trait(name, notify=True, optional=False):
     """
     observer = _NamedTraitObserver(
         name=name, notify=notify, optional=optional)
-    return Expression()._new_with_branches(nodes=[observer])
+    return Expression(_SingleObserverExpression(observer))

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -44,7 +44,7 @@ class Expression:
 
     def __or__(self, expression):
         """ Create a new expression that matches this expression OR
-        the given expression. Equivalent expressions will be ignored.
+        the given expression.
 
         e.g. ``trait("age") | trait("number")`` will match either trait
         **age** or trait **number** on an object.
@@ -57,8 +57,6 @@ class Expression:
         -------
         new_expression : traits.observers.expression.Expression
         """
-        if self == expression:
-            return self
         return ParallelExpression(self, expression)
 
     def then(self, expression):

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -8,6 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
+import abc
 import functools as _functools
 
 from traits.observers._named_trait_observer import (
@@ -134,7 +135,7 @@ class Expression:
         return self._expression.create_graphs(branches=[])
 
 
-class _IExpression:
+class _IExpression(abc.ABC):
     """ Interface to be implemented for objects to be wrapped in
     Expression. Such objects are responsible for constructing an ObserverGraph
     with the given information and context.
@@ -153,6 +154,7 @@ class _IExpression:
         raise NotImplementedError("'create_graphs' must be implemented.")
 
 
+@_IExpression.register
 class _EmptyExpression:
     """ Empty expression as a placeholder."""
 
@@ -160,6 +162,7 @@ class _EmptyExpression:
         return []
 
 
+@_IExpression.register
 class _SingleObserverExpression:
     """ Container of Expression for wrapping a single observer.
     Used internally in this module.
@@ -174,6 +177,7 @@ class _SingleObserverExpression:
         ]
 
 
+@_IExpression.register
 class _SeriesExpression:
     """ Container of Expression for joining expressions in series.
     Used internally in this module.
@@ -195,6 +199,7 @@ class _SeriesExpression:
         return self._first.create_graphs(branches=branches)
 
 
+@_IExpression.register
 class _ParallelExpression:
     """ Container of Expression for joining expressions in parallel.
     Used internally in this module.

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -46,7 +46,9 @@ def create_expression(observer):
     -------
     expression : Expression
     """
-    return expression.Expression()._new_with_branches(nodes=[observer])
+    return expression.Expression(
+        expression._SingleObserverExpression(observer)
+    )
 
 
 class TestExpressionComposition(unittest.TestCase):
@@ -115,18 +117,6 @@ class TestExpressionComposition(unittest.TestCase):
         ]
         actual = expr._as_graphs()
         self.assertEqual(actual, expected)
-
-    def test_then_optimization(self):
-        # If the expression is empty to start with, just make a copy
-        # An empty bootstrapping expression is common when an user creates an
-        # expression using a high-level helper function.
-        expr1 = expression.Expression()
-        expr2 = create_expression(1)
-        expr = expr1.then(expr2)
-
-        self.assertEqual(expr._levels, expr2._levels)
-        self.assertIsNot(expr._levels, expr2._levels)
-        self.assertIsNone(expr._prior_expression)
 
     def test_chained_then_or(self):
         observer1 = 1
@@ -306,48 +296,3 @@ class TestExpressionEquality(unittest.TestCase):
     def test_equality_different_type(self):
         expr = create_expression(1)
         self.assertNotEqual(expr, "1")
-
-
-class TestExpressionCopy(unittest.TestCase):
-    """ Test the Expression._copy method."""
-
-    def test_expression_copy_current_levels(self):
-        expr = create_expression(1)
-        copied = expr._copy()
-        self.assertEqual(expr._levels, copied._levels)
-        self.assertIsNot(copied._levels, expr._levels)
-        self.assertEqual(copied._as_graphs(), expr._as_graphs())
-
-    def test_expression_copy_prior_expression_parallel(self):
-        expr = create_expression(1) | create_expression(2)
-        self.assertIsNotNone(expr._prior_expression)
-
-        copied = expr._copy()
-        self.assertEqual(copied._as_graphs(), expr._as_graphs())
-        self.assertIsNotNone(copied._prior_expression)
-        self.assertIsNot(copied._prior_expression, expr._prior_expression)
-        self.assertEqual(
-            copied._prior_expression.expressions,
-            expr._prior_expression.expressions,
-        )
-        self.assertIsNot(
-            copied._prior_expression.expressions,
-            expr._prior_expression.expressions,
-        )
-
-    def test_expression_copy_prior_expression_serial(self):
-        expr = create_expression(1).then(create_expression(2))
-        self.assertIsNotNone(expr._prior_expression)
-
-        copied = expr._copy()
-        self.assertEqual(copied._as_graphs(), expr._as_graphs())
-        self.assertIsNotNone(copied._prior_expression)
-        self.assertIsNot(copied._prior_expression, expr._prior_expression)
-        self.assertEqual(
-            copied._prior_expression.expressions,
-            expr._prior_expression.expressions,
-        )
-        self.assertIsNot(
-            copied._prior_expression.expressions,
-            expr._prior_expression.expressions,
-        )

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -46,9 +46,7 @@ def create_expression(observer):
     -------
     expression : Expression
     """
-    return expression.Expression(
-        expression._SingleObserverExpression(observer)
-    )
+    return expression.SingleObserverExpression(observer)
 
 
 class TestExpressionComposition(unittest.TestCase):

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -75,19 +75,6 @@ class TestExpressionComposition(unittest.TestCase):
         actual = expr._as_graphs()
         self.assertEqual(actual, expected)
 
-    def test_or_operator_same_elements(self):
-        observer = 1
-        expr1 = create_expression(observer)
-        expr2 = create_expression(observer)
-        expr = expr1 | expr2
-
-        # the two elements are equal
-        expected = [
-            create_graph(observer),
-        ]
-        actual = expr._as_graphs()
-        self.assertEqual(actual, expected)
-
     def test_or_maintain_order(self):
         # Test __or__ will maintain the order provided by the user.
         observer1 = 1


### PR DESCRIPTION
Closes #1076

This PR moves the construction of a single observer to a separate expression object.
`Expression` remains to be user-facing: it aims at providing a user-friendly interface, e.g. instance methods for composing expressions.

The internal expression objects are hidden from the user, and all implement a common interface called `_IExpression`. (That interface is rather basic at the moment). Despite the name, `Expression` is not an instance of `_IExpression`.  An alternative naming suggestion (for either renaming `Expression` or renaming `_IExpression` is very welcome).

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
