### PR TITLE
Bump version for 6.1.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Traits CHANGELOG
 Release 6.1.0
 -------------
 
-Released: 2020-06-03
+Released: 2020-06-05
 
 The Traits library is a foundational component of the Enthought Tool Suite. It
 provides observable, typed attributes for Python classes, making those classes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Traits CHANGELOG
 Release 6.1.0
 -------------
 
-Released: 2020-05-XX
+Released: 2020-06-03
 
 The Traits library is a foundational component of the Enthought Tool Suite. It
 provides observable, typed attributes for Python classes, making those classes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,7 +139,7 @@ future changes:
 Detailed PR-by-PR changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-More than 150 PRs went into this release. The following people contributed
+More than 160 PRs went into this release. The following people contributed
 code changes for this release:
 
 * Ieva Cernyte

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 6
 MINOR = 1
 MICRO = 0
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
Bump the version in preparation for release.

Ideally, this should not be merged until after all other PRs targeted at the 6.1.0 release have been merged. (Currently, that's just #1167, but there may be more PRs as a result of testing.)