### PR TITLE
Don't configure logging for trait notification handler exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,25 @@ However, there are a few things to be aware of when upgrading.
   TraitsUI views, and an error will be raised if you attempt to create a
   TraitsUI view.
 
+* The approach to logging configuration of the Traits library has changed.
+  Trait notification handlers should not raise exceptions in normal use, and as
+  before, an exception is logged whenever a trait notification handler raises.
+
+  What differs is the way that that log record is handled under default
+  exception handling. Previously, Traits added a
+  :class:`~logging.StreamHandler` to the ``"traits"`` logger, so that log
+  messages would automatically be printed to standard error. Traits also added
+  a :class:`~logging.NullHandler` to that logger. Both of those handlers are
+  now removed, and Traits now does no logging configuration at all, leaving all
+  such configuration to the application.
+
+  The net effect of these changes is that in the absence of any logging
+  configuration, errors occurring in notification handlers will show up on the
+  console as before, as a result of the logging module's "handler of last
+  resort". Traits-using applications that *do* configure logging may need to
+  double check that their log configuration suppresses or records these
+  messages as appropriate for their application.
+
 * When listening for changes to the items of a :class:`.List` trait, an index
   or slice set operation no longer performs an equality check between the
   replaced elements and the replacement elements when deciding whether to issue

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,7 +75,7 @@ However, there are a few things to be aware of when upgrading.
   always be visible. Traits also added a :class:`~logging.NullHandler` to that
   logger. Both of those handlers have now been removed. We now rely on
   Python's "handler of last resort", which will continue to make notification
-  exceptions to the user visiable in the absence of any application-level
+  exceptions to the user visible in the absence of any application-level
   log configuration.
 
 * When listening for changes to the items of a :class:`.List` trait, an index

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,23 +63,20 @@ However, there are a few things to be aware of when upgrading.
   TraitsUI view.
 
 * The approach to logging configuration of the Traits library has changed.
-  Trait notification handlers should not raise exceptions in normal use, and as
-  before, an exception is logged whenever a trait notification handler raises.
+  Traits now does no logging configuration at all, leaving all such
+  configuration to the application.
 
-  What differs is the way that that log record is handled under default
-  exception handling. Previously, Traits added a
-  :class:`~logging.StreamHandler` to the ``"traits"`` logger, so that log
-  messages would automatically be printed to standard error. Traits also added
-  a :class:`~logging.NullHandler` to that logger. Both of those handlers have
-  been removed, and Traits now does no logging configuration at all, leaving
-  all such configuration to the application.
-
-  The net effect of these changes is that in the absence of any logging
-  configuration, errors occurring in notification handlers will show up on the
-  console as before, as a result of the logging module's "handler of last
-  resort". Traits-using applications that *do* configure logging may need to
-  double check that their log configuration suppresses or records these
-  messages as appropriate for their application.
+  In more detail: trait notification handlers should not raise exceptions in
+  normal use, so an exception is logged whenever a trait notification handler
+  raises. This part of the behaviour has not changed. What *has* changed is the
+  way that logged exception is handled under default exception handling.
+  Previously, Traits added a :class:`~logging.StreamHandler` to the
+  top-level ``"traits"`` logger, so that trait notification exceptions would
+  always be visible. Traits also added a :class:`~logging.NullHandler` to that
+  logger. Both of those handlers have now been removed. We now realy on
+  Python's "handler of last resort", which will continue to make notification
+  exceptions to the user visiable in the absence of any application-level
+  log configuration.
 
 * When listening for changes to the items of a :class:`.List` trait, an index
   or slice set operation no longer performs an equality check between the
