### PR TITLE
Add test for regular Python properties in HasTraits classes

### DIFF
--- a/traits/tests/test_python_properties.py
+++ b/traits/tests/test_python_properties.py
@@ -1,0 +1,56 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Tests for regular Python properties in a HasTraits subclass. """
+
+import unittest
+
+from traits.api import HasTraits
+
+
+class Model(HasTraits):
+    def __init__(self):
+        super(Model, self).__init__()
+        self._value = 0
+
+    @property
+    def read_only(self):
+        return 1729
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, new):
+        self._value = new
+
+
+class TestPythonProperty(unittest.TestCase):
+    def test_read_only_property(self):
+        model = Model()
+        self.assertEqual(model.read_only, 1729)
+
+        with self.assertRaises(AttributeError):
+            model.read_only = 2034
+
+        with self.assertRaises(AttributeError):
+            del model.read_only
+
+    def test_read_write_property(self):
+        model = Model()
+        self.assertEqual(model.value, 0)
+        model.value = 23
+        self.assertEqual(model.value, 23)
+        model.value = 77
+        self.assertEqual(model.value, 77)
+
+        with self.assertRaises(AttributeError):
+            del model.value


### PR DESCRIPTION
This PR adds tests that check that normal Python properties in a `HasTraits` subclass behave in the expected manner.

These tests should ~prevent~ deter any unthinking attempt to remove these lines in `HasTraits`, which are there to support exactly this use-case: https://github.com/enthought/traits/blob/e16be1004bde938f969895b543cae01317fd2756/traits/has_traits.py#L479-L480

I've verified that the new tests fail if the two lines above are removed.

Closes #947.
