### PR TITLE
Assume DatetimeEditor exists

### DIFF
--- a/traits/editor_factories.py
+++ b/traits/editor_factories.py
@@ -122,23 +122,8 @@ def datetime_editor():
     """ Factory function that returns an editor with date & time for
     editing Datetime values.
     """
-
-    try:
-        from traitsui.api import DatetimeEditor
-
-        return DatetimeEditor()
-
-    except ImportError:
-
-        logger.warn(msg="Could not import DatetimeEditor from "
-                        "traitsui.api, using TextEditor instead")
-
-        from traitsui.api import TextEditor
-
-        return TextEditor(
-            evaluate=_datetime_str_to_datetime,
-            format_func=_datetime_to_datetime_str
-        )
+    from traitsui.api import DatetimeEditor
+    return DatetimeEditor()
 
 
 def _expects_hastraits_instance(handler):

--- a/traits/tests/test_editor_factories.py
+++ b/traits/tests/test_editor_factories.py
@@ -29,14 +29,6 @@ from traits.editor_factories import (
 from traits.testing.optional_dependencies import requires_traitsui, traitsui
 
 
-# The DatetimeEditor is not yet in a released version of TraitsUI. It
-# will be available in TraitsUI >= 6.2.0.
-try:
-    DatetimeEditor = traitsui.api.DatetimeEditor
-except AttributeError:
-    DatetimeEditor = None
-
-
 class SimpleEditorTestMixin:
 
     def setUp(self):
@@ -55,12 +47,11 @@ class SimpleEditorTestMixin:
 
 @requires_traitsui
 class TestDateEditor(SimpleEditorTestMixin, unittest.TestCase):
-    cache_name = "DateEditor"
     traitsui_name = "DateEditor"
     factory_name = "date_editor"
 
 
-@unittest.skipIf(DatetimeEditor is None, "DatetimeEditor not available")
+@requires_traitsui
 class TestDatetimeEditor(SimpleEditorTestMixin, unittest.TestCase):
     traitsui_name = "DatetimeEditor"
     factory_name = "datetime_editor"
@@ -93,28 +84,24 @@ class TestDatetimeEditor(SimpleEditorTestMixin, unittest.TestCase):
 
 @requires_traitsui
 class TestCodeEditor(SimpleEditorTestMixin, unittest.TestCase):
-    cache_name = "SourceCodeEditor"
     traitsui_name = "CodeEditor"
     factory_name = "code_editor"
 
 
 @requires_traitsui
 class TestHTMLEditor(SimpleEditorTestMixin, unittest.TestCase):
-    cache_name = "HTMLTextEditor"
     traitsui_name = "HTMLEditor"
     factory_name = "html_editor"
 
 
 @requires_traitsui
 class TestShellEditor(SimpleEditorTestMixin, unittest.TestCase):
-    cache_name = "PythonShellEditor"
     traitsui_name = "ShellEditor"
     factory_name = "shell_editor"
 
 
 @requires_traitsui
 class TestTimeEditor(SimpleEditorTestMixin, unittest.TestCase):
-    cache_name = "TimeEditor"
     traitsui_name = "TimeEditor"
     factory_name = "time_editor"
 


### PR DESCRIPTION
We're now requiring TraitsUI >= 7.0, so we can reasonably assume that `DatetimeEditor` exists. This PR removes workarounds for an unavailable `DatetimeEditor`.

Also does a drive-by cleanup of the unused `cache_name` variable in several tests.
