### PR TITLE
Bump version for 6.1.2; also fix 6.1.1 release date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Traits CHANGELOG
 Release 6.1.1
 -------------
 
-Released: XXXX-XX-XX
+Released: 2020-07-23
 
 Traits 6.1.1 is a bugfix release fixing a handful of minor documentation and
 test-related issues with the Traits 6.1.0 release. There are no API-breaking

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import setuptools
 # into the package source.
 MAJOR = 6
 MINOR = 1
-MICRO = 1
+MICRO = 2
 PRERELEASE = ""
 IS_RELEASED = False
 


### PR DESCRIPTION
This PR updates the release/6.1.x branch for continued development towards a possible 6.1.2 bugfix release (which may never happen).

- Bump micro version number
- Fill in the correct release date for Traits 6.1.1