### PR TITLE
DOC/FIX: User manual mentioning a nonexisting feature in metadata filter

### DIFF
--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -165,7 +165,7 @@ functions from the |observation.api| module.
    * - |trait|
      - For observing a specific named trait.
    * - |metadata|
-     - For observing multiple traits with a specific metadata.
+     - For observing multiple traits with specific metadata.
    * - |dict_items|
      - For observing items in a dict.
    * - |list_items|

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -165,8 +165,7 @@ functions from the |observation.api| module.
    * - |trait|
      - For observing a specific named trait.
    * - |metadata|
-     - For observing multiple traits with a specific metadata. Support further
-       filtering on the metadata value.
+     - For observing multiple traits with a specific metadata.
    * - |dict_items|
      - For observing items in a dict.
    * - |list_items|


### PR DESCRIPTION
This PR fixes a sentence in the documentation that mentions a nonexisting feature of `metadata`: the feature was removed in https://github.com/enthought/traits/pull/1095 to defer adding a feature we are not sure if it'd be needed.

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~
