### PR TITLE
Make Traits 6.1.1 bugfix release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Traits CHANGELOG
 Release 6.1.1
 -------------
 
-Released: XXXX-XX-XX
+Released: 2020-07-23
 
 Traits 6.1.1 is a bugfix release fixing a handful of minor documentation and
 test-related issues with the Traits 6.1.0 release. There are no API-breaking

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 6
 MINOR = 1
 MICRO = 1
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
Changes for the Traits 6.1.1 bugfix release:

- Update the release date (to today)
- Set `IS_RELEASED` to `True`.