### PR TITLE
Use ComparisonMode constants instead of magic numbers

### DIFF
--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -450,7 +450,7 @@ Suppose we have these classes::
         value = Int()
 
     class Foo(HasTraits):
-        container = List(Instance(Bar), comparison_mode=1)
+        container = List(Instance(Bar), comparison_mode=ComparisonMode.identity)
 
 To notify for changes on *Bar.value* for an item in *Foo.container*,
 with |@on_trait_change|, one may do::
@@ -509,7 +509,7 @@ For example, with |@on_trait_change|::
 
 With |@observe|, it would be best to change this to::
 
-    container = List(comparison_mode=1)
+    container = List(comparison_mode=ComparisonMode.identity)
 
     @observe("container.items")
     def container_updated(self):
@@ -552,7 +552,7 @@ For mutations to container, e.g.::
 
 It will have to be changed to::
 
-    container = List(comparison_mode=1)
+    container = List(comparison_mode=ComparisonMode.identity)
 
     @observe("container:items")
     def name_updated(self, event):

--- a/examples/tutorials/doc_examples/examples/observe_different_events.py
+++ b/examples/tutorials/doc_examples/examples/observe_different_events.py
@@ -21,7 +21,7 @@ from traits.observation.api import trait
 
 class Person(HasTraits):
 
-    scores = List(Int, comparison_mode=1)
+    scores = List(Int, comparison_mode=ComparisonMode.identity)
 
     @observe("scores")
     def notify_scores_change(self, event):

--- a/traits/observation/tests/test_has_traits_helpers.py
+++ b/traits/observation/tests/test_has_traits_helpers.py
@@ -13,7 +13,8 @@ from unittest import mock
 import warnings
 
 from traits.api import (
-    Bool, Dict, HasTraits, List, Instance, Int, Property, Set, Union,
+    Bool, ComparisonMode, Dict, HasTraits, List, Instance, Int, Property, Set,
+    Union,
 )
 from traits.observation import _has_traits_helpers as helpers
 from traits.observation import expression
@@ -140,14 +141,14 @@ class TestHasTraitsHelpersIterObjects(unittest.TestCase):
 class ObjectWithEqualityComparisonMode(HasTraits):
     """ Class for supporting TestHasTraitsHelpersWarning """
 
-    list_values = List(comparison_mode=2)
-    dict_values = Dict(comparison_mode=2)
-    set_values = Set(comparison_mode=2)
-    property_list = Property(List(comparison_mode=2))
+    list_values = List(comparison_mode=ComparisonMode.equality)
+    dict_values = Dict(comparison_mode=ComparisonMode.equality)
+    set_values = Set(comparison_mode=ComparisonMode.equality)
+    property_list = Property(List(comparison_mode=ComparisonMode.equality))
     container_in_union = Union(
         None,
-        Set(comparison_mode=1),
-        comparison_mode=2,
+        Set(comparison_mode=ComparisonMode.identity),
+        comparison_mode=ComparisonMode.equality,
     )
 
 

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -17,6 +17,7 @@ import unittest
 from traits.api import (
     Any,
     Bool,
+    ComparisonMode,
     DelegatesTo,
     Dict,
     Event,
@@ -44,7 +45,7 @@ class Student(HasTraits):
 class Teacher(HasTraits):
     """ Model for testing list + post_init (enthought/traits#275) """
 
-    students = List(Instance(Student), comparison_mode=1)
+    students = List(Instance(Student), comparison_mode=ComparisonMode.identity)
 
     student_graduate_events = List()
 
@@ -102,13 +103,14 @@ class Record(HasTraits):
 
 class Album(HasTraits):
 
-    records = List(Instance(Record), comparison_mode=1)
+    records = List(Instance(Record), comparison_mode=ComparisonMode.identity)
 
     records_default_call_count = Int()
 
     record_number_change_events = List()
 
-    name_to_records = Dict(Str, Record, comparison_mode=1)
+    name_to_records = Dict(
+        Str, Record, comparison_mode=ComparisonMode.identity)
 
     name_to_records_default_call_count = Int()
 
@@ -192,13 +194,14 @@ class SingleValue(HasTraits):
 
 class ClassWithListOfInstance(HasTraits):
 
-    list_of_instances = List(Instance(SingleValue), comparison_mode=1)
+    list_of_instances = List(
+        Instance(SingleValue), comparison_mode=ComparisonMode.identity)
 
 
 class ClassWithListOfListOfInstance(HasTraits):
 
     list_of_list_of_instances = List(
-        List(Instance(SingleValue)), comparison_mode=1)
+        List(Instance(SingleValue)), comparison_mode=ComparisonMode.identity)
 
 
 class TestHasTraitsObserveListOfInstance(unittest.TestCase):
@@ -324,7 +327,8 @@ class TestHasTraitsObserveListOfInstance(unittest.TestCase):
 
 class ClassWithDictOfInstance(HasTraits):
 
-    name_to_instance = Dict(Str, Instance(SingleValue), comparison_mode=1)
+    name_to_instance = Dict(
+        Str, Instance(SingleValue), comparison_mode=ComparisonMode.identity)
 
 
 class TestHasTraitsObserveDictOfInstance(unittest.TestCase):
@@ -367,10 +371,11 @@ class TestHasTraitsObserveDictOfInstance(unittest.TestCase):
 
 class ClassWithSetOfInstance(HasTraits):
 
-    instances = Set(Instance(SingleValue), comparison_mode=1)
+    instances = Set(
+        Instance(SingleValue), comparison_mode=ComparisonMode.identity)
 
     instances_compat = Set(
-        Instance(SingleValue), comparison_mode=1)
+        Instance(SingleValue), comparison_mode=ComparisonMode.identity)
 
 
 class TestHasTraitsObserveSetOfInstance(unittest.TestCase):
@@ -417,12 +422,12 @@ class Potato(HasTraits):
 
 class PotatoBag(HasTraits):
 
-    potatos = List(Instance(Potato), comparison_mode=1)
+    potatos = List(Instance(Potato), comparison_mode=ComparisonMode.identity)
 
 
 class Crate(HasTraits):
 
-    potato_bags = List(PotatoBag, comparison_mode=1)
+    potato_bags = List(PotatoBag, comparison_mode=ComparisonMode.identity)
 
 
 class TestHasTraitsObserverDifferentiateParent(unittest.TestCase):
@@ -532,7 +537,7 @@ class Person(HasTraits):
 class Team(HasTraits):
     leader = Instance(Person)
 
-    member_names = List(Str(), comparison_mode=1)
+    member_names = List(Str(), comparison_mode=ComparisonMode.identity)
 
     any_value = Any()
 


### PR DESCRIPTION
Minor cleanup PR: replace uses of magic numbers for comparison modes with the corresponding `ComparisonMode` elements. (The numbers should eventually become just an implementation detail; we  want to encourage all traits users to use the `ComparisonMode` constants instead.)