### PR TITLE
Fix truncated List description in documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -245,7 +245,7 @@ Documentation
   #1140, #1143)
 * Add user manual section on the ``Union`` trait type and how to migrate from
   ``Either`` (#779, #1153, #1162)
-* Other minor cleanups and fixes. (#949, #1141)
+* Other minor cleanups and fixes. (#949, #1141, #1178)
 
 Test suite
 ~~~~~~~~~~

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -273,8 +273,9 @@ the table.
 | CArray           | CArray( [*dtype* = None, *shape* = None, *value* = None, |
 |                  | *typecode* = None, \*\*\ *metadata*] )                   |
 +------------------+----------------------------------------------------------+
-| Code             | Code( [*value* = '', *minlen* = 0, *maxlen* = sys.maxint,|
-|                  | *regex* = '', \*\*\ *metadata*] )                        |
+| Code             | Code( [*value* = '', *minlen* = 0,                       |
+|                  | *maxlen* = sys.maxsize, *regex* = '',                    |
+|                  | \*\*\ *metadata*] )                                      |
 +------------------+----------------------------------------------------------+
 | CSet             | CSet( [*trait* = None, *value* = None, *items* = True,   |
 |                  | \*\*\ *metadata*] )                                      |
@@ -305,15 +306,16 @@ the table.
 +------------------+----------------------------------------------------------+
 | generic_trait    | n/a                                                      |
 +------------------+----------------------------------------------------------+
-| HTML             | HTML( [*value* = '', *minlen* = 0, *maxlen* = sys.maxint,|
-|                  | *regex* = '',  \*\*\ *metadata* ] )                      |
+| HTML             | HTML( [*value* = '', *minlen* = 0,                       |
+|                  | *maxlen* = sys.maxsize, *regex* = '',                    |
+|                  | \*\*\ *metadata* ] )                                     |
 +------------------+----------------------------------------------------------+
 | Instance         | Instance( [*klass* = None, *factory* = None, *args* =    |
 |                  | None, *kw* = None, *allow_none* = True, *adapt* = None,  |
 |                  | *module* = None, \*\*\ *metadata*] )                     |
 +------------------+----------------------------------------------------------+
 | List             | List( [*trait* = None, *value* = None, *minlen* = 0,     |
-|                  | *maxlen* = sys.maxint, *items* = True,                   |
+|                  | *maxlen* = sys.maxsize, *items* = True,                  |
 |                  | \*\*\ *metadata*] )                                      |
 +------------------+----------------------------------------------------------+
 | Map              | Map( *map*\ [, \*\*\ *metadata*] )                       |
@@ -323,7 +325,7 @@ the table.
 | Module           | Module ( [\*\*\ *metadata*] )                            |
 +------------------+----------------------------------------------------------+
 | Password         | Password( [*value* = '', *minlen* = 0, *maxlen* =        |
-|                  | sys.maxint, *regex* = '', \*\*\ *metadata*] )            |
+|                  | sys.maxsize, *regex* = '', \*\*\ *metadata*] )           |
 +------------------+----------------------------------------------------------+
 | PrefixList       | PrefixList( *values*\ [, \*\*\ *metadata*] )             |
 +------------------+----------------------------------------------------------+
@@ -353,7 +355,7 @@ the table.
 |                  | \*\*\ *metadata*] )                                      |
 +------------------+----------------------------------------------------------+
 | String           | String( [*value* = '', *minlen* = 0, *maxlen* =          |
-|                  | sys.maxint, *regex* = '', \*\*\ *metadata*] )            |
+|                  | sys.maxsize, *regex* = '', \*\*\ *metadata*] )           |
 +------------------+----------------------------------------------------------+
 | Subclass         | Subclass( [*value* = None, *klass* = None, *allow_none* =|
 |                  | True, \*\*\ *metadata*] )                                |

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -312,7 +312,9 @@ the table.
 |                  | None, *kw* = None, *allow_none* = True, *adapt* = None,  |
 |                  | *module* = None, \*\*\ *metadata*] )                     |
 +------------------+----------------------------------------------------------+
-| List             | List([*trait* = None, *value* = None, *minlen* = 0,      |
+| List             | List( [*trait* = None, *value* = None, *minlen* = 0,     |
+|                  | *maxlen* = sys.maxint, *items* = True,                   |
+|                  | \*\*\ *metadata*] )                                      |
 +------------------+----------------------------------------------------------+
 | Map              | Map( *map*\ [, \*\*\ *metadata*] )                       |
 +------------------+----------------------------------------------------------+


### PR DESCRIPTION
Fixes #1177.

EDIT: also replaces occurrences of `sys.maxint` (which doesn't exist in Python 3) with `sys.maxsize`.