@@ -188,11 +185,8 @@ Changes
 * ``TraitListEvent.index`` reported by mutations to a list is now normalized.
   (#1009)
 * The default notification error handler for Traits no longer configures
-  logging. It used to explicitly add a ``StreamHandler`` to the top-level
-  Traits logger so that trait notification exceptions would always be
-  visible. Instead, we rely on Python's "handler of last resort", which
-  will continue to make notification exceptions to the user visible in
-  the absence of any application-level log configuration. (#1161)
+  logging, and the top-level ``NullHandler`` log handler has been removed.
+  (#1161)
 
 Fixes
 ~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,9 +70,9 @@ However, there are a few things to be aware of when upgrading.
   exception handling. Previously, Traits added a
   :class:`~logging.StreamHandler` to the ``"traits"`` logger, so that log
   messages would automatically be printed to standard error. Traits also added
-  a :class:`~logging.NullHandler` to that logger. Both of those handlers are
-  now removed, and Traits now does no logging configuration at all, leaving all
-  such configuration to the application.
+  a :class:`~logging.NullHandler` to that logger. Both of those handlers have
+  been removed, and Traits now does no logging configuration at all, leaving
+  all such configuration to the application.
 
   The net effect of these changes is that in the absence of any logging
   configuration, errors occurring in notification handlers will show up on the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,18 +62,18 @@ However, there are a few things to be aware of when upgrading.
   TraitsUI views, and an error will be raised if you attempt to create a
   TraitsUI view.
 
-* The approach to logging configuration of the Traits library has changed.
-  Traits now does no logging configuration at all, leaving all such
+* Traits now does no logging configuration at all, leaving all such
   configuration to the application.
 
   In more detail: trait notification handlers should not raise exceptions in
   normal use, so an exception is logged whenever a trait notification handler
   raises. This part of the behaviour has not changed. What *has* changed is the
   way that logged exception is handled under default exception handling.
+
   Previously, Traits added a :class:`~logging.StreamHandler` to the
   top-level ``"traits"`` logger, so that trait notification exceptions would
   always be visible. Traits also added a :class:`~logging.NullHandler` to that
-  logger. Both of those handlers have now been removed. We now realy on
+  logger. Both of those handlers have now been removed. We now rely on
   Python's "handler of last resort", which will continue to make notification
   exceptions to the user visiable in the absence of any application-level
   log configuration.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -168,6 +168,12 @@ Changes
   result in content that compares equally to the old values. (#1026)
 * ``TraitListEvent.index`` reported by mutations to a list is now normalized.
   (#1009)
+* The default notification error handler for Traits no longer configures
+  logging. It used to explicitly add a ``StreamHandler`` to the top-level
+  Traits logger so that trait notification exceptions would always be
+  visible. Instead, we rely on Python's "handler of last resort", which
+  will continue to make notification exceptions to the user visible in
+  the absence of any application-level log configuration. (#1161)
 
 Fixes
 ~~~~~

--- a/traits/__init__.py
+++ b/traits/__init__.py
@@ -16,10 +16,3 @@ except ImportError:
     # hasn't been built, so this isn't a viable Traits installation. OTOH, it
     # can be useful if a simple "import traits" doesn't actually fail.
     __version__ = "unknown"
-
-# Add a NullHandler so 'traits' loggers don't complain when they get used.
-import logging
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())
-
-del logging

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -12,6 +12,7 @@
 """
 
 import contextlib
+import logging
 import threading
 from threading import local as thread_local
 from threading import Thread
@@ -211,16 +212,7 @@ class NotificationExceptionHandler(object):
 
         logger = self.traits_logger
         if logger is None:
-            import logging
-
             self.traits_logger = logger = logging.getLogger("traits")
-            handler = logging.StreamHandler()
-            handler.setFormatter(logging.Formatter("%(message)s"))
-            logger.addHandler(handler)
-            print(
-                "Exception occurred in traits notification handler.\n"
-                "Please check the log file for details."
-            )
 
         try:
             logger.exception(


### PR DESCRIPTION
The default handler for trait notification exceptions configures logging, adding a `StreamHandler` to the top-level `traits` logger. This has the (desirable) effect of ensuring that, in the absence of any logging configuration, errors occurring in listeners are visible to the user, printed on stderr.

However, it also makes it awkward for an application to configure logging, and particularly for an application to _suppress_ the traits log messages if it wants to: that application would have to mess with the handler that Traits has already set up.

Instead, we should follow the usual logging best practices and allow the application to configure logging, restricting Traits to simply emitting log messages.

This PR removes the log configuration.

We also remove the top-level `NullHandler`. That handler was particularly needed for Python 2, where a logged exception resulted in an uninformative message about logging not being configured. However, in Python 3, the logger of last resort will report the log message, but only if no other handlers have been configured.

The net result is that:

- in the absence of user log configuration, Traits behaves much as before, printing out exception details to stderr as a result of the handler of last resort
- in the presence of user log configuration, little will have changed, assuming that the user has at least configured a handler for the top-level logger (as would happen, for example, with `basicConfig`)
- if an application wants to choose how to deal with Traits log messages, it's better able to do so