### PR TITLE
Fix attribute name in documentation

### DIFF
--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -100,7 +100,7 @@ most of the use cases commonly encountered by users.
      - Meaning
    * - *attr1\.attr2*
      - Matches a trait named *attr2* on an object referenced by a trait named
-       *item1* on the current object. Changes to *attr1* or *attr2* will
+       *attr1* on the current object. Changes to *attr1* or *attr2* will
        trigger notifications.
    * - *attr1\:attr2*
      - Matches a trait named *attr2* on an object referenced by a trait named


### PR DESCRIPTION
Thanks to @rahulporuri pointing this out in https://github.com/enthought/traits/pull/1060#discussion_r429174328, this PR fixes a wrong attribute name in the mini-language semantics.

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~
