### PR TITLE
Add missing Py_DECREF to fix a reference leak

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -185,7 +185,7 @@ Fixes
   subclasses for mapped traits, used by ``Map``, ``Expression``, ``PrefixMap``.
   (#1091)
 * Fix setting default values via dynamic default methods or overriding trait in
-  subclasses for ``Expression`` and ``AdaptsTo``. (#1088, #1119)
+  subclasses for ``Expression`` and ``AdaptsTo``. (#1088, #1119, #1152)
 
 Deprecations
 ~~~~~~~~~~~~

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1833,6 +1833,7 @@ default_value_for(trait_object *trait, has_traits_object *obj, PyObject *name)
                         Py_DECREF(result);
                         return NULL;
                     }
+                    Py_DECREF(value);
                     return result;
                 }
                 else {


### PR DESCRIPTION
#1088 introduced a reference leak; this PR fixes that leak.

No regression test, because (a) it's hard to test for, and (b) this is picked up by running Python-level reference leak tests.

Fixes #1145.