### PR TITLE
Fix trait_documenter to be less fragile

### DIFF
--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -33,6 +33,7 @@ if sphinx is not None:
 
     from traits.util.trait_documenter import (
         _get_definition_tokens,
+        trait_definition,
         TraitDocumenter,
     )
 
@@ -138,6 +139,10 @@ class TestTraitDocumenter(unittest.TestCase):
         # Annotation should be a single line.
         self.assertIn("First line", item)
         self.assertNotIn("\n", item)
+
+    def test_failed_trait_definition(self):
+        with self.assertRaises(ValueError):
+            trait_definition(cls=Fake, trait_name="not_a_trait")
 
     @contextlib.contextmanager
     def create_directive(self):

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -164,8 +164,7 @@ class TestTraitDocumenter(unittest.TestCase):
     def test_successful_trait_definition(self):
         definition = trait_definition(cls=Fake, trait_name="test_attribute")
         self.assertEqual(
-            definition,
-            "Property(Bool, label=\"ミスあり\")",
+            definition, 'Property(Bool, label="ミスあり")',
         )
 
     def test_failed_trait_definition(self):

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -20,7 +20,7 @@ import tokenize
 import unittest
 import unittest.mock as mock
 
-from traits.api import HasTraits, Int
+from traits.api import Bool, HasTraits, Int, Property
 from traits.testing.optional_dependencies import sphinx, requires_sphinx
 
 
@@ -65,6 +65,12 @@ class MyTestClass(HasTraits):
     """)
 
 
+class Fake(HasTraits):
+
+    #: Test attribute
+    test_attribute = Property(Bool, label="ミスあり")
+
+
 @requires_sphinx
 class TestTraitDocumenter(unittest.TestCase):
     """ Tests for the trait documenter. """
@@ -97,29 +103,19 @@ class TestTraitDocumenter(unittest.TestCase):
 
     def test_add_line(self):
 
-        src = textwrap.dedent(
-            """\
-        class Fake(HasTraits):
-
-            #: Test attribute
-            test = Property(Bool, label="ミスあり")
-        """
-        )
         mocked_directive = mock.MagicMock()
 
         documenter = TraitDocumenter(mocked_directive, "test", "   ")
-        documenter.object_name = "Property"
+        documenter.object_name = "test_attribute"
+        documenter.parent = Fake
 
         with mock.patch(
-            "traits.util.trait_documenter.inspect.getsource", return_value=src
+            (
+                "traits.util.trait_documenter.ClassLevelDocumenter"
+                ".add_directive_header"
+            )
         ):
-            with mock.patch(
-                (
-                    "traits.util.trait_documenter.ClassLevelDocumenter"
-                    ".add_directive_header"
-                )
-            ):
-                documenter.add_directive_header("")
+            documenter.add_directive_header("")
 
         self.assertEqual(
             len(documenter.directive.result.append.mock_calls), 1)

--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -140,6 +140,13 @@ class TestTraitDocumenter(unittest.TestCase):
         self.assertIn("First line", item)
         self.assertNotIn("\n", item)
 
+    def test_successful_trait_definition(self):
+        definition = trait_definition(cls=Fake, trait_name="test_attribute")
+        self.assertEqual(
+            definition,
+            "Property(Bool, label=\"ミスあり\")",
+        )
+
     def test_failed_trait_definition(self):
         with self.assertRaises(ValueError):
             trait_definition(cls=Fake, trait_name="not_a_trait")

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -115,9 +115,9 @@ class TraitDocumenter(ClassLevelDocumenter):
 
         """
         ClassLevelDocumenter.add_directive_header(self, sig)
