### PR TITLE
Fix trait_documenter for properties

### DIFF
--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -25,7 +25,7 @@ from traits.testing.optional_dependencies import sphinx, requires_sphinx
 
 
 if sphinx is not None:
-    from sphinx.ext.autodoc import Options
+    from sphinx.ext.autodoc import ClassDocumenter, INSTANCEATTR, Options
     from sphinx.ext.autodoc.directive import DocumenterBridge
     from sphinx.testing.path import path
     from sphinx.testing.util import SphinxTestApp
@@ -63,6 +63,27 @@ class MyTestClass(HasTraits):
 
         and Everything.
     """)
+
+
+class FindTheTraits(HasTraits):
+    """
+    Class for testing the can_document_member functionality.
+    """
+
+    #: A TraitType subclass on the right-hand side.
+    an_int = Int
+
+    #: A TraitType instance on the right-hand side.
+    another_int = Int()
+
+    #: A non-trait integer
+    magic_number = 1729
+
+    @property
+    def not_a_trait(self):
+        """
+        I'm a regular property, not a trait.
+        """
 
 
 @requires_sphinx
@@ -142,6 +163,40 @@ class TestTraitDocumenter(unittest.TestCase):
         # Annotation should be a single line.
         self.assertIn("First line", item)
         self.assertNotIn("\n", item)
+
+    def test_can_document_member(self):
+        # Regression test for enthought/traits#1238
+
+        with self.create_directive() as directive:
+            class_documenter = ClassDocumenter(
+                directive, __name__ + ".FindTheTraits"
+            )
+            class_documenter.parse_name()
+            class_documenter.import_object()
+
+            self.assertTrue(
+                TraitDocumenter.can_document_member(
+                    INSTANCEATTR, "an_int", True, class_documenter,
+                )
+            )
+
+            self.assertTrue(
+                TraitDocumenter.can_document_member(
+                    INSTANCEATTR, "another_int", True, class_documenter,
+                )
+            )
+
+            self.assertFalse(
+                TraitDocumenter.can_document_member(
+                    INSTANCEATTR, "magic_number", True, class_documenter,
+                )
+            )
+
+            self.assertFalse(
+                TraitDocumenter.can_document_member(
+                    INSTANCEATTR, "not_a_trait", True, class_documenter,
+                )
+            )
 
     @contextlib.contextmanager
     def create_directive(self):

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -22,14 +22,19 @@ import traceback
 
 from sphinx.ext.autodoc import ClassLevelDocumenter
 
-from ..trait_type import TraitType
-from ..has_traits import MetaHasTraits
+from traits.has_traits import MetaHasTraits
+from traits.trait_type import TraitType
+from traits.traits import generic_trait
 
 
 def _is_class_trait(name, cls):
     """ Check if the name is in the list of class defined traits of ``cls``.
     """
-    return isinstance(cls, MetaHasTraits) and name in cls.__class_traits__
+    return (
+        isinstance(cls, MetaHasTraits)
+        and name in cls.__class_traits__
+        and cls.__class_traits__[name] is not generic_trait
+    )
 
 
 class TraitDocumenter(ClassLevelDocumenter):


### PR DESCRIPTION
This PR fixes the trait_documenter Sphinx extension so that it no longer fails on regular Python properties. It does this by modifying the `can_document_member` function so that it doesn't recognise generic traits. This makes sense, since a generic trait is deliberately designed to behave like a standard Python `object` attribute.

Mostly fixes #1238, but independently of this fix, it would be good to fix the trait-documenter to be less fragile, so that if it fails in some other situation in the future then that failure doesn't prevent the Sphinx build from completing.

EDIT: See #1247 for the "make trait-documenter less fragile" fix.