### PR TITLE
Rename (observers) Expression to ObserverExpression

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -724,7 +724,7 @@ def observe(expression, *, post_init=False, dispatch="same"):
 
     Parameters
     ----------
-    expression : str or list or traits.observers.expression.Expression
+    expression : str or list or ObserverExpression
         A description of what traits are being observed.
         If this is a list, each item must be a string or Expression.
         See :py:func:`HasTraits.observe` for details on the
@@ -2196,7 +2196,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         All spaces will be ignored.
 
-        The :py:class:`traits.observers.expression.Expression` object supports
+        The :py:class:`ObserverExpression` object supports
         the above features and more.
 
         Parameters
@@ -2206,7 +2206,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             It must accept one argument, which is an event object providing
             information about the change.
             See :py:mod:`traits.observers.events` for details.
-        expression : str or list or traits.observers.expression.Expression
+        expression : str or list or ObserverExpression
             A description of what traits are being observed.
             If this is a list, each item must be a string or an Expression.
         remove : boolean, optional

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -37,17 +37,17 @@ from traits.observers._set_item_observer import (
 
 class ObserverExpression:
     """
-    ObserverExpression is an object for describing what traits are being observed
-    for change notifications. It can be passed directly to
+    ObserverExpression is an object for describing what traits are being
+    observed for change notifications. It can be passed directly to
     ``HasTraits.observe`` method or the ``observe`` decorator.
 
-    An ObserverExpression is typically created using one of the top-level functions
-    provided in this module, e.g. ``trait``.
+    An ObserverExpression is typically created using one of the top-level
+    functions provided in this module, e.g. ``trait``.
     """
 
     def __eq__(self, other):
-        """ Return true if the other value is an ObserverExpression with equivalent
-        content.
+        """ Return true if the other value is an ObserverExpression with
+        equivalent content.
 
         Returns
         -------

--- a/traits/observers/expression.py
+++ b/traits/observers/expression.py
@@ -32,21 +32,21 @@ from traits.observers._set_item_observer import (
     SetItemObserver as _SetItemObserver,
 )
 
-# Expression is a public user interface for constructing ObserverGraph.
+# ObserverExpression is a public user interface for constructing ObserverGraph.
 
 
-class Expression:
+class ObserverExpression:
     """
-    Expression is an object for describing what traits are being observed
+    ObserverExpression is an object for describing what traits are being observed
     for change notifications. It can be passed directly to
     ``HasTraits.observe`` method or the ``observe`` decorator.
 
-    An Expression is typically created using one of the top-level functions
+    An ObserverExpression is typically created using one of the top-level functions
     provided in this module, e.g. ``trait``.
     """
 
     def __eq__(self, other):
-        """ Return true if the other value is an Expression with equivalent
+        """ Return true if the other value is an ObserverExpression with equivalent
         content.
 
         Returns
@@ -66,13 +66,13 @@ class Expression:
 
         Parameters
         ----------
-        expression : traits.observers.expression.Expression
+        expression : ObserverExpression
 
         Returns
         -------
-        new_expression : traits.observers.expression.Expression
+        new_expression : ObserverExpression
         """
-        return ParallelExpression(self, expression)
+        return ParallelObserverExpression(self, expression)
 
     def then(self, expression):
         """ Create a new expression by extending this expression with
@@ -83,13 +83,13 @@ class Expression:
 
         Parameters
         ----------
-        expression : traits.observers.expression.Expression
+        expression : ObserverExpression
 
         Returns
         -------
-        new_expression : traits.observers.expression.Expression
+        new_expression : ObserverExpression
         """
-        return SeriesExpression(self, expression)
+        return SeriesObserverExpression(self, expression)
 
     def match(self, filter, notify=True):
         """ Create a new expression for observing traits using the
@@ -111,7 +111,7 @@ class Expression:
 
         Returns
         -------
-        new_expression : traits.observers.expression.Expression
+        new_expression : ObserverExpression
         """
         return self.then(match(filter=filter, notify=notify))
 
@@ -134,7 +134,7 @@ class Expression:
 
         Returns
         -------
-        new_expression : traits.observers.expression.Expression
+        new_expression : ObserverExpression
         """
         return self.match(
             filter=_MetadataFilter(metadata_name=metadata_name),
@@ -165,7 +165,7 @@ class Expression:
 
         Returns
         -------
-        new_expression : traits.observers.expression.Expression
+        new_expression : ObserverExpression
         """
         return self.then(dict_items(notify=notify, optional=optional))
 
@@ -192,7 +192,7 @@ class Expression:
 
         Returns
         -------
-        new_expression : traits.observers.expression.Expression
+        new_expression : ObserverExpression
         """
         return self.then(list_items(notify=notify, optional=optional))
 
@@ -213,7 +213,7 @@ class Expression:
 
         Returns
         -------
-        new_expression : traits.observers.expression.Expression
+        new_expression : ObserverExpression
         """
         return self.then(set_items(notify=notify, optional=optional))
 
@@ -237,7 +237,7 @@ class Expression:
 
         Returns
         -------
-        new_expression : traits.observers.expression.Expression
+        new_expression : ObserverExpression
         """
         return self.then(trait(name=name, notify=notify, optional=optional))
 
@@ -270,8 +270,8 @@ class Expression:
         raise NotImplementedError("'_create_graphs' must be implemented.")
 
 
-class SingleObserverExpression(Expression):
-    """ Container of Expression for wrapping a single observer.
+class SingleObserverExpression(ObserverExpression):
+    """ Container of ObserverExpression for wrapping a single observer.
     """
 
     def __init__(self, observer):
@@ -283,14 +283,14 @@ class SingleObserverExpression(Expression):
         ]
 
 
-class SeriesExpression(Expression):
-    """ Container of Expression for joining expressions in series.
+class SeriesObserverExpression(ObserverExpression):
+    """ Container of ObserverExpression for joining expressions in series.
 
     Parameters
     ----------
-    first : traits.observers.expression.Expression
+    first : ObserverExpression
         Left expression to be joined in series.
-    second : traits.observers.expression.Expression
+    second : ObserverExpression
         Right expression to be joined in series.
     """
 
@@ -303,14 +303,14 @@ class SeriesExpression(Expression):
         return self._first._create_graphs(branches=branches)
 
 
-class ParallelExpression(Expression):
-    """ Container of Expression for joining expressions in parallel.
+class ParallelObserverExpression(ObserverExpression):
+    """ Container of ObserverExpression for joining expressions in parallel.
 
     Parameters
     ----------
-    left : traits.observers.expression.Expression
+    left : ObserverExpression
         Left expression to be joined in parallel.
-    right : traits.observers.expression.Expression
+    right : ObserverExpression
         Right expression to be joined in parallel.
     """
 
@@ -326,15 +326,15 @@ class ParallelExpression(Expression):
 
 def join_(*expressions):
     """ Convenient function for joining many expressions in series
-    using ``Expression.then``
+    using ``ObserverExpression.then``
 
     Parameters
     ----------
-    *expressions : iterable of traits.observers.expression.Expression
+    *expressions : iterable of ObserverExpression
 
     Returns
     -------
-    new_expression : traits.observers.expression.Expression
+    new_expression : ObserverExpression
         Joined expression.
     """
     return _functools.reduce(lambda e1, e2: e1.then(e2), expressions)
@@ -364,7 +364,7 @@ def dict_items(notify=True, optional=False):
 
     Returns
     -------
-    new_expression : traits.observers.expression.Expression
+    new_expression : ObserverExpression
     """
     observer = _DictItemObserver(notify=notify, optional=optional)
     return SingleObserverExpression(observer)
@@ -393,7 +393,7 @@ def list_items(notify=True, optional=False):
 
     Returns
     -------
-    new_expression : traits.observers.expression.Expression
+    new_expression : ObserverExpression
     """
     observer = _ListItemObserver(notify=notify, optional=optional)
     return SingleObserverExpression(observer)
@@ -419,7 +419,7 @@ def match(filter, notify=True):
 
     Returns
     -------
-    new_expression : traits.observers.expression.Expression
+    new_expression : ObserverExpression
     """
     observer = _FilteredTraitObserver(notify=notify, filter=filter)
     return SingleObserverExpression(observer)
@@ -444,7 +444,7 @@ def metadata(metadata_name, notify=True):
 
     Returns
     -------
-    new_expression : traits.observers.expression.Expression
+    new_expression : ObserverExpression
     """
     return match(
         filter=_MetadataFilter(metadata_name=metadata_name),
@@ -469,7 +469,7 @@ def set_items(notify=True, optional=False):
 
     Returns
     -------
-    new_expression : traits.observers.expression.Expression
+    new_expression : ObserverExpression
     """
     observer = _SetItemObserver(notify=notify, optional=optional)
     return SingleObserverExpression(observer)
@@ -495,7 +495,7 @@ def trait(name, notify=True, optional=False):
 
     Returns
     -------
-    new_expression : traits.observers.expression.Expression
+    new_expression : ObserverExpression
     """
     observer = _NamedTraitObserver(
         name=name, notify=notify, optional=optional)

--- a/traits/observers/observe.py
+++ b/traits/observers/observe.py
@@ -37,7 +37,7 @@ def observe(
     ----------
     object : object
         An object to be observed. Usually an instance of ``HasTraits``.
-    expression : traits.observers.expressions.Expression
+    expression : ObserverExpression
         An object describing what traits are being observed.
     handler : callable(event)
         User-defined callable to handle change events.

--- a/traits/observers/parsing.py
+++ b/traits/observers/parsing.py
@@ -33,7 +33,7 @@ def _handle_series(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expression.Expression
+    expression : ObserverExpression
     """
     expressions = (
         _handle_tree(tree, default_notifies=default_notifies)
@@ -55,7 +55,7 @@ def _handle_parallel(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expression.Expression
+    expression : ObserverExpression
     """
     expressions = (
         _handle_tree(tree, default_notifies=default_notifies) for tree in trees
@@ -98,7 +98,7 @@ def _handle_notify(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expression.Expression
+    expression : ObserverExpression
     """
     with _notify_flag(default_notifies, True):
         return _handle_last(trees, default_notifies=default_notifies)
@@ -118,7 +118,7 @@ def _handle_quiet(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expression.Expression
+    expression : ObserverExpression
     """
     with _notify_flag(default_notifies, False):
         return _handle_last(trees, default_notifies=default_notifies)
@@ -141,7 +141,7 @@ def _handle_last(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expression.Expression
+    expression : ObserverExpression
     """
     tree, = trees
     return _handle_tree(tree, default_notifies=default_notifies)
@@ -160,7 +160,7 @@ def _handle_trait(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expression.Expression
+    expression : ObserverExpression
     """
     token, = trees
     name = token.value
@@ -181,7 +181,7 @@ def _handle_metadata(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expression.Expression
+    expression : ObserverExpression
     """
     token, = trees
     metadata_name = token.value
@@ -202,7 +202,7 @@ def _handle_items(trees, default_notifies):
 
     Returns
     -------
-    expression : traits.observers.expression.Expression
+    expression : ObserverExpression
     """
     if trees:
         # Nothing should be wrapped in items
@@ -226,7 +226,7 @@ def _handle_tree(tree, default_notifies=None):
     Parameters
     ----------
     tree : lark.tree.Tree
-        Tree to be converted to an Expression.
+        Tree to be converted to an ObserverExpression.
     default_notifies : list of boolean
         The notify flag stack.
         The last item is the current notify flag.
@@ -235,7 +235,7 @@ def _handle_tree(tree, default_notifies=None):
 
     Returns
     -------
-    expression: traits.observers.expression.Expression
+    expression: ObserverExpression
     """
     if default_notifies is None:
         default_notifies = [True]
@@ -257,7 +257,7 @@ def _handle_tree(tree, default_notifies=None):
 
 
 def parse(text):
-    """ Top-level function for parsing user's text to an Expression.
+    """ Top-level function for parsing user's text to an ObserverExpression.
 
     Parameters
     ----------
@@ -266,7 +266,7 @@ def parse(text):
 
     Returns
     -------
-    expression : traits.observers.expression.Expression
+    expression : ObserverExpression
     """
     tree = _LARK_PARSER.parse(text)
     return _handle_tree(tree)

--- a/traits/observers/tests/test_expression.py
+++ b/traits/observers/tests/test_expression.py
@@ -49,13 +49,13 @@ def create_expression(observer):
 
     Returns
     -------
-    expression : Expression
+    expression : ObserverExpression
     """
     return expression.SingleObserverExpression(observer)
 
 
-class TestExpressionComposition(unittest.TestCase):
-    """ Test composition of Expression with generic observers."""
+class TestObserverExpressionComposition(unittest.TestCase):
+    """ Test composition of ObserverExpression with generic observers."""
 
     def test_new_with_branches(self):
         observer = 1
@@ -183,8 +183,8 @@ class TestExpressionComposition(unittest.TestCase):
         self.assertEqual(actual, expected)
 
 
-class TestExpressionFilter(unittest.TestCase):
-    """ Test Expression.match """
+class TestObserverExpressionFilter(unittest.TestCase):
+    """ Test ObserverExpression.match """
 
     def setUp(self):
 
@@ -247,14 +247,14 @@ class TestExpressionFilter(unittest.TestCase):
         # Test to help developers keeping the two function signatures in-sync.
         # Remove this if the two need to divert in the future.
         top_level = expression.match
-        method = expression.Expression().match
+        method = expression.ObserverExpression().match
         self.assertEqual(
             inspect.signature(top_level), inspect.signature(method)
         )
 
 
-class TestExpressionFilterMetadata(unittest.TestCase):
-    """ Test Expression.metadata """
+class TestObserverExpressionFilterMetadata(unittest.TestCase):
+    """ Test ObserverExpression.metadata """
 
     def test_metadata_notify_true(self):
         # Test the top-level function
@@ -324,14 +324,14 @@ class TestExpressionFilterMetadata(unittest.TestCase):
         # Test to help developers keeping the two function signatures in-sync.
         # Remove this if the two need to divert in the future.
         top_level = expression.metadata
-        method = expression.Expression().metadata
+        method = expression.ObserverExpression().metadata
         self.assertEqual(
             inspect.signature(top_level), inspect.signature(method)
         )
 
 
-class TestExpressionTrait(unittest.TestCase):
-    """ Test Expression.trait """
+class TestObserverExpressionTrait(unittest.TestCase):
+    """ Test ObserverExpression.trait """
 
     def test_trait_name(self):
         # Test the top-level function
@@ -406,14 +406,14 @@ class TestExpressionTrait(unittest.TestCase):
         # Test to help developers keeping the two function signatures in-sync.
         # Remove this if the two need to divert in the future.
         top_level_trait = expression.trait
-        method_trait = expression.Expression().trait
+        method_trait = expression.ObserverExpression().trait
         self.assertEqual(
             inspect.signature(top_level_trait), inspect.signature(method_trait)
         )
 
 
-class TestExpressionDictItem(unittest.TestCase):
-    """ Test Expression.dict_items """
+class TestObserverExpressionDictItem(unittest.TestCase):
+    """ Test ObserverExpression.dict_items """
 
     def test_dict_items(self):
         expr = expression.dict_items()
@@ -473,14 +473,14 @@ class TestExpressionDictItem(unittest.TestCase):
         # Test to help developers keeping the two function signatures in-sync.
         # Remove this if the two need to divert in the future.
         top_level = expression.dict_items
-        method = expression.Expression().dict_items
+        method = expression.ObserverExpression().dict_items
         self.assertEqual(
             inspect.signature(top_level), inspect.signature(method)
         )
 
 
-class TestExpressionListItem(unittest.TestCase):
-    """ Test Expression.list_items """
+class TestObserverExpressionListItem(unittest.TestCase):
+    """ Test ObserverExpression.list_items """
 
     def test_list_items(self):
         expr = expression.list_items()
@@ -540,14 +540,14 @@ class TestExpressionListItem(unittest.TestCase):
         # Test to help developers keeping the two function signatures in-sync.
         # Remove this if the two need to divert in the future.
         top_level = expression.list_items
-        method = expression.Expression().list_items
+        method = expression.ObserverExpression().list_items
         self.assertEqual(
             inspect.signature(top_level), inspect.signature(method)
         )
 
 
-class TestExpressionSetItem(unittest.TestCase):
-    """ Test Expression.set_items """
+class TestObserverExpressionSetItem(unittest.TestCase):
+    """ Test ObserverExpression.set_items """
 
     def test_set_items(self):
         expr = expression.set_items()
@@ -607,14 +607,14 @@ class TestExpressionSetItem(unittest.TestCase):
         # Test to help developers keeping the two function signatures in-sync.
         # Remove this if the two need to divert in the future.
         top_level = expression.set_items
-        method = expression.Expression().set_items
+        method = expression.ObserverExpression().set_items
         self.assertEqual(
             inspect.signature(top_level), inspect.signature(method)
         )
 
 
-class TestExpressionEquality(unittest.TestCase):
-    """ Test Expression.__eq__ """
+class TestObserverExpressionEquality(unittest.TestCase):
+    """ Test ObserverExpression.__eq__ """
 
     def test_trait_equality(self):
         expr1 = create_expression(1)


### PR DESCRIPTION
There is already an `Expression` in `trait_types`.  #977 introduces another expression object for the use of `observe`.  The name clash is unnecessary. It causes confusion in discussion and requires extra work for Sphinx to find the correct cross-reference.

This PR renames all `Expression` in `traits.observers` to `ObserverExpression` before this gets released. 

**Checklist**
- ~Tests~
- [x] Update API reference (`docs/source/traits_api_reference`): Autodoc handled that. The source does not require changes.
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
