### PR TITLE
Remove logging configuration for logging observe's change handler failure

### DIFF
--- a/traits/observation/exception_handling.py
+++ b/traits/observation/exception_handling.py
@@ -11,9 +11,9 @@
 # This module provides the push_exception_handler and pop_exception_handler
 # for the observers.
 
+import warnings
 import sys
 import traceback
-import warnings
 
 
 class ObserverExceptionHandler:

--- a/traits/observation/exception_handling.py
+++ b/traits/observation/exception_handling.py
@@ -11,9 +11,9 @@
 # This module provides the push_exception_handler and pop_exception_handler
 # for the observers.
 
-import warnings
 import sys
 import traceback
+import warnings
 
 
 class ObserverExceptionHandler:

--- a/traits/observation/exception_handling.py
+++ b/traits/observation/exception_handling.py
@@ -11,9 +11,11 @@
 # This module provides the push_exception_handler and pop_exception_handler
 # for the observers.
 
-import warnings
+import logging
 import sys
-import traceback
+
+
+_logger = logging.getLogger("traits")
 
 
 class ObserverExceptionHandler:
@@ -23,31 +25,27 @@ class ObserverExceptionHandler:
     ----------
     handler : callable(event) or None
         A callable to handle an event, in the context of
-        an exception. If None, the exceptions will result in a warning.
+        an exception. If None, the exceptions will be logged.
     reraise_exceptions : boolean
         Whether to reraise the exception.
     """
 
     def __init__(self, handler, reraise_exceptions):
-        self.handler = handler if handler is not None else self._warn
+        self.handler = handler if handler is not None else self._log_exception
         self.reraise_exceptions = reraise_exceptions
 
-    def _warn(self, event):
-        """ A handler that warns about the exception with the given event.
+    def _log_exception(self, event):
+        """ A handler that logs the exception with the given event.
 
         Parameters
         ----------
         event : object
             An event object emitted by the notification.
         """
