### PR TITLE
Nit: Remove aliases just for preceding underscores

### DIFF
--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -8,29 +8,15 @@
 #
 # Thanks for using Enthought open source!
 
-import functools as _functools
+import functools
 
-from traits.observation._dict_item_observer import (
-    DictItemObserver as _DictItemObserver,
-)
-from traits.observation._filtered_trait_observer import (
-    FilteredTraitObserver as _FilteredTraitObserver,
-)
-from traits.observation._list_item_observer import (
-    ListItemObserver as _ListItemObserver,
-)
-from traits.observation._metadata_filter import (
-    MetadataFilter as _MetadataFilter,
-)
-from traits.observation._named_trait_observer import (
-    NamedTraitObserver as _NamedTraitObserver,
-)
-from traits.observation._observer_graph import (
-    ObserverGraph as _ObserverGraph,
-)
-from traits.observation._set_item_observer import (
-    SetItemObserver as _SetItemObserver,
-)
+from traits.observation._dict_item_observer import DictItemObserver
+from traits.observation._filtered_trait_observer import FilteredTraitObserver
+from traits.observation._list_item_observer import ListItemObserver
+from traits.observation._metadata_filter import MetadataFilter
+from traits.observation._named_trait_observer import NamedTraitObserver
+from traits.observation._observer_graph import ObserverGraph
+from traits.observation._set_item_observer import SetItemObserver
 
 # ObserverExpression is a public user interface for constructing ObserverGraph.
 
@@ -137,7 +123,7 @@ class ObserverExpression:
         new_expression : ObserverExpression
         """
         return self.match(
-            filter=_MetadataFilter(metadata_name=metadata_name),
+            filter=MetadataFilter(metadata_name=metadata_name),
             notify=notify,
         )
 
@@ -279,7 +265,7 @@ class SingleObserverExpression(ObserverExpression):
 
     def _create_graphs(self, branches):
         return [
-            _ObserverGraph(node=self.observer, children=branches),
+            ObserverGraph(node=self.observer, children=branches),
         ]
 
 
@@ -337,7 +323,7 @@ def join(*expressions):
     new_expression : ObserverExpression
         Joined expression.
     """
-    return _functools.reduce(lambda e1, e2: e1.then(e2), expressions)
+    return functools.reduce(lambda e1, e2: e1.then(e2), expressions)
 
 
 def dict_items(notify=True, optional=False):
@@ -366,7 +352,7 @@ def dict_items(notify=True, optional=False):
     -------
     new_expression : ObserverExpression
     """
-    observer = _DictItemObserver(notify=notify, optional=optional)
+    observer = DictItemObserver(notify=notify, optional=optional)
     return SingleObserverExpression(observer)
 
 
@@ -395,7 +381,7 @@ def list_items(notify=True, optional=False):
     -------
     new_expression : ObserverExpression
     """
-    observer = _ListItemObserver(notify=notify, optional=optional)
+    observer = ListItemObserver(notify=notify, optional=optional)
     return SingleObserverExpression(observer)
 
 
@@ -421,7 +407,7 @@ def match(filter, notify=True):
     -------
     new_expression : ObserverExpression
     """
-    observer = _FilteredTraitObserver(notify=notify, filter=filter)
+    observer = FilteredTraitObserver(notify=notify, filter=filter)
     return SingleObserverExpression(observer)
 
 
@@ -447,7 +433,7 @@ def metadata(metadata_name, notify=True):
     new_expression : ObserverExpression
     """
     return match(
-        filter=_MetadataFilter(metadata_name=metadata_name),
+        filter=MetadataFilter(metadata_name=metadata_name),
         notify=notify,
     )
 
@@ -471,7 +457,7 @@ def set_items(notify=True, optional=False):
     -------
     new_expression : ObserverExpression
     """
-    observer = _SetItemObserver(notify=notify, optional=optional)
+    observer = SetItemObserver(notify=notify, optional=optional)
     return SingleObserverExpression(observer)
 
 
@@ -497,6 +483,6 @@ def trait(name, notify=True, optional=False):
     -------
     new_expression : ObserverExpression
     """
-    observer = _NamedTraitObserver(
+    observer = NamedTraitObserver(
         name=name, notify=notify, optional=optional)
     return SingleObserverExpression(observer)

--- a/traits/observation/observe.py
+++ b/traits/observation/observe.py
@@ -8,9 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.observation._observe import (
-    add_or_remove_notifiers as _add_or_remove_notifiers,
-)
+from traits.observation._observe import add_or_remove_notifiers
 
 
 def dispatch_same(handler, event):
@@ -52,7 +50,7 @@ def observe(
     # Implicit interface: ``expression`` can be anything with a method
     # ``_as_graphs`` that returns a list of ObserverGraph.
     for graph in expression._as_graphs():
-        _add_or_remove_notifiers(
+        add_or_remove_notifiers(
             object=object,
             graph=graph,
             handler=handler,

--- a/traits/observation/parsing.py
+++ b/traits/observation/parsing.py
@@ -12,12 +12,10 @@ import contextlib
 from functools import reduce
 import operator
 
-import traits.observation.expression as _expr_module
-from traits.observation._generated_parser import (
-    Lark_StandAlone as _Lark_StandAlone
-)
+from traits.observation import _generated_parser
+import traits.observation.expression as expression_module
 
-_LARK_PARSER = _Lark_StandAlone()
+_LARK_PARSER = _generated_parser.Lark_StandAlone()
 
 
 def _handle_series(trees, default_notifies):
@@ -39,7 +37,7 @@ def _handle_series(trees, default_notifies):
         _handle_tree(tree, default_notifies=default_notifies)
         for tree in trees
     )
-    return _expr_module.join(*expressions)
+    return expression_module.join(*expressions)
 
 
 def _handle_parallel(trees, default_notifies):
@@ -165,7 +163,7 @@ def _handle_trait(trees, default_notifies):
     token, = trees
     name = token.value
     notify = default_notifies[-1]
-    return _expr_module.trait(name, notify=notify)
+    return expression_module.trait(name, notify=notify)
 
 
 def _handle_metadata(trees, default_notifies):
@@ -186,7 +184,7 @@ def _handle_metadata(trees, default_notifies):
     token, = trees
     metadata_name = token.value
     notify = default_notifies[-1]
-    return _expr_module.metadata(metadata_name, notify=notify)
+    return expression_module.metadata(metadata_name, notify=notify)
 
 
 def _handle_items(trees, default_notifies):
@@ -212,10 +210,10 @@ def _handle_items(trees, default_notifies):
     return reduce(
         operator.or_,
         (
-            _expr_module.trait("items", notify=notify, optional=True),
-            _expr_module.dict_items(notify=notify, optional=True),
-            _expr_module.list_items(notify=notify, optional=True),
-            _expr_module.set_items(notify=notify, optional=True),
+            expression_module.trait("items", notify=notify, optional=True),
+            expression_module.dict_items(notify=notify, optional=True),
+            expression_module.list_items(notify=notify, optional=True),
+            expression_module.set_items(notify=notify, optional=True),
         )
     )
 


### PR DESCRIPTION
As promised, this PR removes import aliases just for adding a preceding underscore.

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
