### PR TITLE
Refactor and simplify HasTraits method checks

### DIFF
--- a/traits-stubs/traits-stubs/has_traits.pyi
+++ b/traits-stubs/traits-stubs/has_traits.pyi
@@ -27,9 +27,6 @@ CHECK_INTERFACES: int
 class AbstractViewElement(abc.ABC): ...
 
 WrapperTypes: _Any
-BoundMethodTypes: _Any
-UnboundMethodTypes: _Any
-FunctionTypes: _Any
 BaseTraits: str
 ClassTraits: str
 PrefixTraits: str
@@ -43,10 +40,7 @@ DeferredCopy: _Any
 extended_trait_pat: _Any
 any_trait: _Any
 
-def is_cython_func_or_method(method: _Any): ...
-def is_bound_method_type(method: _Any): ...
 def is_unbound_method_type(method: _Any): ...
-def is_function_type(function: _Any): ...
 def get_delegate_pattern(name: _Any, trait: _Any): ...
 
 class _SimpleTest:


### PR DESCRIPTION
The `HasTraits` machinery needs function and method checks at various points, mostly to look for magic-named methods like `_mytrait_changed` and `_myevent_fired`.

Those checks are currently performed inconsistently, and for methods written in Cython also rely on a rather fragile mechanism for recognising the method. (That mechanism also fails for C extensions other than Cython extensions.)

This PR:

- makes the checks consistent: they all now rely on the `_is_unbound_method_type` helper function.
- uses `inspect.ismethoddescriptor` as a better way to catch something that behaves like an unbound method without relying on Cython-specific details
- cleans up unused related functions and constants