### PR TITLE
Fix KeyError from observe trying to filter events for trait named "*_items"

### DIFF
--- a/traits/observation/_has_traits_helpers.py
+++ b/traits/observation/_has_traits_helpers.py
@@ -129,8 +129,7 @@ def ctrait_prevent_event(event):
     """
     if event.old is Uninitialized:
         return True
-
-    ctrait = event.object.traits()[event.name]
+    ctrait = event.object._trait(event.name, 2)
     if (ctrait.type == TraitKind.trait.name
             and ctrait.comparison_mode == ComparisonMode.equality):
         try:

--- a/traits/observation/_has_traits_helpers.py
+++ b/traits/observation/_has_traits_helpers.py
@@ -129,7 +129,7 @@ def ctrait_prevent_event(event):
     """
     if event.old is Uninitialized:
         return True
-    ctrait = event.object._trait(event.name, 2)
+    ctrait = event.object.trait(event.name)
     if (ctrait.type == TraitKind.trait.name
             and ctrait.comparison_mode == ComparisonMode.equality):
         try:

--- a/traits/observation/_has_traits_helpers.py
+++ b/traits/observation/_has_traits_helpers.py
@@ -129,6 +129,7 @@ def ctrait_prevent_event(event):
     """
     if event.old is Uninitialized:
         return True
+
     ctrait = event.object.trait(event.name)
     if (ctrait.type == TraitKind.trait.name
             and ctrait.comparison_mode == ComparisonMode.equality):

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -638,9 +638,10 @@ class TestDelegateToInteraction(unittest.TestCase):
 
 
 # Integration tests with on_trait_change and observe ------------------
-# The legacy of on_trait_change means trait named with "_items" suffix is
-# handled differently in HasTraits. This tests the awkward interaction that
-# could arise while using on_trait_change together with observe.
+# The legacy of on_trait_change means instance trait named with "_items"
+# suffix is handled differently in HasTraits. This tests the awkward
+# interaction that could arise while using on_trait_change together with
+# observe involving "*_items"
 
 class Application(HasTraits):
     pass
@@ -649,10 +650,9 @@ class Application(HasTraits):
 class TestObserveAnytrait(unittest.TestCase):
 
     def test_observe_event_with_undefined_name_suffix_items(self):
-        # A trait name with suffix "*_items" is special-cased by
-        # HasTraits.traits such that it is not reported.
-        # When filtering events, we should not use HasTraits.traits
-        # to retrieve the CTrait associated with the "*_items" name.
+        # Regression test for the error resulting from trying (and failing) to
+        # retrieve the CTrait for an instance trait with name "*_items"
+        # via HasTraits.traits
         app = Application()
 
         def dummy_handler():

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -635,3 +635,43 @@ class TestDelegateToInteraction(unittest.TestCase):
         self.assertFalse(mess.handler_called)
         mess.dummy1.x = 20
         self.assertTrue(mess.handler_called)
+
+
+# Integration tests with on_trait_change and observe ------------------
+# The legacy of on_trait_change means trait named with "_items" suffix is
+# handled differently in HasTraits. This tests the awkward interaction that
+# could arise while using on_trait_change together with observe.
+
+class Application(HasTraits):
+    pass
+
+
+class TestObserveAnytrait(unittest.TestCase):
+
+    def test_observe_event_with_undefined_name_suffix_items(self):
+        # A trait name with suffix "*_items" is special-cased by
+        # HasTraits.traits such that it is not reported.
+        # When filtering events, we should not use HasTraits.traits
+        # to retrieve the CTrait associated with the "*_items" name.
+        app = Application()
+
+        def dummy_handler():
+            pass
+
+        # on_trait_change does not check if the trait has been defined.
+        # This has the side-effect of creating the CTrait for this trait name.
+        app.on_trait_change(dummy_handler, "i_am_undefined_with_items")
+        self.assertIsNotNone(app._trait("i_am_undefined_with_items", 0))
+
+        # Precondition for this test, i_am_undefined_with_items is still not
+        # reported by HasTraits.traits method
+        self.assertNotIn("i_am_undefined_with_items", app.traits())
+
+        events = []
+        # This works because the CTrait is created by on_trait_change
+        app.observe(events.append, "i_am_undefined_with_items")
+
+        # This should not fail.
+        app.trait_property_changed("i_am_undefined_with_items", 1, 2)
+
+        self.assertEqual(len(events), 1)

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -647,7 +647,7 @@ class Application(HasTraits):
     pass
 
 
-class TestObserveAnytrait(unittest.TestCase):
+class TestObserveItemsFromOnTraitChange(unittest.TestCase):
 
     def test_observe_event_with_undefined_name_suffix_items(self):
         # Regression test for the error resulting from trying (and failing) to


### PR DESCRIPTION
This PR fixes a new bug introduced by #1165 (hence not released).

The first commit adds a test that reveals the issue, it fails with the following error:
```
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_observe.py", line 675, in test_observe_event_with_undefined_name_suffix_items
    app.trait_property_changed("i_am_undefined_with_items", 1, 2)
  File "/Users/kchoi/Work/ETS/traits/traits/observation/_trait_event_notifier.py", line 119, in __call__
    if self.prevent_event(event):
  File "/Users/kchoi/Work/ETS/traits/traits/observation/_has_traits_helpers.py", line 132, in ctrait_prevent_event
    ctrait = event.object.traits()[event.name]
KeyError: 'i_am_undefined_with_items'
```

The second commit fixes it.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
