### PR TITLE
Rename the changed object as 'object' in all events

### DIFF
--- a/traits/observers/_dict_change_event.py
+++ b/traits/observers/_dict_change_event.py
@@ -21,9 +21,11 @@ class DictChangeEvent:
     "*name* _items" trait. In particular, the attribute ``changed`` is not
     defined here.
 
+    The interface of this object is provisional as of version 6.1.
+
     Attributes
     ----------
-    trait_dict : traits.trait_dict_object.TraitDict
+    object : traits.trait_dict_object.TraitDict
         The dict being mutated.
     removed : dict
         Keys and values for removed or updated items.
@@ -35,15 +37,15 @@ class DictChangeEvent:
         and the values are new.
     """
 
-    def __init__(self, *, trait_dict, removed, added):
-        self.trait_dict = trait_dict
+    def __init__(self, *, object, removed, added):
+        self.object = object
         self.removed = removed
         self.added = added
 
     def __repr__(self):
         return (
             "{event.__class__.__name__}("
-            "trait_dict={event.trait_dict!r}, "
+            "object={event.object!r}, "
             "removed={event.removed!r}, "
             "added={event.added!r}"
             ")".format(event=self)
@@ -75,5 +77,5 @@ def dict_event_factory(trait_dict, removed, added, changed):
     for key in changed:
         added[key] = trait_dict[key]
     return DictChangeEvent(
-        trait_dict=trait_dict, added=added, removed=removed,
+        object=trait_dict, added=added, removed=removed,
     )

--- a/traits/observers/_list_change_event.py
+++ b/traits/observers/_list_change_event.py
@@ -17,9 +17,11 @@
 class ListChangeEvent:
     """ Event object to represent mutations to a list.
 
+    The interface of this object is provisional as of version 6.1.
+
     Attributes
     ----------
-    trait_list : traits.trait_list_object.TraitList
+    object : traits.trait_list_object.TraitList
         The list being mutated.
     index : int or slice
         The index used for the mutation.
@@ -29,8 +31,8 @@ class ListChangeEvent:
         Values removed from the list.
     """
 
-    def __init__(self, *, trait_list, index, removed, added):
-        self.trait_list = trait_list
+    def __init__(self, *, object, index, removed, added):
+        self.object = object
         self.added = added
         self.removed = removed
         self.index = index
@@ -38,7 +40,7 @@ class ListChangeEvent:
     def __repr__(self):
         return (
             "{event.__class__.__name__}("
-            "trait_list={event.trait_list!r}, "
+            "object={event.object!r}, "
             "index={event.index!r}, "
             "removed={event.removed!r}, "
             "added={event.added!r}"
@@ -65,5 +67,5 @@ def list_event_factory(trait_list, index, removed, added):
     ListChangeEvent
     """
     return ListChangeEvent(
-        trait_list=trait_list, index=index, removed=removed, added=added,
+        object=trait_list, index=index, removed=removed, added=added,
     )

--- a/traits/observers/_set_change_event.py
+++ b/traits/observers/_set_change_event.py
@@ -15,9 +15,11 @@
 class SetChangeEvent:
     """ Event object to represent mutations on a set.
 
+    The interface of this object is provisional as of version 6.1.
+
     Attributes
     ----------
-    trait_set : traits.trait_set_object.TraitSet
+    object : traits.trait_set_object.TraitSet
         The set being mutated.
     removed : set
         Values removed from the set.
@@ -25,15 +27,15 @@ class SetChangeEvent:
         Values added to the set.
     """
 
