### PR TITLE
Fix Union to use default_value for setting static default

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -655,9 +655,6 @@ Note that static default values are defined on Union via the
 **default_value** attribute, whereas Either uses the **default** attribute.
 The naming of **default_value** is consistent with other trait types.
 
-If a default value is not defined on Union, the default value from the
-first trait type will be used.
-
 .. index:: multiple values, defining trait with
 
 .. _list-of-possibl-values:

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -651,6 +651,12 @@ The following example illustrates the difference between `Either` and `Union`::
     ...     primes = Union([2], None, {'3':6}, 5, 7, 11)
     ValueError: Union trait declaration expects a trait type or an instance of trait type or None, but got [2] instead
 
+Note that static default values are defined on Union via the
+**default_value** attribute, whereas Either uses the **default** attribute.
+The naming of **default_value** is consistent with other trait types.
+
+If a default value is not defined on Union, the default value from the
+first trait type will be used.
 
 .. index:: multiple values, defining trait with
 

--- a/traits/tests/test_none.py
+++ b/traits/tests/test_none.py
@@ -15,7 +15,7 @@ from traits.trait_types import _NoneTrait
 
 
 class A(HasTraits):
-    none_atr = _NoneTrait(default=None)
+    none_atr = _NoneTrait(default_value=None)
 
 
 class TestCaseNoneTrait(unittest.TestCase):
@@ -30,7 +30,7 @@ class TestCaseNoneTrait(unittest.TestCase):
     def test_default_value_not_none(self):
         with self.assertRaises(ValueError):
             class TestClass(HasTraits):
-                none_trait = _NoneTrait(default=[])
+                none_trait = _NoneTrait(default_value=[])
 
 
 if __name__ == '__main__':

--- a/traits/tests/test_union.py
+++ b/traits/tests/test_union.py
@@ -96,7 +96,10 @@ class TestCaseEnumTrait(unittest.TestCase):
         self.assertEqual(TestClass().atr, 3)
 
         class TestClass(HasTraits):
-            atr = Union(Int(3), Float(4.1), Str("Something"), default="XYZ")
+            atr = Union(
+                Int(3), Float(4.1), Str("Something"),
+                default_value="XYZ",
+            )
 
         self.assertEqual(TestClass().atr, "XYZ")
 
@@ -109,6 +112,20 @@ class TestCaseEnumTrait(unittest.TestCase):
             atr = Union(None)
 
         self.assertEqual(TestClass().atr, None)
+
+    def test_default_raise_error(self):
+        # If 'default' is defined, it could be caused by migration from
+        # ``Either``. Raise an error to aid migrations from ``Either``
+        # to ``Union``
+
+        with self.assertRaises(ValueError) as exception_context:
+            Union(Int(), Float(), default=1.0)
+
+        self.assertEqual(
+            str(exception_context.exception),
+            "Union default value should be set via 'default_value', not "
+            "'default'."
+        )
 
     def test_inner_traits(self):
         class TestClass(HasTraits):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3823,7 +3823,7 @@ class _NoneTrait(TraitType):
     default_value_type = DefaultValue.constant
 
     def __init__(self, **metadata):
-        default_value = metadata.pop("default", None)
+        default_value = metadata.pop("default_value", None)
         if default_value is not None:
             raise ValueError("Cannot set default value {} "
                              "for _NoneTrait".format(default_value))
@@ -3858,9 +3858,17 @@ class Union(TraitType):
 
             self.list_ctrait_instances.append(ctrait_instance)
 
+        # ``Either`` uses 'default' for defining static default values.
+        # Raise if 'default' is found in order to help code migrate to Union
+        if "default" in metadata:
+            raise ValueError(
+                "Union default value should be set via 'default_value', not "
+                "'default'."
+            )
+
         default_value = None
-        if 'default' in metadata:
-            default_value = metadata.pop("default")
+        if 'default_value' in metadata:
+            default_value = metadata.pop("default_value")
         elif self.list_ctrait_instances:
             default_value = self.list_ctrait_instances[0].default
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3839,6 +3839,9 @@ class _NoneTrait(TraitType):
 class Union(TraitType):
     """ Defines a trait whose value can be any of of a specified list of
     trait types or list of trait type instances or None
+
+    If the default value is not defined on Union, the default value from the
+    first trait will be used.
     """
 
     def __init__(self, *traits, **metadata):


### PR DESCRIPTION
Closes #1104 

This PR makes `Union` use `default_value` instead of `default` for defining static default. This name is consistent with other trait types.

Unfortunately `Either` uses `default` instead and is an anomaly. In order to help downstream code migrates, an error is raised if a metadata named `'default'` is found.

Expanded user manual to mention the different naming used for static defaults in `Either` and `Union`. 

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~: default_value is not mentioned there
