### PR TITLE
FIX: Don't notify on empty 'update's of Dict traits

### DIFF
--- a/traits/tests/test_trait_dict_object.py
+++ b/traits/tests/test_trait_dict_object.py
@@ -143,7 +143,7 @@ class TestTraitDict(unittest.TestCase):
         self.assertEqual(self.changed, {"a": 1, "b": 2})
         self.assertEqual(self.removed, {})
 
-    def test_update_with_tranformation(self):
+    def test_update_with_transformation(self):
         td = TraitDict(
             {"1": 1, "2": 2},
             key_validator=str,
@@ -159,6 +159,37 @@ class TestTraitDict(unittest.TestCase):
         self.assertEqual(self.changed, {"1": 1})
         self.assertEqual(self.removed, {})
 
+    def test_update_with_empty_argument(self):
+        td = TraitDict(
+            {"1": 1, "2": 2},
+            key_validator=str,
+            notifiers=[self.notification_handler],
+        )
+
+        # neither of these should cause a notification to be emitted
+        td.update([])
+        td.update({})
+        self.assertEqual(td, {"1": 1, "2": 2})
+        self.assertIsNone(self.added)
+        self.assertIsNone(self.changed)
+        self.assertIsNone(self.removed)
+
+    def test_update_notifies_with_nonempty_argument(self):
+        # Corner case: we don't want to get into the difficulties of
+        # comparing values for equality, so we notify for a non-empty
+        # argument even if the dictionary has not actually changed.
+        td = TraitDict(
+            {"1": 1, "2": 2},
+            key_validator=str,
+            notifiers=[self.notification_handler],
+        )
+
+        td.update({"1": 1})
+        self.assertEqual(td, {"1": 1, "2": 2})
+        self.assertEqual(self.added, {})
+        self.assertEqual(self.changed, {"1": 1})
+        self.assertEqual(self.removed, {})
+
     def test_clear(self):
         td = TraitDict({"a": 1, "b": 2}, key_validator=str_validator,
                        value_validator=int_validator,
@@ -169,6 +200,21 @@ class TestTraitDict(unittest.TestCase):
         self.assertEqual(self.added, {})
         self.assertEqual(self.changed, {})
         self.assertEqual(self.removed, {"a": 1, "b": 2})
+
+    def test_clear_empty_dictionary(self):
+        # Clearing an empty dictionary should not notify.
+        td = TraitDict(
+            {},
+            key_validator=str_validator,
+            value_validator=int_validator,
+            notifiers=[self.notification_handler],
+        )
+
+        td.clear()
+
+        self.assertIsNone(self.added)
+        self.assertIsNone(self.changed)
+        self.assertIsNone(self.removed)
 
     def test_invalid_key(self):
         td = TraitDict({"a": 1, "b": 2}, key_validator=str_validator,

--- a/traits/tests/test_trait_dict_object.py
+++ b/traits/tests/test_trait_dict_object.py
@@ -143,7 +143,7 @@ class TestTraitDict(unittest.TestCase):
         self.assertEqual(self.changed, {"a": 1, "b": 2})
         self.assertEqual(self.removed, {})
 
-    def test_update_with_transformation(self):
+    def test_update_with_tranformation(self):
         td = TraitDict(
             {"1": 1, "2": 2},
             key_validator=str,

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -232,7 +232,8 @@ class TraitDict(dict):
             validated_dict[validated_key] = validated_value
 
         super().update(validated_dict)
-        self.notify(removed={}, added=added, changed=changed)
+        if added or changed:
+            self.notify(removed={}, added=added, changed=changed)
 
     def setdefault(self, key, value=None):
         """ Returns the value if key is present in the dict, else creates the


### PR DESCRIPTION
This PR modifies the `TraitDict.update` method so that notifications are not issues when updating with an empty argument. This is similar to the behaviour of extending a list or updating a set with an empty argument.

The PR also adds a test for the `TraitDict.clear` method, to verify that it doesn't notify when clearing an already-empty dictionary.

Fixes #1307

**Checklist**
- [x] Tests
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~ Not needed
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~ Not needed
- [ ] ~Update type annotation hints in `traits-stubs`~ Not needed
