### PR TITLE
Add github workflow to build wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,145 @@
+name: Release
+# This workflow builds the sdist and bdist "on tag".
+# If run from the enthought/traits repository, the wheels will be uploaded to pypi ;
+# otherwise, the wheels will be available as a github artifact.
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - '*'
+
+jobs:
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Get the version
+        id: get_version
+        run: |
+          echo ::set-output name=version::${GITHUB_REF#refs/tags/}
+
+
+  build_wheels:
+    name: Wheels on ${{ matrix.os }}/py${{ matrix.python-version }}
+    needs: create_release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: What OS and Python version
+        run: |
+          uname -a
+          python --version
+          which python
+
+      - name: Install Visual C++ for Python 2.7
+        if: runner.os == 'Windows'
+        run: |
+          choco install vcpython27 -f -y
+
+      - name: install pep517
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pep517
+
+      - name: Build wheels
+        run: |
+          python -m pep517.build --binary --out-dir dist/ .
+
+      - name: Display content dist folder
+        run: |
+          ls dist/
+
+      - name: Install distribution
+        env:
+          MPLBACKEND: agg
+        run: |
+          pip install --pre --find-links dist traits
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/*.whl
+
+      - name: Publish distribution 📦 to PyPI
+        if: github.repository_owner == 'enthought'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+           # Github secret set in the enthought/traits repository
+           # not available from fork
+           password: ${{ secrets.pypi_password }}
+
+  build_wheels_linux:
+    name: Wheels on ubuntu-latest
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Build manylinux Python wheels
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
+        with:
+          build-requirements: 'cython'
+
+      - name: Build source distribution
+        run: |
+          pip install pep517
+          python -m pep517.build --source --out-dir sdist/ .
+
+      - name: Display content dist folder
+        run: |
+          ls dist/
+          ls sdist/
+
+      - name: Install distribution
+        env:
+          MPLBACKEND: agg
+        run: |
+          pip install --pre --find-links dist traits
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: |
+            ./dist/*-manylinux*.whl
+            ./sdist/*.tar.gz
+
+      - name: Publish distribution 📦 to PyPI
+        if: github.repository_owner == 'enthought'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+           # Github secret set in the enthought/traits repository
+           # not available from fork
+           password: ${{ secrets.pypi_password }}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel", "cython"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
Closes #357. Recently, I have been setting up building wheels for some package of the hyperspy framework using github CI and it works very well! In this PR, I have adapted the template to build wheels for traits.

Example of this github workflow running: https://github.com/ericpre/traits/actions/runs/247784316

**Checklist**
- [ ] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)
- [ ] Update User manual (`docs/source/traits_user_manual`)
- [ ] Update type annotation hints in `traits-stubs`
