### PR TITLE
Tweaks and fixes to setup keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -266,7 +266,7 @@ Build and continuous integration
 * CI tests requiring a GUI are now run against PyQt5 rather than PyQt4.
   (#1127)
 * Add Slack notifications for CI. (#1074)
-* Fix and improve various ``setup.py`` package metadata fields. (#1181)
+* Fix and improve various ``setup.py`` package metadata fields. (#1185)
 
 Maintenance and code organization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -266,6 +266,7 @@ Build and continuous integration
 * CI tests requiring a GUI are now run against PyQt5 rather than PyQt4.
   (#1127)
 * Add Slack notifications for CI. (#1074)
+* Fix and improve various ``setup.py`` package metadata fields. (#1181)
 
 Maintenance and code organization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -274,13 +274,13 @@ setuptools.setup(
         Operating System :: MacOS :: MacOS X
         Operating System :: Microsoft :: Windows
         Operating System :: POSIX :: Linux
-        Programming Language :: C
         Programming Language :: Python
         Programming Language :: Python :: 3
         Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
+        Programming Language :: Python :: 3.9
         Programming Language :: Python :: Implementation :: CPython
         Topic :: Scientific/Engineering
         Topic :: Software Development
@@ -289,10 +289,15 @@ setuptools.setup(
         """.splitlines()
         if len(c.strip()) > 0
     ],
-    description="Explicitly typed attributes for Python",
+    description="Observable typed attributes for Python classes",
     long_description=get_long_description(),
     long_description_content_type="text/x-rst",
-    download_url="https://github.com/enthought/traits",
+    download_url="https://pypi.python.org/pypi/traits",
+    project_urls={
+        "Issue Tracker": "https://github.com/enthought/traits/issues",
+        "Documentation": "https://docs.enthought.com/traits",
+        "Source Code": "https://github.com/enthought/traits",
+    },
     install_requires=[],
     extras_require={
         "test": [
@@ -314,8 +319,6 @@ setuptools.setup(
         ],
     },
     license="BSD",
-    maintainer="ETS Developers",
-    maintainer_email="enthought-dev@enthought.com",
     packages=setuptools.find_packages(include=["traits", "traits.*"]),
     python_requires=">=3.5",
     zip_safe=False,


### PR DESCRIPTION
This PR makes some minor updates and changes to the setup script. The most notable change is to the short description.

- Adjust classifiers: remove "Programming Language :: C", since it's misleading, and add "Programming Language :: Python :: 3.9" for future-proofing purposes
- Update the description to "Observable typed attributes ..."; this captures the (to my mind) key benefit of Traits.
- Change the download url to point to PyPI (this seems to be fairly standard practice)
- Add explicit project URLs pointing to issues, documentation and source. (The homepage also points to docs, but that's not obvious to someone browsing PyPI, so I think it's worth having the explicit documentation link.)
- Remove the maintainer and maintainer email fields; these are redundant with the existing author and author_email. The [setuptools docs](https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords) say for "maintainer":
  > A string specifying the name of the current maintainer, if different from the author.
  
  and similarly for "maintainer_email".

Closes #1181.