### PR TITLE
Add MetadataFilter for observing traits using metadata

### DIFF
--- a/traits/observers/_metadata_filter.py
+++ b/traits/observers/_metadata_filter.py
@@ -18,8 +18,8 @@ class MetadataFilter:
     """ Callable to be used with FilteredTraitObserver for filtering traits
     with the given metadata name.
 
-    This filter returns true if the metadata is defined on the trait, false
-    if it is undefined.
+    This filter returns true if the metadata value is not None, false
+    if the metadata is not defined or the value is None.
 
     Attributes
     ----------
@@ -31,7 +31,9 @@ class MetadataFilter:
         self.metadata_name = metadata_name
 
     def __call__(self, name, trait):
-        return self.metadata_name in trait.__dict__
+        # Consistent with the current behaviour where metadata with None as
+        # the value is equivalent to the metadata not having been defined.
+        return getattr(trait, self.metadata_name, None) is not None
 
     def __eq__(self, other):
         return (

--- a/traits/observers/_metadata_filter.py
+++ b/traits/observers/_metadata_filter.py
@@ -31,8 +31,7 @@ class MetadataFilter:
         self.metadata_name = metadata_name
 
     def __call__(self, name, trait):
-        # Consistent with the current behaviour where metadata with None as
-        # the value is equivalent to the metadata not having been defined.
+        # If the metadata is not defined, CTrait still returns None.
         return getattr(trait, self.metadata_name) is not None
 
     def __eq__(self, other):

--- a/traits/observers/_metadata_filter.py
+++ b/traits/observers/_metadata_filter.py
@@ -9,53 +9,40 @@
 # Thanks for using Enthought open source!
 
 """ A filter to be used with FilteredTraitObserver for observing traits
-with a given metadata and value filter. The filter is defined here so that two
+with a given metadata. The filter is defined here so that two
 observers created using the same parameters compare equally.
 """
 
 
 class MetadataFilter:
     """ Callable to be used with FilteredTraitObserver for filtering traits
-    using defined metadata.
+    with the given metadata name.
 
-    If the metadata is not defined, the filter will return False.
+    This filter returns true if the metadata is defined on the trait, false
+    if it is undefined.
 
     Attributes
     ----------
     metadata_name : str
         Name of the metadata to filter traits with.
-        If the trait does not have the requested metadata, this filter will
-        return false.
-    value : callable(value) -> boolean
-        The callable must accept a single argument which is
-        the metadata value on the trait and return true if the trait
-        is to be observed. For removing an existing observer, the ``value``
-        callables must compare equally. The callable must be hashable as well.
     """
 
-    def __init__(self, metadata_name, value):
+    def __init__(self, metadata_name):
         self.metadata_name = metadata_name
-        self.value = value
 
     def __call__(self, name, trait):
-        # hasattr on an CTrait always return true, and the
-        # value would be None if it is not defined.
-        if self.metadata_name in trait.__dict__:
-            value = getattr(trait, self.metadata_name)
-            return self.value(value)
-        return False
+        return self.metadata_name in trait.__dict__
 
     def __eq__(self, other):
         return (
             type(self) is type(other)
             and self.metadata_name == other.metadata_name
-            and self.value == other.value
         )
 
     def __hash__(self):
-        return hash((type(self).__name__, self.metadata_name, self.value))
+        return hash((type(self).__name__, self.metadata_name))
 
     def __repr__(self):
-        return "MetadataFilter(metadata_name={!r}, value={})".format(
-            self.metadata_name, self.value.__name__
+        return "MetadataFilter(metadata_name={!r})".format(
+            self.metadata_name
         )

--- a/traits/observers/_metadata_filter.py
+++ b/traits/observers/_metadata_filter.py
@@ -1,0 +1,61 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" A filter to be used with FilteredTraitObserver for observing traits
+with a given metadata and value filter. The filter is defined here so that two
+observers created using the same parameters compare equally.
+"""
+
+
+class MetadataFilter:
+    """ Callable to be used with FilteredTraitObserver for filtering traits
+    using defined metadata.
+
+    If the metadata is not defined, the filter will return False.
+
+    Attributes
+    ----------
+    metadata_name : str
+        Name of the metadata to filter traits with.
+        If the trait does not have the requested metadata, this filter will
+        return false.
+    value : callable(value) -> boolean
+        The callable must accept a single argument which is
+        the metadata value on the trait and return true if the trait
+        is to be observed. For removing an existing observer, the ``value``
+        callables must compare equally. The callable must be hashable as well.
+    """
+
+    def __init__(self, metadata_name, value):
+        self.metadata_name = metadata_name
+        self.value = value
+
+    def __call__(self, name, trait):
+        # hasattr on an CTrait always return true, and the
+        # value would be None if it is not defined.
+        if self.metadata_name in trait.__dict__:
+            value = getattr(trait, self.metadata_name)
+            return self.value(value)
+        return False
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self.metadata_name == other.metadata_name
+            and self.value == other.value
+        )
+
+    def __hash__(self):
+        return hash((type(self).__name__, self.metadata_name, self.value))
+
+    def __repr__(self):
+        return "MetadataFilter(metadata_name={!r}, value={})".format(
+            self.metadata_name, self.value.__name__
+        )

