### PR TITLE
Add license and MANIFEST.in and missing setup fields

### DIFF
--- a/traits-stubs/LICENSE.txt
+++ b/traits-stubs/LICENSE.txt
@@ -1,0 +1,28 @@
+This software is OSI Certified Open Source Software.
+OSI Certified is a certification mark of the Open Source Initiative.
+
+Copyright (c) 2006-2016, Enthought, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Enthought, Inc. nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/traits-stubs/MANIFEST.in
+++ b/traits-stubs/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE.txt
+include MANIFEST.in
+include README.rst
+recursive-include traits *.pyi

--- a/traits-stubs/README.rst
+++ b/traits-stubs/README.rst
@@ -2,51 +2,34 @@
 traits-stubs: Type annotations for Traits
 =========================================
 
-This package contains stub files which are type annotations for the most
-commonly used classes in the Traits package.
-
-Type annotations are used by static type checkers
-to find common bugs without running the program. These merely recommend
-and does not enforce changes to the source code for api compatibility.
-
-These annotations have been tested with the `mypy` static type checker.
-
-Information on how to setup and run `mypy` can be found here:
-
-- Repository & Quickstart: https://github.com/python/mypy
-- Documentation: https://mypy.readthedocs.io/en/stable/index.html
+The *traits-stubs* package contains external type annotations for the Traits_
+package. These annotations can be used with static type checkers like mypy_ to
+type-check your Traits-using Python code.
 
 
 Installation
 ------------
-- Activate an environment with `traits` installed.
-- Install mypy by following the instructions found in the links above.
-- Run `pip install .` inside the dirctory /traits-stubs.
-- Run `mypy` with `mypy <somefile.py>`.
+- To install from PyPI, simply use ``pip install traits-stubs``.
 
-Note: `mypy` creates a `.mypy_cache` folder when run. This may be excluded
-from source control.
+- To install from source, run ``pip install .`` from this directory.
 
-Plugins
--------
-The recommended way to use `mypy` is by installing the plugin for your favourite
-editor. Some plugins call out errors as the files are being modified which can
-be very useful.
 
-Here are some plugins that you may want to try:
+Usage
+-----
+You'll usually want to install mypy_ (or another type checker) into your Python
+environment alongside these stubs. You can then use mypy_ from the command
+line to check a file or directory, for example with::
 
-- PyCharm:
-    - Mypy ​(Official)​: https://plugins.jetbrains.com/plugin/13348-mypy-official
-    - Mypy (More Popular): https://plugins.jetbrains.com/plugin/11086-mypy
+    mypy <somefile.py>
 
-- Visual Studio Code:
-    - Mypy: https://marketplace.visualstudio.com/items?itemName=matangover.mypy
-
+Alternatively, some IDEs (including VS Code and PyCharm) can be configured to
+perform type checking as you edit.
 
 
 Dependencies
 ------------
 
-* `Traits <https://github.com/enthought/traits>`_
-* `mypy <https://github.com/python/mypy>`_
+This package depends on Traits_.
 
+.. _Traits: https://pypi.org/project/traits/
+.. _mypy: https://pypi.org/project/mypy/

--- a/traits-stubs/setup.py
+++ b/traits-stubs/setup.py
@@ -27,15 +27,13 @@ if __name__ == "__main__":
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
         install_requires=["traits"],
-        extras_require={
-            "test": ["mypy"],
-        },
-        packages=["traits-stubs",
-                  "traits_stubs_tests",
-                  "traits_stubs_tests.examples"],
-        package_data={
-            'traits-stubs': ['./*.pyi', './**/*.pyi'],
-        },
+        extras_require={"test": ["mypy"]},
+        packages=[
+            "traits-stubs",
+            "traits_stubs_tests",
+            "traits_stubs_tests.examples",
+        ],
+        package_data={"traits-stubs": ["./*.pyi", "./**/*.pyi"]},
         license="BSD",
         python_requires=">=3.5",
     )

--- a/traits-stubs/setup.py
+++ b/traits-stubs/setup.py
@@ -21,6 +21,8 @@ if __name__ == "__main__":
     setuptools.setup(
         name="traits-stubs",
         version="6.1.0",
+        author="Enthought",
+        author_email="info@enthought.com",
         description="Type annotation integration stubs for the Traits library",
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
@@ -35,7 +37,5 @@ if __name__ == "__main__":
             'traits-stubs': ['./*.pyi', './**/*.pyi'],
         },
         license="BSD",
-        maintainer="ETS Developers",
-        maintainer_email="enthought-dev@enthought.com",
         python_requires=">=3.5",
     )

