### PR TITLE
Fix an order-dependency bug in the test_subclasses_weakref regression test

### DIFF
--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -172,7 +172,11 @@ class TestRegression(unittest.TestCase):
         _create_subclass()
         _create_subclass()
         gc.collect()
-        self.assertEqual(previous_subclasses, HasTraits.__subclasses__())
+
+        # In Python < 3.6, we can end up seeing the same subclasses but in
+        # a different order, so use assertCountEqual rather than assertEqual.
+        # Ref: enthought/traits#1282.
+        self.assertCountEqual(previous_subclasses, HasTraits.__subclasses__())
 
     def test_leaked_property_tuple(self):
         """ the property ctrait constructor shouldn't leak a tuple. """


### PR DESCRIPTION
Use assertCountEqual rather than assertEqual so as not to depend on order. Should fix #1282.

