### PR TITLE
Require Sphinx 2.1 for trait_documenter tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -309,7 +309,7 @@ setuptools.setup(
             "flake8",
             "mypy",
             "setuptools",
-            "Sphinx",
+            "Sphinx>=2.1.0",
             # Python 3.9 exclusions:
             #
             # * NumPy installation fails on Python 3.9 on the Ubuntu Xenial

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -165,16 +165,10 @@ class TestTraitDocumenter(unittest.TestCase):
             app.builder.env.app = app
             app.builder.env.temp_data["docname"] = "dummy"
 
-            # Backwards compatibility hack: for now, we need to be compatible
-            # with both Sphinx < 2.1 (whose DocumenterBridge doesn't take
-            # a state argument) and Sphinx >= 2.3 (which warns if the state
-            # isn't passed). Eventually we should be able to drop support
-            # for Sphinx < 2.1.
             kwds = {}
-            if sphinx.version_info >= (2, 1):
-                state = mock.Mock()
-                state.document.settings.tab_width = 8
-                kwds["state"] = state
+            state = mock.Mock()
+            state.document.settings.tab_width = 8
+            kwds["state"] = state
             yield DocumenterBridge(
                 app.env, LoggingReporter(''), Options(), 1, **kwds)
 


### PR DESCRIPTION
This PR remove some backwards compatibility code needed for ancient Sphinx versions.

Just to be safe, we also add a minimum Sphinx version in the test requirements.

Closes #1054.