### PR TITLE
Fix description in README to match the one in the setup script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-==============================================
-traits: explicitly typed attributes for Python
-==============================================
+======================================================
+Traits: observable typed attributes for Python classes
+======================================================
 
 http://docs.enthought.com/traits
 


### PR DESCRIPTION
This is a tiny PR to harmonize the descriptions of the Traits library: it makes the description in the README match the short description in the `setup.py` script (which now also matches the GitHub repository description).

And yes, the whole README likely needs rewriting. One step at a time.