### PR TITLE
Remove unused catch_logs contextmanager

### DIFF
--- a/traits/tests/test_trait_get_set.py
+++ b/traits/tests/test_trait_get_set.py
@@ -26,28 +26,6 @@ class TraitsObject(HasTraits):
     integer = Int
 
 
-class ListHandler(logging.Handler):
-    def __init__(self):
-        logging.Handler.__init__(self)
-        self.records = []
-
-    def emit(self, record):
-        self.records.append(record)
-
-
-@contextmanager
-def catch_logs(module_name):
-    logger = logging.getLogger(module_name)
-    logger.propagate = False
-    handler = ListHandler()
-    logger.addHandler(handler)
-    try:
-        yield handler
-    finally:
-        logger.removeHandler(handler)
-        logger.propagate = True
-
-
 class TestTraitGet(UnittestTools, unittest.TestCase):
     def test_trait_set(self):
         obj = TraitsObject()

--- a/traits/tests/test_trait_get_set.py
+++ b/traits/tests/test_trait_get_set.py
@@ -12,8 +12,6 @@
 Test the 'trait_set', 'trait_get' interface to the HasTraits class.
 
 """
-from contextlib import contextmanager
-import logging
 import unittest
 
 from traits.api import HasTraits, Str, Int


### PR DESCRIPTION
Remove an unused `catch_logs` context manager factory. Now that we've dropped Python 2 support, we can use unittest's `assertLogs` for checking log messages.