### PR TITLE
[Draft] Recursion support for observe

### DIFF
--- a/traits/observation/_filtered_trait_observer.py
+++ b/traits/observation/_filtered_trait_observer.py
@@ -170,5 +170,5 @@ class FilteredTraitObserver:
                 match_func=self.filter,
                 optional=False,
             ),
-            children=[graph],
+            branches=[graph],
         )

--- a/traits/observation/_named_trait_observer.py
+++ b/traits/observation/_named_trait_observer.py
@@ -196,5 +196,5 @@ class NamedTraitObserver:
                 match_func=lambda name, trait: name == self.name,
                 optional=self.optional,
             ),
-            children=[graph],
+            branches=[graph],
         )

--- a/traits/observation/_testing.py
+++ b/traits/observation/_testing.py
@@ -38,7 +38,7 @@ def create_graph(*nodes):
     node = nodes[-1]
     graph = ObserverGraph(node=node)
     for node in nodes[:-1][::-1]:
-        graph = ObserverGraph(node=node, children=[graph])
+        graph = ObserverGraph(node=node, branches=[graph])
     return graph
 
 

--- a/traits/observation/_trait_added_observer.py
+++ b/traits/observation/_trait_added_observer.py
@@ -170,7 +170,7 @@ class TraitAddedObserver:
                 name=event.new,
                 wrapped_observer=graph.node,
             ),
