### PR TITLE
Remove unreachable code and refactor trait_getattr for readability

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1937,8 +1937,7 @@ getattr_trait(trait_object *trait, has_traits_object *obj, PyObject *name)
     onotifiers = obj->notifiers;
     if (has_notifiers(tnotifiers, onotifiers)) {
         rc = call_notifiers(
-            tnotifiers, onotifiers, obj, name, Uninitialized,
-            result);
+            tnotifiers, onotifiers, obj, name, Uninitialized, result);
         if (rc < 0) {
             goto error;
         }

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1934,42 +1934,10 @@ getattr_trait(trait_object *trait, has_traits_object *obj, PyObject *name)
 
         return NULL;
     }
-
-    if (!PyUnicode_Check(name)) {
+    else {
         invalid_attribute_error(name);
         return NULL;
     }
-
-    if ((result = default_value_for(trait, obj, name)) != NULL) {
-        if (PyDict_SetItem(dict, name, result) >= 0) {
-            rc = 0;
-            if ((trait->post_setattr != NULL)
-                && !(trait->flags & TRAIT_IS_MAPPED)) {
-                rc = trait->post_setattr(trait, obj, name, result);
-            }
-
-            if (rc == 0) {
-                tnotifiers = trait->notifiers;
-                onotifiers = obj->notifiers;
-                if (has_notifiers(tnotifiers, onotifiers)) {
-                    rc = call_notifiers(
-                        tnotifiers, onotifiers, obj, name, Uninitialized,
-                        result);
-                }
-            }
-            if (rc == 0) {
-                return result;
-            }
-        }
-        Py_DECREF(result);
-    }
-
-    if (PyErr_ExceptionMatches(PyExc_KeyError)) {
-        PyErr_SetObject(PyExc_AttributeError, name);
-    }
-
-    Py_DECREF(name);
-    return NULL;
 }
 
 /*-----------------------------------------------------------------------------

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1925,8 +1925,7 @@ getattr_trait(trait_object *trait, has_traits_object *obj, PyObject *name)
     }
 
     /* Call any post_setattr operations. */
-    if ((trait->post_setattr != NULL)
-        && !(trait->flags & TRAIT_IS_MAPPED)) {
+    if ((trait->post_setattr != NULL) && !(trait->flags & TRAIT_IS_MAPPED)) {
         rc = trait->post_setattr(trait, obj, name, result);
         if (rc < 0) {
             goto error;


### PR DESCRIPTION
Remove an unreachable block of code: it follows an `if (PyUnicode_Check(name)) { ...` block and an `if (!PyUnicode_Check(name)) {` block, both of which return. At least one of those if conditions must evaluate to true. (I refuse to consider the possibility that `name` somehow changed type within the scope of the first block. It's possible in theory, but insane in practice.)

I haven't looked into the history, but my suspicion is that once upon a time these two blocks dealt with Unicode strings and bytestrings separately.