### PR TITLE
FIX : Pin sphinx version to get docs to build

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -93,7 +93,7 @@ common_dependencies = {
     "mypy",
     "numpy",
     "pyqt5",
-    "Sphinx^=2.3.1",
+    "Sphinx!=3.2.0",
     "traitsui",
 }
 

--- a/etstool.py
+++ b/etstool.py
@@ -93,7 +93,7 @@ common_dependencies = {
     "mypy",
     "numpy",
     "pyqt5",
-    "Sphinx",
+    "Sphinx^=2.3.1",
     "traitsui",
 }
 

--- a/setup.py
+++ b/setup.py
@@ -302,14 +302,14 @@ setuptools.setup(
     extras_require={
         "docs": [
             "enthought-sphinx-theme",
-            "Sphinx",
+            "Sphinx==2.3.1",
         ],
         "test": [
             "Cython",
             "flake8",
             "mypy",
             "setuptools",
-            "Sphinx>=2.1.0",
+            "Sphinx==2.3.1",
             # Python 3.9 exclusions:
             #
             # * NumPy installation fails on Python 3.9 on the Ubuntu Xenial

--- a/setup.py
+++ b/setup.py
@@ -302,14 +302,14 @@ setuptools.setup(
     extras_require={
         "docs": [
             "enthought-sphinx-theme",
-            "Sphinx==2.3.1",
+            "Sphinx!=3.2.0",
         ],
         "test": [
             "Cython",
             "flake8",
             "mypy",
             "setuptools",
-            "Sphinx==2.3.1",
+            "Sphinx!=3.2.0",
             # Python 3.9 exclusions:
             #
             # * NumPy installation fails on Python 3.9 on the Ubuntu Xenial


### PR DESCRIPTION
For reasons which i'm not sure of, sphinx 2.3.1 works but sphinx 3.2.0 which is the latest version available on pypi doesn't work.

fixes #1273 

**Checklist**
~- [ ] Tests~
~- [ ] Update API reference (`docs/source/traits_api_reference`)~
~- [ ] Update User manual (`docs/source/traits_user_manual`)~
~- [ ] Update type annotation hints in `traits-stubs`~
