### PR TITLE
Check setattr_original_value before setting inherited trait default

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -519,8 +519,13 @@ def update_traits_class_dict(class_name, bases, class_dict):
                     class_traits[name] = value = ictrait(default_value)
                     # Make sure that the trait now has the default value
                     # has the correct initializer.
-                    value.set_default_value(
-                        DefaultValue.missing, value.default)
+                    if value.setattr_original_value:
+                        # Set the original, non validated value
+                        value.set_default_value(
+                            DefaultValue.missing, default_value)
+                    else:
+                        value.set_default_value(
+                            DefaultValue.missing, value.default)
                     del class_dict[name]
                     break
 

--- a/traits/tests/test_expression.py
+++ b/traits/tests/test_expression.py
@@ -77,10 +77,8 @@ class TestExpression(unittest.TestCase):
             bar = "3"
 
         f = Foo()
-        with self.assertRaises(AssertionError):  # FIXME issue #1096
-            self.assertEqual(f.bar, "3")
-        with self.assertRaises(TypeError):  # FIXME issue #1096
-            self.assertEqual(eval(f.bar_), 3)
+        self.assertEqual(f.bar, "3")
+        self.assertEqual(eval(f.bar_), 3)
 
     def test_default_static_override_method(self):
         class BaseFoo(HasTraits):
@@ -114,10 +112,8 @@ class TestExpression(unittest.TestCase):
             bar = "3"
 
         f = Foo()
-        with self.assertRaises(AssertionError):  # FIXME issue #1096
-            self.assertEqual(f.bar, "3")
-        with self.assertRaises(TypeError):  # FIXME issue #1096
-            self.assertEqual(eval(f.bar_), 3)
+        self.assertEqual(f.bar, "3")
+        self.assertEqual(eval(f.bar_), 3)
         self.assertEqual(f.default_calls, 0)
 
     def test_default_method_override_method(self):


### PR DESCRIPTION
Closes #1096 

PR adds another check for `setattr_original_value` flag when copying an inherited trait and setting a new default value.

**Checklist**
- [x] Tests
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~
- ~[ ] Update type annotation hints in `traits-stubs`~