### PR TITLE
Refresh Traits 6.0 documentation to use newest Enthought Sphinx Theme

### DIFF
--- a/_modules/index.html
+++ b/_modules/index.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -70,7 +72,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>All modules for which code is available</h1>
 <ul><li><a href="builtins.html">builtins</a></li>
@@ -154,7 +156,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/adaptation/adaptation_error.html
+++ b/_modules/traits/adaptation/adaptation_error.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.adaptation.adaptation_error</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -131,7 +133,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/adaptation/adaptation_manager.html
+++ b/_modules/traits/adaptation/adaptation_manager.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.adaptation.adaptation_manager</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -555,7 +557,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/adaptation/adaptation_offer.html
+++ b/_modules/traits/adaptation/adaptation_offer.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.adaptation.adaptation_offer</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -278,7 +280,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/adaptation/adapter.html
+++ b/_modules/traits/adaptation/adapter.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.adaptation.adapter</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -152,7 +154,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/base_trait_handler.html
+++ b/_modules/traits/base_trait_handler.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.base_trait_handler</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -279,7 +281,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/constants.html
+++ b/_modules/traits/constants.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.constants</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -329,7 +331,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/ctrait.html
+++ b/_modules/traits/ctrait.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.ctrait</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -376,7 +378,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/editor_factories.html
+++ b/_modules/traits/editor_factories.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.editor_factories</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -370,7 +372,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/etsconfig/etsconfig.html
+++ b/_modules/traits/etsconfig/etsconfig.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.etsconfig.etsconfig</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -633,7 +635,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/has_traits.html
+++ b/_modules/traits/has_traits.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.has_traits</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -3833,7 +3835,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/interface_checker.html
+++ b/_modules/traits/interface_checker.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.interface_checker</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -331,7 +333,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/testing/doctest_tools.html
+++ b/_modules/traits/testing/doctest_tools.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.testing.doctest_tools</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -182,7 +184,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/testing/nose_tools.html
+++ b/_modules/traits/testing/nose_tools.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.testing.nose_tools</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -179,7 +181,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/testing/optional_dependencies.html
+++ b/_modules/traits/testing/optional_dependencies.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.testing.optional_dependencies</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -167,7 +169,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/testing/unittest_tools.html
+++ b/_modules/traits/testing/unittest_tools.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.testing.unittest_tools</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -617,7 +619,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_base.html
+++ b/_modules/traits/trait_base.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_base</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -594,7 +596,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_converters.html
+++ b/_modules/traits/trait_converters.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_converters</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -239,7 +241,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_dict_object.html
+++ b/_modules/traits/trait_dict_object.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_dict_object</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -443,7 +445,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_errors.html
+++ b/_modules/traits/trait_errors.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_errors</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -242,7 +244,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_factory.html
+++ b/_modules/traits/trait_factory.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_factory</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -184,7 +186,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_handler.html
+++ b/_modules/traits/trait_handler.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_handler</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -192,7 +194,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_handlers.html
+++ b/_modules/traits/trait_handlers.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_handlers</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -1363,7 +1365,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_list_object.html
+++ b/_modules/traits/trait_list_object.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_list_object</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -624,7 +626,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_notifiers.html
+++ b/_modules/traits/trait_notifiers.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_notifiers</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -815,7 +817,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_numeric.html
+++ b/_modules/traits/trait_numeric.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_numeric</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -523,7 +525,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_set_object.html
+++ b/_modules/traits/trait_set_object.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_set_object</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -407,7 +409,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_type.html
+++ b/_modules/traits/trait_type.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_type</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -584,7 +586,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/trait_types.html
+++ b/_modules/traits/trait_types.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.trait_types</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -3910,7 +3912,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/traits.html
+++ b/_modules/traits/traits.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.traits</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -884,7 +886,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/traits_listener.html
+++ b/_modules/traits/traits_listener.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.traits_listener</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -1519,7 +1521,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/async_trait_wait.html
+++ b/_modules/traits/util/async_trait_wait.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.async_trait_wait</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -178,7 +180,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/camel_case.html
+++ b/_modules/traits/util/camel_case.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.camel_case</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -194,7 +196,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/clean_strings.html
+++ b/_modules/traits/util/clean_strings.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.clean_strings</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -235,7 +237,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/deprecated.html
+++ b/_modules/traits/util/deprecated.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.deprecated</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -149,7 +151,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/event_tracer.html
+++ b/_modules/traits/util/event_tracer.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.event_tracer</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -489,7 +491,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/home_directory.html
+++ b/_modules/traits/util/home_directory.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.home_directory</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -151,7 +153,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/import_symbol.html
+++ b/_modules/traits/util/import_symbol.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.import_symbol</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -163,7 +165,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/resource.html
+++ b/_modules/traits/util/resource.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.resource</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -309,7 +311,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/toposort.html
+++ b/_modules/traits/util/toposort.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.toposort</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -163,7 +165,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/_modules/traits/util/trait_documenter.html
+++ b/_modules/traits/util/trait_documenter.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -72,7 +74,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1>Source code for traits.util.trait_documenter</h1><div class="highlight"><pre>
 <span></span><span class="c1"># (C) Copyright 2005-2020 Enthought, Inc., Austin, TX</span>
