### PR TITLE
BLD: Add CI runner for core test suite (no optional dependencies)

### DIFF
--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .
-        python -m pip uninstall setuptools wheel
+        python -m pip uninstall -y setuptools wheel
     - name: Test Traits package
       run: |
         mkdir testdir

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -1,0 +1,33 @@
+# Test run with no optional dependencies installed, to help
+# detect any accidental dependencies.
+
+name: Core tests
+
+on:
+  pull_request
+
+jobs:
+  core:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.9]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install local package
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install .
+        python -m pip uninstall setuptools wheel
+    - name: Test Traits package
+      run: |
+        mkdir testdir
+        cd testdir
+        python -m unittest discover -v traits


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for running the test suite with none of the optional dependencies present in the environment.

The idea is to catch bugs where either a test or (worse) a piece of the core Traits functionality accidentally depends on another package being present.

It seems unnecessary to runs these tests on all possible combinations of Python version and platform (which would give 12 jobs), but given that there's potential for dependency bugs to be both platform-specific and Python-version specific, we compromise by testing only on Windows and Linux, and only on Python 3.6 and Python 3.9, for a total of four jobs.

Closes #1299.