### PR TITLE
Make mypy an optional dependency

### DIFF
--- a/traits-stubs/traits_stubs_tests/test_all.py
+++ b/traits-stubs/traits_stubs_tests/test_all.py
@@ -14,9 +14,11 @@ from unittest import TestCase
 
 import pkg_resources
 
+from traits.testing.optional_dependencies import requires_mypy
 from traits_stubs_tests.util import MypyAssertions
 
 
+@requires_mypy
 class TestAnnotations(TestCase, MypyAssertions):
     def test_all(self, filename_suffix=''):
         """ Run mypy for all files contained in traits_stubs_tests/examples

--- a/traits-stubs/traits_stubs_tests/util.py
+++ b/traits-stubs/traits_stubs_tests/util.py
@@ -15,8 +15,6 @@ import shutil
 import re
 import tempfile
 
-from mypy import api as mypy_api
-
 
 def parse_py_file(filepath):
     """ This function parses a python file that have been annotated with error
@@ -98,6 +96,9 @@ def run_mypy(filepath):
         The exit status
 
     """
+    # Local import to make it easier to skip tests if mypy is not in
+    # the environment.
+    from mypy import api as mypy_api
 
     # Need to use  tempdir since mypy complains that:
     # "site-packages is in PYTHONPATH. Please change directory so it is not."

--- a/traits/testing/optional_dependencies.py
+++ b/traits/testing/optional_dependencies.py
@@ -39,6 +39,9 @@ def optional_import(name):
 cython = optional_import("cython")
 requires_cython = unittest.skipIf(cython is None, "Cython not available")
 
+mypy = optional_import("mypy")
+requires_mypy = unittest.skipIf(mypy is None, "Mypy not available")
+
 numpy = optional_import("numpy")
 requires_numpy = unittest.skipIf(numpy is None, "NumPy not available")
 


### PR DESCRIPTION
This PR makes `mypy` an optional dependency for the `mypy` tests.

This might seem like an odd thing to do, but some test runners (notably `pytest`) will discover those tests. If `pytest` is run on a clean Python environment with a freshly-installed Traits, then it should gracefully skip the tests for which the dependencies aren't installed. We already do this for Sphinx, numpy, and various other packages.

Related: #1288 
