### PR TITLE
Speed up CI builds by caching the pip directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: xenial
 services:
   - xvfb
 
+cache: pip
+
 addons:
   apt:
     packages:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 build: false
 
+cache:
+  - '%LOCALAPPDATA%\pip\Cache'
+
 environment:
   global:
     PYTHONUNBUFFERED: "1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 build: false
-
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 build: false
+
 cache:
-  - '%LOCALAPPDATA%\pip\Cache'
+  - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor.yml
 
 environment:
   global:


### PR DESCRIPTION
A trivial build PR to cache pip eggs.

I plan to run the CI build twice: if this worked, the second run should be appreciably faster than that first.