### PR TITLE
CLN: Deprecate UnittestTools._catch_warnings

### DIFF
--- a/traits/testing/tests/test_unittest_tools.py
+++ b/traits/testing/tests/test_unittest_tools.py
@@ -439,3 +439,8 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
             with self.assertRaises(self.failureException):
                 with self.assertNotDeprecated():
                     old_and_dull_caller()
+
+    def test__catch_warnings_deprecated(self):
+        with self.assertWarns(DeprecationWarning):
+            with self._catch_warnings():
+                pass

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -454,6 +454,15 @@ class UnittestTools(object):
 
     @contextlib.contextmanager
     def _catch_warnings(self):
+
+        warnings.warn(
+            (
+                "The _catch_warnings method is deprecated. "
+                "Use warnings.catch_warnings instead."
+            ),
+            DeprecationWarning,
+        )
+
         # Ugly hack copied from the core Python code (see
         # Lib/test/test_support.py) to reset the warnings registry
         # for the module making use of this context manager.
@@ -475,8 +484,10 @@ class UnittestTools(object):
         for testing uses of traits.util.deprecated.deprecated.
 
         """
-        with self._catch_warnings() as w:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DeprecationWarning)
             yield w
+
         self.assertGreater(
             len(w),
             0,
@@ -490,8 +501,10 @@ class UnittestTools(object):
         for testing uses of traits.util.deprecated.deprecated.
 
         """
-        with self._catch_warnings() as w:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DeprecationWarning)
             yield w
+
         self.assertEqual(
             len(w),
             0,

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -454,7 +454,21 @@ class UnittestTools(object):
 
     @contextlib.contextmanager
     def _catch_warnings(self):
+        """
+        Replacement for warnings.catch_warnings.
 
+        This method wraps warnings.catch_warnings, takes care to
+        reset the warning registry before entering the with context,
+        and ensures that DeprecationWarnings are always emitted.
+
+        The hack to reset the warning registry is no longer needed in
+        Python 3.4 and later. See http://bugs.python.org/issue4180 for
+        more background.
+
+        .. deprecated:: 6.2
+            Use :func:`warnings.catch_warnings` instead.
+
+        """
         warnings.warn(
             (
                 "The _catch_warnings method is deprecated. "


### PR DESCRIPTION
This PR :

- Deprecated the `UnittestTools._catch_warnings` method
- Replaces existing uses of this method with `warnings.catch_warnings`
- Adds a docstring to `UnittestTools._catch_warning` (but note that `_catch_warnings` doesn't appear in the current documentation build, so the docstring is only useful for code readers or those exploring at the prompt)

Closes #1270 

**Checklist**
- [x] Tests
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~ private method is not documented
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~ not necessary
- [ ] ~Update type annotation hints in `traits-stubs`~ not necessary

