### PR TITLE
Update super usage

### DIFF
--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -1279,7 +1279,7 @@ However, in cases where this strategy is insufficient, use the following pattern
 to override __getstate__() to remove items that should not be persisted::
 
     def __getstate__ ( self ):
-        state = super( XXX, self ).__getstate__()
+        state = super().__getstate__()
 
         for key in [ 'foo', 'bar' ]:
             if key in state:
@@ -1309,8 +1309,8 @@ ensure that their internal object state remains consistent and up to date.
    pickling time.  If this key is not present when unpickling, the HasTraits
    __setstate__() method falls back to a compatibility mode and may not restore
    the state correctly.  For the same reason, if you're overriding
-   __getstate__(), you should be careful to make the appropriate ``super(...,
-   self).__getstate__()`` call.
+   __getstate__(), you should be careful to make the appropriate
+   ``super().__getstate__()`` call.
 
 .. index:: __setstate__(); overriding
 

--- a/docs/source/traits_user_manual/custom.rst
+++ b/docs/source/traits_user_manual/custom.rst
@@ -44,7 +44,7 @@ Here's an example of subclassing a predefined trait class::
         info_text = 'an odd integer'
 
         def validate ( self, object, name, value ):
-            value = super(OddInt, self).validate(object, name, value)
+            value = super().validate(object, name, value)
             if (value % 2) == 1:
                 return value
 

--- a/examples/tutorials/doc_examples/examples/trait_subclass.py
+++ b/examples/tutorials/doc_examples/examples/trait_subclass.py
@@ -23,7 +23,7 @@ class OddInt(BaseInt):
     info_text = "an odd integer"
 
     def validate(self, object, name, value):
-        value = super(OddInt, self).validate(object, name, value)
+        value = super().validate(object, name, value)
         if (value % 2) == 1:
             return value
 

--- a/examples/tutorials/traits_4.0/getstate_setstate/getstate.py
+++ b/examples/tutorials/traits_4.0/getstate_setstate/getstate.py
@@ -96,7 +96,7 @@ overriding *__getstate__* using the follow pattern to remove items that should
 not be persisted::
 
     def __getstate__(self):
-        state = super(XXX, self).__getstate__()
+        state = super().__getstate__()
 
         for key in [ 'foo', 'bar' ]:
             if key in state:

--- a/examples/tutorials/traits_4.0/trait_types/new_types.py
+++ b/examples/tutorials/traits_4.0/trait_types/new_types.py
@@ -186,7 +186,7 @@ class RandInt(TraitType):
 
     # Define the type's constructor:
     def __init__(self, low=1, high=10, **metadata):
-        super(RandInt, self).__init__(**metadata)
+        super().__init__(**metadata)
         self.low = int(low)
         self.high = int(high)
 

--- a/examples/tutorials/traits_4.0/trait_types/trait_types.py
+++ b/examples/tutorials/traits_4.0/trait_types/trait_types.py
@@ -67,7 +67,7 @@ example as follows::
         info_text = 'an odd integer'
 
         def validate(self, object, name, value):
-            value = super(OddInt, self).validate(object, name, value)
+            value = super().validate(object, name, value)
             if (value % 2) == 1:
                 return value
 
@@ -112,7 +112,7 @@ class OddInt(BaseInt):
     info_text = "an odd integer"
 
     def validate(self, object, name, value):
-        value = super(OddInt, self).validate(object, name, value)
+        value = super().validate(object, name, value)
         if (value % 2) == 1:
             return value
 

--- a/traits/adaptation/adapter.py
+++ b/traits/adaptation/adapter.py
@@ -33,6 +33,6 @@ class Adapter(HasTraits):
 
     def __init__(self, adaptee, **traits):
         traits["adaptee"] = adaptee
-        super(Adapter, self).__init__(**traits)
+        super().__init__(**traits)
 
     adaptee = Any

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -113,7 +113,7 @@ class ETSConfigTestCase(unittest.TestCase):
     def run(self, result=None):
         # Extend TestCase.run to use a temporary home directory.
         with temporary_home_directory():
-            super(ETSConfigTestCase, self).run(result)
+            super().run(result)
 
     ###########################################################################
     # 'ETSConfigTestCase' interface.

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3438,7 +3438,7 @@ class HasRequiredTraits(HasStrictTraits):
                 "{}.".format(", ".join(sorted(missing_required_traits)))
             )
 
