### PR TITLE
Add 'observe' keyword to the Property trait for observation

### DIFF
--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -1159,9 +1159,9 @@ next time its value is requested.
 One strategy to accomplish caching would be to use a private attribute for the
 cached value, and notification observer methods on the attributes that are
 depended on. However, to simplify the situation, Property traits support a
-@cached_property decorator and **observes** metadata. Use @cached_property to
+@cached_property decorator and **observe** metadata. Use @cached_property to
 indicate that a getter method's return value should be cached. Use
-**observes** to indicate the other attributes that the property depends on.
+**observe** to indicate the other attributes that the property depends on.
 
 .. index:: examples; cached property
 
@@ -1173,7 +1173,7 @@ For example:
 The @cached_property decorator takes no arguments. Place it on the line
 preceding the property's getter method.
 
-The **observes** metadata attribute accepts extended trait references, using
+The **observe** metadata attribute accepts extended trait references, using
 the same syntax as the :func:`~traits.has_traits.HasTraits.observe` method's
 expression parameter, which is also described in
 :ref:`the expression section <observe-expression>`. As a result,

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -1159,8 +1159,8 @@ next time its value is requested.
 One strategy to accomplish caching would be to use a private attribute for the
 cached value, and notification observer methods on the attributes that are
 depended on. However, to simplify the situation, Property traits support a
-@cached_property decorator and **observe** metadata. Use @cached_property to
-indicate that a getter method's return value should be cached. Use
+|@cached_property| decorator and **observe** metadata. Use |@cached_property|
+to indicate that a getter method's return value should be cached. Use
 **observe** to indicate the other attributes that the property depends on.
 
 .. index:: examples; cached property
@@ -1170,15 +1170,15 @@ For example:
 .. literalinclude:: /../../examples/tutorials/doc_examples/examples/cached_prop.py
    :start-at: from traits.api
 
-The @cached_property decorator takes no arguments. Place it on the line
+The |@cached_property| decorator takes no arguments. Place it on the line
 preceding the property's getter method.
 
 The **observe** metadata attribute accepts extended trait references, using
-the same syntax as the :func:`~traits.has_traits.HasTraits.observe` method's
-expression parameter, which is also described in
-:ref:`the expression section <observe-expression>`. As a result,
-it can take values that specify attributes on referenced objects, multiple
-attributes, or attributes that are selected based on their metadata attributes.
+the same syntax as the |HasTraits.observe| method's expression parameter,
+which is also described in :ref:`expression section <observe-expression>`.
+As a result, it can take values that specify attributes on referenced objects,
+multiple attributes, or attributes that are selected based on their metadata
+attributes.
 
 .. index:: persistence, __getstate__(), __setstate__()
 
@@ -1509,3 +1509,9 @@ course, this is offset by the convenience and flexibility provided by the
 deferral model. As with any powerful tool, it is best to understand its
 strengths and weaknesses and apply that understanding in determining when use of
 the tool is justified and appropriate.
+
+..
+   # substitutions
+
+.. |HasTraits.observe| replace:: :func:`~traits.has_traits.HasTraits.observe`
+.. |@cached_property| replace:: :func:`~traits.has_traits.cached_property`

--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -1157,39 +1157,28 @@ next time its value is requested.
 .. index:: cached_property decorator, depends_on metadata
 
 One strategy to accomplish caching would be to use a private attribute for the
-cached value, and notification listener methods on the attributes that are
+cached value, and notification observer methods on the attributes that are
 depended on. However, to simplify the situation, Property traits support a
-@cached_property decorator and **depends_on** metadata. Use @cached_property to
+@cached_property decorator and **observes** metadata. Use @cached_property to
 indicate that a getter method's return value should be cached. Use
-**depends_on** to indicate the other attributes that the property depends on.
+**observes** to indicate the other attributes that the property depends on.
 
 .. index:: examples; cached property
 
-For example::
+For example:
 
-    # cached_prop.py -- Example of @cached_property decorator
-    from traits.api import HasPrivateTraits, List, Int,\
-                                     Property, cached_property
-
-    class TestScores ( HasPrivateTraits ):
-
-        scores  = List( Int )
-        average = Property( depends_on = 'scores' )
-
-        @cached_property
-        def _get_average ( self ):
-            s = self.scores
-            return (float( reduce( lambda n1, n2: n1 + n2, s, 0 ) )
-                     / len( s ))
+.. literalinclude:: /../../examples/tutorials/doc_examples/examples/cached_prop.py
+   :start-at: from traits.api
 
 The @cached_property decorator takes no arguments. Place it on the line
 preceding the property's getter method.
 
-The **depends_on** metadata attribute accepts extended trait references, using
-the same syntax as the on_trait_change() method's name parameter, described in
-:ref:`the-name-parameter`. As a result, it can take values that specify
-attributes on referenced objects, multiple attributes, or attributes that are
-selected based on their metadata attributes.
+The **observes** metadata attribute accepts extended trait references, using
+the same syntax as the :func:`~traits.has_traits.HasTraits.observe` method's
+expression parameter, which is also described in
+:ref:`the expression section <observe-expression>`. As a result,
+it can take values that specify attributes on referenced objects, multiple
+attributes, or attributes that are selected based on their metadata attributes.
 
 .. index:: persistence, __getstate__(), __setstate__()
 

--- a/docs/source/traits_user_manual/appendix.rst
+++ b/docs/source/traits_user_manual/appendix.rst
@@ -4,5 +4,44 @@ Appendix
 ========
 
 .. toctree::
