### PR TITLE
Expose expressions for observing traits with filters

### DIFF
--- a/traits/observers/api.py
+++ b/traits/observers/api.py
@@ -11,6 +11,8 @@
 from traits.observers.expression import (   # noqa: F401
     dict_items,
     list_items,
+    match,
+    metadata,
     set_items,
     trait,
 )

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -100,14 +100,18 @@ class Expression:
 
         Parameters
         ----------
-        filter : callable(str, CTrait) -> boolean
+        filter : callable(str, CTrait) -> bool
             A callable that receives the name of a trait and the corresponding
-            trait definition. The returned boolean indicates whether the trait
+            trait definition. The returned bool indicates whether the trait
             is observed. In order to remove an existing observer with the
             equivalent filter, the filter callables must compare equally. The
             callable must also be hashable.
-        notify : boolean, optional
-            Whether to notify for changes.
+        notify : bool, optional
+            Whether to notify for changes. Default is to notify.
+
+        Returns
+        -------
+        new_expression : traits.observers.expression.Expression
         """
         return self.then(match(filter=filter, notify=notify))
 
@@ -125,8 +129,12 @@ class Expression:
         ----------
         metadata_name : str
             Name of the metadata to filter traits with.
-        notify : boolean, optional
-            Whether to notify for changes.
+        notify : bool, optional
+            Whether to notify for changes. Default is to notify.
+
+        Returns
+        -------
+        new_expression : traits.observers.expression.Expression
         """
         return self.match(
             filter=_MetadataFilter(metadata_name=metadata_name),
@@ -400,14 +408,18 @@ def match(filter, notify=True):
 
     Parameters
     ----------
-    filter : callable(str, CTrait) -> boolean
+    filter : callable(str, CTrait) -> bool
         A callable that receives the name of a trait and the corresponding
-        trait definition. The returned boolean indicates whether the trait is
+        trait definition. The returned bool indicates whether the trait is
         observed. In order to remove an existing observer with the equivalent
         filter, the filter callables must compare equally. The callable must
         also be hashable.
-    notify : boolean, optional
+    notify : bool, optional
         Whether to notify for changes.
+
+    Returns
+    -------
+    new_expression : traits.observers.expression.Expression
     """
     observer = _FilteredTraitObserver(notify=notify, filter=filter)
     return SingleObserverExpression(observer)
@@ -427,8 +439,12 @@ def metadata(metadata_name, notify=True):
     ----------
     metadata_name : str
         Name of the metadata to filter traits with.
-    notify : boolean, optional
-        Whether to notify for changes.
+    notify : bool, optional
+        Whether to notify for changes. Default is to notify.
+
+    Returns
+    -------
+    new_expression : traits.observers.expression.Expression
     """
     return match(
         filter=_MetadataFilter(metadata_name=metadata_name),
@@ -471,7 +487,7 @@ def trait(name, notify=True, optional=False):
     name : str
         Name of the trait to match.
     notify : bool, optional
-        Whether to notify for changes.
+        Whether to notify for changes. Default is to notify.
     optional : bool, optional
         If true, skip this observer if the requested trait is not found.
         Default is false, and an error will be raised if the requested

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -96,7 +96,7 @@ class Expression:
         given filter.
 
         Events emitted (if any) will be instances of
-        :py:class:`~traits.observers.events.TraitChangeEvent`.
+        :class:`~traits.observers.events.TraitChangeEvent`.
 
         Parameters
         ----------
@@ -120,7 +120,7 @@ class Expression:
         metadata is not None.
 
         Events emitted (if any) will be instances of
-        :py:class:`~traits.observers.events.TraitChangeEvent`.
+        :class:`~traits.observers.events.TraitChangeEvent`.
 
         e.g. ``metadata("age")`` matches traits whose 'age' attribute has a
         non-None value.
@@ -404,7 +404,7 @@ def match(filter, notify=True):
     given filter.
 
     Events emitted (if any) will be instances of
-    :py:class:`~traits.observers.events.TraitChangeEvent`.
+    :class:`~traits.observers.events.TraitChangeEvent`.
 
     Parameters
     ----------
@@ -430,7 +430,7 @@ def metadata(metadata_name, notify=True):
     is not None.
 
     Events emitted (if any) will be instances of
-    :py:class:`~traits.observers.events.TraitChangeEvent`.
+    :class:`~traits.observers.events.TraitChangeEvent`.
 
     e.g. ``metadata("age")`` matches traits whose 'age' attribute has a
     non-None value.

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -13,6 +13,9 @@ import functools as _functools
 from traits.observers._filtered_trait_observer import (
     FilteredTraitObserver as _FilteredTraitObserver,
 )
+from traits.observers._metadata_filter import (
+    MetadataFilter as _MetadataFilter,
+)
 from traits.observers._named_trait_observer import (
     NamedTraitObserver as _NamedTraitObserver,
 )
@@ -99,9 +102,35 @@ class Expression:
 
         Returns
         -------
-        new_expression : traits.observers.expressions.Expression
+        new_expression : traits.observers.expression.Expression
         """
         return self.then(match(filter=filter, notify=notify))
+
+    def metadata(self, metadata_name, notify=True):
+        """ Return a new expression for observing traits where the given
+        metadata is not None.
+
+        Events emitted (if any) will be instances of
+        :py:class:`~traits.observers.events.TraitChangeEvent`.
+
+        e.g. ``metadata("age")`` matches traits whose 'age' attribute has a
+        non-None value.
+
+        Parameters
+        ----------
+        metadata_name : str
+            Name of the metadata to filter traits with.
+        notify : boolean, optional
+            Whether to notify for changes.
+
+        Returns
+        -------
+        new_expression : traits.observers.expression.Expression
+        """
+        return self.match(
+            filter=_MetadataFilter(metadata_name=metadata_name),
+            notify=notify,
+        )
 
     def trait(self, name, notify=True, optional=False):
         """ Create a new expression for observing a trait with the exact
@@ -243,10 +272,37 @@ def match(filter, notify=True):
 
     Returns
     -------
-    new_expression : traits.observers.expressions.Expression
+    new_expression : traits.observers.expression.Expression
     """
     observer = _FilteredTraitObserver(notify=notify, filter=filter)
     return SingleObserverExpression(observer)
+
+
+def metadata(metadata_name, notify=True):
+    """ Return a new expression for observing traits where the given metadata
+    is not None.
+
+    Events emitted (if any) will be instances of
+    :py:class:`~traits.observers.events.TraitChangeEvent`.
+
+    e.g. ``metadata("age")`` matches traits whose 'age' attribute has a
+    non-None value.
+
+    Parameters
+    ----------
+    metadata_name : str
+        Name of the metadata to filter traits with.
+    notify : boolean, optional
+        Whether to notify for changes.
+
+    Returns
+    -------
+    new_expression : traits.observers.expression.Expression
+    """
+    return match(
+        filter=_MetadataFilter(metadata_name=metadata_name),
+        notify=notify,
+    )
 
 
 def trait(name, notify=True, optional=False):

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -10,6 +10,9 @@
 
 import functools as _functools
 
+from traits.observers._filtered_trait_observer import (
+    FilteredTraitObserver as _FilteredTraitObserver,
+)
 from traits.observers._named_trait_observer import (
     NamedTraitObserver as _NamedTraitObserver,
 )
@@ -75,6 +78,30 @@ class Expression:
         new_expression : traits.observers.expression.Expression
         """
         return SeriesExpression(self, expression)
+
+    def match(self, filter, notify=True):
+        """ Create a new expression for observing traits using the
+        given filter.
+
+        Events emitted (if any) will be instances of
+        :py:class:`~traits.observers.events.TraitChangeEvent`.
+
+        Parameters
+        ----------
+        filter : callable(str, CTrait) -> boolean
+            A callable that receives the name of a trait and the corresponding
+            trait definition. The returned boolean indicates whether the trait
+            is observed. In order to remove an existing observer with the
+            equivalent filter, the filter callables must compare equally. The
+            callable must also be hashable.
+        notify : boolean, optional
+            Whether to notify for changes.
+
+        Returns
+        -------
+        new_expression : traits.observers.expressions.Expression
+        """
+        return self.then(match(filter=filter, notify=notify))
 
     def trait(self, name, notify=True, optional=False):
         """ Create a new expression for observing a trait with the exact
@@ -194,6 +221,32 @@ def join_(*expressions):
         Joined expression.
     """
     return _functools.reduce(lambda e1, e2: e1.then(e2), expressions)
+
+
+def match(filter, notify=True):
+    """ Create a new expression for observing traits using the
+    given filter.
+
+    Events emitted (if any) will be instances of
+    :py:class:`~traits.observers.events.TraitChangeEvent`.
+
+    Parameters
+    ----------
+    filter : callable(str, CTrait) -> boolean
+        A callable that receives the name of a trait and the corresponding
+        trait definition. The returned boolean indicates whether the trait is
+        observed. In order to remove an existing observer with the equivalent
+        filter, the filter callables must compare equally. The callable must
+        also be hashable.
+    notify : boolean, optional
+        Whether to notify for changes.
+
+    Returns
+    -------
+    new_expression : traits.observers.expressions.Expression
+    """
+    observer = _FilteredTraitObserver(notify=notify, filter=filter)
+    return SingleObserverExpression(observer)
 
 
 def trait(name, notify=True, optional=False):

--- a/traits/observers/parsing.py
+++ b/traits/observers/parsing.py
@@ -183,7 +183,10 @@ def _handle_metadata(trees, default_notifies):
     -------
     expression : traits.observers.expression.Expression
     """
-    raise NotImplementedError("metadata is not yet implemented.")
+    token, = trees
+    metadata_name = token.value
+    notify = default_notifies[-1]
+    return _expr_module.metadata(metadata_name, notify=notify)
 
 
 def _handle_items(trees, default_notifies):

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -13,6 +13,7 @@ import unittest
 
 from traits.observers import expression
 from traits.observers._filtered_trait_observer import FilteredTraitObserver
+from traits.observers._metadata_filter import MetadataFilter
 from traits.observers._named_trait_observer import NamedTraitObserver
 from traits.observers._observer_graph import ObserverGraph
 
@@ -244,6 +245,83 @@ class TestExpressionFilter(unittest.TestCase):
         # Remove this if the two need to divert in the future.
         top_level = expression.match
         method = expression.Expression().match
+        self.assertEqual(
+            inspect.signature(top_level), inspect.signature(method)
+        )
+
+
+class TestExpressionFilterMetadata(unittest.TestCase):
+    """ Test Expression.metadata """
+
+    def test_metadata_notify_true(self):
+        # Test the top-level function
+        expr = expression.metadata("butterfly")
+        expected = [
+            create_graph(
+                FilteredTraitObserver(
+                    filter=MetadataFilter(metadata_name="butterfly"),
+                    notify=True,
+                ),
+            ),
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+    def test_metadata_notify_false(self):
+        # Test the top-level function
+        expr = expression.metadata("butterfly", notify=False)
+        expected = [
+            create_graph(
+                FilteredTraitObserver(
+                    filter=MetadataFilter(metadata_name="butterfly"),
+                    notify=False,
+                ),
+            ),
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+    def test_metadata_method_notify_true(self):
+        # Test the instance method calls the top-level function correctly.
+        expr = expression.metadata("bee").metadata("ant")
+        expected = [
+            create_graph(
+                FilteredTraitObserver(
+                    filter=MetadataFilter(metadata_name="bee"),
+                    notify=True,
+                ),
+                FilteredTraitObserver(
+                    filter=MetadataFilter(metadata_name="ant"),
+                    notify=True,
+                ),
+            ),
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+    def test_metadata_method_notify_false(self):
+        # Test the instance method calls the top-level function correctly.
+        expr = expression.metadata("bee").metadata("ant", notify=False)
+        expected = [
+            create_graph(
+                FilteredTraitObserver(
+                    filter=MetadataFilter(metadata_name="bee"),
+                    notify=True,
+                ),
+                FilteredTraitObserver(
+                    filter=MetadataFilter(metadata_name="ant"),
+                    notify=False,
+                ),
+            ),
+        ]
+        actual = expr._as_graphs()
+        self.assertEqual(actual, expected)
+
+    def test_call_signatures(self):
+        # Test to help developers keeping the two function signatures in-sync.
+        # Remove this if the two need to divert in the future.
+        top_level = expression.metadata
+        method = expression.Expression().metadata
         self.assertEqual(
             inspect.signature(top_level), inspect.signature(method)
         )

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -189,7 +189,7 @@ class TestExpressionFilter(unittest.TestCase):
 
         self.anytrait = anytrait
 
-    def test_matchnotify_true(self):
+    def test_match_notify_true(self):
         # Test the top-level function
         expr = expression.match(filter=self.anytrait)
         expected = [
@@ -200,7 +200,7 @@ class TestExpressionFilter(unittest.TestCase):
         actual = expr._as_graphs()
         self.assertEqual(actual, expected)
 
-    def test_matchnotify_false(self):
+    def test_match_notify_false(self):
         # Test the top-level function
         expr = expression.match(filter=self.anytrait, notify=False)
         expected = [
@@ -211,7 +211,7 @@ class TestExpressionFilter(unittest.TestCase):
         actual = expr._as_graphs()
         self.assertEqual(actual, expected)
 
-    def test_matchmethod_notify_true(self):
+    def test_match_method_notify_true(self):
         # Test the instance method calls the top-level function correctly.
         expr = expression.match(filter=self.anytrait).match(
             filter=self.anytrait
@@ -225,7 +225,7 @@ class TestExpressionFilter(unittest.TestCase):
         actual = expr._as_graphs()
         self.assertEqual(actual, expected)
 
-    def test_matchmethod_notify_false(self):
+    def test_match_method_notify_false(self):
         # Test the instance method calls the top-level function correctly.
         expr = expression.match(filter=self.anytrait).match(
             filter=self.anytrait, notify=False,

--- a/traits/observers/tests/test_parsing.py
+++ b/traits/observers/tests/test_parsing.py
@@ -12,6 +12,7 @@ import unittest
 
 from traits.observers.parsing import parse
 from traits.observers.expression import (
+    metadata,
     trait,
 )
 
@@ -69,6 +70,19 @@ class TestParsingGroup(unittest.TestCase):
                 | trait("value", False)
             ).trait("g")
         )
+        self.assertEqual(actual, expected)
+
+
+class TestParsingMetadata(unittest.TestCase):
+
+    def test_metadata(self):
+        actual = parse("+name")
+        expected = metadata("name", notify=True)
+        self.assertEqual(actual, expected)
+
+    def test_metadata_notify_false(self):
+        actual = parse("+name:+attr")
+        expected = metadata("name", notify=False).metadata("attr", notify=True)
         self.assertEqual(actual, expected)
 
 


### PR DESCRIPTION
Part of #977

This PR:
- Add `metadata` in the expression for observing traits with a given metadata name
- Implement the parsing of `"+metadata_name"` in the mini-language
- Add `match` in the expression for wrapping the FilteredTraitObserver, useful for use cases not supported by the other expressions.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`): autodoc handles that
- Update User manual (`docs/source/traits_user_manual`): Will be in a separate PR
- ~Update type annotation hints in `traits-stubs`~