--- a/traits/observers/_metadata_filter.py
+++ b/traits/observers/_metadata_filter.py
@@ -33,7 +33,7 @@ class MetadataFilter:
     def __call__(self, name, trait):
         # Consistent with the current behaviour where metadata with None as
         # the value is equivalent to the metadata not having been defined.
-        return getattr(trait, self.metadata_name, None) is not None
+        return getattr(trait, self.metadata_name) is not None
 
     def __eq__(self, other):
         return (

--- a/traits/observers/_metadata_filter.py
+++ b/traits/observers/_metadata_filter.py
@@ -43,6 +43,7 @@ class MetadataFilter:
         return hash((type(self).__name__, self.metadata_name))
 
     def __repr__(self):
-        return "MetadataFilter(metadata_name={!r})".format(
-            self.metadata_name
+        return (
+            "{self.__class__.__name__}"
+            "(metadata_name={self.metadata_name!r})".format(self=self)
         )

--- a/traits/observers/tests/test_metadata_filter.py
+++ b/traits/observers/tests/test_metadata_filter.py
@@ -42,10 +42,6 @@ class TestMetadataFilter(unittest.TestCase):
         metadata_filter = MetadataFilter(
             metadata_name="name",
         )
-        self.assertTrue(
-            metadata_filter("name", Int(name=True).as_ctrait()),
-            "Expected the filter to return true"
-        )
         self.assertFalse(
             metadata_filter("name", Int(name=None).as_ctrait()),
             "Expected the filter to return false"

--- a/traits/observers/tests/test_metadata_filter.py
+++ b/traits/observers/tests/test_metadata_filter.py
@@ -23,34 +23,14 @@ from traits.observers._testing import (
 class TestMetadataFilter(unittest.TestCase):
     """ Test the behaviour of the MetadataFilter """
 
-    def setUp(self):
-
-        def value_is_not_none(value):
-            return value is not None
-
-        self.value_is_not_none = value_is_not_none
-
-    def test_value_is_a_callable(self):
+    def test_metadata_defined_vs_undefined(self):
         metadata_filter = MetadataFilter(
             metadata_name="name",
-            value=self.value_is_not_none,
         )
         self.assertTrue(
             metadata_filter("name", Int(name=True).as_ctrait()),
             "Expected the filter to return true"
         )
-        self.assertFalse(
-            metadata_filter("name", Int(name=None).as_ctrait()),
-            "Expected the filter to return false"
-        )
-
-    def test_skip_undefined_metadata(self):
-        # Handle when a value is not defined.
-        metadata_filter = MetadataFilter(
-            metadata_name="name",
-            value=self.value_is_not_none,
-        )
-
         self.assertFalse(
             metadata_filter("name", Int().as_ctrait()),
             "Expected the filter to return false"
@@ -59,11 +39,9 @@ class TestMetadataFilter(unittest.TestCase):
     def test_filter_equality(self):
         filter1 = MetadataFilter(
             metadata_name="name",
-            value=self.value_is_not_none,
         )
         filter2 = MetadataFilter(
             metadata_name="name",
-            value=self.value_is_not_none,
         )
         self.assertEqual(filter1, filter2)
         self.assertEqual(hash(filter1), hash(filter2))
@@ -71,45 +49,28 @@ class TestMetadataFilter(unittest.TestCase):
     def test_filter_not_equal_name_different(self):
         filter1 = MetadataFilter(
             metadata_name="number",
-            value=self.value_is_not_none,
         )
         filter2 = MetadataFilter(
             metadata_name="name",
-            value=self.value_is_not_none,
-        )
-        self.assertNotEqual(filter1, filter2)
-
-    def test_filter_not_equal_value_different(self):
-        # the value filters do not compare equally
-        filter1 = MetadataFilter(
-            metadata_name="name",
-            value=lambda v: v is not None,
-        )
-        filter2 = MetadataFilter(
-            metadata_name="name",
-            value=lambda v: v is not None,
         )
         self.assertNotEqual(filter1, filter2)
 
     def test_filter_not_equal_different_type(self):
         filter1 = MetadataFilter(
             metadata_name="name",
-            value=self.value_is_not_none,
         )
         imposter = mock.Mock()
         imposter.metadata_name = "name"
-        imposter.value = self.value_is_not_none
         self.assertNotEqual(imposter, filter1)
 
     def test_repr_value(self):
         metadata_filter = MetadataFilter(
             metadata_name="name",
-            value=self.value_is_not_none,
         )
         actual = repr(metadata_filter)
         self.assertEqual(
             actual,
-            "MetadataFilter(metadata_name='name', value=value_is_not_none)"
+            "MetadataFilter(metadata_name='name')"
         )
 
 
@@ -119,14 +80,12 @@ class TestWithFilteredTraitObserver(unittest.TestCase):
     def test_filter_metadata(self):
 
         class Person(HasTraits):
-            age = Int(status="private")
             n_jobs = Int(status="public")
             n_children = Int()   # no metadata
 
         observer = FilteredTraitObserver(
             filter=MetadataFilter(
                 metadata_name="status",
-                value=lambda value: value == "public",
             ),
             notify=True,
         )
@@ -144,12 +103,6 @@ class TestWithFilteredTraitObserver(unittest.TestCase):
         # then
         self.assertEqual(handler.call_count, 1)
         handler.reset_mock()
-
-        # when
-        person.age += 1
-
-        # then
-        self.assertEqual(handler.call_count, 0)
 
         # when
         person.n_children += 1

--- a/traits/observers/tests/test_metadata_filter.py
+++ b/traits/observers/tests/test_metadata_filter.py
@@ -18,7 +18,6 @@ from traits.observers._testing import (
     call_add_or_remove_notifiers,
     create_graph,
 )
-from traits.trait_types import Int
 
 
 class TestMetadataFilter(unittest.TestCase):

--- a/traits/observers/tests/test_metadata_filter.py
+++ b/traits/observers/tests/test_metadata_filter.py
@@ -1,0 +1,159 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+from unittest import mock
+
+from traits.api import HasTraits, Int
+from traits.observers._filtered_trait_observer import FilteredTraitObserver
+from traits.observers._metadata_filter import MetadataFilter
+from traits.observers._testing import (
+    call_add_or_remove_notifiers,
+    create_graph,
+)
+from traits.trait_types import Int
+
+
+class TestMetadataFilter(unittest.TestCase):
+    """ Test the behaviour of the MetadataFilter """
+
+    def setUp(self):
+
+        def value_is_not_none(value):
+            return value is not None
+
+        self.value_is_not_none = value_is_not_none
+
+    def test_value_is_a_callable(self):
+        metadata_filter = MetadataFilter(
+            metadata_name="name",
+            value=self.value_is_not_none,
+        )
+        self.assertTrue(
+            metadata_filter("name", Int(name=True).as_ctrait()),
+            "Expected the filter to return true"
+        )
+        self.assertFalse(
+            metadata_filter("name", Int(name=None).as_ctrait()),
+            "Expected the filter to return false"
+        )
+
+    def test_skip_undefined_metadata(self):
+        # Handle when a value is not defined.
+        metadata_filter = MetadataFilter(
+            metadata_name="name",
+            value=self.value_is_not_none,
+        )
+
+        self.assertFalse(
+            metadata_filter("name", Int().as_ctrait()),
+            "Expected the filter to return false"
+        )
+
+    def test_filter_equality(self):
+        filter1 = MetadataFilter(
+            metadata_name="name",
+            value=self.value_is_not_none,
+        )
+        filter2 = MetadataFilter(
+            metadata_name="name",
+            value=self.value_is_not_none,
+        )
+        self.assertEqual(filter1, filter2)
+        self.assertEqual(hash(filter1), hash(filter2))
+
+    def test_filter_not_equal_name_different(self):
+        filter1 = MetadataFilter(
+            metadata_name="number",
+            value=self.value_is_not_none,
+        )
+        filter2 = MetadataFilter(
+            metadata_name="name",
+            value=self.value_is_not_none,
+        )
+        self.assertNotEqual(filter1, filter2)
+
+    def test_filter_not_equal_value_different(self):
+        # the value filters do not compare equally
+        filter1 = MetadataFilter(
+            metadata_name="name",
+            value=lambda v: v is not None,
+        )
+        filter2 = MetadataFilter(
+            metadata_name="name",
+            value=lambda v: v is not None,
+        )
+        self.assertNotEqual(filter1, filter2)
+
+    def test_filter_not_equal_different_type(self):
+        filter1 = MetadataFilter(
+            metadata_name="name",
+            value=self.value_is_not_none,
+        )
+        imposter = mock.Mock()
+        imposter.metadata_name = "name"
+        imposter.value = self.value_is_not_none
+        self.assertNotEqual(imposter, filter1)
+
+    def test_repr_value(self):
+        metadata_filter = MetadataFilter(
+            metadata_name="name",
+            value=self.value_is_not_none,
+        )
+        actual = repr(metadata_filter)
+        self.assertEqual(
+            actual,
+            "MetadataFilter(metadata_name='name', value=value_is_not_none)"
+        )
+
+
+class TestWithFilteredTraitObserver(unittest.TestCase):
+    """ Test MetadataFilter with FilteredTraitObserver and HasTraits. """
+
+    def test_filter_metadata(self):
+
+        class Person(HasTraits):
+            age = Int(status="private")
+            n_jobs = Int(status="public")
+            n_children = Int()   # no metadata
+
+        observer = FilteredTraitObserver(
+            filter=MetadataFilter(
+                metadata_name="status",
+                value=lambda value: value == "public",
+            ),
+            notify=True,
+        )
+        person = Person()
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=person,
+            graph=create_graph(observer),
+            handler=handler,
+        )
+
+        # when
+        person.n_jobs += 1
+
+        # then
+        self.assertEqual(handler.call_count, 1)
+        handler.reset_mock()
+
+        # when
+        person.age += 1
+
+        # then
+        self.assertEqual(handler.call_count, 0)
+
+        # when
+        person.n_children += 1
+
+        # then
+        self.assertEqual(handler.call_count, 0)

--- a/traits/observers/tests/test_metadata_filter.py
+++ b/traits/observers/tests/test_metadata_filter.py
@@ -36,6 +36,21 @@ class TestMetadataFilter(unittest.TestCase):
             "Expected the filter to return false"
         )
 
+    def test_metadata_defined_as_none_is_same_as_undefined(self):
+        # If a metadata has a None value, it is equivalent to the metadata
+        # not being defined.
+        metadata_filter = MetadataFilter(
+            metadata_name="name",
+        )
+        self.assertTrue(
+            metadata_filter("name", Int(name=True).as_ctrait()),
+            "Expected the filter to return true"
+        )
+        self.assertFalse(
+            metadata_filter("name", Int(name=None).as_ctrait()),
+            "Expected the filter to return false"
+        )
+
     def test_filter_equality(self):
         filter1 = MetadataFilter(
             metadata_name="name",


### PR DESCRIPTION
This PR targets this item in #977:

> Implement the logic for observing traits whose metadata fulfils a given criterion (depends on 12). This will support the metadata method in Expression, and the use of "+" in the text parser.

- Add `MetadataFilter` to be used as the `filter` callable in `FilteredTraitObserver`.   Users typically create these observers via text `"+metadata"`, and a new `filter` instance will be created.  The reason why we need a separate class for this filter is for supporting equality check on the filter when the user requests an existing observer to be removed. 
- See `TestWithFilteredTraitObserver` for how this is used with an instance of `HasTraits`.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
