### PR TITLE
DOC: Autogenerate the version used in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,7 +69,11 @@ traits_init_path = os.path.join("..", "..", "traits", "__init__.py")
 with open(traits_init_path, "r", encoding="utf-8") as version_module:
     version_code = compile(version_module.read(), "__init__.py", "exec")
     exec(version_code, version_info)
-version = release = version_info["__version__"]
+
+# "release" is the full version string, including the bugfix portion and any
+# modifiers. "version" is of the form "6.2" and is what's used in titles.
+release = version_info["__version__"]
+version = ".".join(release.split(".")[:2])
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -163,7 +167,7 @@ if BUILD_DOCSET:
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "Traits 6 User Manual"
+html_title = "Traits {version} User Manual".format(version=version)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None
@@ -220,7 +224,7 @@ latex_documents = [
     (
         "index",
         "Traits.tex",
-        "Traits 6 User Manual",
+        "Traits {version} User Manual".format(version=version),
         "Enthought, Inc.",
         "manual",
     )
@@ -254,7 +258,7 @@ texinfo_documents = [
     (
         "index",
         "traits",
-        "Traits 6 User Manual",
+        "Traits {version} User Manual".format(version=version),
         "Enthought, Inc.",
         "Traits",
         "Explicitly typed attributes for Python.",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
-Traits Documentation
-====================
+Traits |version| Documentation
+==============================
 
 User Reference
 --------------

--- a/docs/source/traits_user_manual/index.rst
+++ b/docs/source/traits_user_manual/index.rst
@@ -1,6 +1,6 @@
-====================
-Traits 6 User Manual
-====================
+============================
+Traits |version| User Manual
+============================
 
 :Authors: David C. Morrill, Janet M. Swisher, and Enthought developers
 :Copyright: 2005-2020 Enthought, Inc. All Rights Reserved.


### PR DESCRIPTION
This PR:

- replaces the hard-coded "Traits 6" that appears in various places in the documentation and its configuration with an autogenerated "major.minor" version (e.g., Traits 6.1)
- Adds the version to the top-level documentation page (it used to read "Traits Documentation"; it now reads "Traits 6.1 Documentation)

Closes #908.