### PR TITLE
logger.warn is deprecated, use logger.warning instead

### DIFF
--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -132,7 +132,7 @@ class TraitDocumenter(ClassLevelDocumenter):
         except ValueError:
             # Without this, a failure to find the trait definition aborts
             # the whole documentation build.
-            logger.warn(
+            logger.warning(
                 "No definition for the trait {!r} could be found in "
                 "class {!r}.".format(self.object_name, self.parent),
                 exc_info=True)


### PR DESCRIPTION
Ref : https://docs.python.org/3.6/library/logging.html#logging.Logger.warning

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