-        _, _, tb = sys.exc_info()
-        texts = traceback.format_tb(tb)
-        warnings.warn(
+        _logger.exception(
             "Exception occurred in traits notification handler "
-            "for event object: {!r}\n{}".format(
-                event, "\n".join(texts)
-            ),
-            RuntimeWarning,
+            "for event object: %r",
+            event,
         )
 
 
@@ -72,7 +70,7 @@ class ObserverExceptionHandlerStack:
         ----------
         handler : callable(event) or None
             A callable to handle an event, in the context of
-            an exception. If None, exceptions will result in warnings.
+            an exception. If None, the exceptions will be logged.
         reraise_exceptions : boolean
             Whether to reraise the exception.
         """

--- a/traits/observation/exception_handling.py
+++ b/traits/observation/exception_handling.py
@@ -15,6 +15,9 @@ import logging
 import sys
 
 
+_logger = logging.getLogger("traits")
+
+
 class ObserverExceptionHandler:
     """ State for an exception handler.
 
@@ -39,8 +42,7 @@ class ObserverExceptionHandler:
         event : object
             An event object emitted by the notification.
         """
-        logger = logging.getLogger("traits")
-        logger.exception(
+        _logger.exception(
             "Exception occurred in traits notification handler "
             "for event object: %r",
             event,

--- a/traits/observation/exception_handling.py
+++ b/traits/observation/exception_handling.py
@@ -30,7 +30,6 @@ class ObserverExceptionHandler:
     def __init__(self, handler, reraise_exceptions):
         self.handler = handler if handler is not None else self._log_exception
         self.reraise_exceptions = reraise_exceptions
-        self.logger = None
 
     def _log_exception(self, event):
         """ A handler that logs the exception with the given event.
@@ -40,14 +39,8 @@ class ObserverExceptionHandler:
         event : object
             An event object emitted by the notification.
         """
-        if self.logger is None:
-            self.logger = logging.getLogger("traits")
-            handler = logging.StreamHandler()
-            handler.setFormatter(logging.Formatter("%(message)s"))
-            self.logger.addHandler(handler)
-            self.logger.setLevel(logging.ERROR)
-
-        self.logger.exception(
+        logger = logging.getLogger("traits")
+        logger.exception(
             "Exception occurred in traits notification handler "
             "for event object: %r",
             event,

--- a/traits/observation/tests/test_exception_handling.py
+++ b/traits/observation/tests/test_exception_handling.py
@@ -24,16 +24,17 @@ class TestExceptionHandling(unittest.TestCase):
     def test_default_logging(self):
         stack = ObserverExceptionHandlerStack()
 
-        with self.assertWarns(RuntimeWarning) as warn_context:
+        with self.assertLogs("traits", level="ERROR") as log_context:
             try:
                 raise ZeroDivisionError()
             except Exception:
                 stack.handle_exception("Event")
 
+        content, = log_context.output
         self.assertIn(
             "Exception occurred in traits notification handler for "
             "event object: {!r}".format("Event"),
-            str(warn_context.warning),
+            content,
         )
 
     def test_push_exception_handler(self):
@@ -44,7 +45,7 @@ class TestExceptionHandling(unittest.TestCase):
 
         stack.push_exception_handler(reraise_exceptions=True)
 
-        with self.assertWarns(RuntimeWarning) as warn_context, \
+        with self.assertLogs("traits", level="ERROR") as log_context, \
                 self.assertRaises(ZeroDivisionError):
 
             try:
@@ -52,7 +53,8 @@ class TestExceptionHandling(unittest.TestCase):
             except Exception:
                 stack.handle_exception("Event")
 
-        self.assertIn("ZeroDivisionError", str(warn_context.warning))
+        content, = log_context.output
+        self.assertIn("ZeroDivisionError", content)
 
     def test_push_exception_handler_collect_events(self):
 

--- a/traits/observation/tests/test_exception_handling.py
+++ b/traits/observation/tests/test_exception_handling.py
@@ -10,7 +10,7 @@
 """
 Test the push_exception_handler and pop_exception_handler for the observers
 """
-import io
+
 import unittest
 from unittest import mock
 
@@ -24,13 +24,13 @@ class TestExceptionHandling(unittest.TestCase):
     def test_default_logging(self):
         stack = ObserverExceptionHandlerStack()
 
-        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+        with self.assertLogs("traits", level="ERROR") as log_context:
             try:
                 raise ZeroDivisionError()
             except Exception:
                 stack.handle_exception("Event")
 
-        content = stderr.getvalue()
+        content, = log_context.output
         self.assertIn(
             "Exception occurred in traits notification handler for "
             "event object: {!r}".format("Event"),
@@ -45,7 +45,7 @@ class TestExceptionHandling(unittest.TestCase):
 
         stack.push_exception_handler(reraise_exceptions=True)
 
-        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr, \
+        with self.assertLogs("traits", level="ERROR") as log_context, \
                 self.assertRaises(ZeroDivisionError):
 
             try:
@@ -53,7 +53,7 @@ class TestExceptionHandling(unittest.TestCase):
             except Exception:
                 stack.handle_exception("Event")
 
-        content = stderr.getvalue()
+        content, = log_context.output
         self.assertIn("ZeroDivisionError", content)
 
     def test_push_exception_handler_collect_events(self):

--- a/traits/observation/tests/test_exception_handling.py
+++ b/traits/observation/tests/test_exception_handling.py
@@ -24,17 +24,16 @@ class TestExceptionHandling(unittest.TestCase):
     def test_default_logging(self):
         stack = ObserverExceptionHandlerStack()
 
-        with self.assertLogs("traits", level="ERROR") as log_context:
+        with self.assertWarns(RuntimeWarning) as warn_context:
             try:
                 raise ZeroDivisionError()
             except Exception:
                 stack.handle_exception("Event")
 
-        content, = log_context.output
         self.assertIn(
             "Exception occurred in traits notification handler for "
             "event object: {!r}".format("Event"),
-            content,
+            str(warn_context.warning),
         )
 
     def test_push_exception_handler(self):
@@ -45,7 +44,7 @@ class TestExceptionHandling(unittest.TestCase):
 
         stack.push_exception_handler(reraise_exceptions=True)
 
-        with self.assertLogs("traits", level="ERROR") as log_context, \
+        with self.assertWarns(RuntimeWarning) as warn_context, \
                 self.assertRaises(ZeroDivisionError):
 
             try:
@@ -53,8 +52,7 @@ class TestExceptionHandling(unittest.TestCase):
             except Exception:
                 stack.handle_exception("Event")
 
-        content, = log_context.output
-        self.assertIn("ZeroDivisionError", content)
+        self.assertIn("ZeroDivisionError", str(warn_context.warning))
 
     def test_push_exception_handler_collect_events(self):
 

--- a/traits/observation/tests/test_trait_event_notifier.py
+++ b/traits/observation/tests/test_trait_event_notifier.py
@@ -8,7 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-import io
 import unittest
 from unittest import mock
 import weakref
@@ -170,11 +169,11 @@ class TestTraitEventNotifierException(unittest.TestCase):
         notifier = create_notifier(handler=misbehaving_handler)
 
         # when
-        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+        with self.assertLogs("traits", level="ERROR") as log_exception:
             notifier(a=1, b=2)
 
         # then
-        content = stderr.getvalue()
+        content, = log_exception.output
         self.assertIn(
             "Exception occurred in traits notification handler",
             content,

--- a/traits/observation/tests/test_trait_event_notifier.py
+++ b/traits/observation/tests/test_trait_event_notifier.py
@@ -169,17 +169,16 @@ class TestTraitEventNotifierException(unittest.TestCase):
         notifier = create_notifier(handler=misbehaving_handler)
 
         # when
-        with self.assertLogs("traits", level="ERROR") as log_exception:
+        with self.assertWarns(RuntimeWarning) as warn_context:
             notifier(a=1, b=2)
 
         # then
-        content, = log_exception.output
         self.assertIn(
             "Exception occurred in traits notification handler",
-            content,
+            str(warn_context.warning),
         )
         # The tracback should be included
-        self.assertIn("ZeroDivisionError", content)
+        self.assertIn("ZeroDivisionError", str(warn_context.warning))
 
 
 class TestTraitEventNotifierEqual(unittest.TestCase):

--- a/traits/observation/tests/test_trait_event_notifier.py
+++ b/traits/observation/tests/test_trait_event_notifier.py
@@ -169,16 +169,17 @@ class TestTraitEventNotifierException(unittest.TestCase):
         notifier = create_notifier(handler=misbehaving_handler)
 
         # when
-        with self.assertWarns(RuntimeWarning) as warn_context:
+        with self.assertLogs("traits", level="ERROR") as log_exception:
             notifier(a=1, b=2)
 
         # then
+        content, = log_exception.output
         self.assertIn(
             "Exception occurred in traits notification handler",
-            str(warn_context.warning),
+            content,
         )
         # The tracback should be included
-        self.assertIn("ZeroDivisionError", str(warn_context.warning))
+        self.assertIn("ZeroDivisionError", content)
 
 
 class TestTraitEventNotifierEqual(unittest.TestCase):


### PR DESCRIPTION
Closes #1154

This PR removes the logging configuration on traits logger in `observe`, which was supposed to be consistent with `on_trait_change` (the logging configuration is still done there) ~, and adds warnings for any unexpected exceptions.~

This marks a slight difference from on_trait_change:
When a change handler using `on_trait_change` raises an exception, the error is always logged to the console regardless of whether the application wants it or not.

When a change handler using `observe` raises an exception, it is logged, and will depend on the last resort handler to get it to the console.

EDITED: ~a warning will be emitted to the console, forcing developers to deal with them.~

EDITED: ~the error is only visible if something else configures the logger on traits, or if a custom handler is pushed using `push_exception_handler`.~

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
-  ~Update type annotation hints in `traits-stubs`~
