### PR TITLE
Update PyPI links and capitalization in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,13 +54,12 @@ Traits has the following optional dependencies:
 
 * `NumPy <http://pypi.python.org/pypi/numpy>`_ to support the trait types
   for arrays.
-* `Traitsui <https://pypi.python.org/pypi/traitsui>`_ to support Gui
+* `TraitsUI <https://pypi.python.org/pypi/traitsui>`_ to support Gui
   Views.
 
 To build the full documentation one needs:
 
-* sphinx >= 1.8
-* `enthought-sphinx-theme
-  <https://github.com/enthought/enthought-sphinx-theme>`_
-  (a version of the documentation can be built without this, but
-  some formatting may be incorrect)
+* `Sphinx <https://pypi.org/project/Sphinx>`_ = 1.8
+* The `Enthought Sphinx Theme <https://pypi.org/project/enthought-sphinx-theme>`_.
+  (A version of the documentation can be built without this, but
+  some formatting may be incorrect.)

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Traits has the following optional dependencies:
 
 To build the full documentation one needs:
 
-* `Sphinx <https://pypi.org/project/Sphinx>`_ = 1.8
+* `Sphinx <https://pypi.org/project/Sphinx>`_ version 1.8 or later.
 * The `Enthought Sphinx Theme <https://pypi.org/project/enthought-sphinx-theme>`_.
   (A version of the documentation can be built without this, but
   some formatting may be incorrect.)

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Traits has the following optional dependencies:
 
 * `NumPy <http://pypi.python.org/pypi/numpy>`_ to support the trait types
   for arrays.
-* `TraitsUI <https://pypi.python.org/pypi/traitsui>`_ to support Gui
+* `TraitsUI <https://pypi.python.org/pypi/traitsui>`_ to support GUI
   Views.
 
 To build the full documentation one needs:


### PR DESCRIPTION
This PR:
- updates incorrect and inconsistent capitalization in the README
- adds a PyPI link for Sphinx
- adds a PyPI link for the Enthought Sphinx Theme (the previous link was to GitHub)