@@ -307,7 +309,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/changelog.html
+++ b/changelog.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -75,7 +77,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="traits-changelog">
 <h1>Traits CHANGELOG<a class="headerlink" href="#traits-changelog" title="Permalink to this headline">¶</a></h1>
@@ -920,7 +922,7 @@ been eliminated and normalized (tabs/spaces, line endings).</p></li>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/genindex.html
+++ b/genindex.html
@@ -17,6 +17,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -71,7 +73,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
 
 <h1 id="index">Index</h1>
@@ -3097,7 +3099,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -73,7 +75,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="traits-documentation">
 <h1>Traits Documentation<a class="headerlink" href="#traits-documentation" title="Permalink to this headline">¶</a></h1>
@@ -269,7 +271,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/py-modindex.html
+++ b/py-modindex.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -73,7 +75,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
 
    <h1>Python Module Index</h1>
@@ -362,7 +364,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/search.html
+++ b/search.html
@@ -17,6 +17,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -75,7 +77,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <h1 id="search-documentation">Search</h1>
   <div id="fallback" class="admonition warning">
@@ -128,7 +130,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/base_trait_handler.html
+++ b/traits_api_reference/base_trait_handler.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.base_trait_handler">
 <span id="traits-base-trait-handler-module"></span><h1><a class="reference internal" href="#module-traits.base_trait_handler" title="traits.base_trait_handler"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.base_trait_handler</span></code></a> Module<a class="headerlink" href="#module-traits.base_trait_handler" title="Permalink to this headline">¶</a></h1>
@@ -276,7 +278,7 @@ trait. For example, in <em>List( Int )</em>, the <em>inner traits</em> for
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/constants.html
+++ b/traits_api_reference/constants.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.constants">
 <span id="traits-constants-module"></span><h1><a class="reference internal" href="#module-traits.constants" title="traits.constants"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.constants</span></code></a> Module<a class="headerlink" href="#module-traits.constants" title="Permalink to this headline">¶</a></h1>
@@ -205,7 +207,7 @@ testing. This is the default.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/ctrait.html
+++ b/traits_api_reference/ctrait.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.ctrait">
 <span id="traits-ctrait-module"></span><h1><a class="reference internal" href="#module-traits.ctrait" title="traits.ctrait"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.ctrait</span></code></a> Module<a class="headerlink" href="#module-traits.ctrait" title="Permalink to this headline">¶</a></h1>
@@ -216,7 +218,7 @@ the trait itself.</p></li>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/ctraits.html
+++ b/traits_api_reference/ctraits.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.ctraits">
 <span id="traits-ctraits-module"></span><h1><a class="reference internal" href="#module-traits.ctraits" title="traits.ctraits"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.ctraits</span></code></a> Module<a class="headerlink" href="#module-traits.ctraits" title="Permalink to this headline">¶</a></h1>
@@ -538,7 +540,7 @@ from the validator will be stored.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/editor_factories.html
+++ b/traits_api_reference/editor_factories.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.editor_factories">
 <span id="traits-editor-factories-module"></span><h1><a class="reference internal" href="#module-traits.editor_factories" title="traits.editor_factories"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.editor_factories</span></code></a> Module<a class="headerlink" href="#module-traits.editor_factories" title="Permalink to this headline">¶</a></h1>
@@ -211,7 +213,7 @@ interpreted HTML.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/has_traits.html
+++ b/traits_api_reference/has_traits.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.has_traits">
 <span id="traits-has-traits-module"></span><h1><a class="reference internal" href="#module-traits.has_traits" title="traits.has_traits"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.has_traits</span></code></a> Module<a class="headerlink" href="#module-traits.has_traits" title="Permalink to this headline">¶</a></h1>
@@ -1814,7 +1816,7 @@ deleted then the function is not called.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/index.html
+++ b/traits_api_reference/index.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -80,7 +82,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="api-reference">
 <h1>API Reference<a class="headerlink" href="#api-reference" title="Permalink to this headline">¶</a></h1>