+   :hidden:
 
    listening.rst
+
+
+Trait Notification with **on_trait_change**
+--------------------------------------------
+
+See :ref:`on-trait-change-notification` for details on how to set up change
+notifications using an older API.
+
+
+Property **depends_on**
+-----------------------
+
+The **depends_on** attribute on a **Property** trait allows change
+notifications to be fired for the property when one of its dependents has
+changed. This makes use of **on_trait_change** internally and therefore this
+is an older API. See :ref:`caching-a-property-value` for the current API.
+
+.. index:: depends_on metadata
+
+For example::
+
+    from traits.api import HasPrivateTraits, List, Int, Property
+
+    class TestScores ( HasPrivateTraits ):
+
+        scores  = List( Int )
+        average = Property( depends_on = 'scores' )
+
+        def _get_average ( self ):
+            s = self.scores
+            return (float( reduce( lambda n1, n2: n1 + n2, s, 0 ) )
+                     / len( s ))
+
+The **depends_on** metadata attribute accepts extended trait references, using
+the same syntax as the on_trait_change() method's name parameter, described in
+:ref:`the-name-parameter`. As a result, it can take values that specify
+attributes on referenced objects, multiple attributes, or attributes that are
+selected based on their metadata attributes.

--- a/docs/source/traits_user_manual/appendix.rst
+++ b/docs/source/traits_user_manual/appendix.rst
@@ -30,12 +30,12 @@ For example::
 
     from traits.api import HasStrictTraits, List, Int, Property
 
-    class TestScores (HasStrictTraits):
+    class TestScores(HasStrictTraits):
 
         scores = List(Int)
         average = Property(depends_on='scores')
 
-        def _get_average (self):
+        def _get_average(self):
             s = self.scores
             return (float(reduce(lambda n1, n2: n1 + n2, s, 0)) / len(s))
 

--- a/docs/source/traits_user_manual/appendix.rst
+++ b/docs/source/traits_user_manual/appendix.rst
@@ -28,17 +28,16 @@ is an older API. See :ref:`caching-a-property-value` for the current API.
 
 For example::
 
-    from traits.api import HasPrivateTraits, List, Int, Property
+    from traits.api import HasStrictTraits, List, Int, Property
 
-    class TestScores ( HasPrivateTraits ):
+    class TestScores (HasStrictTraits):
 
-        scores  = List( Int )
-        average = Property( depends_on = 'scores' )
+        scores = List(Int)
+        average = Property(depends_on='scores')
 
-        def _get_average ( self ):
+        def _get_average (self):
             s = self.scores
-            return (float( reduce( lambda n1, n2: n1 + n2, s, 0 ) )
-                     / len( s ))
+            return (float(reduce(lambda n1, n2: n1 + n2, s, 0)) / len(s))
 
 The **depends_on** metadata attribute accepts extended trait references, using
 the same syntax as the on_trait_change() method's name parameter, described in

--- a/examples/tutorials/doc_examples/examples/cached_prop.py
+++ b/examples/tutorials/doc_examples/examples/cached_prop.py
@@ -15,10 +15,10 @@ support.
 """
 
 from traits.api import (
-    cached_property, HasPrivateTraits, Str, observe, Property,
+    cached_property, HasStrictTraits, Str, observe, Property,
 )
 
-class Person(HasPrivateTraits):
+class Person(HasStrictTraits):
 
     full_name = Str()
     last_name = Property(observe="full_name")

--- a/examples/tutorials/doc_examples/examples/cached_prop.py
+++ b/examples/tutorials/doc_examples/examples/cached_prop.py
@@ -21,7 +21,7 @@ from traits.api import (
 class Person(HasPrivateTraits):
 
     full_name = Str()
-    last_name = Property(observes="full_name")
+    last_name = Property(observe="full_name")
 
     @cached_property
     def _get_last_name(self):

--- a/examples/tutorials/doc_examples/examples/cached_prop.py
+++ b/examples/tutorials/doc_examples/examples/cached_prop.py
@@ -8,18 +8,29 @@
 #
 # Thanks for using Enthought open source!
 
-# cached_prop.py - Example of @cached_property decorator
-# --[Imports]------------------------------------------------------------------
-from traits.api import HasPrivateTraits, List, Int, Property, cached_property
+"""
+This example demonstrates the use of Property, with caching and notifcation
+support.
 
+"""
 
-# --[Code]---------------------------------------------------------------------
-class TestScores(HasPrivateTraits):
+from traits.api import (
+    cached_property, HasPrivateTraits, Str, observe, Property,
+)
 
-    scores = List(Int)
-    average = Property(depends_on="scores")
+class Person(HasPrivateTraits):
+
+    full_name = Str()
+    last_name = Property(observes="full_name")
 
     @cached_property
-    def _get_average(self):
-        s = self.scores
-        return sum(s) / len(s)
+    def _get_last_name(self):
+        return self.full_name.split(" ")[-1]
+
+    @observe("last_name")
+    def _last_name_updated(self, event):
+        print("last_name is changed.")
+
+
+obj = Person()
+obj.full_name = "John Doe"   # print: last_name is changed.

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -322,7 +322,7 @@ def _create_property_observe_state(observe, property_name, cached):
     Parameters
     ----------
     observe : str or list or Expression
-        As is accepted by HasTraits.observe
+        As is accepted by HasTraits.observe expression argument
         This is the value provided in Property(observe=...)
     property_name : str
         The name of the property trait.

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -316,14 +316,14 @@ def _property_method(class_dict, name):
     return class_dict.get(name)
 
 
-def _create_property_observe_state(observes, property_name, cached):
+def _create_property_observe_state(observe, property_name, cached):
     """ Create the metadata for setting up an observer for Property.
 
     Parameters
     ----------
