### PR TITLE
Cleanup comparison mode setting in tests and documentation

### DIFF
--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -450,7 +450,7 @@ Suppose we have these classes::
         value = Int()
 
     class Foo(HasTraits):
-        container = List(Instance(Bar), comparison_mode=ComparisonMode.identity)
+        container = List(Instance(Bar))
 
 To notify for changes on *Bar.value* for an item in *Foo.container*,
 with |@on_trait_change|, one may do::

--- a/examples/tutorials/doc_examples/examples/observe_different_events.py
+++ b/examples/tutorials/doc_examples/examples/observe_different_events.py
@@ -21,7 +21,7 @@ from traits.observation.api import trait
 
 class Person(HasTraits):
 
-    scores = List(Int, comparison_mode=ComparisonMode.identity)
+    scores = List(Int)
 
     @observe("scores")
     def notify_scores_change(self, event):

--- a/traits/observation/tests/test_has_traits_helpers.py
+++ b/traits/observation/tests/test_has_traits_helpers.py
@@ -144,7 +144,7 @@ class CannotCompare:
 
 
 class ObjectWithEqualityComparisonMode(HasTraits):
-    """ Class for supporting TestHasTraitsHelpersWarning """
+    """ Class for supporting TestHasTraitsHelpersComparisonMode """
 
     list_values = List(comparison_mode=ComparisonMode.equality)
     dict_values = Dict(comparison_mode=ComparisonMode.equality)

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -17,7 +17,6 @@ import unittest
 from traits.api import (
     Any,
     Bool,
-    ComparisonMode,
     DelegatesTo,
     Dict,
     Event,

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -45,7 +45,7 @@ class Student(HasTraits):
 class Teacher(HasTraits):
     """ Model for testing list + post_init (enthought/traits#275) """
 
-    students = List(Instance(Student), comparison_mode=ComparisonMode.identity)
+    students = List(Instance(Student))
 
     student_graduate_events = List()
 
@@ -103,14 +103,13 @@ class Record(HasTraits):
 
 class Album(HasTraits):
 
-    records = List(Instance(Record), comparison_mode=ComparisonMode.identity)
+    records = List(Instance(Record))
 
     records_default_call_count = Int()
 
     record_number_change_events = List()
 
-    name_to_records = Dict(
-        Str, Record, comparison_mode=ComparisonMode.identity)
+    name_to_records = Dict(Str, Record)
 
     name_to_records_default_call_count = Int()
 
@@ -194,14 +193,12 @@ class SingleValue(HasTraits):
 
 class ClassWithListOfInstance(HasTraits):
 
-    list_of_instances = List(
-        Instance(SingleValue), comparison_mode=ComparisonMode.identity)
+    list_of_instances = List(Instance(SingleValue))
 
 
 class ClassWithListOfListOfInstance(HasTraits):
 
-    list_of_list_of_instances = List(
-        List(Instance(SingleValue)), comparison_mode=ComparisonMode.identity)
+    list_of_list_of_instances = List(List(Instance(SingleValue)))
 
 
 class TestHasTraitsObserveListOfInstance(unittest.TestCase):
@@ -327,8 +324,7 @@ class TestHasTraitsObserveListOfInstance(unittest.TestCase):
 
 class ClassWithDictOfInstance(HasTraits):
 
-    name_to_instance = Dict(
-        Str, Instance(SingleValue), comparison_mode=ComparisonMode.identity)
+    name_to_instance = Dict(Str, Instance(SingleValue))
 
 
 class TestHasTraitsObserveDictOfInstance(unittest.TestCase):
@@ -371,11 +367,9 @@ class TestHasTraitsObserveDictOfInstance(unittest.TestCase):
 
 class ClassWithSetOfInstance(HasTraits):
 
-    instances = Set(
-        Instance(SingleValue), comparison_mode=ComparisonMode.identity)
+    instances = Set(Instance(SingleValue))
 
-    instances_compat = Set(
-        Instance(SingleValue), comparison_mode=ComparisonMode.identity)
+    instances_compat = Set(Instance(SingleValue))
 
 
 class TestHasTraitsObserveSetOfInstance(unittest.TestCase):
@@ -422,12 +416,12 @@ class Potato(HasTraits):
 
 class PotatoBag(HasTraits):
 
-    potatos = List(Instance(Potato), comparison_mode=ComparisonMode.identity)
+    potatos = List(Instance(Potato))
 
 
 class Crate(HasTraits):
 
-    potato_bags = List(PotatoBag, comparison_mode=ComparisonMode.identity)
+    potato_bags = List(PotatoBag)
 
 
 class TestHasTraitsObserverDifferentiateParent(unittest.TestCase):
@@ -537,7 +531,7 @@ class Person(HasTraits):
 class Team(HasTraits):
     leader = Instance(Person)
 
-    member_names = List(Str(), comparison_mode=ComparisonMode.identity)
+    member_names = List(Str())
 
     any_value = Any()
 


### PR DESCRIPTION
After #1165, we no longer need to set `comparison_mode` to `identity` in container traits in order to silence warnings and support `observe`. This PR cleans up such definitions in tests and documentation.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~