@@ -193,7 +195,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/interface_checker.html
+++ b/traits_api_reference/interface_checker.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.interface_checker">
 <span id="traits-interface-checker-module"></span><h1><a class="reference internal" href="#module-traits.interface_checker" title="traits.interface_checker"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.interface_checker</span></code></a> Module<a class="headerlink" href="#module-traits.interface_checker" title="Permalink to this headline">¶</a></h1>
@@ -179,7 +181,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_base.html
+++ b/traits_api_reference/trait_base.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_base">
 <span id="traits-trait-base-module"></span><h1><a class="reference internal" href="#module-traits.trait_base" title="traits.trait_base"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_base</span></code></a> Module<a class="headerlink" href="#module-traits.trait_base" title="Permalink to this headline">¶</a></h1>
@@ -288,7 +290,7 @@ name[.name2[.name3…]].</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_converters.html
+++ b/traits_api_reference/trait_converters.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_converters">
 <span id="traits-trait-converters-module"></span><h1><a class="reference internal" href="#module-traits.trait_converters" title="traits.trait_converters"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_converters</span></code></a> Module<a class="headerlink" href="#module-traits.trait_converters" title="Permalink to this headline">¶</a></h1>
@@ -214,7 +216,7 @@ converted to a CTrait.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_dict_object.html
+++ b/traits_api_reference/trait_dict_object.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_dict_object">
 <span id="traits-trait-dict-object-module"></span><h1><a class="reference internal" href="#module-traits.trait_dict_object" title="traits.trait_dict_object"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_dict_object</span></code></a> Module<a class="headerlink" href="#module-traits.trait_dict_object" title="Permalink to this headline">¶</a></h1>
@@ -298,7 +300,7 @@ In either case, this is followed by: for k in F:  D[k] = F[k]</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_errors.html
+++ b/traits_api_reference/trait_errors.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_errors">
 <span id="traits-trait-errors-module"></span><h1><a class="reference internal" href="#module-traits.trait_errors" title="traits.trait_errors"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_errors</span></code></a> Module<a class="headerlink" href="#module-traits.trait_errors" title="Permalink to this headline">¶</a></h1>
@@ -175,7 +177,7 @@ error messages.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_factory.html
+++ b/traits_api_reference/trait_factory.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_factory">
 <span id="traits-trait-factory-module"></span><h1><a class="reference internal" href="#module-traits.trait_factory" title="traits.trait_factory"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_factory</span></code></a> Module<a class="headerlink" href="#module-traits.trait_factory" title="Permalink to this headline">¶</a></h1>
@@ -186,7 +188,7 @@ encountering code that actually tries to use the unimportable trait.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_handler.html
+++ b/traits_api_reference/trait_handler.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_handler">
 <span id="traits-trait-handler-module"></span><h1><a class="reference internal" href="#module-traits.trait_handler" title="traits.trait_handler"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_handler</span></code></a> Module<a class="headerlink" href="#module-traits.trait_handler" title="Permalink to this headline">¶</a></h1>
@@ -203,7 +205,7 @@ is the actual value assigned to <em>object.name</em>.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_handlers.html
+++ b/traits_api_reference/trait_handlers.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_handlers">
 <span id="traits-trait-handlers-module"></span><h1><a class="reference internal" href="#module-traits.trait_handlers" title="traits.trait_handlers"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_handlers</span></code></a> Module<a class="headerlink" href="#module-traits.trait_handlers" title="Permalink to this headline">¶</a></h1>
@@ -1388,7 +1390,7 @@ trait handler accepts values that are tuples of the same length as
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_list_object.html
+++ b/traits_api_reference/trait_list_object.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_list_object">
 <span id="traits-trait-list-object-module"></span><h1><a class="reference internal" href="#module-traits.trait_list_object" title="traits.trait_list_object"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_list_object</span></code></a> Module<a class="headerlink" href="#module-traits.trait_list_object" title="Permalink to this headline">¶</a></h1>
@@ -325,7 +327,7 @@ mutated.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_notifiers.html
+++ b/traits_api_reference/trait_notifiers.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_notifiers">
 <span id="traits-trait-notifiers-module"></span><h1><a class="reference internal" href="#module-traits.trait_notifiers" title="traits.trait_notifiers"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_notifiers</span></code></a> Module<a class="headerlink" href="#module-traits.trait_notifiers" title="Permalink to this headline">¶</a></h1>
