### PR TITLE
Fix containment check relying on ability to check for equality

### DIFF
--- a/traits/observation/_has_traits_helpers.py
+++ b/traits/observation/_has_traits_helpers.py
@@ -68,7 +68,7 @@ def iter_objects(object, name):
         skipped values.
     """
     value = object.__dict__.get(name, Undefined)
-    if value not in UNOBSERVABLE_VALUES:
+    if all(value is not skipped for skipped in UNOBSERVABLE_VALUES):
         yield value
 
 
@@ -89,7 +89,7 @@ def observer_change_handler(event, graph, handler, target, dispatcher):
     dispatcher : callable
         Callable for dispatching the handler.
     """
-    if event.old not in UNOBSERVABLE_VALUES:
+    if all(event.old is not skipped for skipped in UNOBSERVABLE_VALUES):
         try:
             add_or_remove_notifiers(
                 object=event.old,
@@ -104,7 +104,7 @@ def observer_change_handler(event, graph, handler, target, dispatcher):
             # notifier.
             pass
 
-    if event.new not in UNOBSERVABLE_VALUES:
+    if all(event.new is not skipped for skipped in UNOBSERVABLE_VALUES):
         add_or_remove_notifiers(
             object=event.new,
             graph=graph,


### PR DESCRIPTION
Fixes #1277

`Undefined`, `Uninitialized`, `None` are sentinel values we should not observe. They are skipped in on_trait_change using identity check as well. This avoids errors like the one in #1277.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
