### PR TITLE
Ensure length check on unconstrained list always passes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,7 +164,7 @@ Features
 * Add ``Map`` and ``PrefixMap`` trait types. (#886, #953, #956, #970, #1139)
 * Add ``TraitList`` as the base list object that can perform validation
   and emit change notifications. (#912, #981, #984, #989, #999, #1003, #1011,
-  #1026, #1009, #1040)
+  #1026, #1009, #1040, #1172)
 * Add ``TraitDict`` as the base dict object that can perform validation and
   emit change notifications. (#913)
 * Add ``TraitSet`` as the base set object that can perform validation and

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -1150,6 +1150,8 @@ class HasLengthConstrainedLists(HasTraits):
 
     at_most_five = List(Int, maxlen=5)
 
+    unconstrained = List(Int)
+
 
 class TestTraitListObject(unittest.TestCase):
     def test_list_of_lists_pickle_with_notifier(self):
@@ -1381,6 +1383,13 @@ class TestTraitListObject(unittest.TestCase):
             foo.at_least_two.pop(10)
         self.assertEqual(foo.at_least_two, [1, 2])
 
+    def test_pop_from_empty(self):
+        foo = HasLengthConstrainedLists()
+        with self.assertRaises(IndexError):
+            foo.unconstrained.pop()
+        with self.assertRaises(IndexError):
+            foo.unconstrained.pop(10)
+
     def test_remove(self):
         foo = HasLengthConstrainedLists(at_least_two=[1, 2, 6, 4])
         foo.at_least_two.remove(2)
@@ -1397,6 +1406,11 @@ class TestTraitListObject(unittest.TestCase):
         with self.assertRaises(TraitError):
             foo.at_least_two.remove(10)
         self.assertEqual(foo.at_least_two, [1, 2])
+
+    def test_remove_from_empty(self):
+        foo = HasLengthConstrainedLists()
+        with self.assertRaises(ValueError):
+            foo.unconstrained.remove(35)
 
     def test_dead_object_reference(self):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4])

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -1216,6 +1216,11 @@ class TestTraitListObject(unittest.TestCase):
             del foo.at_least_two[:]
         self.assertEqual(foo.at_least_two, [1, 2])
 
+    def test_delitem_from_empty(self):
+        foo = HasLengthConstrainedLists()
+        with self.assertRaises(IndexError):
+            del foo.unconstrained[0]
+
     def test_iadd(self):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2])
         foo.at_most_five += [6, 7, 8]

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -776,7 +776,7 @@ class TraitListObject(TraitList):
             If list is empty or index is out of range.
         """
 
-        self._validate_length(len(self) - 1)
+        self._validate_length(max(len(self) - 1, 0))
         return super().pop(index)
 
     def remove(self, value):
@@ -797,7 +797,7 @@ class TraitListObject(TraitList):
             If the value is not present.
         """
 
-        self._validate_length(len(self) - 1)
+        self._validate_length(max(len(self) - 1, 0))
         super().remove(value)
 
     # -- pickle and copy support ----------------------------------------------

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -634,7 +634,7 @@ class TraitListObject(TraitList):
         """
 
         removed_count = len(self[key]) if isinstance(key, slice) else 1
-        self._validate_length(len(self) - removed_count)
+        self._validate_length(max(len(self) - removed_count, 0))
         super().__delitem__(key)
 
     def __iadd__(self, value):


### PR DESCRIPTION
This PR is a workaround to make sure that we don't raise something that looks like a length error on an unconstrained list.

This isn't the solution I'd prefer - it's the least invasive solution that unblocks the Traits 6.1.0 release.

For Traits 6.2.0, I'd like to rework so that the `minlen` and `maxlen` attributes of a `List` trait are `None` for an unconstrained list, and have the rest of the code interpret that properly. But that feels like too invasive and risky a fix this close to the release, so for 6.1.0 we get this workaround instead.

Fixes #1171 