### PR TITLE
Remove Python 3.5 compatibility code

### DIFF
--- a/traits/tests/test_directory.py
+++ b/traits/tests/test_directory.py
@@ -9,17 +9,11 @@
 # Thanks for using Enthought open source!
 
 import pathlib
-import sys
 from tempfile import gettempdir
 
 import unittest
 
 from traits.api import BaseDirectory, Directory, HasTraits, TraitError
-
-
-requires_fspath = unittest.skipIf(
-    sys.version_info < (3, 6),
-    "Test requires os.fspath, which is unavailable before Python 3.6")
 
 
 class ExampleModel(HasTraits):
@@ -86,21 +80,18 @@ class TestBaseDirectory(unittest.TestCase):
         with self.assertRaises(TraitError):
             foo.path = __file__
 
-    @requires_fspath
     def test_accepts_valid_pathlib_dir(self):
         foo = ExistsBaseDirectory()
         foo.path = pathlib.Path(gettempdir())
 
         self.assertIsInstance(foo.path, str)
 
-    @requires_fspath
     def test_rejects_invalid_pathlib_dir(self):
         foo = ExistsBaseDirectory()
 
         with self.assertRaises(TraitError):
             foo.path = pathlib.Path("!!!invalid_directory")
 
-    @requires_fspath
     def test_rejects_valid_pathlib_file(self):
         foo = ExistsBaseDirectory()
 
@@ -124,7 +115,6 @@ class TestBaseDirectory(unittest.TestCase):
         foo = SimpleBaseDirectory()
         foo.path = "!!!invalid_directory"
 
-    @requires_fspath
     def test_simple_accepts_any_pathlib(self):
         """ BaseDirectory with no existence check accepts any pathlib path.
         """

--- a/traits/tests/test_file.py
+++ b/traits/tests/test_file.py
@@ -10,7 +10,6 @@
 
 import os
 from pathlib import Path
-import sys
 import unittest
 
 from traits.api import File, HasTraits, TraitError
@@ -30,7 +29,6 @@ class FileTestCase(unittest.TestCase):
         example_model = ExampleModel(file_name=__file__)
         example_model.file_name = os.path.__file__
 
-    @unittest.skipIf(sys.version_info < (3, 6), "PathLike File trait test")
     def test_valid_pathlike_file(self):
         ExampleModel(file_name=Path(__file__))
 
@@ -40,7 +38,6 @@ class FileTestCase(unittest.TestCase):
         with self.assertRaises(TraitError):
             example_model.file_name = "not_valid_path!#!#!#"
 
-    @unittest.skipIf(sys.version_info < (3, 6), "PathLike File trait test")
     def test_invalid_pathlike_file(self):
         example_model = ExampleModel(file_name=__file__)
 
@@ -53,7 +50,6 @@ class FileTestCase(unittest.TestCase):
         with self.assertRaises(TraitError):
             example_model.file_name = os.path.dirname(__file__)
 
-    @unittest.skipIf(sys.version_info < (3, 6), "PathLike File trait test")
     def test_pathlike_directory(self):
         example_model = ExampleModel(file_name=__file__)
 

--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -13,7 +13,6 @@ Tests for the Map handler.
 """
 
 import pickle
-import sys
 import unittest
 
 from traits.api import HasTraits, Int, List, Map, on_trait_change, TraitError
@@ -71,16 +70,11 @@ class TestMap(unittest.TestCase):
             married = Map(mapping)
 
         p = Person()
-        if sys.version_info >= (3, 6):
-            # If we're using Python >= 3.6, we can rely on dictionaries
-            # being ordered, and then the default is predictable.
-            self.assertEqual(p.married, "yes")
-            self.assertEqual(p.married_, 1)
-        else:
-            # Otherwise, all we can expect is that the default is _one_
-            # of the dictionary entries.
-            self.assertIn(p.married, mapping)
-            self.assertEqual(p.married_, mapping[p.married])
+
+        # Since we're using Python >= 3.6, we can rely on dictionaries
+        # being ordered, and then the default is predictable.
+        self.assertEqual(p.married, "yes")
+        self.assertEqual(p.married_, 1)
 
     def test_no_default_reverse_access_order(self):
         mapping = {"yes": 1, "yeah": 1, "no": 0, "nah": 0}
@@ -91,14 +85,11 @@ class TestMap(unittest.TestCase):
         p = Person()
         shadow_value = p.married_
         primary_value = p.married
-        if sys.version_info >= (3, 6):
-            self.assertEqual(primary_value, "yes")
-            self.assertEqual(shadow_value, 1)
-        else:
-            # For Python < 3.6, dictionary ordering and hence the default
-            # value aren't predictable.
-            self.assertIn(primary_value, mapping)
-            self.assertEqual(shadow_value, mapping[primary_value])
+
+        # For Python >= 3.6, dictionary ordering and hence the default
+        # value are predictable.
+        self.assertEqual(primary_value, "yes")
+        self.assertEqual(shadow_value, 1)
 
     def test_default(self):
         class Person(HasTraits):

--- a/traits/tests/test_prefix_map.py
+++ b/traits/tests/test_prefix_map.py
@@ -13,7 +13,6 @@ Tests for the PrefixMap handler.
 """
 
 import pickle
