### PR TITLE
Add trait_added support for FilteredTraitObserver

### DIFF
--- a/traits/observers/_filtered_trait_observer.py
+++ b/traits/observers/_filtered_trait_observer.py
@@ -14,7 +14,9 @@ from traits.observers._has_traits_helpers import (
 )
 from traits.observers._i_observer import IObserver
 from traits.observers._observer_change_notifier import ObserverChangeNotifier
+from traits.observers._observer_graph import ObserverGraph
 from traits.observers._trait_change_event import trait_event_factory
+from traits.observers._trait_added_observer import TraitAddedObserver
 from traits.observers._trait_event_notifier import TraitEventNotifier
 from traits.trait_base import Uninitialized
 
@@ -163,7 +165,10 @@ class FilteredTraitObserver:
         ------
         ObserverGraph
         """
-        # This will yield a new ObserverGraph with an observer specialized in
-        # observing trait_added event.
-        # enthought/traits#1077
-        yield from ()
+        yield ObserverGraph(
+            node=TraitAddedObserver(
+                match_func=self.filter,
+                optional=False,
+            ),
+            children=[graph],
+        )

--- a/traits/observers/tests/test_filtered_trait_observer.py
+++ b/traits/observers/tests/test_filtered_trait_observer.py
@@ -347,6 +347,8 @@ class TestFilteredTraitObserverTraitAdded(unittest.TestCase):
         # If the maintainer from TraitAddedObserver did not restrict its
         # action to just the added trait, when 'count' is added, the previously
         # added 'another_number' would have received a second notifier again.
+        # Then it would require two *remove* actions in order to clean up
+        # notifiers on 'another_number'.
         instance.add_trait("another_number", Int())
         instance.add_trait("count", Int())
 

--- a/traits/observers/tests/test_filtered_trait_observer.py
+++ b/traits/observers/tests/test_filtered_trait_observer.py
@@ -280,3 +280,86 @@ class TestFilteredTraitObserverNotifications(unittest.TestCase):
 
         # then
         self.assertEqual(observable.notifiers, [])
+
+
+class TestFilteredTraitObserverTraitAdded(unittest.TestCase):
+    """ Test support for HasTraits.add_trait ."""
+
+    def test_trait_added_filtered_matched(self):
+
+        instance = DummyParent()
+        integer_observer = create_observer(
+            filter=lambda name, trait: type(trait.trait_type) is Int,
+            notify=True,
+        )
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance,
+            graph=create_graph(integer_observer),
+            handler=handler,
+        )
+
+        # when
+        instance.add_trait("another_number", Int())
+        instance.another_number += 1
+
+        # then
+        self.assertEqual(handler.call_count, 1)
+
+    def test_trait_added_match_func_correct(self):
+        # Test the match function supplied to TraitAddedObserver is consistent
+        # with the filter.
+        instance = DummyParent()
+        integer_observer = create_observer(
+            filter=lambda name, trait: type(trait.trait_type) is Int,
+            notify=True,
+        )
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance,
+            graph=create_graph(integer_observer),
+            handler=handler,
+        )
+
+        # when
+        # This trait does not satisfy the filter
+        instance.add_trait("another_number", Float())
+        instance.another_number += 1
+
+        # then
+        self.assertEqual(handler.call_count, 0)
+
+    def test_trait_added_removed(self):
+
+        instance = Dummy()
+        integer_observer = create_observer(
+            filter=lambda name, trait: type(trait.trait_type) is Int,
+            notify=True,
+        )
+        handler = mock.Mock()
+        call_add_or_remove_notifiers(
+            object=instance,
+            graph=create_graph(integer_observer),
+            handler=handler,
+        )
+
+        # Add two traits.
+        # If the maintainer from TraitAddedObserver did not restrict its
+        # action to just the added trait, when 'count' is added, the previously
+        # added 'another_number' would have received a second notifier again.
+        instance.add_trait("another_number", Int())
+        instance.add_trait("count", Int())
+
+        # when
+        call_add_or_remove_notifiers(
+            object=instance,
+            graph=create_graph(integer_observer),
+            handler=handler,
+            remove=True,
+        )
+
+        # then
+        instance.another_number += 1
+        self.assertEqual(handler.call_count, 0)
+        instance.count += 1
+        self.assertEqual(handler.call_count, 0)


### PR DESCRIPTION
Part of #977

This PR adds `trait_added` support for the observer that observes traits using a generic filter (`FilteredTraitObserver`).

When a new trait is added via `HasTraits.add_trait`, provided that the `trait_added` event is fired, the new trait will be tested against the filter defined in `FilteredTraitObserver`, and if the trait is a match, notifiers will be attached to the new trait. 

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
