### PR TITLE
Fix tests that require pkg_resources

### DIFF
--- a/traits-stubs/traits_stubs_tests/test_all.py
+++ b/traits-stubs/traits_stubs_tests/test_all.py
@@ -12,15 +12,18 @@
 from pathlib import Path
 from unittest import TestCase
 
-import pkg_resources
-
-from traits.testing.optional_dependencies import requires_mypy
+from traits.testing.optional_dependencies import (
+    pkg_resources,
+    requires_mypy,
+    requires_pkg_resources,
+)
 from traits_stubs_tests.util import MypyAssertions
 
 
 @requires_mypy
 class TestAnnotations(TestCase, MypyAssertions):
-    def test_all(self, filename_suffix=''):
+    @requires_pkg_resources
+    def test_all(self, filename_suffix=""):
         """ Run mypy for all files contained in traits_stubs_tests/examples
         directory.
 

--- a/traits/testing/optional_dependencies.py
+++ b/traits/testing/optional_dependencies.py
@@ -45,6 +45,11 @@ requires_mypy = unittest.skipIf(mypy is None, "Mypy not available")
 numpy = optional_import("numpy")
 requires_numpy = unittest.skipIf(numpy is None, "NumPy not available")
 
+pkg_resources = optional_import("pkg_resources")
+requires_pkg_resources = unittest.skipIf(
+    pkg_resources is None, "pkg_resources not available"
+)
+
 pyface = optional_import("pyface")
 requires_pyface = unittest.skipIf(pyface is None, "Pyface not available")
 

--- a/traits/tests/test_historical_unpickling.py
+++ b/traits/tests/test_historical_unpickling.py
@@ -17,7 +17,10 @@ import pathlib
 import pickle
 import unittest
 
-import pkg_resources
+from traits.testing.optional_dependencies import (
+    pkg_resources,
+    requires_pkg_resources,
+)
 
 
 def find_pickles():
@@ -52,6 +55,7 @@ def find_pickles():
 
 
 class TestHistoricalPickles(unittest.TestCase):
+    @requires_pkg_resources
     def test_unpickling_historical_pickles(self):
         # Just test that the pickle can be unpickled.
         for pickle_path in find_pickles():

--- a/traits/tests/test_version.py
+++ b/traits/tests/test_version.py
@@ -15,12 +15,16 @@ module contents.
 
 import unittest
 
-import pkg_resources
+from traits.testing.optional_dependencies import (
+    pkg_resources,
+    requires_pkg_resources,
+)
 
 import traits
 
 
 class TestVersion(unittest.TestCase):
+    @requires_pkg_resources
     def test_dunder_version(self):
         self.assertIsInstance(traits.__version__, str)
         # Round-trip through parse_version; this verifies not only
@@ -29,6 +33,7 @@ class TestVersion(unittest.TestCase):
         parsed_version = pkg_resources.parse_version(traits.__version__)
         self.assertEqual(str(parsed_version), traits.__version__)
 
+    @requires_pkg_resources
     def test_version_version(self):
         # Importing inside the test to ensure that we get a test error
         # in the case where the version module does not exist.


### PR DESCRIPTION
Three of the tests require the `pkg_resources` package to be present in the environment. It usually will be (since it's a part of the `setuptools` distribution), but if it's not, then the tests should be skipped rather than causing the test run to fail.

This PR fixes that, adding `pkg_resources` to the existing optional imports machinery in `traits.testing`.

Part of the motivation here is to be able to create a test run that validates that Traits doesn't have any "accidental" dependencies. See #1299.

Closes #1300.