-        super(HasRequiredTraits, self).__init__(**traits)
+        super().__init__(**traits)
 
 
 class HasPrivateTraits(HasTraits):

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1243,7 +1243,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         not be persisted::
 
             def __getstate__(self):
-                state = super(X,self).__getstate__()
+                state = super().__getstate__()
                 for key in ['foo', 'bar']:
                     if key in state:
                         del state[key]

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -168,7 +168,7 @@ class _TraitsChangeCollector(HasStrictTraits):
             )
             warnings.warn(message, DeprecationWarning, stacklevel=2)
             traits["trait_name"] = value
-        super(_TraitsChangeCollector, self).__init__(**traits)
+        super().__init__(**traits)
 
     def start_collecting(self):
         self.obj.on_trait_change(self._event_handler, self.trait_name)

--- a/traits/tests/test_copy_traits.py
+++ b/traits/tests/test_copy_traits.py
@@ -41,7 +41,7 @@ class CopyTraitsBase(unittest.TestCase):
     __test__ = False
 
     def setUp(self):
-        super(CopyTraitsBase, self).setUp()
+        super().setUp()
         self.shared = Shared(s="shared")
         self.foo = Foo(shared=self.shared, s="foo")
         self.bar = Bar(shared=self.shared, foo=self.foo, s="bar")
@@ -63,7 +63,7 @@ class TestCopyTraitsSetup(CopyTraitsBase):
     __test__ = True
 
     def setUp(self):
-        super(TestCopyTraitsSetup, self).setUp()
+        super().setUp()
 
     def test_setup(self):
         self.assertIs(self.foo, self.bar.foo)

--- a/traits/tests/test_extended_notifiers.py
+++ b/traits/tests/test_extended_notifiers.py
@@ -48,7 +48,7 @@ class ExtendedNotifiers(HasTraits):
         for listener in fail_listeners:
             self._on_trait_change(listener, "fail", dispatch="extended")
 
-        super(ExtendedNotifiers, self).__init__(**traits)
+        super().__init__(**traits)
 
     ok = Float
     fail = Float

--- a/traits/tests/test_pickle_validated_dict.py
+++ b/traits/tests/test_pickle_validated_dict.py
@@ -20,7 +20,7 @@ class C(HasTraits):
 
     # And we must initialize it to something non-trivial
     def __init__(self):
-        super(C, self).__init__()
+        super().__init__()
         self.a = {1: [2, 3]}
 
 

--- a/traits/tests/test_python_properties.py
+++ b/traits/tests/test_python_properties.py
@@ -17,7 +17,7 @@ from traits.api import HasTraits
 
 class Model(HasTraits):
     def __init__(self):
-        super(Model, self).__init__()
+        super().__init__()
         self._value = 0
 
     @property

--- a/traits/tests/test_union.py
+++ b/traits/tests/test_union.py
@@ -172,7 +172,7 @@ class TestCaseEnumTrait(unittest.TestCase):
             def validate(self, obj, name, value):
                 if isinstance(value, str):
                     return value
-                return super(UnionAllowStr, self).validate(obj, name, value)
+                return super().validate(obj, name, value)
 
         class TestClass(HasTraits):
             s = UnionAllowStr(Int, Float)

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -768,7 +768,7 @@ class TraitPrefixMap(TraitMap):
             self.error(object, name, value)
 
     def info(self):
-        return super(TraitPrefixMap, self).info() + " (or any unique prefix)"
+        return super().info() + " (or any unique prefix)"
 
 
 class TraitCompound(TraitHandler):

--- a/traits/trait_numeric.py
+++ b/traits/trait_numeric.py
@@ -134,7 +134,7 @@ class AbstractArray(TraitType):
         self.coerce = coerce
         self.casting = casting
 
