### PR TITLE
Maint: Improve validation error message and free PrefixList from subclassing BaseStr

### DIFF
--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -55,9 +55,14 @@ class TestPrefixList(unittest.TestCase):
             a.foo = "abc"
 
     def test_invalid_default(self):
-        with self.assertRaises(TraitError):
+        with self.assertRaises(TraitError) as exception_context:
             class A(HasTraits):
                 foo = PrefixList(["zero", "one", "two"], default_value="uno")
+
+        self.assertIn(
+            "but a value 'uno' was specified",
+            str(exception_context.exception),
+        )
 
     def test_values_not_sequence(self):
         # Defining values with this signature is not supported

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2541,7 +2541,7 @@ class CList(List):
         )
 
 
-class PrefixList(BaseStr):
+class PrefixList(TraitType):
     r"""Ensures that a value assigned to the attribute is a member of a list of
      specified string values, or is a unique prefix of one of those values.
 
@@ -2604,19 +2604,18 @@ class PrefixList(BaseStr):
         default = self.default_value
         if 'default_value' in metadata:
             default = metadata.pop('default_value')
-            try:
-                default = self.validate(None, None, default)
-            except TraitError:
-                raise TraitError("Default value for PrefixTrait must be "
-                                 "a unique prefix present in the prefix list")
+            default = self.value_for(default)
         elif self.values:
             default = self.values[0]
 
         super().__init__(default, **metadata)
 
-    def validate(self, object, name, value):
+    def value_for(self, value):
         if not isinstance(value, str):
-            self.error(object, name, value)
+            raise TraitError(
+                "Value must be {}, but a value {!r} was specified.".format(
+                    self.info(), value)
+            )
 
         if value in self.values_:
             return self.values_[value]
@@ -2626,7 +2625,10 @@ class PrefixList(BaseStr):
             self.values_[value] = match = matches[0]
             return match
 
-        self.error(object, name, value)
+        raise TraitError(
+            "Value must be {}, but a value {!r} was specified.".format(
+                self.info(), value)
+        )
 
     def info(self):
         return (


### PR DESCRIPTION
`PrefixList` subclasses `BaseStr` but then overrides most of what `BaseStr` offers. 
The one thing not overridden was the default TraitsUI editor, but the default (TextEditor) is actually fine to be used, so the one from `BaseStr` is also redundant.

By subclassing `BaseStr`, `PrefixList` inherits `validate` and it cannot use alternative validation interface further down the precedence list (fas_validate > validate > is_valid_for > value_for).

This PR:
- Free `PrefixList` from subclassing `BaseStr`
- Use `value_for` to validate *and* transform a value independently of the HasTraits, hence allows the error message to be used in `PrefixList.__init__`.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