-import sys
 import unittest
 
 from traits.api import HasTraits, Int, PrefixMap, TraitError
@@ -63,16 +62,11 @@ class TestPrefixMap(unittest.TestCase):
             married = PrefixMap(mapping)
 
         p = Person()
-        if sys.version_info >= (3, 6):
-            # If we're using Python >= 3.6, we can rely on dictionaries
-            # being ordered, and then the default is predictable.
-            self.assertEqual(p.married, "yes")
-            self.assertEqual(p.married_, 1)
-        else:
-            # Otherwise, all we can expect is that the default is _one_
-            # of the dictionary entries.
-            self.assertIn(p.married, mapping)
-            self.assertEqual(p.married_, mapping[p.married])
+
+        # Since we're using Python >= 3.6, we can rely on dictionaries
+        # being ordered, and then the default is predictable.
+        self.assertEqual(p.married, "yes")
+        self.assertEqual(p.married_, 1)
 
     def test_default(self):
         class Person(HasTraits):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -15,13 +15,10 @@ import collections.abc
 import datetime
 from importlib import import_module
 import operator
+from os import fspath
+from os.path import isfile, isdir
 import re
 import sys
-try:
-    from os import fspath
-except ImportError:
-    fspath = None
-from os.path import isfile, isdir
 from types import FunctionType, MethodType, ModuleType
 import uuid
 
@@ -1298,8 +1295,8 @@ class PythonValue(Any):
 class BaseFile(BaseStr):
     """ A trait type whose value must be a file path string.
 
-    For Python 3.6 and later this will accept os.pathlib Path objects,
-    converting them to the corresponding string value.
+    This will accept both strings and os.pathlib Path objects,
+    converting the latter to the corresponding string value.
 
     Parameters
     ----------
@@ -1358,15 +1355,13 @@ class BaseFile(BaseStr):
 
             Note: The 'fast validator' version performs this check in C.
         """
-        if fspath is not None:
-            # Python 3.5 does not implement __fspath__
-            try:
-                # If value is of type os.PathLike, get the path representation
-                # The path representation could be either a str or bytes type
-                # If fspath returns bytes, further validation will fail.
-                value = fspath(value)
-            except TypeError:
-                pass
+        try:
+            # If value is of type os.PathLike, get the path representation
+            # The path representation could be either a str or bytes type
+            # If fspath returns bytes, further validation will fail.
+            value = fspath(value)
+        except TypeError:
+            pass
 
         validated_value = super().validate(object, name, value)
         if not self.exists:
@@ -1391,8 +1386,8 @@ class BaseFile(BaseStr):
 class File(BaseFile):
     """ A fast-validating trait type whose value must be a file path string.
 
-    For Python 3.6 and later this will accept os.pathlib Path objects,
-    converting them to the corresponding string value.
+    This will accept both strings and os.pathlib Path objects,
+    converting the latter to the corresponding string value.
 
     Parameters
     ----------
@@ -1444,9 +1439,8 @@ class File(BaseFile):
 class BaseDirectory(BaseStr):
     """ A trait type whose value must be a directory path string.
 
-    For Python 3.6 and greater, it also accepts objects implementing
-    the :class:`os.PathLike` interface, converting them to the corresponding
-    string.
+    This also accepts objects implementing the :class:`os.PathLike` interface,
+    converting them to the corresponding string.
 
     Parameters
     ----------
@@ -1493,12 +1487,10 @@ class BaseDirectory(BaseStr):
 
         Note: The 'fast validator' version performs this check in C.
         """
-        if fspath is not None:
-            # Python 3.5 does not implement __fspath__
-            try:
-                value = fspath(value)
-            except TypeError:
-                pass
+        try:
+            value = fspath(value)
+        except TypeError:
+            pass
 
         validated_value = super().validate(
             object, name, value
@@ -1520,9 +1512,8 @@ class BaseDirectory(BaseStr):
 class Directory(BaseDirectory):
     """ A fast-validating trait type whose value is a directory path string.
 
-    For Python 3.6 and greater, it also accepts objects implementing
-    the :class:`os.PathLike` interface, converting them to the corresponding
-    string.
+    This also accepts objects implementing the :class:`os.PathLike` interface,
+    converting them to the corresponding string.
 
     Parameters
     ----------


### PR DESCRIPTION
This is a follow-on PR to #1312. Strictly speaking, it probably shouldn't be merged until after #1312 (but the CI won't care, because we already removed the 3.5 runs).

This PR:

- Removes some test code that needed to worry about dictionary ordering.
- Removes conditional imports of `os.fspath`: with Python >= 3.6, we can assume the presence of `os.fspath`.

**Checklist**
- [ ] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)
- [ ] Update User manual (`docs/source/traits_user_manual`)
- [ ] Update type annotation hints in `traits-stubs`
