### PR TITLE
Use absolute import in a test

### DIFF
--- a/traits/util/tests/test_weakidddict.py
+++ b/traits/util/tests/test_weakidddict.py
@@ -10,7 +10,7 @@
 
 import unittest
 
-from ..weakiddict import WeakIDDict, WeakIDKeyDict
+from traits.utils.weakiddict import WeakIDDict, WeakIDKeyDict
 
 
 class AllTheSame(object):

--- a/traits/util/tests/test_weakidddict.py
+++ b/traits/util/tests/test_weakidddict.py
@@ -10,7 +10,7 @@
 
 import unittest
 
-from traits.utils.weakiddict import WeakIDDict, WeakIDKeyDict
+from traits.util.weakiddict import WeakIDDict, WeakIDKeyDict
 
 
 class AllTheSame(object):


### PR DESCRIPTION
This PR changes one test to use an absolute import rather than a relative one. This makes the corresponding test script executable standalone.

This is the only test that needs fixing this way. The relative import was preventing a refleak test run from completing normally (with `python -E -Wd -m test -R: --testdir ../traits/util/tests`).