-    observes : str or list or Expression
+    observe : str or list or Expression
         As is accepted by HasTraits.observe
-        This is the value provided in Property(observes=...)
+        This is the value provided in Property(observe=...)
     property_name : str
         The name of the property trait.
     cached : boolean
@@ -347,7 +347,7 @@ def _create_property_observe_state(observes, property_name, cached):
         return types.MethodType(handler, instance)
 
     return dict(
-        expression=observes,
+        expression=observe,
         dispatch="same",
         handler_getter=handler_getter,
         post_init=False,
@@ -720,9 +720,9 @@ def update_traits_class_dict(class_name, bases, class_dict):
 
             listeners[name] = ("property", cached, depends_on)
 
-        if trait.type == "property" and trait.observes is not None:
+        if trait.type == "property" and trait.observe is not None:
             observer_state = _create_property_observe_state(
-                observes=trait.observes,
+                observe=trait.observe,
                 property_name=name,
                 cached=trait.cached,
             )
@@ -883,7 +883,7 @@ def cached_property(function):
         write boilerplate cache management code explicitly. For example::
 
             file_name = File
-            file_contents = Property( observes = 'file_name' )
+            file_contents = Property( observe = 'file_name' )
 
             @cached_property
             def _get_file_contents(self):
@@ -896,7 +896,7 @@ def cached_property(function):
         **_file_contents**, which maintained by the @cached_property wrapper
         code, is returned.
 
-        Note the use, in the example, of the **observes** metadata attribute
+        Note the use, in the example, of the **observe** metadata attribute
         to specify that the value of **file_contents** depends on
         **file_name**, so that _get_file_contents() is called only when
         **file_name** changes. For details, see the traits.traits.Property()

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -883,7 +883,7 @@ def cached_property(function):
         write boilerplate cache management code explicitly. For example::
 
             file_name = File
-            file_contents = Property( observe = 'file_name' )
+            file_contents = Property(observe='file_name')
 
             @cached_property
             def _get_file_contents(self):

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -883,7 +883,7 @@ def cached_property(function):
         write boilerplate cache management code explicitly. For example::
 
             file_name = File
-            file_contents = Property( depends_on = 'file_name' )
+            file_contents = Property( observes = 'file_name' )
 
             @cached_property
             def _get_file_contents(self):
@@ -896,7 +896,7 @@ def cached_property(function):
         **_file_contents**, which maintained by the @cached_property wrapper
         code, is returned.
 
-        Note the use, in the example, of the **depends_on** metadata attribute
+        Note the use, in the example, of the **observes** metadata attribute
         to specify that the value of **file_contents** depends on
         **file_name**, so that _get_file_contents() is called only when
         **file_name** changes. For details, see the traits.traits.Property()

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -318,6 +318,7 @@ def _property_method(class_dict, name):
 
 def _create_property_observe_state(observes, property_name, cached):
     """ Create the metadata for setting up an observer for Property.
+
     Parameters
     ----------
     observes : str or list or Expression
@@ -327,6 +328,7 @@ def _create_property_observe_state(observes, property_name, cached):
         The name of the property trait.
     cached : boolean
         Whether the property is cached or not.
+
     Returns
     -------
     state : dict

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -200,11 +200,13 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
                         "expression": "name",
                         "post_init": False,
                         "dispatch": "same",
+                        "handler_getter": getattr,
                     },
                     {
                         "expression": trait("value"),
                         "post_init": True,
                         "dispatch": "ui",
+                        "handler_getter": getattr,
                     },
                 ],
             },

--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -10,8 +10,27 @@
 
 import io
 import unittest
+from unittest import mock
+import weakref
 
-from traits.api import Any, HasTraits, Property
+from traits.api import (
+    Any,
+    Bool,
+    cached_property,
+    HasTraits,
+    Instance,
+    Int,
+    List,
+    observe,
+    on_trait_change,
+    Property,
+    Str,
+)
+from traits.observation.api import (
+    trait,
+    pop_exception_handler,
+    push_exception_handler,
+)
 
 
 class Test(HasTraits):
@@ -45,3 +64,405 @@ class TestPropertyNotifications(unittest.TestCase):
 
         test_obj.value = "value_2"
         self.assertEqual(output_buffer.getvalue(), "value_1value_2")
+
+
+
+# Integration test for Property notifications via 'observes' / 'depends_on'
+
+class PersonInfo(HasTraits):
+
+    age = Int()
+
+    gender = Str()
+
+
+class ClassWithInstanceDefaultInit(HasTraits):
+
+    info_without_default = Instance(PersonInfo)
+
+    list_of_infos = List(Instance(PersonInfo), comparison_mode=1)
+
+    sample_info = Instance(PersonInfo)
+
+    sample_info_default_computed = Bool()
+
+    def _sample_info_default(self):
+        self.sample_info_default_computed = True
+        return PersonInfo(age=self.info_without_default.age)
+
+    info_with_default = Instance(PersonInfo)
+
+    info_with_default_computed = Bool()
+
+    def _info_with_default_default(self):
+        self.info_with_default_computed = True
+        return PersonInfo(age=12)
+
+
+class ClassWithPropertyObservesDefault(ClassWithInstanceDefaultInit):
+    """ Dummy class for testing property with an observer on an extended
+    attribute. 'info_with_default has a default initializer.
+    To be compared with the next class using depends_on
+    """
+
+    extended_age = Property(observes="info_with_default.age")
+
+    extended_age_n_calculations = Int()
+
+    def _get_extended_age(self):
+        self.extended_age_n_calculations += 1
+        return self.info_with_default.age
+
+
+class ClassWithPropertyDependsOnDefault(ClassWithInstanceDefaultInit):
+    """ Dummy class for testing property with an observer on an extended
+    attribute. 'info_with_default' has a default initializer.
+    """
+
+    extended_age = Property(depends_on="info_with_default.age")
+
+    extended_age_n_calculations = Int()
+
+    def _get_extended_age(self):
+        self.extended_age_n_calculations += 1
+        return self.info_with_default.age
+
+
+class ClassWithPropertyObservesInit(ClassWithInstanceDefaultInit):
+    """ Dummy class for testing property with an observer on an extended
+    attribute. sample_info has a default value depending on
+    'info_without_default'. The value of 'info_without_default' is provided
+    by __init__.
+    To be compared with the next class using depends_on.
+    """
+
+    extended_age = Property(observes="sample_info.age")
+
+    extended_age_n_calculations = Int()
+
+    def _get_extended_age(self):
+        self.extended_age_n_calculations += 1
+        return self.sample_info.age
+
+
+class ClassWithPropertyDependsOnInit(ClassWithInstanceDefaultInit):
+    # This class cannot be instantiated.
+    # enthought/traits#709
+
+    extended_age = Property(depends_on="sample_info.age")
+
+    def _get_extended_age(self):
+        return self.sample_info.age
+
+
+class ClassWithPropertyMultipleObserves(PersonInfo):
+    """ Dummy class to test observing multiple values.
+    """
+
+    computed_value = Property(observes=[trait("age"), trait("gender")])
+
+    computed_value_n_calculations = Int()
+
+    def _get_computed_value(self):
+        self.computed_value_n_calculations += 1
+        return len(self.gender) + self.age
+
+
+class ClassWithPropertyMultipleDependsOn(PersonInfo):
+    """ Dummy class using 'depends_on', to be compared with the one above.
+    """
+
+    computed_value = Property(depends_on=["age", "gender"])
+
+    computed_value_n_calculations = Int()
+
+    def _get_computed_value(self):
+        self.computed_value_n_calculations += 1
+        return len(self.gender) + self.age
+
+
+class ClassWithPropertyObservesItems(ClassWithInstanceDefaultInit):
+    """ Dummy class to test property observing container items"""
+
+    discounted = Property(
+        Bool(), observes=trait("list_of_infos").list_items().trait("age"))
+
+    discounted_n_calculations = Int()
+
+    def _get_discounted(self):
+        self.discounted_n_calculations += 1
+        return any(info.age > 70 for info in self.list_of_infos)
+
+
+class ClassWithPropertyDependsOnItems(ClassWithInstanceDefaultInit):
+    """ Dummy class using depends_on to be compared with the one using
+    observes."""
+
+    discounted = Property(Bool(), depends_on="list_of_infos.age")
+
+    discounted_n_calculations = Int()
+
+    def _get_discounted(self):
+        self.discounted_n_calculations += 1
+        return any(info.age > 70 for info in self.list_of_infos)
+
+
+class ClassWithPropertyObservesWithCache(PersonInfo):
+
+    discounted = Property(Bool(), observes="age")
+
+    discounted_n_calculations = Int()
+
+    @cached_property
+    def _get_discounted(self):
+        self.discounted_n_calculations += 1
+        return self.age > 10
+
+
+class ClassWithPropertyObservesDecorated(PersonInfo):
+    """ Dummy class to test property with observers setup at init time."""
+
+    discounted = Property(Bool(), observes="age")
+
+    discounted_n_calculations = Int()
+
+    def _get_discounted(self):
+        self.discounted_n_calculations += 1
+        return self.age > 60
+
+    discounted_events = List()
+
+    @observe("discounted")
+    def discounted_updated(self, event):
+        self.discounted_events.append(event)
+
+
+class ClassWithPropertyDependsOnDecorated(PersonInfo):
+    """ Dummy class to test property with depends_on and on_trait_change
+    setup at init time."""
+
+    discounted = Property(Bool(), depends_on="age")
+
+    discounted_n_calculations = Int()
+
+    def _get_discounted(self):
+        self.discounted_n_calculations += 1
+        return self.age > 60
+
+    discounted_events = List()
+
+    @on_trait_change("discounted")
+    def discounted_updated(self, event):
+        self.discounted_events.append(event)
+
+
+class ClassWithPropertyMissingGetter(PersonInfo):
+    """ Dummy class to test property that does not have getter/setter.
+    """
+
+    discounted = Property(Bool(), observes="age")
+
+
+class TestHasTraitsPropertyObserves(unittest.TestCase):
+    """ Tests Property notifications using 'observes', and compared the
+    behavior with 'depends_on'
+    """
+
+    def setUp(self):
+        push_exception_handler(reraise_exceptions=True)
+        self.addCleanup(pop_exception_handler)
+
+    def test_property_observes_extended_trait(self):
+        instance_observes = ClassWithPropertyObservesDefault()
+        handler_observes = mock.Mock()
+        instance_observes.observe(handler_observes, "extended_age")
+
+        # sanity check against depends_on
+        instance_depends_on = ClassWithPropertyDependsOnDefault()
+        handler_otc = mock.Mock()
+        instance_depends_on.on_trait_change(
+            get_otc_handler(handler_otc), "extended_age"
+        )
+        instances = [instance_observes, instance_depends_on]
+        handlers = [handler_observes, handler_otc]
+
+        for instance, handler in zip(instances, handlers):
+            with self.subTest(instance=instance, handler=handler):
+                # when
+                instance.info_with_default.age = 70
+                # then
+                self.assertEqual(handler.call_count, 1)
+                self.assertEqual(instance.extended_age_n_calculations, 1)
+
+    def test_property_observes_does_not_fire_default(self):
+        instance_observes = ClassWithPropertyObservesDefault()
+        handler_observes = mock.Mock()
+        instance_observes.observe(handler_observes, "extended_age")
+
+        # compared with 'depends_on'
+        instance_depends_on = ClassWithPropertyDependsOnDefault()
+        instance_depends_on.on_trait_change(
+            get_otc_handler(mock.Mock()), "extended_age")
+
+        # then
+        # they are different. See enthought/traits#481, #709
+        self.assertFalse(instance_observes.info_with_default_computed)
+        self.assertTrue(instance_depends_on.info_with_default_computed)
+
+    def test_property_multi_observes(self):
+        instance_observes = ClassWithPropertyMultipleObserves()
+        handler_observes = mock.Mock()
+        instance_observes.observe(handler_observes, "computed_value")
+        self.assertEqual(instance_observes.computed_value_n_calculations, 0)
+
+        instance_depends_on = ClassWithPropertyMultipleDependsOn()
+        instance_depends_on.on_trait_change(
+            get_otc_handler(mock.Mock()), "computed_value")
+        self.assertEqual(instance_depends_on.computed_value_n_calculations, 0)
+
+        for instance in [instance_observes, instance_depends_on]:
+            with self.subTest(instance=instance):
+                # when
+                instance.age = 1
+                # then
+                self.assertEqual(instance.computed_value_n_calculations, 1)
+                # when
+                instance.gender = "male"
+                # then
+                self.assertEqual(instance.computed_value_n_calculations, 2)
+
+    def test_property_observes_container(self):
+        instance_observes = ClassWithPropertyObservesItems()
+        handler_observes = mock.Mock()
+        instance_observes.observe(handler_observes, "discounted")
+
+        instance_depends_on = ClassWithPropertyDependsOnItems()
+        instance_depends_on.on_trait_change(
+            get_otc_handler(mock.Mock()), "discounted")
+
+        for instance in [instance_observes, instance_depends_on]:
+            with self.subTest(instance=instance):
+                self.assertEqual(instance.discounted_n_calculations, 0)
+
+                instance.list_of_infos.append(PersonInfo(age=30))
+                self.assertEqual(instance.discounted_n_calculations, 1)
+
+                instance.list_of_infos[-1].age = 80
+                self.assertEqual(instance.discounted_n_calculations, 2)
+
+    def test_property_old_value_uncached(self):
+        instance = ClassWithPropertyMultipleObserves()
+        handler = mock.Mock()
+        instance.observe(handler, "computed_value")
+
+        instance.age = 1
+
+        ((event, ), _), = handler.call_args_list
+        self.assertIs(event.object, instance)
+        self.assertEqual(event.name, "computed_value")
+        self.assertIs(event.old, Undefined)  # property is not cached
+        self.assertIs(event.new, 1)
+
+        handler.reset_mock()
+        instance.gender = "male"
+
+        ((event, ), _), = handler.call_args_list
+        self.assertIs(event.object, instance)
+        self.assertEqual(event.name, "computed_value")
+        self.assertIs(event.old, Undefined)  # property is not cached
+        self.assertIs(event.new, 5)  # len("male") + 1
+
+    def test_property_with_cache(self):
+        instance = ClassWithPropertyObservesWithCache()
+        handler = mock.Mock()
+        instance.observe(handler, "discounted")
+        instance.age = 1
+
+        (event, ), _ = handler.call_args_list[-1]
+        self.assertIs(event.object, instance)
+        self.assertEqual(event.name, "discounted")
+        self.assertIs(event.old, Undefined)
+        self.assertIs(event.new, False)
+        handler.reset_mock()
+
+        instance.age = 80
+
+        (event, ), _ = handler.call_args_list[-1]
+        self.assertIs(event.object, instance)
+        self.assertEqual(event.name, "discounted")
+        self.assertIs(event.old, False)
+        self.assertIs(event.new, True)
+
+    def test_property_default_initializer_with_value_in_init(self):
+        # With "depends_on", instantiation will fail.
+        # enthought/traits#709
+        with self.assertRaises(AttributeError):
+            ClassWithPropertyDependsOnInit(
+                info_without_default=PersonInfo(age=30))
+
+        # With "observes", initialization works.
+        instance = ClassWithPropertyObservesInit(
+            info_without_default=PersonInfo(age=30)
+        )
+        handler = mock.Mock()
+        instance.observe(handler, "extended_age")
+        self.assertFalse(instance.sample_info_default_computed)
+        self.assertEqual(instance.sample_info.age, 30)
+        self.assertEqual(instance.extended_age, 30)
+        # not called because 'sample_info' is still the "default" value.
+        self.assertEqual(handler.call_count, 0)
+
+        # when
+        instance.sample_info.age = 40
+
+        # then
+        self.assertEqual(handler.call_count, 1)
+
+        # sanity check this is consistent with when property is not defined.
+        instance_no_property = ClassWithInstanceDefaultInit(
+            info_without_default=PersonInfo(age=30)
+        )
+        self.assertFalse(instance_no_property.sample_info_default_computed)
+        self.assertEqual(instance_no_property.sample_info.age, 30)
+
+    def test_property_decorated_observer(self):
+        instance_observes = ClassWithPropertyObservesDecorated(age=30)
+        instance_depends_on = ClassWithPropertyDependsOnDecorated(age=30)
+
+        for instance in [instance_observes, instance_depends_on]:
+            with self.subTest(instance=instance):
+                self.assertEqual(len(instance.discounted_events), 1)
+
+    def test_garbage_collectable(self):
+        instance = ClassWithPropertyObservesDefault()
+
+        instance_ref = weakref.ref(instance)
+
+        del instance
+
+        self.assertIsNone(instance_ref())
+
+    def test_property_with_no_getter(self):
+        instance = ClassWithPropertyMissingGetter()
+        try:
+            instance.age += 1
+        except Exception:
+            self.fail(
+                "Having property with undefined getter/setter should not "
+                "prevent the observed traits from being changed."
+            )
+
+
+def get_otc_handler(mock_obj):
+    """ Return a callable to be used with on_trait_change, which will
+    inspect call signature.
+    Parameters
+    ----------
+    mock_obj : mock.Mock
+        Mock object for tracking calls.
+    """
+
+    def handler():
+        mock_obj()
+
+    return handler

--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -27,6 +27,7 @@ from traits.api import (
     Property,
     Str,
 )
+from traits.trait_base import Undefined
 from traits.observation.api import (
     trait,
     pop_exception_handler,
@@ -67,8 +68,8 @@ class TestPropertyNotifications(unittest.TestCase):
         self.assertEqual(output_buffer.getvalue(), "value_1value_2")
 
 
-
 # Integration test for Property notifications via 'observes' / 'depends_on'
+
 
 class PersonInfo(HasTraits):
 
@@ -457,13 +458,18 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
         instance = ClassWithPropertyMultipleObserves()
 
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
-            serialized = pickle.dumps(foo, protocol=protocol)
+            serialized = pickle.dumps(instance, protocol=protocol)
             deserialized = pickle.loads(serialized)
+            handler = mock.Mock()
+            deserialized.observe(handler, "computed_value")
+            deserialized.age = 1
+            self.assertEqual(handler.call_count, 1)
 
 
 def get_otc_handler(mock_obj):
     """ Return a callable to be used with on_trait_change, which will
     inspect call signature.
+
     Parameters
     ----------
     mock_obj : mock.Mock

--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -265,6 +265,15 @@ class ClassWithPropertyMissingGetter(PersonInfo):
     discounted = Property(Bool(), observes="age")
 
 
+class ClassWithPropertyTraitNotFound(HasTraits):
+    """ Dummy class to test error, prevent issues like enthought/traits#447
+    """
+
+    person = Instance(PersonInfo)
+
+    last_name = Property(observes="person.last_name")  # last_name not defined
+
+
 class TestHasTraitsPropertyObserves(unittest.TestCase):
     """ Tests Property notifications using 'observes', and compared the
     behavior with 'depends_on'
@@ -453,6 +462,17 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
                 "Having property with undefined getter/setter should not "
                 "prevent the observed traits from being changed."
             )
+
+    def test_property_with_missing_dependent(self):
+        # This will prevent incidents like the one in enthought/traits#447
+        instance = ClassWithPropertyTraitNotFound()
+        with self.assertRaises(ValueError) as exception_context:
+            instance.person = PersonInfo()
+
+        self.assertIn(
+            "Trait named 'last_name' not found",
+            str(exception_context.exception),
+        )
 
     def test_pickle_has_traits_with_property_observe(self):
         instance = ClassWithPropertyMultipleObserves()

--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -68,7 +68,7 @@ class TestPropertyNotifications(unittest.TestCase):
         self.assertEqual(output_buffer.getvalue(), "value_1value_2")
 
 
-# Integration test for Property notifications via 'observes' / 'depends_on'
+# Integration test for Property notifications via 'observe' / 'depends_on'
 
 
 class PersonInfo(HasTraits):
@@ -107,7 +107,7 @@ class ClassWithPropertyObservesDefault(ClassWithInstanceDefaultInit):
     To be compared with the next class using depends_on
     """
 
-    extended_age = Property(observes="info_with_default.age")
+    extended_age = Property(observe="info_with_default.age")
 
     extended_age_n_calculations = Int()
 
@@ -138,7 +138,7 @@ class ClassWithPropertyObservesInit(ClassWithInstanceDefaultInit):
     To be compared with the next class using depends_on.
     """
 
-    extended_age = Property(observes="sample_info.age")
+    extended_age = Property(observe="sample_info.age")
 
     extended_age_n_calculations = Int()
 
@@ -161,7 +161,7 @@ class ClassWithPropertyMultipleObserves(PersonInfo):
     """ Dummy class to test observing multiple values.
     """
 
-    computed_value = Property(observes=[trait("age"), trait("gender")])
+    computed_value = Property(observe=[trait("age"), trait("gender")])
 
     computed_value_n_calculations = Int()
 
@@ -187,7 +187,7 @@ class ClassWithPropertyObservesItems(ClassWithInstanceDefaultInit):
     """ Dummy class to test property observing container items"""
 
     discounted = Property(
-        Bool(), observes=trait("list_of_infos").list_items().trait("age"))
+        Bool(), observe=trait("list_of_infos").list_items().trait("age"))
 
     discounted_n_calculations = Int()
 
@@ -198,7 +198,7 @@ class ClassWithPropertyObservesItems(ClassWithInstanceDefaultInit):
 
 class ClassWithPropertyDependsOnItems(ClassWithInstanceDefaultInit):
     """ Dummy class using depends_on to be compared with the one using
-    observes."""
+    observe."""
 
     discounted = Property(Bool(), depends_on="list_of_infos.age")
 
@@ -211,7 +211,7 @@ class ClassWithPropertyDependsOnItems(ClassWithInstanceDefaultInit):
 
 class ClassWithPropertyObservesWithCache(PersonInfo):
 
-    discounted = Property(Bool(), observes="age")
+    discounted = Property(Bool(), observe="age")
 
     discounted_n_calculations = Int()
 
@@ -224,7 +224,7 @@ class ClassWithPropertyObservesWithCache(PersonInfo):
 class ClassWithPropertyObservesDecorated(PersonInfo):
     """ Dummy class to test property with observers setup at init time."""
 
-    discounted = Property(Bool(), observes="age")
+    discounted = Property(Bool(), observe="age")
 
     discounted_n_calculations = Int()
 
@@ -262,7 +262,7 @@ class ClassWithPropertyMissingGetter(PersonInfo):
     """ Dummy class to test property that does not have getter/setter.
     """
 
-    discounted = Property(Bool(), observes="age")
+    discounted = Property(Bool(), observe="age")
 
 
 class ClassWithPropertyTraitNotFound(HasTraits):
@@ -271,11 +271,11 @@ class ClassWithPropertyTraitNotFound(HasTraits):
 
     person = Instance(PersonInfo)
 
-    last_name = Property(observes="person.last_name")  # last_name not defined
+    last_name = Property(observe="person.last_name")  # last_name not defined
 
 
 class TestHasTraitsPropertyObserves(unittest.TestCase):
-    """ Tests Property notifications using 'observes', and compared the
+    """ Tests Property notifications using 'observe', and compared the
     behavior with 'depends_on'
     """
 
@@ -283,10 +283,10 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
         push_exception_handler(reraise_exceptions=True)
         self.addCleanup(pop_exception_handler)
 
-    def test_property_observes_extended_trait(self):
-        instance_observes = ClassWithPropertyObservesDefault()
-        handler_observes = mock.Mock()
-        instance_observes.observe(handler_observes, "extended_age")
+    def test_property_observe_extended_trait(self):
+        instance_observe = ClassWithPropertyObservesDefault()
+        handler_observe = mock.Mock()
+        instance_observe.observe(handler_observe, "extended_age")
 
         # sanity check against depends_on
         instance_depends_on = ClassWithPropertyDependsOnDefault()
@@ -294,8 +294,8 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
         instance_depends_on.on_trait_change(
             get_otc_handler(handler_otc), "extended_age"
         )
-        instances = [instance_observes, instance_depends_on]
-        handlers = [handler_observes, handler_otc]
+        instances = [instance_observe, instance_depends_on]
+        handlers = [handler_observe, handler_otc]
 
         for instance, handler in zip(instances, handlers):
             with self.subTest(instance=instance, handler=handler):
@@ -305,10 +305,10 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
                 self.assertEqual(handler.call_count, 1)
                 self.assertEqual(instance.extended_age_n_calculations, 1)
 
-    def test_property_observes_does_not_fire_default(self):
-        instance_observes = ClassWithPropertyObservesDefault()
-        handler_observes = mock.Mock()
-        instance_observes.observe(handler_observes, "extended_age")
+    def test_property_observe_does_not_fire_default(self):
+        instance_observe = ClassWithPropertyObservesDefault()
+        handler_observe = mock.Mock()
+        instance_observe.observe(handler_observe, "extended_age")
 
         # compared with 'depends_on'
         instance_depends_on = ClassWithPropertyDependsOnDefault()
@@ -317,21 +317,21 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
 
         # then
         # they are different. See enthought/traits#481, #709
-        self.assertFalse(instance_observes.info_with_default_computed)
+        self.assertFalse(instance_observe.info_with_default_computed)
         self.assertTrue(instance_depends_on.info_with_default_computed)
 
-    def test_property_multi_observes(self):
-        instance_observes = ClassWithPropertyMultipleObserves()
-        handler_observes = mock.Mock()
-        instance_observes.observe(handler_observes, "computed_value")
-        self.assertEqual(instance_observes.computed_value_n_calculations, 0)
+    def test_property_multi_observe(self):
+        instance_observe = ClassWithPropertyMultipleObserves()
+        handler_observe = mock.Mock()
+        instance_observe.observe(handler_observe, "computed_value")
+        self.assertEqual(instance_observe.computed_value_n_calculations, 0)
 
         instance_depends_on = ClassWithPropertyMultipleDependsOn()
         instance_depends_on.on_trait_change(
             get_otc_handler(mock.Mock()), "computed_value")
         self.assertEqual(instance_depends_on.computed_value_n_calculations, 0)
 
-        for instance in [instance_observes, instance_depends_on]:
+        for instance in [instance_observe, instance_depends_on]:
             with self.subTest(instance=instance):
                 # when
                 instance.age = 1
@@ -342,16 +342,16 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
                 # then
                 self.assertEqual(instance.computed_value_n_calculations, 2)
 
-    def test_property_observes_container(self):
-        instance_observes = ClassWithPropertyObservesItems()
-        handler_observes = mock.Mock()
-        instance_observes.observe(handler_observes, "discounted")
+    def test_property_observe_container(self):
+        instance_observe = ClassWithPropertyObservesItems()
+        handler_observe = mock.Mock()
+        instance_observe.observe(handler_observe, "discounted")
 
         instance_depends_on = ClassWithPropertyDependsOnItems()
         instance_depends_on.on_trait_change(
             get_otc_handler(mock.Mock()), "discounted")
 
-        for instance in [instance_observes, instance_depends_on]:
+        for instance in [instance_observe, instance_depends_on]:
             with self.subTest(instance=instance):
                 self.assertEqual(instance.discounted_n_calculations, 0)
 
@@ -411,7 +411,7 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
             ClassWithPropertyDependsOnInit(
                 info_without_default=PersonInfo(age=30))
 
-        # With "observes", initialization works.
+        # With "observe", initialization works.
         instance = ClassWithPropertyObservesInit(
             info_without_default=PersonInfo(age=30)
         )
@@ -437,10 +437,10 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
         self.assertEqual(instance_no_property.sample_info.age, 30)
 
     def test_property_decorated_observer(self):
-        instance_observes = ClassWithPropertyObservesDecorated(age=30)
+        instance_observe = ClassWithPropertyObservesDecorated(age=30)
         instance_depends_on = ClassWithPropertyDependsOnDecorated(age=30)
 
-        for instance in [instance_observes, instance_depends_on]:
+        for instance in [instance_observe, instance_depends_on]:
             with self.subTest(instance=instance):
                 self.assertEqual(len(instance.discounted_events), 1)
 

--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 import io
+import pickle
 import unittest
 from unittest import mock
 import weakref
@@ -451,6 +452,13 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
                 "Having property with undefined getter/setter should not "
                 "prevent the observed traits from being changed."
             )
+
+    def test_pickle_has_traits_with_property_observe(self):
+        instance = ClassWithPropertyMultipleObserves()
+
+        for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+            serialized = pickle.dumps(foo, protocol=protocol)
+            deserialized = pickle.loads(serialized)
 
 
 def get_otc_handler(mock_obj):

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -535,15 +535,15 @@ def Property(
             def _get_foo(self):
                 return self._foo
 
-    You can use the **observes** metadata attribute to indicate that the
-    property depends on the value of another trait. The value of **observes**
+    You can use the **observe** metadata attribute to indicate that the
+    property depends on the value of another trait. The value of **observe**
     follows the same signature as the **expression** parameter in
     ``HasTraits.observe``. The property will fire a trait change notification
-    if any of the traits specified by **observes** change. For example::
+    if any of the traits specified by **observe** change. For example::
 
         class Wheel ( Part ):
             axle     = Instanced( Axle )
-            position = Property( observes = 'axle.chassis.position' )
+            position = Property( observe = 'axle.chassis.position' )
 
     For details of the extended trait name syntax, refer to the
     observe() method of the HasTraits class.

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -617,9 +617,7 @@ def Property(
             metadata["editor"] = trait.editor
 
     metadata.setdefault("depends_on", getattr(fget, "depends_on", None))
-    if (metadata.get("depends_on") is not None) and getattr(
-        fget, "cached_property", False
-    ):
+    if getattr(fget, "cached_property", False):
         metadata.setdefault("cached", True)
 
     trait = CTrait(TraitKind.property)

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -535,18 +535,18 @@ def Property(
             def _get_foo(self):
                 return self._foo
 
-    You can use the **depends_on** metadata attribute to indicate that the
-    property depends on the value of another trait. The value of **depends_on**
-    is an extended name specifier for traits that the property depends on. The
-    property will a trait change notification if any of the traits specified
-    by **depends_on** change. For example::
+    You can use the **observes** metadata attribute to indicate that the
+    property depends on the value of another trait. The value of **observes**
+    follows the same signature as the **expression** parameter in
+    ``HasTraits.observe``. The property will fire a trait change notification
+    if any of the traits specified by **observes** change. For example::
 
         class Wheel ( Part ):
             axle     = Instanced( Axle )
-            position = Property( depends_on = 'axle.chassis.position' )
+            position = Property( observes = 'axle.chassis.position' )
 
     For details of the extended trait name syntax, refer to the
-    on_trait_change() method of the HasTraits class.
+    observe() method of the HasTraits class.
 
     Parameters
     ----------

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -541,9 +541,9 @@ def Property(
     ``HasTraits.observe``. The property will fire a trait change notification
     if any of the traits specified by **observe** change. For example::
 
-        class Wheel ( Part ):
-            axle     = Instanced( Axle )
-            position = Property( observe = 'axle.chassis.position' )
+        class Wheel(Part):
+            axle = Instance(Axle)
+            position = Property(observe='axle.chassis.position')
 
     For details of the extended trait name syntax, refer to the
     observe() method of the HasTraits class.


### PR DESCRIPTION
In very much the same way `depends_on` uses `on_trait_change` in `Property`, this PR extends the use of `observe` to the `Property` trait using a new metadata named "observe" ~(name to be confirmed)~.

This PR also marks the use of "depends_on" as an "older" API.

Objectives:
- Resolve issues such as #447, #481 (or #709, which is similar)
- Reduce traits's own dependency on `on_trait_change`

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~