-            children=graph.children
+            branches=graph.children
         )
         add_or_remove_notifiers(
             object=event.object,

--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -265,7 +265,7 @@ class SingleObserverExpression(ObserverExpression):
 
     def _create_graphs(self, branches):
         return [
-            ObserverGraph(node=self.observer, children=branches),
+            ObserverGraph(node=self.observer, branches=branches),
         ]
 
 

--- a/traits/observation/tests/test_expression.py
+++ b/traits/observation/tests/test_expression.py
@@ -35,7 +35,7 @@ def create_graph(*nodes):
     node = nodes[-1]
     graph = ObserverGraph(node=node)
     for node in nodes[:-1][::-1]:
-        graph = ObserverGraph(node=node, children=[graph])
+        graph = ObserverGraph(node=node, branches=[graph])
     return graph
 
 
@@ -149,14 +149,14 @@ class TestObserverExpressionComposition(unittest.TestCase):
         expected = [
             ObserverGraph(
                 node=observer1,
-                children=[
+                branches=[
                     create_graph(observer3),
                     create_graph(observer4),
                 ],
             ),
             ObserverGraph(
                 node=observer2,
-                children=[
+                branches=[
                     create_graph(observer3),
                     create_graph(observer4),
                 ],

--- a/traits/observation/tests/test_named_trait_observer.py
+++ b/traits/observation/tests/test_named_trait_observer.py
@@ -77,13 +77,13 @@ class TestObserverGraphIntegrateNamedTraitObserver(unittest.TestCase):
 
         path1 = ObserverGraph(
             node=create_observer(name="foo"),
-            children=[
+            branches=[
                 ObserverGraph(node=create_observer(name="bar")),
             ],
         )
         path2 = ObserverGraph(
             node=create_observer(name="foo"),
-            children=[
+            branches=[
                 ObserverGraph(node=create_observer(name="bar")),
             ],
         )

--- a/traits/observation/tests/test_observe.py
+++ b/traits/observation/tests/test_observe.py
@@ -87,7 +87,7 @@ class TestObserveAddNotifier(unittest.TestCase):
         # two children, each will have a maintainer
         graph = ObserverGraph(
             node=root_observer,
-            children=[
+            branches=[
                 ObserverGraph(node=DummyObserver()),
                 ObserverGraph(node=DummyObserver()),
             ],
@@ -119,7 +119,7 @@ class TestObserveAddNotifier(unittest.TestCase):
         )
         graph = ObserverGraph(
             node=parent_observer,
-            children=[
+            branches=[
                 ObserverGraph(
                     node=child_observer1,
                 ),
@@ -279,7 +279,7 @@ class TestObserveRemoveNotifier(unittest.TestCase):
         # two maintainers will be removed.
         graph = ObserverGraph(
             node=root_observer,
-            children=[
+            branches=[
                 ObserverGraph(node=DummyObserver()),
                 ObserverGraph(node=DummyObserver()),
             ],
@@ -313,7 +313,7 @@ class TestObserveRemoveNotifier(unittest.TestCase):
 
         graph = ObserverGraph(
             node=parent_observer,
-            children=[
+            branches=[
                 ObserverGraph(
                     node=child_observer1,
                 ),

--- a/traits/observation/tests/test_observer_graph.py
+++ b/traits/observation/tests/test_observer_graph.py
@@ -17,7 +17,7 @@ def graph_from_nodes(*nodes):
     nodes = nodes[::-1]
     graph = ObserverGraph(node=nodes[0])
     for node in nodes[1:]:
-        graph = ObserverGraph(node=node, children=[graph])
+        graph = ObserverGraph(node=node, branches=[graph])
     return graph
 
 
@@ -37,14 +37,14 @@ class TestObserverGraph(unittest.TestCase):
     def test_equality_different_length_children(self):
         graph1 = ObserverGraph(
             node=1,
-            children=[
+            branches=[
                 ObserverGraph(node=2),
                 ObserverGraph(node=3),
             ],
         )
         graph2 = ObserverGraph(
             node=1,
-            children=[
+            branches=[
                 ObserverGraph(node=2),
             ],
         )
@@ -54,14 +54,14 @@ class TestObserverGraph(unittest.TestCase):
         # The order of items in children does not matter
         graph1 = ObserverGraph(
             node=1,
-            children=[
+            branches=[
                 ObserverGraph(node=2),
                 ObserverGraph(node=3),
             ],
         )
         graph2 = ObserverGraph(
             node=1,
-            children=[
+            branches=[
                 ObserverGraph(node=3),
                 ObserverGraph(node=2),
             ],
@@ -73,7 +73,7 @@ class TestObserverGraph(unittest.TestCase):
         child_graph = ObserverGraph(node=2)
         graph = ObserverGraph(
             node=1,
-            children=[
+            branches=[
                 child_graph,
                 ObserverGraph(node=3),
             ],
@@ -86,7 +86,7 @@ class TestObserverGraph(unittest.TestCase):
         with self.assertRaises(ValueError) as exception_cm:
             ObserverGraph(
                 node=1,
-                children=[
+                branches=[
                     child_graph,
                     ObserverGraph(node=2),
                 ],


### PR DESCRIPTION
This is a draft PR that will be closed immediately. This is created solely for future reference and to keep a record for work that was done before.

Background: In the two proof-of-concept PRs for the observe framework (#942 and #969), recursion support was experimented with because `on_trait_change` does have this support. The feature was excluded for it is not clear if there is indeed a need, and the implementation isn't trivial.

The main difficulties are:
- We need to compare two graphs containing cycles to determine if they are equivalent (graph isomorphism problem). But given our use case, we can make a few assumptions and shortcuts to make this easier.
- We need to construct an `ObserverGraph` containing cycles from an expression (e.g. in the mini-language `"a.[b,c]*"`). This requires maintaining the identity of objects as the graph is constructed.

This implementation does the following:
- Change the data structure of `ObserverGraph` so it keeps track of what are branches and what are cycles.
- In `Expression`, keeps track of the `ObserverGraph` objects in a cache, it is similar to how `deepcopy` handles cycle references.

Important note:
- Previous work in #969 tried to construct the graph "from inside-out", because "outside-in" did not work then. Here the construction is made from the outside-in. I realized that previously the "outside-in" approach did not work because the `ObserverGraph` was hashing its children graphs too early and the hash was persisted.  It is important that during the process of constructing the observer graph with cycles, the hashes of the intermediate observer graphs are never used or persisted.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