--- a/traits-stubs/setup.py
+++ b/traits-stubs/setup.py
@@ -24,6 +24,31 @@ if __name__ == "__main__":
         url="https://github.com/enthought/traits",
         author="Enthought",
         author_email="info@enthought.com",
+        classifiers=[
+            c.strip()
+            for c in """
+            Development Status :: 5 - Production/Stable
+            Intended Audience :: Developers
+            Intended Audience :: Science/Research
+            License :: OSI Approved :: BSD License
+            Operating System :: MacOS :: MacOS X
+            Operating System :: Microsoft :: Windows
+            Operating System :: POSIX :: Linux
+            Programming Language :: C
+            Programming Language :: Python
+            Programming Language :: Python :: 3
+            Programming Language :: Python :: 3.5
+            Programming Language :: Python :: 3.6
+            Programming Language :: Python :: 3.7
+            Programming Language :: Python :: 3.8
+            Programming Language :: Python :: Implementation :: CPython
+            Topic :: Scientific/Engineering
+            Topic :: Software Development
+            Topic :: Software Development :: Libraries
+            Topic :: Software Development :: User Interfaces
+            """.splitlines()
+            if len(c.strip()) > 0
+        ],
         description="Type annotations for the Traits package",
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",

--- a/traits-stubs/setup.py
+++ b/traits-stubs/setup.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         classifiers=[
             c.strip()
             for c in """
-            Development Status :: 5 - Production/Stable
+            Development Status :: 4 - Beta
             Intended Audience :: Developers
             Intended Audience :: Science/Research
             License :: OSI Approved :: BSD License
@@ -46,6 +46,7 @@ if __name__ == "__main__":
             Topic :: Software Development
             Topic :: Software Development :: Libraries
             Topic :: Software Development :: User Interfaces
+            Typing :: Typed
             """.splitlines()
             if len(c.strip()) > 0
         ],

--- a/traits-stubs/setup.py
+++ b/traits-stubs/setup.py
@@ -21,11 +21,13 @@ if __name__ == "__main__":
     setuptools.setup(
         name="traits-stubs",
         version="6.1.0",
+        url="https://github.com/enthought/traits",
         author="Enthought",
         author_email="info@enthought.com",
         description="Type annotations for the Traits package",
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
+        download_url="https://pypi.python.org/pypi/traits-stubs",
         install_requires=["traits"],
         extras_require={"test": ["mypy"]},
         packages=[

--- a/traits-stubs/setup.py
+++ b/traits-stubs/setup.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         version="6.1.0",
         author="Enthought",
         author_email="info@enthought.com",
-        description="Type annotation integration stubs for the Traits library",
+        description="Type annotations for the Traits package",
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
         install_requires=["traits"],

--- a/traits-stubs/setup.py
+++ b/traits-stubs/setup.py
@@ -24,7 +24,10 @@ if __name__ == "__main__":
         description="Type annotation integration stubs for the Traits library",
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
-        install_requires=["mypy", "traits"],
+        install_requires=["traits"],
+        extras_require={
+            "test": ["mypy"],
+        },
         packages=["traits-stubs",
                   "traits_stubs_tests",
                   "traits_stubs_tests.examples"],

--- a/traits-stubs/setup.py
+++ b/traits-stubs/setup.py
@@ -10,11 +10,20 @@
 
 import setuptools
 
+
+def get_long_description():
+    """ Read long description from README.rst. """
+    with open("README.rst", "r", encoding="utf-8") as readme:
+        return readme.read()
+
+
 if __name__ == "__main__":
     setuptools.setup(
         name="traits-stubs",
-        version="0.1.0",
-        description="type annotation integration stubs for traits",
+        version="6.1.0",
+        description="Type annotation integration stubs for the Traits library",
+        long_description=get_long_description(),
+        long_description_content_type="text/x-rst",
         install_requires=["mypy", "traits"],
         packages=["traits-stubs",
                   "traits_stubs_tests",
@@ -22,4 +31,8 @@ if __name__ == "__main__":
         package_data={
             'traits-stubs': ['./*.pyi', './**/*.pyi'],
         },
+        license="BSD",
+        maintainer="ETS Developers",
+        maintainer_email="enthought-dev@enthought.com",
+        python_requires=">=3.5",
     )


### PR DESCRIPTION
[Note: PR is against the Traits 6.1.x release branch]

Work towards making `traits-stubs` distributable:

- Add missing setup fields
- Add MANIFEST.in, so that the sdist also contains the license
- Add LICENSE.txt

I haven't figured out a good way not to have to hardcode the version. Ideally we'd pick it up from Traits somehow.

The README could also use some work before we make the release.