### PR TITLE
Add warning while observing container items with comparison mode set to equality

### DIFF
--- a/traits/observers/_has_traits_helpers.py
+++ b/traits/observers/_has_traits_helpers.py
@@ -11,10 +11,14 @@
 """ Module for HasTraits and CTrait specific utility functions for observers.
 """
 
+import warnings
+
+from traits.constants import ComparisonMode
 from traits.ctraits import CHasTraits
-from traits.trait_base import Undefined, Uninitialized
 from traits.observers._exceptions import NotifierNotFound
 from traits.observers._observe import add_or_remove_notifiers
+from traits.trait_base import Undefined, Uninitialized
+from traits.trait_types import Dict, List, Set
 
 
 #: List of values not to be passed onto the next observers because they are
@@ -25,6 +29,51 @@ UNOBSERVABLE_VALUES = [
     Uninitialized,
     None,
 ]
+
+
+def warn_comparison_mode(object, name):
+    """ Check if the trait is a Dict/List/Set with comparison_mode set to
+    equality (or higher). If so, warn about the fact that observers will be
+    lost in the event of reassignment.
+
+    Parameters
+    ----------
+    object : HasTraits
+        Object where a trait is defined
+    name : str
+        Name of a trait to check if warning needs to be issued for it.
+    """
+    ctrait = object.traits()[name]
+
+    def has_container_trait(ctrait):
+        # Return true if the CTrait trait type contains container trait
+        # at the top-level. Also handle Union
+        container_types = (Dict, List, Set)
+        if not isinstance(ctrait.trait_type, container_types):
+            return any(
+                isinstance(trait.trait_type, container_types)
+                for trait in ctrait.inner_traits
+            )
+        return isinstance(ctrait.trait_type, container_types)
+
+    if (not ctrait.is_property
+            and has_container_trait(ctrait)
+            and ctrait.comparison_mode > ComparisonMode.identity):
+        warnings.warn(
+            "Trait {name!r} (trait type: {trait_type}) on class {class_name} "
+            "is defined with comparison_mode={current_mode!r}. "
+            "Mutations and extended traits cannot be observed if a new "
+            "container compared equally to the old one is set. Redefine the "
+            "trait with {trait_type}(..., comparison_mode={new_mode!r}) "
+            "to avoid this.".format(
+                name=name,
+                class_name=object.__class__.__name__,
+                current_mode=ctrait.comparison_mode,
+                trait_type=ctrait.trait_type.__class__.__name__,
+                new_mode=ComparisonMode.identity,
+            ),
+            RuntimeWarning,
+        )
 
 
 def object_has_named_trait(object, name):
