### PR TITLE
Fix error message for a list length violation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,7 +164,7 @@ Features
 * Add ``Map`` and ``PrefixMap`` trait types. (#886, #953, #956, #970, #1139)
 * Add ``TraitList`` as the base list object that can perform validation
   and emit change notifications. (#912, #981, #984, #989, #999, #1003, #1011,
-  #1026, #1009, #1040)
+  #1026, #1009, #1040, #1173)
 * Add ``TraitDict`` as the base dict object that can perform validation and
   emit change notifications. (#913)
 * Add ``TraitSet`` as the base set object that can perform validation and

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -1398,6 +1398,18 @@ class TestTraitListObject(unittest.TestCase):
             foo.at_least_two.remove(10)
         self.assertEqual(foo.at_least_two, [1, 2])
 
+    def test_length_violation_error_message(self):
+        # Regression test for enthought/traits#1170
+        foo = HasLengthConstrainedLists(at_least_two=[1, 2])
+        with self.assertRaises(TraitError) as exc_cm:
+            foo.at_least_two.remove(1)
+
+        exc_message = str(exc_cm.exception)
+        self.assertIn("'at_least_two' trait", exc_message)
+        self.assertIn("HasLengthConstrainedLists instance", exc_message)
+        self.assertIn("an integer", exc_message)
+        self.assertIn("at least 2 items", exc_message)
+
     def test_dead_object_reference(self):
         foo = HasLengthConstrainedLists(at_most_five=[1, 2, 3, 4])
         list_object = foo.at_most_five

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -889,8 +889,8 @@ class TraitListObject(TraitList):
                 "but you attempted to change its length to %d %s."
                 % (
                     self.name,
-                    class_of(object),
-                    self.trait.full_info(object, self.name, Undefined),
+                    class_of(self.object()),
+                    self.trait.full_info(self.object(), self.name, Undefined),
                     new_length,
                     "element" if new_length == 1 else "elements",
                 )


### PR DESCRIPTION
Fix an error message that was mistakenly using the built-in type `object` in place of the `HasTraits` object that the trait lives on.

Fixes #1170