### PR TITLE
Use class name in hash consistently

### DIFF
--- a/traits/observation/_named_trait_observer.py
+++ b/traits/observation/_named_trait_observer.py
@@ -51,7 +51,9 @@ class NamedTraitObserver:
         self.optional = optional
 
     def __hash__(self):
-        return hash((type(self), self.name, self.notify, self.optional))
+        return hash(
+            (type(self).__name__, self.name, self.notify, self.optional)
+        )
 
     def __eq__(self, other):
         return (

--- a/traits/observation/_observer_graph.py
+++ b/traits/observation/_observer_graph.py
@@ -70,7 +70,7 @@ class ObserverGraph:
     def __hash__(self):
         """ Return the hash of this ObserverGraph."""
         return hash(
-            (type(self), self.node, frozenset(self.children))
+            (type(self).__name__, self.node, frozenset(self.children))
         )
 
     def __eq__(self, other):


### PR DESCRIPTION
All except two of classes in `traits.observation` use class names for `__hash__`.
This PR fixes the other two so they are consistent with others.

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