-        definition = _get_trait_definition(
-            parent=self.parent,
-            object_name=self.object_name,
+        definition = trait_definition(
+            cls=self.parent,
+            trait_name=self.object_name,
         )
 
         # Workaround for enthought/traits#493: if the definition is multiline,
@@ -128,7 +128,7 @@ class TraitDocumenter(ClassLevelDocumenter):
         self.add_line("   :annotation: = {0}".format(definition), "<autodoc>")
 
 
-def _get_trait_definition(*, parent, object_name):
+def trait_definition(*, cls, trait_name):
     """ Retrieve the portion of the source defining a Trait attribute.
 
     For example, given a class::
@@ -136,15 +136,14 @@ def _get_trait_definition(*, parent, object_name):
         class MyModel(HasStrictTraits)
             foo = List(Int, [1, 2, 3])
 
-    ``_get_trait_definition(MyModel, "foo")`` will return
-    ``"List(Int, [1, 2, 3])"``.
+    ``trait_definition(MyModel, "foo")`` returns ``"List(Int, [1, 2, 3])"``.
 
     Parameters
     ----------
-    parent : type
-        Class being documented, typically a HasTraits subclass.
-    object_name : str
-        Name of the attribute being documented.
+    cls : MetaHasTraits
+        Class being documented.
+    trait_name : str
+        Name of the trait being documented.
 
     Returns
     -------
@@ -155,7 +154,7 @@ def _get_trait_definition(*, parent, object_name):
 
     """
     # Get the class source and tokenize it.
-    source = inspect.getsource(parent)
+    source = inspect.getsource(cls)
     string_io = io.StringIO(source)
     tokens = tokenize.generate_tokens(string_io.readline)
 
@@ -167,7 +166,7 @@ def _get_trait_definition(*, parent, object_name):
         if name_found and item[:2] == (token.OP, "="):
             trait_found = True
             continue
-        if item[:2] == (token.NAME, object_name):
+        if item[:2] == (token.NAME, trait_name):
             name_found = True
 
     # Retrieve the trait definition.

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -21,9 +21,13 @@ import tokenize
 import traceback
 
 from sphinx.ext.autodoc import ClassLevelDocumenter
+from sphinx.util import logging
 
 from ..trait_type import TraitType
 from ..has_traits import MetaHasTraits
+
+
+logger = logging.getLogger(__name__)
 
 
 def _is_class_trait(name, cls):
@@ -123,6 +127,10 @@ class TraitDocumenter(ClassLevelDocumenter):
         except ValueError:
             # Without this, a failure to find the trait definition aborts
             # the whole documentation build.
+            logger.warn(
+                "No definition for the trait {!r} could be found in "
+                "class {!r}.".format(self.object_name, self.parent),
+                exc_info=True)
             return
 
         # Workaround for enthought/traits#493: if the definition is multiline,

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -115,7 +115,10 @@ class TraitDocumenter(ClassLevelDocumenter):
 
         """
         ClassLevelDocumenter.add_directive_header(self, sig)
-        definition = self._get_trait_definition()
+        definition = self._get_trait_definition(
+            parent=self.parent,
+            object_name=self.object_name,
+        )
 
         # Workaround for enthought/traits#493: if the definition is multiline,
         # throw away all lines after the first.
@@ -126,10 +129,24 @@ class TraitDocumenter(ClassLevelDocumenter):
 
     # Private Interface #####################################################
 
-    def _get_trait_definition(self):
-        """ Retrieve the Trait attribute definition
-        """
+    def _get_trait_definition(self, *, parent, object_name):
+        """ Retrieve the Trait attribute definition.
 
+        Parameters
+        ----------
+        parent : type
+            Class being documented, typically a HasTraits subclass.
+        object_name : str
+            Name of the attribute being documented.
+
+        Returns
+        -------
+        str
+            The portion of the source containing the trait definition. For
+            example, for a class trait defined as ``"my_trait = Float(3.5)"``,
+            the returned string will contain ``"Float(3.5)"``.
+
+        """
         # Get the class source and tokenize it.
         source = inspect.getsource(self.parent)
         string_io = io.StringIO(source)

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -154,7 +154,8 @@ def trait_definition(*, cls, trait_name):
         class MyModel(HasStrictTraits)
             foo = List(Int, [1, 2, 3])
 
-    ``trait_definition(MyModel, "foo")`` returns ``"List(Int, [1, 2, 3])"``.
+    ``trait_definition(cls=MyModel, trait_name="foo")`` returns
+    ``"List(Int, [1, 2, 3])"``.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR modifies trait_documenter to be less fragile when a trait definition can't be found.

Previously, a failure to find a trait definition would raise `StopIteration` and cause the entire documentation build to be aborted. With the changes in this PR, that failure will instead issue a warning, and the documentation build will continue.

The PR also includes some refactoring to make it easier to add unit tests: in particular, the `_get_trait_definition` method, which depended on hard-to-set-up objects like the `ClassLevelDocumenter`, has had its logic moved into a standalone function `trait_definition` that doesn't need to know anything about Sphinx.

This PR fixes the aspect of #1238 that a failed definition retrieval breaks the doc build. It doesn't fix the underlying issue that caused the failed trait definition retrieval in the first place. That part is fixed by #1246. Note that the two PRs will almost certainly conflict, but resolving those conflicts shouldn't be particularly hard.

Also: #1246 should be backported to the release branch, while this PR is less bug-fixy, so should probably not be backported.