@@ -66,6 +115,7 @@ def iter_objects(object, name):
         The value of the trait, if it is defined and is not one of those
         skipped values.
     """
+    warn_comparison_mode(object, name)
     value = object.__dict__.get(name, Undefined)
     if value not in UNOBSERVABLE_VALUES:
         yield value

--- a/traits/observers/_has_traits_helpers.py
+++ b/traits/observers/_has_traits_helpers.py
@@ -47,14 +47,16 @@ def warn_comparison_mode(object, name):
 
     def has_container_trait(ctrait):
         # Return true if the CTrait trait type contains container trait
-        # at the top-level. Also handle Union
+        # at the top-level.
         container_types = (Dict, List, Set)
-        if not isinstance(ctrait.trait_type, container_types):
-            return any(
-                isinstance(trait.trait_type, container_types)
-                for trait in ctrait.inner_traits
-            )
-        return isinstance(ctrait.trait_type, container_types)
+        is_container = ctrait.is_trait_type(container_types)
+        if is_container:
+            return True
+        # Try inner traits, e.g. to support Union
+        return any(
+            trait.is_trait_type(container_types)
+            for trait in ctrait.inner_traits
+        )
 
     if (not ctrait.is_property
             and has_container_trait(ctrait)

--- a/traits/observers/_has_traits_helpers.py
+++ b/traits/observers/_has_traits_helpers.py
@@ -60,7 +60,7 @@ def warn_comparison_mode(object, name):
 
     if (not ctrait.is_property
             and has_container_trait(ctrait)
-            and ctrait.comparison_mode > ComparisonMode.identity):
+            and ctrait.comparison_mode == ComparisonMode.equality):
         warnings.warn(
             "Trait {name!r} (trait type: {trait_type}) on class {class_name} "
             "is defined with comparison_mode={current_mode!r}. "

--- a/traits/observers/tests/test_has_traits_helpers.py
+++ b/traits/observers/tests/test_has_traits_helpers.py
@@ -138,10 +138,8 @@ class TestHasTraitsHelpersIterObjects(unittest.TestCase):
 
 
 class ObjectWithEqualityComparisonMode(HasTraits):
+    """ Class for supporting TestHasTraitsHelpersWarning """
 
-    # If the comparison mode is equality, downstream observers cannot be
-    # maintained . A warning should be emitted if an observer is attached
-    # for obeserving mutations to containers.
     list_values = List(comparison_mode=2)
     dict_values = Dict(comparison_mode=2)
     set_values = Set(comparison_mode=2)

--- a/traits/observers/tests/test_has_traits_helpers.py
+++ b/traits/observers/tests/test_has_traits_helpers.py
@@ -180,9 +180,8 @@ class TestHasTraitsHelpersWarning(unittest.TestCase):
                 )
 
     def test_union_equality_comparison_mode_prevent_change_event(self):
-        # Justification for the warning: If the comparison mode is equality,
-        # one cannot observe mutations after reassigning an equal but new
-        # object.
+        # Justification for the warning: Reassess if the warning is still
+        # needed if this test fails.
         instance = ObjectWithEqualityComparisonMode()
         instance.container_in_union = {1}
         handler = mock.Mock()
@@ -207,9 +206,8 @@ class TestHasTraitsHelpersWarning(unittest.TestCase):
         self.assertEqual(handler.call_count, 0)
 
     def test_list_equality_comparison_mode_prevent_change_event(self):
-        # Justification for the warning: If the comparison mode is equality,
-        # one cannot observe mutations after reassigning an equal but new list
-        # object.
+        # Justification for the warning: Reassess if the warning is still
+        # needed if this test fails.
         instance = ObjectWithEqualityComparisonMode()
         instance.list_values = [1]
         handler = mock.Mock()
@@ -234,9 +232,8 @@ class TestHasTraitsHelpersWarning(unittest.TestCase):
         self.assertEqual(handler.call_count, 0)
 
     def test_dict_equality_comparison_mode_prevent_change_event(self):
-        # Justification for the warning: If the comparison mode is equality,
-        # one cannot observe mutations after reassigning an equal but new dict
-        # object.
+        # Justification for the warning: Reassess if the warning is still
+        # needed if this test fails.
         instance = ObjectWithEqualityComparisonMode()
         instance.dict_values = {"1": 1}
         handler = mock.Mock()
@@ -261,9 +258,8 @@ class TestHasTraitsHelpersWarning(unittest.TestCase):
         self.assertEqual(handler.call_count, 0)
 
     def test_set_equality_comparison_mode_prevent_change_event(self):
-        # Justification for the warning: If the comparison mode is equality,
-        # one cannot observe mutations after reassigning an equal but new set
-        # object.
+        # Justification for the warning: Reassess if the warning is still
+        # needed if this test fails.
         instance = ObjectWithEqualityComparisonMode()
         instance.set_values = {1}
         handler = mock.Mock()


### PR DESCRIPTION
Part of #977

This PR adds a warning when item changes in a list/dict/set are observed, if the list/dict/set is a top-level container and the `comparison_mode` is set to equality.

*Motivation*: When a new container is assigned to a trait where the comparison mode is set to equality (the default), no change event will be fired if the new container compared equally to the old one. Consequently, mutation and extended trait change cannot be observed on the new container, and the old container (if it is still around) will continue to emit notifications. This would be an unexpected behaviour.

Changing the default comparison mode is going to break code. So instead, the warning instructs users to fix this by setting `comparison_mode` to identity, like this:
```
class Foo(HasTraits):
    container = List(comparison_mode=1)
```

Note that the warning is not emitted until an observer is requested, this is such that we don't create warnings for existing code using `on_trait_change`. The downside is that the warning occurs late.

**Checklist**
- [x] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`) <--- *Not sure where this can go*
- ~Update User manual (`docs/source/traits_user_manual`)~: Will be in a separate PR
- ~Update type annotation hints in `traits-stubs`~
