### PR TITLE
Rename observer expression join function

### DIFF
--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -324,7 +324,7 @@ class ParallelObserverExpression(ObserverExpression):
         return left_graphs + right_graphs
 
 
-def join_(*expressions):
+def join(*expressions):
     """ Convenient function for joining many expressions in series
     using ``ObserverExpression.then``
 

--- a/traits/observation/parsing.py
+++ b/traits/observation/parsing.py
@@ -39,7 +39,7 @@ def _handle_series(trees, default_notifies):
         _handle_tree(tree, default_notifies=default_notifies)
         for tree in trees
     )
-    return _expr_module.join_(*expressions)
+    return _expr_module.join(*expressions)
 
 
 def _handle_parallel(trees, default_notifies):

--- a/traits/observation/tests/test_expression.py
+++ b/traits/observation/tests/test_expression.py
@@ -165,13 +165,13 @@ class TestObserverExpressionComposition(unittest.TestCase):
         actual = expr._as_graphs()
         self.assertEqual(actual, expected)
 
-    def test_join_expressions(self):
+    def test_joinexpressions(self):
         observer1 = 1
         observer2 = 2
         expr1 = create_expression(observer1)
         expr2 = create_expression(observer2)
 
-        expr = expression.join_(expr1, expr2)
+        expr = expression.join(expr1, expr2)
 
         expected = [
             create_graph(
@@ -621,12 +621,12 @@ class TestObserverExpressionEquality(unittest.TestCase):
         expr2 = create_expression(1)
         self.assertEqual(expr1, expr2)
 
-    def test_join_equality_with_then(self):
+    def test_joinequality_with_then(self):
         # The following all result in the same graphs
         expr1 = create_expression(1)
         expr2 = create_expression(2)
 
-        combined1 = expression.join_(expr1, expr2)
+        combined1 = expression.join(expr1, expr2)
         combined2 = expr1.then(expr2)
 
         self.assertEqual(combined1, combined2)

--- a/traits/observation/tests/test_expression.py
+++ b/traits/observation/tests/test_expression.py
@@ -165,7 +165,7 @@ class TestObserverExpressionComposition(unittest.TestCase):
         actual = expr._as_graphs()
         self.assertEqual(actual, expected)
 
-    def test_joinexpressions(self):
+    def test_join_expressions(self):
         observer1 = 1
         observer2 = 2
         expr1 = create_expression(observer1)
@@ -621,7 +621,7 @@ class TestObserverExpressionEquality(unittest.TestCase):
         expr2 = create_expression(1)
         self.assertEqual(expr1, expr2)
 
-    def test_joinequality_with_then(self):
+    def test_join_equality_with_then(self):
         # The following all result in the same graphs
         expr1 = create_expression(1)
         expr2 = create_expression(2)

--- a/traits/observation/tests/test_parsing.py
+++ b/traits/observation/tests/test_parsing.py
@@ -27,7 +27,7 @@ class TestParsingSeriesJoin(unittest.TestCase):
         expected = trait("a").trait("b").trait("c")
         self.assertEqual(actual, expected)
 
-    def test_join_with_colon(self):
+    def test_joinwith_colon(self):
         actual = parse("a:b:c")
         expected = trait("a", False).trait("b", False).trait("c")
         self.assertEqual(actual, expected)
@@ -40,7 +40,7 @@ class TestParsingOr(unittest.TestCase):
         expected = trait("a") | trait("b") | trait("c")
         self.assertEqual(actual, expected)
 
-    def test_or_with_join_nested(self):
+    def test_or_with_joinnested(self):
         actual = parse("a.b.c,d.e")
         expected = (
             trait("a").trait("b").trait("c")

--- a/traits/observation/tests/test_parsing.py
+++ b/traits/observation/tests/test_parsing.py
@@ -27,7 +27,7 @@ class TestParsingSeriesJoin(unittest.TestCase):
         expected = trait("a").trait("b").trait("c")
         self.assertEqual(actual, expected)
 
-    def test_joinwith_colon(self):
+    def test_join_with_colon(self):
         actual = parse("a:b:c")
         expected = trait("a", False).trait("b", False).trait("c")
         self.assertEqual(actual, expected)
@@ -40,7 +40,7 @@ class TestParsingOr(unittest.TestCase):
         expected = trait("a") | trait("b") | trait("c")
         self.assertEqual(actual, expected)
 
-    def test_or_with_joinnested(self):
+    def test_or_with_join_nested(self):
         actual = parse("a.b.c,d.e")
         expected = (
             trait("a").trait("b").trait("c")


### PR DESCRIPTION
This PR renames `join_` to `join` in `traits.observation.expression`.

It was initially named `join_` for no good reasons.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~