### PR TITLE
Restrict PrefixList signature to accept a list or tuple of values

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -323,7 +323,7 @@ the table.
 | Password         | Password( [*value* = '', *minlen* = 0, *maxlen* =        |
 |                  | sys.maxint, *regex* = '', \*\*\ *metadata*] )            |
 +------------------+----------------------------------------------------------+
-| PrefixList       | PrefixList( [*values* = None, \*\*\ *metadata*] )        |
+| PrefixList       | PrefixList( *values*\ [, \*\*\ *metadata*] )             |
 +------------------+----------------------------------------------------------+
 | PrefixMap        | PrefixMap( *map*\ [, \*\*\ *metadata*] )                 |
 +------------------+----------------------------------------------------------+
@@ -535,7 +535,7 @@ The following is an example of using PrefixList::
     from traits.api import HasTraits, PrefixList
 
     class Person(HasTraits):
-        married = PrefixList("yes", "no")
+        married = PrefixList(["yes", "no"])
 
 This example defines a Person class which has a **married** trait
 attribute which accepts values "yes" and "no" or any unique

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -409,7 +409,7 @@ class CList(_List[_S, _T]):
 class PrefixList(BaseStr):
     def __init__(
             self,
-            *values: _Union[str, _Sequence[str]],
+            values: _Sequence[str],
             **metadata: _Any,
     ) -> None:
         ...

--- a/traits-stubs/traits_stubs_tests/examples/PrefixList.py
+++ b/traits-stubs/traits_stubs_tests/examples/PrefixList.py
@@ -2,10 +2,9 @@ from traits.api import HasTraits, PrefixList
 
 
 class Person(HasTraits):
-    atr = PrefixList('yes', 'no')
-    atr2 = PrefixList(('yes', 'no'))
-    atr3 = PrefixList(['yes', 'no'])
+    atr1 = PrefixList(('yes', 'no'))
+    atr2 = PrefixList(['yes', 'no'])
 
 
 p = Person()
-p.atr = 5  # E: assignment
+p.atr1 = 5  # E: assignment

--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -71,7 +71,7 @@ class TestPrefixList(unittest.TestCase):
 
         self.assertEqual(
             str(exception_context.exception),
-            "Legal values should be provided via a list, "
+            "Legal values should be provided via an iterable of strings, "
             "got 'zero'."
         )
 

--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -21,7 +21,7 @@ from traits.api import HasTraits, TraitError, PrefixList
 class TestPrefixList(unittest.TestCase):
     def test_assignment(self):
         class A(HasTraits):
-            foo = PrefixList("zero", "one", "two", default_value="one")
+            foo = PrefixList(["zero", "one", "two"], default_value="one")
 
         a = A()
 
@@ -33,7 +33,7 @@ class TestPrefixList(unittest.TestCase):
 
     def test_bad_types(self):
         class A(HasTraits):
-            foo = PrefixList("zero", "one", "two", default_value="one")
+            foo = PrefixList(["zero", "one", "two"], default_value="one")
 
         a = A()
 
@@ -45,7 +45,7 @@ class TestPrefixList(unittest.TestCase):
 
     def test_repeated_prefix(self):
         class A(HasTraits):
-            foo = PrefixList("abc1", "abc2")
+            foo = PrefixList(("abc1", "abc2"))
         a = A()
 
         a.foo = "abc1"
@@ -57,11 +57,27 @@ class TestPrefixList(unittest.TestCase):
     def test_invalid_default(self):
         with self.assertRaises(ValueError):
             class A(HasTraits):
-                foo = PrefixList("zero", "one", "two", default_value="uno")
+                foo = PrefixList(["zero", "one", "two"], default_value="uno")
+
+    def test_values_not_sequence(self):
+        # Defining values with this signature is not supported
+        with self.assertRaises(TypeError):
+            PrefixList("zero", "one", "two")
+
+    def test_values_not_all_iterables(self):
+        # Make sure we don't confuse other sequence types, e.g. str
+        with self.assertRaises(ValueError) as exception_context:
+            PrefixList("zero")
+
+        self.assertEqual(
+            str(exception_context.exception),
+            "Legal values should be provided via a list or a tuple, "
+            "got 'zero'."
+        )
 
     def test_pickle_roundtrip(self):
         class A(HasTraits):
-            foo = PrefixList("zero", "one", "two", default_value="one")
+            foo = PrefixList(["zero", "one", "two"], default_value="one")
 
         a = A()
         foo_trait = a.traits()["foo"]

--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -71,7 +71,7 @@ class TestPrefixList(unittest.TestCase):
 
         self.assertEqual(
             str(exception_context.exception),
-            "Legal values should be provided via a list or a tuple, "
+            "Legal values should be provided via a list, "
             "got 'zero'."
         )
 

--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -66,7 +66,7 @@ class TestPrefixList(unittest.TestCase):
 
     def test_values_not_all_iterables(self):
         # Make sure we don't confuse other sequence types, e.g. str
