### PR TITLE
DOC: Expand user manual on migration from Either to Union

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,7 +139,7 @@ Features
 ~~~~~~~~
 
 * Add ``os.PathLike`` support for ``Directory`` traits. (#867)
-* Add ``Union`` trait type. (#779, #1103, #1107, #1116, #1115)
+* Add ``Union`` trait type. (#779, #1103, #1107, #1116, #1115, #1153)
 * Add ``PrefixList`` trait type. (#871, #1142, #1144, #1147)
 * Add ``allow_none`` flag for ``Callable`` trait. (#885)
 * Add support for type annotation. (#904, #1064)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -224,7 +224,7 @@ Documentation
 * Add user manual section on the new ``observe`` notification system. (#1060,
   #1140, #1143)
 * Add user manual section on the ``Union`` trait type and how to migrate from
-  Either (#779, #1153)
+  ``Either`` (#779, #1153)
 * Other minor cleanups and fixes. (#949, #1141)
 
 Test suite

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,7 +139,7 @@ Features
 ~~~~~~~~
 
 * Add ``os.PathLike`` support for ``Directory`` traits. (#867)
-* Add ``Union`` trait type. (#779, #1103, #1107, #1116, #1115, #1153)
+* Add ``Union`` trait type. (#779, #1103, #1107, #1116, #1115)
 * Add ``PrefixList`` trait type. (#871, #1142, #1144, #1147)
 * Add ``allow_none`` flag for ``Callable`` trait. (#885)
 * Add support for type annotation. (#904, #1064)
@@ -223,6 +223,8 @@ Documentation
 * Add intersphinx support to configuration. (#1136)
 * Add user manual section on the new ``observe`` notification system. (#1060,
   #1140, #1143)
+* Add user manual section on the ``Union`` trait type and how to migrate from
+  Either (#779, #1153)
 * Other minor cleanups and fixes. (#949, #1141)
 
 Test suite

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -659,9 +659,9 @@ The following example illustrates the difference between `Either` and `Union`::
 
 .. rubric:: Migration from Either to Union
 
-* Static default value on Union is provided via the **default_value**
-  attribute, whereas Either uses the **default** attribute.
-  The naming of **default_value** is consistent with other trait types.
+* Static default values are defined on Union via the **default_value**
+  attribute, whereas Either uses the **default** attribute. The naming of
+  **default_value** is consistent with other trait types.
   For example::
 
       Either(None, Str(), default="unknown")
@@ -686,7 +686,7 @@ The following example illustrates the difference between `Either` and `Union`::
       Union(Int(), Float())
 
   Then the default value will be 0, which is the default value of the first
-  Int trait.
+  trait.
 
   To keep None as the default, one could add None as the first item::
 

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -688,7 +688,7 @@ The following example illustrates the difference between `Either` and `Union`::
   Then the default value will be 0, which is the default value of the first
   trait.
 
-  To keep None as the default, one could add None as the first item::
+  To keep None as the default, use None as the first item::
 
       Union(None, Int(), Float())
 

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -654,9 +654,45 @@ The following example illustrates the difference between `Either` and `Union`::
     ...     primes = Union([2], None, {'3':6}, 5, 7, 11)
     ValueError: Union trait declaration expects a trait type or an instance of trait type or None, but got [2] instead
 
-Note that static default values are defined on Union via the
-**default_value** attribute, whereas Either uses the **default** attribute.
-The naming of **default_value** is consistent with other trait types.
+
+.. _migration_either_to_union:
+
+.. rubric:: Migration from Either to Union
+
+* Static default value on Union is provided via the **default_value**
+  attribute, whereas Either uses the **default** attribute.
+  The naming of **default_value** is consistent with other trait types.
+  For example::
+
+      Either(None, Str(), default="unknown")
+
+  would be changed to::
+
+      Union(None, Str(), default_value="unknown")
+
+* If a default value is not defined, Union uses the default value from the
+  first trait in its definition, whereas Either uses None.
+
+  For example::
+
+      Either(Int(), Float())
+
+  has a default value of None. However None is not one of the allowed values.
+  If the trait is later set to None from a non-None value, a validation error
+  will occur.
+
+  If the trait definition is changed to::
+
+      Union(Int(), Float())
+
+  Then the default value will be 0, which is the default value of the first
+  Int trait.
+
+  To keep None as the default, one could add None as the first item::
+
+      Union(None, Int(), Float())
+
+  With this, None also becomes one of the allowed values.
 
 .. index:: multiple values, defining trait with
 


### PR DESCRIPTION
This PR expands the user manual to mention some points worth noting while migrating from Either to Union.

(There is already a section on migration from on_trait_change to observe. We could possibly have a separate index page for Traits 6.1 that references both sections.)

**Checklist**
- Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~
