### PR TITLE
[MAINT] Remove python 3.9 exclusions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -309,18 +309,10 @@ setuptools.setup(
             "mypy",
             "setuptools",
             "Sphinx!=3.2.0",
-            # Python 3.9 exclusions:
-            #
-            # * NumPy installation fails on Python 3.9 on the Ubuntu Xenial
-            #   system used by Travis CI.
-            # * PySide2 is installable but also currently not working
-            #   on Python 3.9.
-            # * Because of the above, we also exclude GUI-using packages
-            #   Pyface and TraitsUI on Python 3.9.
-            "numpy;python_version<'3.9'",
-            "pyface;python_version<'3.9'",
-            "PySide2;python_version<'3.9'",
-            "traitsui;python_version<'3.9'",
+            "numpy",
+            "pyface",
+            "PySide2",
+            "traitsui",
         ],
         "examples": [
             # dependencies for examples


### PR DESCRIPTION
This PR removes the Python 3.9 exclusions from `setup.py`

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