-        with self.assertRaises(ValueError) as exception_context:
+        with self.assertRaises(TypeError) as exception_context:
             PrefixList("zero")
 
         self.assertEqual(

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2555,7 +2555,7 @@ class PrefixList(BaseStr):
     then the actual value assigned to the trait attribute is the
     corresponding *s*\ :sub:`i` value that *v* matched.
 
-    The legal values can be provided as a list or tuple of values.
+    The legal values can be provided as a list of values.
 
     Example
     -------
@@ -2576,7 +2576,7 @@ class PrefixList(BaseStr):
     Parameters
     ----------
     values
-        A single list or tuple of legal string values.
+        A single list of legal string values.
 
     Attributes
     ----------

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2592,7 +2592,7 @@ class PrefixList(BaseStr):
 
     def __init__(self, values, **metadata):
         if not isinstance(values, SequenceTypes):
-            raise ValueError(
+            raise TypeError(
                 "Legal values should be provided via a list or a tuple, "
                 "got {!r}.".format(values)
             )

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2555,7 +2555,7 @@ class PrefixList(BaseStr):
     then the actual value assigned to the trait attribute is the
     corresponding *s*\ :sub:`i` value that *v* matched.
 
-    The legal values can be provided as a list of values.
+    The legal values can be provided as an iterable of values.
 
     Example
     -------
@@ -2576,7 +2576,7 @@ class PrefixList(BaseStr):
     Parameters
     ----------
     values
-        A single list of legal string values.
+        A single iterable of legal string values.
 
     Attributes
     ----------
@@ -2591,12 +2591,12 @@ class PrefixList(BaseStr):
     default_value_type = DefaultValue.constant
 
     def __init__(self, values, **metadata):
-        if not isinstance(values, SequenceTypes):
+        if isinstance(values, (str, bytes, bytearray)):
             raise TypeError(
-                "Legal values should be provided via a list, "
+                "Legal values should be provided via an iterable of strings, "
                 "got {!r}.".format(values)
             )
-        self.values = tuple(values)
+        self.values = list(values)
         self.values_ = values_ = {}
         for key in values:
             values_[key] = key

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2555,15 +2555,13 @@ class PrefixList(BaseStr):
     then the actual value assigned to the trait attribute is the
     corresponding *s*\ :sub:`i` value that *v* matched.
 
-    The list of legal values can be provided as a list or tuple of values.
-    That is, ``PrefixList(['one', 'two', 'three'])`` and
-    ``PrefixList('one', 'two', 'three')`` are equivalent.
+    The legal values can be provided as a list or tuple of values.
 
     Example
     -------
     ::
         class Person(HasTraits):
-            married = PrefixList('yes', 'no')
+            married = PrefixList(['yes', 'no'])
 
     The Person class has a **married** trait that accepts any of the
     strings 'y', 'ye', 'yes', 'n', or 'no' as valid values. However, the
@@ -2577,9 +2575,8 @@ class PrefixList(BaseStr):
 
     Parameters
     ----------
-    *values
-        Either all legal string values for the enumeration, or a single list
-        or tuple of legal string values.
+    values
+        A single list or tuple of legal string values.
 
     Attributes
     ----------
@@ -2593,11 +2590,13 @@ class PrefixList(BaseStr):
     #: The default value type to use (i.e. 'constant'):
     default_value_type = DefaultValue.constant
 
-    def __init__(self, *values, **metadata):
-
-        if (len(values) == 1) and (type(values[0]) in SequenceTypes):
-            values = values[0]
-        self.values = values[:]
+    def __init__(self, values, **metadata):
+        if not isinstance(values, SequenceTypes):
+            raise ValueError(
+                "Legal values should be provided via a list or a tuple, "
+                "got {!r}.".format(values)
+        )
+        self.values = tuple(values)
         self.values_ = values_ = {}
         for key in values:
             values_[key] = key

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2595,7 +2595,7 @@ class PrefixList(BaseStr):
             raise ValueError(
                 "Legal values should be provided via a list or a tuple, "
                 "got {!r}.".format(values)
-        )
+            )
         self.values = tuple(values)
         self.values_ = values_ = {}
         for key in values:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2593,7 +2593,7 @@ class PrefixList(BaseStr):
     def __init__(self, values, **metadata):
         if not isinstance(values, SequenceTypes):
             raise TypeError(
-                "Legal values should be provided via a list or a tuple, "
+                "Legal values should be provided via a list, "
                 "got {!r}.".format(values)
             )
         self.values = tuple(values)


### PR DESCRIPTION
Closes #1137 

This forces `PrefixList` to have ~at least~ exactly one positional argument, and that legal values must be provided via a list or a tuple.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] Update User manual (`docs/source/traits_user_manual`)
- [x] Update type annotation hints in `traits-stubs`
