### PR TITLE
DOC: Mention dispatch is used for distinguishing observers

### DIFF
--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -602,6 +602,28 @@ usage can be replaced by |match|::
   match(lambda name, trait: trait.metadata_name is None)
 
 
+Dispatch parameter differentiates observers
+```````````````````````````````````````````
+
+In the following example with |@on_trait_change|, the second call is an no-op
+because a handler for *"name"* has already been added::
+
+    instance.on_trait_change(handler, "name", dispatch="same")
+    instance.on_trait_change(handler, "name", dispatch="ui")    # does nothing
+
+With |@observe|, the **dispatch** parameter is taken into account for
+distinguishing observers. The following example will result in the change
+handler being called twice, via different dispatching routes::
+
+    instance.observe(handler, "name", dispatch="same")
+    instance.observe(handler, "name", dispatch="ui")
+
+Likewise, when removing change handlers, **dispatch** must match the value
+used for putting up the observer::
+
+    instance.observe(handler, "name", dispatch="ui")
+    instance.observe(handler, "name", dispatch="ui", remove=True)
+
 ..
    # substitutions
 


### PR DESCRIPTION
This PR expands the user manual to highlight another difference in `observe`: `dispatch` is used while distinguishing observers.

Context: I was looking at TraitsUI code, and noticed that existing calls to remove change handlers do not specify `dispatch="ui"`. It works because `on_trait_change` does not differentiate it. 
https://github.com/enthought/traitsui/blob/f919dbd2044bcbff7280e5580286e93caa8a153a/traitsui/qt4/list_editor.py#L138-L140
https://github.com/enthought/traitsui/blob/f919dbd2044bcbff7280e5580286e93caa8a153a/traitsui/qt4/list_editor.py#L149-L151
`observe` does, and the call with `remove=True` in the above example will need to include `dispatch="ui"` when it is switched to use `observe`

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~
