### PR TITLE
Use released Python 3.9 instead of prerelease

### DIFF
--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9-dev]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ jobs:
       python: "3.7"
     - name: "Python 3.8 on Xenial Linux"
       python: "3.8"
-    - name: "Python 3.9 (dev) on Xenial Linux"
-      python: "3.9-dev"
+    - name: "Python 3.9 on Xenial Linux"
+      python: "3.9"
     - name: "Python 3.7 on macOS"
       os: osx
       osx_image: xcode11.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
 
 jobs:
   include:
-    - name: "Python 3.5 on Xenial Linux"
-      python: "3.5"
     - name: "Python 3.6 on Xenial Linux"
       python: "3.6"
     - name: "Python 3.7 on Xenial Linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ jobs:
       python: "3.7"
     - name: "Python 3.8 on Xenial Linux"
       python: "3.8"
-    - name: "Python 3.9 on Xenial Linux"
-      python: "3.9"
+    - name: "Python 3.9 (dev) on Xenial Linux"
+      python: "3.9-dev"
     - name: "Python 3.7 on macOS"
       os: osx
       osx_image: xcode11.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,12 @@ environment:
     PYTHONUNBUFFERED: "1"
 
   matrix:
-    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
 
 install:
   - "%PYTHON%/python.exe --version"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,8 @@ environment:
   matrix:
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
-    - PYTHON: "C:\\Python38-x64"
 
 install:
   - "%PYTHON%/python.exe --version"


### PR DESCRIPTION
Python 3.9 has been released, so we should update the GitHub Actions continuous integration to run on 3.9 proper instead of on a pre-release version.

This PR updates the GitHub Actions test script accordingly.

xref: https://github.com/actions/setup-python/issues/148

We should also update the Travis and Appveyor scripts, but I'm having difficulty finding evidence that the systems support Python 3.9 yet. I'll give it a try once the GitHub Actions change has completed.

---

EDIT: Updated to also drop Python 3.5 support for both Appveyor and Travis CI.