### PR TITLE
Add intersphinx extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
     "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "traits.util.trait_documenter",
@@ -265,3 +266,11 @@ texinfo_documents = [
         "Python",
     )
 ]
+
+# Options for intersphinx extension
+# ---------------------------------
+
+intersphinx_mapping = {
+    "pyface": ("https://docs.enthought.com/pyface", None),
+    "traitsui": ("https://docs.enthought.com/traitsui", None),
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -272,5 +272,6 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     "pyface": ("https://docs.enthought.com/pyface", None),
+    "python": ("https://docs.python.org/3", None),
     "traitsui": ("https://docs.enthought.com/traitsui", None),
 }


### PR DESCRIPTION
This PR adds the intersphinx extension so that we can refer to TraitsUI docs from the Traits docs where necessary. (I've also added Pyface, in case we need it at some point.)