### PR TITLE
Validate and transform static default value for PrefixMap

### DIFF
--- a/traits/tests/test_prefix_map.py
+++ b/traits/tests/test_prefix_map.py
@@ -161,6 +161,32 @@ class TestPrefixMap(unittest.TestCase):
         self.assertEqual(p.married_, 1)
         self.assertEqual(p.default_calls, 1)
 
+    def test_static_default_transformed(self):
+        # Test the static default is transformed
+        class Person(HasTraits):
+            married = PrefixMap(
+                {"yes": 1, "yeah": 1, "no": 0}, default_value="yea")
+
+        p = Person()
+        self.assertEqual(p.married, "yeah")
+        self.assertEqual(p.married_, 1)
+
+        # access mapped trait first is okay
+        p = Person()
+        self.assertEqual(p.married_, 1)
+        self.assertEqual(p.married, "yeah")
+
+    def test_static_default_validation_error(self):
+        with self.assertRaises(TraitError) as exception_context:
+            class Person(HasTraits):
+                married = PrefixMap(
+                    {"yes": 1, "yeah": 1, "no": 0}, default_value="meh")
+
+        self.assertIn(
+            "but a value 'meh' was specified",
+            str(exception_context.exception),
+        )
+
     def test_pickle_roundtrip(self):
         class Person(HasTraits):
             married = PrefixMap({"yes": 1, "yeah": 1, "no": 0, "nah": 0},

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3007,8 +3007,8 @@ class PrefixMap(TraitType):
         if not isinstance(value, str):
             raise TraitError(
                 "Value must be {}, but a value {!r} was specified.".format(
-                    self.info(), value
-            ))
+                    self.info(), value)
+            )
 
         if value in self._map:
             return self._map[value]
@@ -3020,8 +3020,8 @@ class PrefixMap(TraitType):
 
         raise TraitError(
             "Value must be {}, but a value {!r} was specified.".format(
-                self.info(), value
-        ))
+                self.info(), value)
+        )
 
     def mapped_value(self, value):
         """ Get the mapped value for a value. """

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2608,7 +2608,7 @@ class PrefixList(BaseStr):
             try:
                 default = self.validate(None, None, default)
             except TraitError:
-                raise ValueError("Default value for PrefixTrait must be "
+                raise TraitError("Default value for PrefixTrait must be "
                                  "a unique prefix present in the prefix list")
         elif self.values:
             default = self.values[0]
@@ -2998,11 +2998,17 @@ class PrefixMap(TraitType):
 
         default_value = metadata.pop("default_value", Undefined)
 
+        if default_value is not Undefined:
+            default_value = self.value_for(default_value)
+
         super().__init__(default_value, **metadata)
 
-    def validate(self, object, name, value):
+    def value_for(self, value):
         if not isinstance(value, str):
-            self.error(object, name, value)
+            raise TraitError(
+                "Value must be {}, but a value {!r} was specified.".format(
+                    self.info(), value
+            ))
 
         if value in self._map:
             return self._map[value]
@@ -3012,7 +3018,10 @@ class PrefixMap(TraitType):
             self._map[value] = match = matches[0]
             return match
 
-        self.error(object, name, value)
+        raise TraitError(
+            "Value must be {}, but a value {!r} was specified.".format(
+                self.info(), value
+        ))
 
     def mapped_value(self, value):
         """ Get the mapped value for a value. """

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2608,7 +2608,7 @@ class PrefixList(BaseStr):
             try:
                 default = self.validate(None, None, default)
             except TraitError:
-                raise TraitError("Default value for PrefixTrait must be "
+                raise ValueError("Default value for PrefixTrait must be "
                                  "a unique prefix present in the prefix list")
         elif self.values:
             default = self.values[0]


### PR DESCRIPTION
Closes #1130

This PR applies the validation+transformation early when a PrefixMap is instantiated, such that a valid static default value can be used.
 
**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
