### PR TITLE
Fix shadow trait notifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -203,7 +203,7 @@ Fixes
   (#1018)
 * Fix setting default values via dynamic default methods or overriding trait in
   subclasses for mapped traits, used by ``Map``, ``Expression``, ``PrefixMap``.
-  (#1091)
+  (#1091, #1188)
 * Fix setting default values via dynamic default methods or overriding trait in
   subclasses for ``Expression`` and ``AdaptsTo``. (#1088, #1119, #1152)
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1937,8 +1937,7 @@ getattr_trait(trait_object *trait, has_traits_object *obj, PyObject *name)
     onotifiers = obj->notifiers;
     if (has_notifiers(tnotifiers, onotifiers)) {
         rc = call_notifiers(
-            tnotifiers, onotifiers, obj, name, Uninitialized,
-            result);
+            tnotifiers, onotifiers, obj, name, Uninitialized, result);
         if (rc < 0) {
             goto error;
         }

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1934,42 +1934,10 @@ getattr_trait(trait_object *trait, has_traits_object *obj, PyObject *name)
 
         return NULL;
     }
-
-    if (!PyUnicode_Check(name)) {
+    else {
         invalid_attribute_error(name);
         return NULL;
     }
-
-    if ((result = default_value_for(trait, obj, name)) != NULL) {
-        if (PyDict_SetItem(dict, name, result) >= 0) {
-            rc = 0;
-            if ((trait->post_setattr != NULL)
-                && !(trait->flags & TRAIT_IS_MAPPED)) {
-                rc = trait->post_setattr(trait, obj, name, result);
-            }
-
-            if (rc == 0) {
-                tnotifiers = trait->notifiers;
-                onotifiers = obj->notifiers;
-                if (has_notifiers(tnotifiers, onotifiers)) {
-                    rc = call_notifiers(
-                        tnotifiers, onotifiers, obj, name, Uninitialized,
-                        result);
-                }
-            }
-            if (rc == 0) {
-                return result;
-            }
-        }
-        Py_DECREF(result);
-    }
-
-    if (PyErr_ExceptionMatches(PyExc_KeyError)) {
-        PyErr_SetObject(PyExc_AttributeError, name);
-    }
-
-    Py_DECREF(name);
-    return NULL;
 }
 
 /*-----------------------------------------------------------------------------

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1925,8 +1925,7 @@ getattr_trait(trait_object *trait, has_traits_object *obj, PyObject *name)
     }
 
     /* Call any post_setattr operations. */
-    if ((trait->post_setattr != NULL)
-        && !(trait->flags & TRAIT_IS_MAPPED)) {
+    if ((trait->post_setattr != NULL) && !(trait->flags & TRAIT_IS_MAPPED)) {
         rc = trait->post_setattr(trait, obj, name, result);
         if (rc < 0) {
             goto error;

--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -197,9 +197,6 @@ class TestMap(unittest.TestCase):
         self.assertEqual(len(preferences.primary_changes), 2)
         self.assertEqual(len(preferences.shadow_changes), 2)
 
-    # XXX Test whether change from Undefined to defined issues a
-    # notification; it should, since Undefined is an observable value.
-
     def test_pickle_roundtrip(self):
         class Person(HasTraits):
             married = Map({"yes": 1, "yeah": 1, "no": 0, "nah": 0},

--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -214,6 +214,31 @@ class TestMap(unittest.TestCase):
         self.assertEqual(len(preferences.primary_changes), 2)
         self.assertEqual(len(preferences.shadow_changes), 2)
 
+    def test_notification_init_value(self):
+
+        preferences = Preferences(color="green")
+
+        self.assertEqual(len(preferences.primary_changes), 1)
+        self.assertEqual(len(preferences.shadow_changes), 1)
+
+    def test_notification_change_shadow_value(self):
+
+        class PreferencesWithDynamicDefault(Preferences):
+
+            def _color_default(self):
+                return "yellow"
+
+        preferences = PreferencesWithDynamicDefault()
+        self.assertEqual(len(preferences.primary_changes), 0)
+        self.assertEqual(len(preferences.shadow_changes), 0)
+
+        # access the dynamic default of color_ should not trigger event
+        # because the value has not changed.
+        preferences.color_
+
+        self.assertEqual(len(preferences.primary_changes), 0)
+        self.assertEqual(len(preferences.shadow_changes), 0)
+
     def test_pickle_roundtrip(self):
         class Person(HasTraits):
             married = Map({"yes": 1, "yeah": 1, "no": 0, "nah": 0},

--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -74,6 +74,14 @@ class TestMap(unittest.TestCase):
         self.assertEqual(p.married, Undefined)
         self.assertEqual(p.married_, Undefined)
 
+    def test_no_default_reverse_access_order(self):
+        class Person(HasTraits):
+            married = Map({"yes": 1, "yeah": 1, "no": 0, "nah": 0})
+
+        p = Person()
+        self.assertEqual(p.married_, Undefined)
+        self.assertEqual(p.married, Undefined)
+
     def test_default(self):
         class Person(HasTraits):
             married = Map({"yes": 1, "yeah": 1, "no": 0, "nah": 0,
@@ -82,6 +90,15 @@ class TestMap(unittest.TestCase):
         p = Person()
         self.assertIsNone(p.married)
         self.assertEqual(p.married_, 2)
+
+    def test_default_reverse_access_order(self):
+        class Person(HasTraits):
+            married = Map({"yes": 1, "yeah": 1, "no": 0, "nah": 0,
+                           None: 2}, default_value=None)
+
+        p = Person()
+        self.assertEqual(p.married_, 2)
+        self.assertIsNone(p.married)
 
     def test_default_method(self):
         class Person(HasTraits):

--- a/traits/trait_converters.py
+++ b/traits/trait_converters.py
@@ -115,9 +115,23 @@ def trait_for(trait):
 
 
 def _mapped_trait_default(trait, name, instance):
-    value = getattr(instance, name, Undefined)
-    if value is Undefined:
-        return Undefined
+    """ Callable providing default for a shadow trait of a mapped trait pair.
+
+    Parameters
+    ----------
+    trait : CTrait
+        The principal trait of the mapped trait pair.
+    name : str
+        The name of the trait on the relevant HasTraits object.
+    instance : HasTraits
+        The HasTraits object on which the mapped trait lives.
+
+    Returns
+    -------
+    default : object
+        The default value for the shadow trait.
+    """
+    value = getattr(instance, name)
     return trait.handler.mapped_value(value)
 
 

--- a/traits/trait_converters.py
+++ b/traits/trait_converters.py
@@ -29,7 +29,6 @@ unwieldy classmethod name ``instantiate_and_get_ctrait``.
 from functools import partial
 
 from .constants import DefaultValue
-from .trait_base import Undefined
 
 
 def trait_cast(obj):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2942,7 +2942,7 @@ class Map(TraitType):
 
     def mapped_value(self, value):
         """ Get the mapped value for a value. """
-        return self.map[value]
+        return Undefined if value is Undefined else self.map[value]
 
     def post_setattr(self, object, name, value):
         setattr(object, name + "_", self.mapped_value(value))
@@ -3028,7 +3028,7 @@ class PrefixMap(TraitType):
 
     def mapped_value(self, value):
         """ Get the mapped value for a value. """
-        return self.map[value]
+        return Undefined if value is Undefined else self.map[value]
 
     def post_setattr(self, object, name, value):
         setattr(object, name + "_", self.mapped_value(value))


### PR DESCRIPTION
This PR fixes the issue where shadow trait notifications were not being issued on the first change of the primary trait.

The essence of the change is to always call `post_setattr` (if it exists) when accessing a default value. That needs changes in two places:

- in `trait_getattr`, where there's already a block that calls `post_setattr`, but the call is skipped for mapped traits, for no clear reason; we re-enable that call
- in `trait_setattr`, where `default_value_for` is called if necessary to retrieve the old value for notifications. Here we add code to (1) poke the computed default value back onto the dictionary, just like we do already in `trait_getattr`, and (2) call `post_setattr`

There's scope for refactoring to remove the duplication, but I'd rather do that refactoring post-release, and do the minimum necessary to fix this bug for the release.

Note that this fix required fixing `Map` and `PrefixMap` to map a value of `Undefined` correctly; I think that's reasonable: `mapped_value` should be prepared to accept any valid value of the principal trait, and currently `Undefined` _is_ such a value. (But see also #1187)

There's also a question of whether in `trait_setattr` we should be issuing notifications with old value `Uninitialized`, like we do in `trait_getattr`. It makes little difference in practice, since the notifiers don't call listeners when `old` is `Uninitialized`. We may want to make that change in master, for consistency, but for the bugfix I suggest leaving it out.

This builds on #1186, and will be easier to review once that PR is merged.

Fixes #1183 