-    def __init__(self, *, trait_set, removed, added):
-        self.trait_set = trait_set
+    def __init__(self, *, object, removed, added):
+        self.object = object
         self.removed = removed
         self.added = added
 
     def __repr__(self):
         return (
             "{event.__class__.__name__}("
-            "trait_set={event.trait_set!r}, "
+            "object={event.object!r}, "
             "removed={event.removed!r}, "
             "added={event.added!r}"
             ")".format(event=self)
@@ -57,5 +59,5 @@ def set_event_factory(trait_set, removed, added):
     SetChangeEvent
     """
     return SetChangeEvent(
-        trait_set=trait_set, added=added, removed=removed,
+        object=trait_set, added=added, removed=removed,
     )

--- a/traits/observers/_trait_change_event.py
+++ b/traits/observers/_trait_change_event.py
@@ -17,6 +17,8 @@
 class TraitChangeEvent:
     """ Emitted when a trait on a HasTraits object is changed.
 
+    The interface of this object is provisional as of version 6.1.
+
     Attributes
     ----------
     object : HasTraits

--- a/traits/observers/tests/test_dict_change_event.py
+++ b/traits/observers/tests/test_dict_change_event.py
@@ -21,14 +21,14 @@ class TestDictChangeEvent(unittest.TestCase):
 
     def test_dict_change_event_repr(self):
         event = DictChangeEvent(
-            trait_dict=dict(),
+            object=dict(),
             added={1: 1},
             removed={"2": 2},
         )
         actual = repr(event)
         self.assertEqual(
             actual,
-            "DictChangeEvent(trait_dict={}, removed={'2': 2}, added={1: 1})"
+            "DictChangeEvent(object={}, removed={'2': 2}, added={1: 1})"
         )
 
 
@@ -53,6 +53,7 @@ class TestDictEventFactory(unittest.TestCase):
 
         # then
         event, = events
+        self.assertIs(event.object, trait_dict)
         self.assertEqual(event.removed, {"4": 4})
 
         # when

--- a/traits/observers/tests/test_list_change_event.py
+++ b/traits/observers/tests/test_list_change_event.py
@@ -21,7 +21,7 @@ class TestListChangeEvent(unittest.TestCase):
 
     def test_list_change_event_repr(self):
         event = ListChangeEvent(
-            trait_list=[],
+            object=[],
             index=3,
             removed=[1, 2],
             added=[3, 4],
@@ -30,7 +30,7 @@ class TestListChangeEvent(unittest.TestCase):
         self.assertEqual(
             actual,
             "ListChangeEvent("
-            "trait_list=[], index=3, removed=[1, 2], added=[3, 4])"
+            "object=[], index=3, removed=[1, 2], added=[3, 4])"
         )
 
 
@@ -56,7 +56,7 @@ class TestListEventFactory(unittest.TestCase):
         # then
         event, = events
         self.assertIsInstance(event, ListChangeEvent)
-        self.assertIs(event.trait_list, trait_list)
+        self.assertIs(event.object, trait_list)
         self.assertEqual(event.index, 1)
         self.assertEqual(event.removed, [1, 2])
         self.assertEqual(event.added, [3, 4])

--- a/traits/observers/tests/test_list_item_observer.py
+++ b/traits/observers/tests/test_list_item_observer.py
@@ -218,7 +218,7 @@ class TestListTraitObserverNotifications(unittest.TestCase):
 
         # then
         ((event, ), _), = handler.call_args_list
-        self.assertEqual(event.trait_list, [1])
+        self.assertIs(event.object, instance.values)
         self.assertEqual(event.added, [1])
         self.assertEqual(event.removed, [])
         self.assertEqual(event.index, 0)
@@ -243,7 +243,7 @@ class TestListTraitObserverNotifications(unittest.TestCase):
 
         # then
         ((event, ), _), = handler.call_args_list
-        self.assertEqual(event.trait_list, [1])
+        self.assertIs(event.object, instance.custom_trait_list)
         self.assertEqual(event.added, [1])
         self.assertEqual(event.removed, [])
         self.assertEqual(event.index, 0)
@@ -280,7 +280,7 @@ class TestListTraitObserverNotifications(unittest.TestCase):
 
         # then
         ((event, ), _), = handler.call_args_list
-        self.assertEqual(event.trait_list, [1])
+        self.assertEqual(event.object, [1])
         self.assertEqual(event.added, [1])
         self.assertEqual(event.removed, [])
         self.assertEqual(event.index, 0)

--- a/traits/observers/tests/test_list_item_observer.py
+++ b/traits/observers/tests/test_list_item_observer.py
@@ -280,7 +280,7 @@ class TestListTraitObserverNotifications(unittest.TestCase):
 
         # then
         ((event, ), _), = handler.call_args_list
-        self.assertEqual(event.object, [1])
+        self.assertEqual(event.object, nested_list)
         self.assertEqual(event.added, [1])
         self.assertEqual(event.removed, [])
         self.assertEqual(event.index, 0)

--- a/traits/observers/tests/test_list_item_observer.py
+++ b/traits/observers/tests/test_list_item_observer.py
@@ -280,7 +280,7 @@ class TestListTraitObserverNotifications(unittest.TestCase):
 
         # then
         ((event, ), _), = handler.call_args_list
-        self.assertEqual(event.object, nested_list)
+        self.assertIs(event.object, nested_list)
         self.assertEqual(event.added, [1])
         self.assertEqual(event.removed, [])
         self.assertEqual(event.index, 0)

--- a/traits/observers/tests/test_set_change_event.py
+++ b/traits/observers/tests/test_set_change_event.py
@@ -21,14 +21,14 @@ class TestSetChangeEvent(unittest.TestCase):
 
     def test_set_change_event_repr(self):
         event = SetChangeEvent(
-            trait_set=set(),
+            object=set(),
             added={1},
             removed={3},
         )
         actual = repr(event)
         self.assertEqual(
             actual,
-            "SetChangeEvent(trait_set=set(), removed={3}, added={1})",
+            "SetChangeEvent(object=set(), removed={3}, added={1})",
         )
 
 
@@ -53,6 +53,7 @@ class TestSetEventFactory(unittest.TestCase):
 
         # then
         event, = events
+        self.assertIs(event.object, trait_set)
         self.assertEqual(event.added, {4})
         self.assertEqual(event.removed, set())
 


### PR DESCRIPTION
Closes #1084

This PR makes `object` exist in all 4 event objects in observe. 

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`): updated docstring
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
