### PR TITLE
Fix test_enum failure if TraitsUI not installed (but Pyface is)

### DIFF
--- a/traits/testing/optional_dependencies.py
+++ b/traits/testing/optional_dependencies.py
@@ -44,6 +44,9 @@ requires_numpy = unittest.skipIf(numpy is None, "NumPy not available")
 
 pyface = optional_import("pyface")
 requires_pyface = unittest.skipIf(pyface is None, "Pyface not available")
+# Import pyface.toolkit so that client code doesn't need an extra import.
+if pyface is not None:
+    import pyface.toolkit
 
 sphinx = optional_import("sphinx")
 requires_sphinx = unittest.skipIf(sphinx is None, "Sphinx not available")


### PR DESCRIPTION
The Traits test suite fails if Pyface is installed but TraitsUI is not. This PR fixes that.

```
mirzakhani:traits mdickinson$ python -m venv --clear ~/.venvs/traits
mirzakhani:traits mdickinson$ source ~/.venvs/traits/bin/activate
(traits) mirzakhani:traits mdickinson$ pip install -q --upgrade pip setuptools wheel
(traits) mirzakhani:traits mdickinson$ pip install -q pyface pyside2
(traits) mirzakhani:traits mdickinson$ pip install -q -e .
(traits) mirzakhani:traits mdickinson$ python -m unittest -f
........................................................................................................................................................................................................................................................................................................................................................ssssssssssss...s..sss.............................ssssss...............................................................................................................ssssssss............................................ssssssssssssssssE
======================================================================
ERROR: traits.tests.test_enum (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: traits.tests.test_enum
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/tests/test_enum.py", line 19, in <module>
    GuiTestAssistant = pyface.toolkit.toolkit_object(
AttributeError: module 'pyface' has no attribute 'toolkit'


----------------------------------------------------------------------
Ran 580 tests in 7.428s

FAILED (errors=1, skipped=46)
```