### PR TITLE
Fix a typo in Str docstring

### DIFF
--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -361,7 +361,7 @@ class BaseStr(TraitType):
 
 
 class Str(BaseStr):
-    """ A fast-validating trait type whose value must be a complex number.
+    """ A fast-validating trait type whose value must be a string.
     """
 
     #: The C-level fast validator to use:


### PR DESCRIPTION
The docstring of the `Str` trait type has a minor typo.

**Checklist**
- [ ] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)
- [ ] Update User manual (`docs/source/traits_user_manual`)
- [ ] Update type annotation hints in `traits-stubs`
