### PR TITLE
Remove commented out dead code

### DIFF
--- a/traits/tests/test_copy_traits.py
+++ b/traits/tests/test_copy_traits.py
@@ -165,8 +165,6 @@ class TestCopyTraitsSharedCopyNone(CopyTraits, CopyTraitsSharedCopyNone):
     __test__ = False
 
     def setUp(self):
-        # super(TestCopyTraitsSharedCopyNone,self).setUp()
-
         # deep is the default value for Instance trait copy
         self.set_shared_copy("deep")
 
@@ -177,7 +175,6 @@ class TestCopyTraitsCopyNotSpecified(
     __test__ = True
 
     def setUp(self):
-        #        super(TestCopyTraitsCopyNotSpecified,self).setUp()
         CopyTraitsBase.setUp(self)
         TestCopyTraitsSharedCopyNone.setUp(self)
         self.baz2.copy_traits(self.baz)
@@ -187,7 +184,6 @@ class TestCopyTraitsCopyShallow(CopyTraitsBase, TestCopyTraitsSharedCopyNone):
     __test__ = True
 
     def setUp(self):
-        #        super(TestCopyTraitsCopyShallow,self).setUp()
         CopyTraitsBase.setUp(self)
         TestCopyTraitsSharedCopyNone.setUp(self)
         self.baz2.copy_traits(self.baz, copy="shallow")
@@ -197,7 +193,6 @@ class TestCopyTraitsCopyDeep(CopyTraitsBase, TestCopyTraitsSharedCopyNone):
     __test__ = True
 
     def setUp(self):
-        #        super(TestCopyTraitsCopyDeep,self).setUp()
         CopyTraitsBase.setUp(self)
         TestCopyTraitsSharedCopyNone.setUp(self)
         self.baz2.copy_traits(self.baz, copy="deep")
@@ -233,7 +228,6 @@ class TestCopyTraitsSharedCopyRef(CopyTraits, CopyTraitsSharedCopyRef):
     __test__ = False
 
     def setUp(self):
-        # super(TestCopyTraitsSharedCopyRef,self).setUp()
         self.set_shared_copy("ref")
 
 


### PR DESCRIPTION
Discovered when working on #1280 

Not sure why it exists. Didn't check git log/blame. 

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