-        super(AbstractArray, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
     def validate(self, object, name, value):
         """ Validates that the value is a valid array.
@@ -334,7 +334,7 @@ class Array(AbstractArray):
         casting="unsafe",
         **metadata
     ):
-        super(Array, self).__init__(
+        super().__init__(
             dtype,
             shape,
             value,
@@ -401,7 +401,7 @@ class CArray(AbstractArray):
         casting="unsafe",
         **metadata
     ):
-        super(CArray, self).__init__(
+        super().__init__(
             dtype,
             shape,
             value,
@@ -424,12 +424,12 @@ class ArrayOrNone(CArray):
     def __init__(self, *args, **metadata):
         # Normally use object identity to detect array values changing:
         metadata.setdefault("comparison_mode", ComparisonMode.identity)
-        super(ArrayOrNone, self).__init__(*args, **metadata)
+        super().__init__(*args, **metadata)
 
     def validate(self, object, name, value):
         if value is None:
             return value
-        return super(ArrayOrNone, self).validate(object, name, value)
+        return super().validate(object, name, value)
 
     def get_default_value(self):
         dv = self.default_value

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -648,7 +648,7 @@ class String(TraitType):
     def __init__(
         self, value="", minlen=0, maxlen=sys.maxsize, regex="", **metadata
     ):
-        super(String, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
         self.minlen = max(0, minlen)
         self.maxlen = max(self.minlen, maxlen)
         self.regex = regex
@@ -779,7 +779,7 @@ class Regex(String):
     """
 
     def __init__(self, value="", regex=".*", **metadata):
-        super(Regex, self).__init__(value=value, regex=regex, **metadata)
+        super().__init__(value=value, regex=regex, **metadata)
 
 
 class Code(String):
@@ -875,7 +875,7 @@ class This(BaseType):
     info_text = "an instance of the same type as the receiver"
 
     def __init__(self, value=None, allow_none=True, **metadata):
-        super(This, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
         if allow_none:
             self.fast_validate = (ValidateTrait.self_type, None)
@@ -1111,7 +1111,7 @@ class Delegate(TraitType):
         metadata["_prefix"] = prefix
         metadata["_listenable"] = listenable
 
-        super(Delegate, self).__init__(**metadata)
+        super().__init__(**metadata)
 
         self.delegate = delegate
         self.prefix = prefix
@@ -1121,7 +1121,7 @@ class Delegate(TraitType):
     def as_ctrait(self):
         """ Returns a CTrait corresponding to the trait defined by this class.
         """
-        trait = super(Delegate, self).as_ctrait()
+        trait = super().as_ctrait()
         trait.delegate(
             self.delegate, self.prefix, self.prefix_type, self.modify
         )
@@ -1175,7 +1175,7 @@ class DelegatesTo(Delegate):
     """
 
     def __init__(self, delegate, prefix="", listenable=True, **metadata):
-        super(DelegatesTo, self).__init__(
+        super().__init__(
             delegate,
             prefix=prefix,
             modify=True,
@@ -1232,7 +1232,7 @@ class PrototypedFrom(Delegate):
     """
 
     def __init__(self, prototype, prefix="", listenable=True, **metadata):
-        super(PrototypedFrom, self).__init__(
+        super().__init__(
             prototype,
             prefix=prefix,
             modify=False,
@@ -1280,7 +1280,7 @@ class Expression(TraitType):
         """
         # Tell the C code that 'setattr' should store the original, unadapted
         # value passed to it:
-        ctrait = super(Expression, self).as_ctrait()
+        ctrait = super().as_ctrait()
         ctrait.setattr_original_value = True
         return ctrait
 
@@ -1351,7 +1351,7 @@ class BaseFile(BaseStr):
         self.entries = entries
         self.exists = exists
 
-        super(BaseFile, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
@@ -1368,7 +1368,7 @@ class BaseFile(BaseStr):
             except TypeError:
                 pass
 
-        validated_value = super(BaseFile, self).validate(object, name, value)
+        validated_value = super().validate(object, name, value)
         if not self.exists:
             return validated_value
         elif isfile(value):
@@ -1436,7 +1436,7 @@ class File(BaseFile):
         exists=False,
         **metadata
     ):
-        super(File, self).__init__(
+        super().__init__(
             value, filter, auto_set, entries, exists, **metadata
         )
 
@@ -1486,7 +1486,7 @@ class BaseDirectory(BaseStr):
         self.auto_set = auto_set
         self.exists = exists
 
-        super(BaseDirectory, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
@@ -1500,7 +1500,7 @@ class BaseDirectory(BaseStr):
             except TypeError:
                 pass
 
-        validated_value = super(BaseDirectory, self).validate(
+        validated_value = super().validate(
             object, name, value
         )
         if not self.exists:
@@ -1555,7 +1555,7 @@ class Directory(BaseDirectory):
         self, value="", auto_set=False, entries=0, exists=False, **metadata
     ):
         # Fast validation is disabled (Github issue #877).
-        super(Directory, self).__init__(
+        super().__init__(
             value, auto_set, entries, exists, **metadata
         )
 
@@ -1603,7 +1603,7 @@ class BaseRange(TraitType):
             else:
                 value = high
 
-        super(BaseRange, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
         vtype = type(high)
         if (low is not None) and (
@@ -1987,10 +1987,10 @@ class BaseEnum(TraitType):
             self.values = None
             self.get, self.set, self.validate = self._get, self._set, None
             if nargs == 0:
-                super(BaseEnum, self).__init__(**metadata)
+                super().__init__(**metadata)
             elif nargs == 1:
                 default_value = args[0]
-                super(BaseEnum, self).__init__(default_value, **metadata)
+                super().__init__(default_value, **metadata)
             else:
                 raise TraitError(
                     "Incorrect number of arguments specified "
@@ -2022,7 +2022,7 @@ class BaseEnum(TraitType):
 
             self.init_fast_validate(ValidateTrait.enum, self.values)
 
-            super(BaseEnum, self).__init__(default_value, **metadata)
+            super().__init__(default_value, **metadata)
 
     def init_fast_validate(self, *args):
         """ Does nothing for the BaseEnum class. Used in the Enum class to set
@@ -2232,7 +2232,7 @@ class BaseTuple(TraitType):
         if len(types) == 0:
             self.init_fast_validate(ValidateTrait.coerce, tuple, None, list)
 
-            super(BaseTuple, self).__init__((), **metadata)
+            super().__init__((), **metadata)
 
             return
 
@@ -2251,7 +2251,7 @@ class BaseTuple(TraitType):
                 [type.default_value()[1] for type in self.types]
             )
 
-        super(BaseTuple, self).__init__(default_value, **metadata)
+        super().__init__(default_value, **metadata)
 
     def init_fast_validate(self, *args):
         """ Saves the validation parameters.
@@ -2325,7 +2325,7 @@ class Tuple(BaseTuple):
     def init_fast_validate(self, *args):
         """ Set up the C-level fast validator.
         """
-        super(Tuple, self).init_fast_validate(*args)
+        super().init_fast_validate(*args)
 
         self.fast_validate = args
 
@@ -2362,12 +2362,12 @@ class ValidatedTuple(BaseTuple):
     def __init__(self, *types, **metadata):
         metadata.setdefault("fvalidate", None)
         metadata.setdefault("fvalidate_info", "")
-        super(ValidatedTuple, self).__init__(*types, **metadata)
+        super().__init__(*types, **metadata)
 
     def validate(self, object, name, value):
         """ Validates that the value is a valid tuple.
         """
-        values = super(ValidatedTuple, self).validate(object, name, value)
+        values = super().validate(object, name, value)
         # Exceptions in the fvalidate function will not result in a TraitError
         # but will be allowed to propagate up the frame stacks.
         if self.fvalidate is None or self.fvalidate(values):
@@ -2453,7 +2453,7 @@ class List(TraitType):
         if self.item_trait.instance_handler == "_instance_changed_handler":
             metadata.setdefault("instance_handler", "_list_changed_handler")
 
-        super(List, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
     def validate(self, object, name, value):
         """ Validates that the values is a valid list.
@@ -2530,14 +2530,14 @@ class CList(List):
             except (ValueError, TypeError):
                 value = [value]
 
-        return super(CList, self).validate(object, name, value)
+        return super().validate(object, name, value)
 
     def full_info(self, object, name, value):
         """ Returns a description of the trait.
         """
         return "%s or %s" % (
             self.item_trait.full_info(object, name, value),
-            super(CList, self).full_info(object, name, value),
+            super().full_info(object, name, value),
         )
 
 
@@ -2679,7 +2679,7 @@ class Set(TraitType):
         self.item_trait = trait_from(trait)
         self.has_items = items
 
-        super(Set, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
     def validate(self, object, name, value):
         """ Validates that the values is a valid set.
@@ -2741,14 +2741,14 @@ class CSet(Set):
             except (ValueError, TypeError):
                 value = set([value])
 
-        return super(CSet, self).validate(object, name, value)
+        return super().validate(object, name, value)
 
     def full_info(self, object, name, value):
         """ Returns a description of the trait.
         """
         return "%s or %s" % (
             self.item_trait.full_info(object, name, value),
-            super(CSet, self).full_info(object, name, value),
+            super().full_info(object, name, value),
         )
 
 
@@ -2811,7 +2811,7 @@ class Dict(TraitType):
             handler.has_items = False
         self.value_handler = handler
 
-        super(Dict, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
     def validate(self, object, name, value):
         """ Validates that the value is a valid dictionary.
@@ -3260,7 +3260,7 @@ class BaseInstance(BaseClass):
 
         self.default_value = value
 
-        super(BaseInstance, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
     def validate(self, object, name, value):
         """ Validates that the value is a valid object instance.
@@ -3330,7 +3330,7 @@ class BaseInstance(BaseClass):
         dvt = self.default_value_type
         if dvt < 0:
             if not isinstance(dv, _InstanceArgs):
-                return super(BaseInstance, self).get_default_value()
+                return super().get_default_value()
 
             self.default_value_type = dvt = DefaultValue.callable_and_args
             self.default_value = dv = (
@@ -3376,7 +3376,7 @@ class BaseInstance(BaseClass):
         pass
 
     def resolve_class(self, object, name, value):
-        super(BaseInstance, self).resolve_class(object, name, value)
+        super().resolve_class(object, name, value)
 
         # fixme: The following is quite ugly, because it wants to try and fix
         # the trait referencing this handler to use the 'fast path' now that
@@ -3457,7 +3457,7 @@ class Supports(Instance):
     def as_ctrait(self):
         """ Returns a CTrait corresponding to the trait defined by this class.
         """
-        return self.modify_ctrait(super(Supports, self).as_ctrait())
+        return self.modify_ctrait(super().as_ctrait())
 
     def modify_ctrait(self, ctrait):
 
@@ -3536,7 +3536,7 @@ class Type(BaseClass):
         self._allow_none = allow_none
         self.module = get_module_name()
 
-        super(Type, self).__init__(value, **metadata)
+        super().__init__(value, **metadata)
 
     def validate(self, object, name, value):
         """ Validates that the value is a valid object instance.
@@ -3580,7 +3580,7 @@ class Type(BaseClass):
         which describes the default value for this trait.
         """
         if not isinstance(self.default_value, str):
-            return super(Type, self).get_default_value()
+            return super().get_default_value()
 
         return (
             DefaultValue.callable_and_args,
@@ -3630,7 +3630,7 @@ class Event(TraitType):
         metadata["type"] = "event"
         metadata["transient"] = True
 
-        super(Event, self).__init__(**metadata)
+        super().__init__(**metadata)
 
         self.trait = None
         if trait is not None:
@@ -3721,7 +3721,7 @@ class Button(Event):
         self.width_padding = width_padding
         self.height_padding = height_padding
         self.view = view
-        super(Button, self).__init__(**metadata)
+        super().__init__(**metadata)
 
     def create_editor(self):
         from traitsui.api import ButtonEditor
@@ -3798,7 +3798,7 @@ class ToolbarButton(Button):
         height_padding=2,
         **metadata
     ):
-        super(ToolbarButton, self).__init__(
+        super().__init__(
             label,
             image=image,
             style=style,
@@ -3853,7 +3853,7 @@ class _NoneTrait(TraitType):
         if default_value is not None:
             raise ValueError("Cannot set default value {} "
                              "for _NoneTrait".format(default_value))
-        super(_NoneTrait, self).__init__(**metadata)
+        super().__init__(**metadata)
 
     def validate(self, obj, name, value):
         if value is None:
@@ -4041,7 +4041,7 @@ class UUID(TraitType):
     info_text = "a read-only UUID"
 
     def __init__(self, can_init=False, **metadata):
-        super(UUID, self).__init__(None, **metadata)
+        super().__init__(None, **metadata)
         self.can_init = can_init
 
     def validate(self, object, name, value):
@@ -4117,7 +4117,7 @@ class WeakRef(Instance):
     ):
         metadata.setdefault("copy", "ref")
 
-        super(WeakRef, self).__init__(
+        super().__init__(
             klass,
             allow_none=allow_none,
             adapt=adapt,

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -1011,7 +1011,7 @@ class ListenerParser(HasPrivateTraits):
 
     def __init__(self, text="", **traits):
         self.text = text
-        super(ListenerParser, self).__init__(**traits)
+        super().__init__(**traits)
 
     # -- Private Methods ------------------------------------------------------
 


### PR DESCRIPTION
This PR cleans up the usage of `super` - I noticed that the codebase was a mix of `super(ClassName, self)` and `super()` calls, which I have updated to use `super()` in this PR.

The update was done using regex-search and replace. The regex string that works for `super(ClassName, self)` is `(super)+\(+(\w+)(,)+\s(self)+\)+`, learnt/debugged using https://regex101.com/.

After making changed using the automated search/replace, the changes were manually checked using `git add -p *`.

Finally, I manually searched the codebase for uses of `super` which the regex didn't match e.g. `super( ClassName , self )` or `super(ClassName,self)` - which were manually updated.

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
