### PR TITLE
Correct the minimum Sphinx version in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Traits has the following optional dependencies:
 
 To build the full documentation one needs:
 
-* `Sphinx <https://pypi.org/project/Sphinx>`_ version 1.8 or later.
+* `Sphinx <https://pypi.org/project/Sphinx>`_ version 2.1 or later.
 * The `Enthought Sphinx Theme <https://pypi.org/project/enthought-sphinx-theme>`_.
   (A version of the documentation can be built without this, but
   some formatting may be incorrect.)

--- a/etstool.py
+++ b/etstool.py
@@ -93,7 +93,7 @@ common_dependencies = {
     "mypy",
     "numpy",
     "pyqt5",
-    "Sphinx!=3.2.0",
+    "Sphinx",
     "traitsui",
 }
 

--- a/setup.py
+++ b/setup.py
@@ -301,14 +301,14 @@ setuptools.setup(
     extras_require={
         "docs": [
             "enthought-sphinx-theme",
-            "Sphinx!=3.2.0",
+            "Sphinx>=2.1.0,!=3.2.0",
         ],
         "test": [
             "Cython",
             "flake8",
             "mypy",
             "setuptools",
-            "Sphinx!=3.2.0",
+            "Sphinx>=2.1.0,!=3.2.0",
             # Python 3.9 exclusions:
             #
             # * NumPy installation fails on Python 3.9 on the Ubuntu Xenial


### PR DESCRIPTION
We require Sphinx >= 2.1. That requirement used to be encoded in the `setup.py`, but was removed in #1276.

Related: #1216.
