### PR TITLE
Provide a nicer error message when upgrading Traits with an older version of TraitsUI

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1765,7 +1765,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         # Provide a nicer failure mode when upgrading to Traits using
         # TraitsUI 6.x
-        _check_traitsui_major_version(7)
+        check_traitsui_major_version(7)
 
         if name:
             if view_element is None:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -54,7 +54,7 @@ from .trait_base import (
 )
 from .trait_errors import TraitError
 from .util.deprecated import deprecated
-from .util.traitsui_helpers import check_traitsui_major_version
+from .util._traitsui_helpers import check_traitsui_major_version
 from .trait_converters import check_trait, mapped_trait_for, trait_for
 
 
@@ -1765,7 +1765,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         # Provide a nicer failure mode when upgrading to Traits using
         # TraitsUI 6.x
-        check_traitsui_major_version(7)
+        _check_traitsui_major_version(7)
 
         if name:
             if view_element is None:

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -54,6 +54,7 @@ from .trait_base import (
 )
 from .trait_errors import TraitError
 from .util.deprecated import deprecated
+from .util.traitsui_helpers import check_traitsui_major_version
 from .trait_converters import check_trait, mapped_trait_for, trait_for
 
 
@@ -1761,6 +1762,10 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         # traits has been fully initialized (such as the default Handler):
         if view_elements is None:
             return None
+
+        # Provide a nicer failure mode when upgrading to Traits using
+        # TraitsUI 6.x
+        check_traitsui_major_version(7)
 
         if name:
             if view_element is None:

--- a/traits/util/_traitsui_helpers.py
+++ b/traits/util/_traitsui_helpers.py
@@ -9,6 +9,8 @@
 # Thanks for using Enthought open source!
 
 """ Functions to help removing TraitsUI being a dependency of Traits.
+
+Used internally by traits only.
 """
 # All imports of TraitsUI should be delayed.
 
@@ -16,6 +18,8 @@
 def check_traitsui_major_version(major):
     """ Raise RuntimeError if TraitsUI major version is less than the required
     value.
+
+    Used internally in traits only.
 
     Parameters
     ----------

--- a/traits/util/tests/test_traitsui_helpers.py
+++ b/traits/util/tests/test_traitsui_helpers.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+import unittest
+from unittest import mock
+
+from traits.testing.optional_dependencies import requires_traitsui
+from traits.util.traitsui_helpers import check_traitsui_major_version
+
+
+@requires_traitsui
+class TestTraitsUIHelper(unittest.TestCase):
+
+    def test_check_version_error(self):
+
+        with mock.patch("traitsui.__version__", "6.1.2"):
+            with self.assertRaises(RuntimeError) as exception_context:
+                check_traitsui_major_version(7)
+
+        self.assertEqual(
+            str(exception_context.exception),
+            "TraitsUI 7 or higher is required. Got version '6.1.2'"
+        )
+
+    def test_check_version_okay(self):
+        with mock.patch("traitsui.__version__", "7.0.0"):
+            try:
+                check_traitsui_major_version(7)
+            except Exception:
+                self.fail(
+                    "Given TraitsUI version is okay, "
+                    "sanity check unexpectedly failed."
+                )

--- a/traits/util/tests/test_traitsui_helpers.py
+++ b/traits/util/tests/test_traitsui_helpers.py
@@ -13,7 +13,7 @@ import unittest
 from unittest import mock
 
 from traits.testing.optional_dependencies import requires_traitsui
-from traits.util.traitsui_helpers import check_traitsui_major_version
+from traits.util._traitsui_helpers import check_traitsui_major_version
 
 
 @requires_traitsui

--- a/traits/util/traitsui_helpers.py
+++ b/traits/util/traitsui_helpers.py
@@ -1,0 +1,36 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Functions to help removing TraitsUI being a dependency of Traits.
+"""
+# All imports of TraitsUI should be delayed.
+
+
+def check_traitsui_major_version(major):
+    """ Raise RuntimeError if TraitsUI major version is less than the required
+    value.
+
+    Parameters
+    ----------
+    major : int
+        Required TraitsUI major version.
+
+    Raises
+    ------
+    RuntimeError
+    """
+    from traitsui import __version__ as traitsui_version
+    actual_major, _ = traitsui_version.split(".", 1)
+    actual_major = int(actual_major)
+    if actual_major < major:
+        raise RuntimeError(
+            "TraitsUI {} or higher is required. Got version {!r}".format(
+                major, traitsui_version)
+        )


### PR DESCRIPTION
Closes #1106

If the user has TraitsUI 6.x and Traits 6.1, using TraitsUI functionality could result in an error like this:
```
  File "/Users/kchoi/Work/ETS/traits/traits/has_traits.py", line 1677, in edit_traits
    args,
  File "/Users/kchoi/.edm/envs/resist-py36/lib/python3.6/site-packages/traitsui/view.py", line 446, in ui
    ui.ui(parent, kind)
  File "/Users/kchoi/.edm/envs/resist-py36/lib/python3.6/site-packages/traitsui/ui.py", line 244, in ui
    self.rebuild(self, parent)
... (excerpted)
  File "/Users/kchoi/Work/ETS/traits/traits/has_traits.py", line 1667, in edit_traits
    view = self.trait_view(view)
  File "/Users/kchoi/Work/ETS/traits/traits/has_traits.py", line 1727, in trait_view
    self,
  File "/Users/kchoi/Work/ETS/traits/traits/has_traits.py", line 1772, in _trait_view
    method = getattr(handler, name, None)
TypeError: getattr(): attribute name must be string
```

This PR adds a check in `_trait_view` so that it is easier to see what went wrong and how to fix it. This is the new error message:
```
...
  File "/Users/kchoi/Work/ETS/traits/traits/has_traits.py", line 1668, in edit_traits
    view = self.trait_view(view)
  File "/Users/kchoi/Work/ETS/traits/traits/has_traits.py", line 1728, in trait_view
    self,
  File "/Users/kchoi/Work/ETS/traits/traits/has_traits.py", line 1768, in _trait_view
    check_traitsui_major_version(7)
  File "/Users/kchoi/Work/ETS/traits/traits/util/_traitsui_helpers.py", line 39, in check_traitsui_major_version
    major, traitsui_version)
RuntimeError: TraitsUI 7 or higher is required. Got version '6.1.3'
```

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
