### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ inherited by any subclass derived from the class.
 Dependencies
 ------------
 
-Traits requires Python >= 3.5.
+Traits requires Python >= 3.6.
 
 Traits has the following optional dependencies:
 

--- a/setup.py
+++ b/setup.py
@@ -276,7 +276,6 @@ setuptools.setup(
         Operating System :: POSIX :: Linux
         Programming Language :: Python
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
@@ -348,6 +347,6 @@ setuptools.setup(
     },
     license="BSD",
     packages=setuptools.find_packages(include=["traits", "traits.*"]),
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     zip_safe=False,
 )

--- a/traits-stubs/setup.py
+++ b/traits-stubs/setup.py
@@ -36,7 +36,6 @@ if __name__ == "__main__":
             Operating System :: POSIX :: Linux
             Programming Language :: Python
             Programming Language :: Python :: 3
-            Programming Language :: Python :: 3.5
             Programming Language :: Python :: 3.6
             Programming Language :: Python :: 3.7
             Programming Language :: Python :: 3.8
@@ -62,5 +61,5 @@ if __name__ == "__main__":
         ],
         package_data={"traits-stubs": ["./*.pyi", "./**/*.pyi"]},
         license="BSD",
-        python_requires=">=3.5",
+        python_requires=">=3.6",
     )


### PR DESCRIPTION
Python 3.5 is past end-of-life, we no longer get package builds for EDM on Python 3.5, and we have no information that anyone is using Traits on Python 3.5. This PR officially removes Python 3.5 support for Traits.

Closes #831.
