### PR TITLE
Improve error message when representing incompatible value for Union

### DIFF
--- a/traits/tests/test_union.py
+++ b/traits/tests/test_union.py
@@ -28,6 +28,17 @@ class CustomStrType(TraitType):
 
 
 class TestCaseEnumTrait(unittest.TestCase):
+
+    def test_union_incompatible_trait(self):
+        with self.assertRaises(ValueError) as exception_context:
+            Union(Str(), "none")
+
+        self.assertEqual(
+            str(exception_context.exception),
+            "Union trait declaration expects a trait type or an instance of "
+            "trait type or None, but got 'none' instead"
+        )
+
     def test_list_trait_types(self):
         class TestClass(HasTraits):
             int_or_str_type = Union(Type, Int, Str)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3852,7 +3852,7 @@ class Union(TraitType):
             if ctrait_instance is None:
                 raise ValueError("Union trait declaration expects a trait "
                                  "type or an instance of trait type or None,"
-                                 " but got {} instead".format(trait))
+                                 " but got {!r} instead".format(trait))
 
             self.list_ctrait_instances.append(ctrait_instance)
 


### PR DESCRIPTION
If I try to create a trait type like this:
```
Union(Dict(), "none")
```
I get an error message:
```
Union trait declaration expects a trait type or an instance of trait type or None, but got none instead
```
This PR improves the error message so that it reads:
```
Union trait declaration expects a trait type or an instance of trait type or None, but got 'none' instead
```
which is much clearer about what went wrong.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
