### PR TITLE
Fix typo in mocking example

### DIFF
--- a/docs/source/traits_user_manual/testing.rst
+++ b/docs/source/traits_user_manual/testing.rst
@@ -122,7 +122,7 @@ the methods and attributes of a |HasStrictTraits| instance. To circumvent the
     my_class.__dict__['add_to_number'] = Mock()
 
     # We can now use the mock in our tests.
-    my_class.add_number(42)
+    my_class.add_to_number(42)
     print(my_class.add_to_number.call_args_list)
 
 .. note::


### PR DESCRIPTION
There was a typo in the example of how to use mocking that meant that the example didn't work as written. This PR fixes that.

Thanks @xamcost for bringing this to my attention.