@@ -240,7 +242,7 @@ a subclass to implement the subclass’s dispatch mechanism.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_numeric.html
+++ b/traits_api_reference/trait_numeric.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_numeric">
 <span id="traits-trait-numeric-module"></span><h1><a class="reference internal" href="#module-traits.trait_numeric" title="traits.trait_numeric"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_numeric</span></code></a> Module<a class="headerlink" href="#module-traits.trait_numeric" title="Permalink to this headline">¶</a></h1>
@@ -289,7 +291,7 @@ second dimension must be at least 2.)</p></li>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_set_object.html
+++ b/traits_api_reference/trait_set_object.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_set_object">
 <span id="traits-trait-set-object-module"></span><h1><a class="reference internal" href="#module-traits.trait_set_object" title="traits.trait_set_object"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_set_object</span></code></a> Module<a class="headerlink" href="#module-traits.trait_set_object" title="Permalink to this headline">¶</a></h1>
@@ -313,7 +315,7 @@ Raises KeyError if the set is empty.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_type.html
+++ b/traits_api_reference/trait_type.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_type">
 <span id="traits-trait-type-module"></span><h1><a class="reference internal" href="#module-traits.trait_type" title="traits.trait_type"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_type</span></code></a> Module<a class="headerlink" href="#module-traits.trait_type" title="Permalink to this headline">¶</a></h1>
@@ -390,7 +392,7 @@ classes without having to explicitly call them.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/trait_types.html
+++ b/traits_api_reference/trait_types.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.trait_types">
 <span id="traits-trait-types-module"></span><h1><a class="reference internal" href="#module-traits.trait_types" title="traits.trait_types"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.trait_types</span></code></a> Module<a class="headerlink" href="#module-traits.trait_types" title="Permalink to this headline">¶</a></h1>
@@ -3321,7 +3323,7 @@ of the editor and return the correct type of value for the trait.</p></li>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/traits.adaptation.html
+++ b/traits_api_reference/traits.adaptation.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.adaptation">
 <span id="traits-adaptation-package"></span><h1><a class="reference internal" href="#module-traits.adaptation" title="traits.adaptation"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.adaptation</span></code></a> Package<a class="headerlink" href="#module-traits.adaptation" title="Permalink to this headline">¶</a></h1>
@@ -378,7 +380,7 @@ constructor takes the object to be adapted as the first and only
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/traits.etsconfig.html
+++ b/traits_api_reference/traits.etsconfig.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.etsconfig">
 <span id="traits-etsconfig-package"></span><h1><a class="reference internal" href="#module-traits.etsconfig" title="traits.etsconfig"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.etsconfig</span></code></a> Package<a class="headerlink" href="#module-traits.etsconfig" title="Permalink to this headline">¶</a></h1>
@@ -159,7 +161,7 @@ will always work no matter which other packages are present.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/traits.html
+++ b/traits_api_reference/traits.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.traits">
 <span id="traits-traits-module"></span><h1><a class="reference internal" href="#module-traits.traits" title="traits.traits"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.traits</span></code></a> Module<a class="headerlink" href="#module-traits.traits" title="Permalink to this headline">¶</a></h1>
@@ -390,7 +392,7 @@ testing. This is the default.</p></li>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/traits.testing.html
+++ b/traits_api_reference/traits.testing.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.testing">
 <span id="traits-testing-package"></span><h1><a class="reference internal" href="#module-traits.testing" title="traits.testing"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.testing</span></code></a> Package<a class="headerlink" href="#module-traits.testing" title="Permalink to this headline">¶</a></h1>
@@ -427,7 +429,7 @@ for testing uses of traits.util.deprecated.deprecated.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/traits.util.html
+++ b/traits_api_reference/traits.util.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.util">
 <span id="traits-util-package"></span><h1><a class="reference internal" href="#module-traits.util" title="traits.util"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.util</span></code></a> Package<a class="headerlink" href="#module-traits.util" title="Permalink to this headline">¶</a></h1>
@@ -776,7 +778,7 @@ traced.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/traits_listener.html
+++ b/traits_api_reference/traits_listener.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.traits_listener">
 <span id="traits-traits-listener-module"></span><h1><a class="reference internal" href="#module-traits.traits_listener" title="traits.traits_listener"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.traits_listener</span></code></a> Module<a class="headerlink" href="#module-traits.traits_listener" title="Permalink to this headline">¶</a></h1>
