### PR TITLE
Remove coverage badge from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,6 @@ http://docs.enthought.com/traits
    :target: https://travis-ci.org/enthought/traits
    :alt: Build status
 
-.. image:: https://coveralls.io/repos/github/enthought/traits/badge.svg?branch=master
-   :target: https://coveralls.io/github/enthought/traits
-   :alt: Coverage status
-
 The Traits project is at the center of all Enthought Tool Suite development
 and has changed the mental model used at Enthought for programming in the
 already extremely efficient Python programming language. We encourage everyone


### PR DESCRIPTION
We're no longer running automated coverage, so the coverage statistic on the badge in the README is out of date. This PR removes it.

