### PR TITLE
Add a shell click command

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -217,6 +217,26 @@ def install(edm, runtime, environment, editable, source):
 @edm_option
 @runtime_option
 @click.option(
+    "--environment",
+    default=None,
+    help="Name of the EDM environment to install",
+)
+def shell(edm, runtime, environment):
+    """ Create a shell into the EDM development environment
+    (aka 'activate' it).
+
+    """
+    parameters = get_parameters(edm, runtime, environment)
+    commands = [
+        "{edm} shell -e {environment}",
+    ]
+    execute(commands, parameters)
+
+
+@cli.command()
+@edm_option
+@runtime_option
+@click.option(
     "--environment", default=None, help="Name of EDM environment to check."
 )
 def flake8(edm, runtime, environment):


### PR DESCRIPTION
This PR adds a new `shell` click command - which when run activates the development environment for traits. The usual command line options are available to choose the environment name and the runtime version of the development environment. Underneath the hood, the click command just uses the `edm shell` command with the appropriate environment name, which is why the docstring for the click command is _almost_ the same as that of `edm shell`.

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
