### PR TITLE
Add changelog link to the Either-to-Union migration guide

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,10 +106,11 @@ deprecated before Traits 7.0. Users should be aware of the following possible
 future changes:
 
 * The :class:`.Either` trait type will eventually be deprecated. Where
-  possible, use :class:`.Union` instead. When transitioning, note that
-  :class:`.Either` and :class:`.Union` use different keywords for specifying a
-  static default value: :class:`.Either` uses ``default``, while
-  :class:`.Union` uses ``default_value``.
+  possible, use :class:`.Union` instead. When replacing uses of
+  :class:`.Either` with :class:`.Union`, note that there are some significant
+  API and behavioral differences between the two trait types, particularly with
+  respect to handling of defaults. See :ref:`migration_either_to_union` for
+  more details.
 
 * The ``trait_modified`` event trait that's present on all :class:`.HasTraits`
   subclasses will eventually be removed. Users should not rely on it being

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -225,7 +225,7 @@ Documentation
 * Add user manual section on the new ``observe`` notification system. (#1060,
   #1140, #1143)
 * Add user manual section on the ``Union`` trait type and how to migrate from
-  ``Either`` (#779, #1153)
+  ``Either`` (#779, #1153, #1162)
 * Other minor cleanups and fixes. (#949, #1141)
 
 Test suite


### PR DESCRIPTION
Following #1153, this PR adds a note in the changelog that links to the Either-to-Union migration guide.