### PR TITLE
Fix TraitChangeEvent repr format to be consistent with others

### DIFF
--- a/traits/observation/_trait_change_event.py
+++ b/traits/observation/_trait_change_event.py
@@ -39,15 +39,12 @@ class TraitChangeEvent:
 
     def __repr__(self):
         return (
-            "<{class_name}("
-            "object={object!r}, name={name!r}, old={old!r}, new={new!r}"
-            ")>".format(
-                class_name=type(self).__name__,
-                object=self.object,
-                name=self.name,
-                old=self.old,
-                new=self.new,
-            )
+            "{event.__class__.__name__}("
+            "object={event.object!r}, "
+            "name={event.name!r}, "
+            "old={event.old!r}, "
+            "new={event.new!r}"
+            ")".format(event=self)
         )
 
 

--- a/traits/observation/tests/test_trait_change_event.py
+++ b/traits/observation/tests/test_trait_change_event.py
@@ -31,7 +31,7 @@ class TestTraitChangeEvent(unittest.TestCase):
         actual = repr(event)
         self.assertEqual(
             actual,
-            "<TraitChangeEvent(object=None, name='name', old=1, new=2)>"
+            "TraitChangeEvent(object=None, name='name', old=1, new=2)"
         )
 
 


### PR DESCRIPTION
This PR removes the "<>" around the representation of `TraitChangeEvent`, to be consistent with other events.
There are drive-by changes to the formatting, for consistencies as well.
**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