@@ -567,7 +569,7 @@ ListenerBase objects described by the text.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_api_reference/version.html
+++ b/traits_api_reference/version.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="module-traits.version">
 <span id="traits-version-module"></span><h1><a class="reference internal" href="#module-traits.version" title="traits.version"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traits.version</span></code></a> Module<a class="headerlink" href="#module-traits.version" title="Permalink to this headline">¶</a></h1>
@@ -163,7 +165,7 @@ for unreleased versions of the package.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/advanced.html
+++ b/traits_user_manual/advanced.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="advanced-topics">
 <span id="id1"></span><h1>Advanced Topics<a class="headerlink" href="#advanced-topics" title="Permalink to this headline">¶</a></h1>
@@ -1453,7 +1455,7 @@ the tool is justified and appropriate.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/custom.html
+++ b/traits_user_manual/custom.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="custom-traits">
 <span id="index-0"></span><span id="id1"></span><h1>Custom Traits<a class="headerlink" href="#custom-traits" title="Permalink to this headline">¶</a></h1>
@@ -618,7 +620,7 @@ BaseType version that does not have the <strong>fast_validate</strong> attribute
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/debugging.html
+++ b/traits_user_manual/debugging.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="tips-for-debugging-traits">
 <span id="index-0"></span><h1>Tips for debugging Traits<a class="headerlink" href="#tips-for-debugging-traits" title="Permalink to this headline">¶</a></h1>
@@ -267,7 +269,7 @@ local folder. The file contents will be similar to the lines below:</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/deferring.html
+++ b/traits_user_manual/deferring.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="deferring-trait-definitions">
 <span id="deferring-traits"></span><span id="index-0"></span><h1>Deferring Trait Definitions<a class="headerlink" href="#deferring-trait-definitions" title="Permalink to this headline">¶</a></h1>
@@ -391,7 +393,7 @@ incongruous.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/defining.html
+++ b/traits_user_manual/defining.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="defining-traits-initialization-and-validation">
 <span id="index-0"></span><span id="id1"></span><h1>Defining Traits: Initialization and Validation<a class="headerlink" href="#defining-traits-initialization-and-validation" title="Permalink to this headline">¶</a></h1>
@@ -880,7 +882,7 @@ existing traits.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/front.html
+++ b/traits_user_manual/front.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="traits-6-user-manual">
 <h1>Traits 6 User Manual<a class="headerlink" href="#traits-6-user-manual" title="Permalink to this headline">¶</a></h1>
@@ -181,7 +183,7 @@ owners.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/index.html
+++ b/traits_user_manual/index.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -80,7 +82,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="traits-6-user-manual">
 <h1>Traits 6 User Manual<a class="headerlink" href="#traits-6-user-manual" title="Permalink to this headline">¶</a></h1>
@@ -287,7 +289,7 @@
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/intro.html
+++ b/traits_user_manual/intro.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="introduction">
 <h1>Introduction<a class="headerlink" href="#introduction" title="Permalink to this headline">¶</a></h1>
@@ -312,7 +314,7 @@ individually, or view them in a tutorial program by running:</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/notification.html
+++ b/traits_user_manual/notification.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="trait-notification">
 <h1>Trait Notification<a class="headerlink" href="#trait-notification" title="Permalink to this headline">¶</a></h1>
@@ -831,7 +833,7 @@ values can be queried from directly from the trait value, if needed).</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.

--- a/traits_user_manual/testing.html
+++ b/traits_user_manual/testing.html
@@ -16,6 +16,8 @@
         VERSION:     '6.0.0',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
+        LINK_SUFFIX: '',
+        SOURCELINK_SUFFIX: '.txt',
         HAS_SOURCE:  true
       };
     </script>
@@ -82,7 +84,7 @@
           <div class="span9">
             
         <div class="bodywrapper">
-          <div class="body" id="spc-section-body">
+          <div class="body" id="spc-section-body" role="main">
             
   <div class="section" id="testing">
 <span id="index-0"></span><h1>Testing<a class="headerlink" href="#testing" title="Permalink to this headline">¶</a></h1>
@@ -283,7 +285,7 @@ getters and validators.</p>
         &copy; Copyright 2008-2020, Enthought Inc
       </li>
       <li>
-      Last updated on Feb 27, 2020.
+      Last updated on May 20, 2020.
       </li>
       <li>
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> 2.3.1.


### PR DESCRIPTION
This PR regenerates the Traits 6.0 documentation to use the latest version of the Enthought Sphinx Theme. This should fix the search issues currently present.

Since the sequence of steps to build or rebuild documentation is non-trivial, I've added wiki how-to page on building documentation: https://github.com/enthought/traits/wiki/How-to:-Build-documentation