### PR TITLE
Raise TraitError for validation error in PrefixList.__init__

### DIFF
--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -55,7 +55,7 @@ class TestPrefixList(unittest.TestCase):
             a.foo = "abc"
 
     def test_invalid_default(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TraitError):
             class A(HasTraits):
                 foo = PrefixList("zero", "one", "two", default_value="uno")
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2608,7 +2608,7 @@ class PrefixList(BaseStr):
             try:
                 default = self.validate(None, None, default)
             except TraitError:
-                raise ValueError("Default value for PrefixTrait must be "
+                raise TraitError("Default value for PrefixTrait must be "
                                  "a unique prefix present in the prefix list")
         elif self.values:
             default = self.values[0]


### PR DESCRIPTION
Closes #1138 

This PR makes sure `PrefixList.__init__` raises `TraitError` for what is exactly a validation error.

I'd have wanted to use `value_for` like in #1139, however that change did not turn out to be as trivial as I hoped, so I will have to dig a bit to see if something else is wrong.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~