### PR TITLE
Change the 'default default' for Map and PrefixMap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -161,7 +161,8 @@ Features
 * Add ``allow_none`` flag for ``Callable`` trait. (#885)
 * Add support for type annotation. (#904, #1064)
 * Allow mutable values in ``Constant`` trait. (#929)
-* Add ``Map`` and ``PrefixMap`` trait types. (#886, #953, #956, #970, #1139)
+* Add ``Map`` and ``PrefixMap`` trait types. (#886, #953, #956, #970, #1139,
+  #1189)
 * Add ``TraitList`` as the base list object that can perform validation
   and emit change notifications. (#912, #981, #984, #989, #999, #1003, #1011,
   #1026, #1009, #1040, #1172, #1173)

--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -13,9 +13,10 @@ Tests for the Map handler.
 """
 
 import pickle
+import sys
 import unittest
 
-from traits.api import HasTraits, Int, Map, TraitError, Undefined
+from traits.api import HasTraits, Int, Map, TraitError
 
 
 class TestMap(unittest.TestCase):
@@ -24,8 +25,6 @@ class TestMap(unittest.TestCase):
             married = Map({"yes": 1, "yeah": 1, "no": 0, "nah": 0})
 
         person = Person()
-
-        self.assertEqual(Undefined, person.married)
 
         person.married = "yes"
         self.assertEqual("yes", person.married)
@@ -42,12 +41,22 @@ class TestMap(unittest.TestCase):
             person.married = []
 
     def test_no_default(self):
+        mapping = {"yes": 1, "yeah": 1, "no": 0, "nah": 0}
+
         class Person(HasTraits):
-            married = Map({"yes": 1, "yeah": 1, "no": 0, "nah": 0})
+            married = Map(mapping)
 
         p = Person()
-        self.assertEqual(p.married, Undefined)
-        self.assertEqual(p.married_, Undefined)
+        if sys.version_info >= (3, 6):
+            # If we're using Python >= 3.6, we can rely on dictionaries
+            # being ordered, and then the default is predictable.
+            self.assertEqual(p.married, "yes")
+            self.assertEqual(p.married_, 1)
+        else:
+            # Otherwise, all we can expect is that the default is _one_
+            # of the dictionary entries.
+            self.assertIn(p.married, mapping)
+            self.assertEqual(p.married_, mapping[p.married])
 
     def test_default(self):
         class Person(HasTraits):

--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -95,6 +95,8 @@ class TestMap(unittest.TestCase):
             self.assertEqual(primary_value, "yes")
             self.assertEqual(shadow_value, 1)
         else:
+            # For Python < 3.6, dictionary ordering and hence the default
+            # value aren't predictable.
             self.assertIn(primary_value, mapping)
             self.assertEqual(shadow_value, mapping[primary_value])
 

--- a/traits/tests/test_prefix_map.py
+++ b/traits/tests/test_prefix_map.py
@@ -13,9 +13,10 @@ Tests for the PrefixMap handler.
 """
 
 import pickle
+import sys
 import unittest
 
-from traits.api import HasTraits, Int, PrefixMap, TraitError, Undefined
+from traits.api import HasTraits, Int, PrefixMap, TraitError
 
 
 class Person(HasTraits):
@@ -25,8 +26,6 @@ class Person(HasTraits):
 class TestPrefixMap(unittest.TestCase):
     def test_assignment(self):
         person = Person()
-
-        self.assertEqual(Undefined, person.married)
 
         # Test prefix
         person.married = "yea"
@@ -58,12 +57,22 @@ class TestPrefixMap(unittest.TestCase):
                     person.married = value
 
     def test_no_default(self):
+        mapping = {"yes": 1, "yeah": 1, "no": 0, "nah": 0}
+
         class Person(HasTraits):
-            married = PrefixMap({"yes": 1, "yeah": 1, "no": 0, "nah": 0})
+            married = PrefixMap(mapping)
 
         p = Person()
-        self.assertEqual(p.married, Undefined)
-        self.assertEqual(p.married_, Undefined)
+        if sys.version_info >= (3, 6):
+            # If we're using Python >= 3.6, we can rely on dictionaries
+            # being ordered, and then the default is predictable.
+            self.assertEqual(p.married, "yes")
+            self.assertEqual(p.married_, 1)
+        else:
+            # Otherwise, all we can expect is that the default is _one_
+            # of the dictionary entries.
+            self.assertIn(p.married, mapping)
+            self.assertEqual(p.married_, mapping[p.married])
 
     def test_default(self):
         class Person(HasTraits):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2927,7 +2927,10 @@ class Map(TraitType):
         self.map = map
         self.fast_validate = (ValidateTrait.map, map)
 
-        default_value = metadata.pop("default_value", Undefined)
+        try:
+            default_value = metadata.pop("default_value")
+        except KeyError:
+            default_value = next(iter(self.map))
 
         super().__init__(default_value, **metadata)
 
@@ -2999,9 +3002,11 @@ class PrefixMap(TraitType):
         for key in map.keys():
             self._map[key] = key
 
-        default_value = metadata.pop("default_value", Undefined)
-
-        if default_value is not Undefined:
+        try:
+            default_value = metadata.pop("default_value")
+        except KeyError:
+            default_value = next(iter(self.map))
+        else:
             default_value = self.value_for(default_value)
 
         super().__init__(default_value, **metadata)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2911,6 +2911,10 @@ class Map(TraitType):
             A dictionary whose keys are valid values for the trait attribute,
             and whose corresponding values are the values for the shadow
             trait attribute.
+        default_value : object, optional
+            The default value for the trait. If given, this should be a key
+            from the mapping. If not given, the first key from the mapping (in
+            normal dictionary iteration order) will be used as the default.
 
         Attributes
         ----------
@@ -2986,6 +2990,11 @@ class PrefixMap(TraitType):
         A dictionary whose keys are strings that are valid values for the
         trait attribute, and whose corresponding values are the values for
         the shadow trait attribute.
+    default_value : object, optional
+        The default value for the trait. If given, this should be either a key
+        from the mapping or a unique prefix of a key from the mapping. If not
+        given, the first key from the mapping (in normal dictionary iteration
+        order) will be used as the default.
 
     Attributes
     ----------


### PR DESCRIPTION
This PR changes the default default value for `Map` and `PrefixMap`: if no default value is given, then it uses the first element of the provided mapping, in normal Python iteration order.

In Python 3.6 this gives something reasonable and deterministic. In Python 3.5, we'll get an arbitrary element (and possibly a different one from run to run).

~Still need to check the documentation to see what needs changing there.~

Closes #1187 

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] ~Update User manual (`docs/source/traits_user_manual`)~ (not needed - no mention of defaults is made in the current user guide)
- [x] ~Update type annotation hints in `traits-stubs`~ (not needed)
