### PR TITLE
Remove an unused logger

### DIFF
--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -35,11 +35,6 @@ from .trait_handler import TraitHandler
 from .trait_list_object import TraitListEvent, TraitListObject
 from .util.deprecated import deprecated
 
-# Set up a logger:
-import logging
-
-logger = logging.getLogger(__name__)
-
 # Constants
 
 CallableTypes = (FunctionType, MethodType)


### PR DESCRIPTION
This PR simply removes an unused logger from the `trait_handler` module.
