### PR TITLE
Testing tool exception handling

### DIFF
--- a/docs/source/traits_user_manual/debugging.rst
+++ b/docs/source/traits_user_manual/debugging.rst
@@ -41,21 +41,21 @@ The script exits normally. The exception is caught and logged::
 
 This logged exception, however, only contains the tip of the traceback. This
 makes debugging a bit difficult. You can force exceptions to be re-raised
-by calling :func:`~traits.testing.unittest_tools.setup_test`:
+by calling :func:`~traits.testing.unittest_tools.push_reraise_exceptions`:
 
 .. code-block:: python
 
-   from traits.testing.api import setup_test
-   setup_test()
+   from traits.testing.api import push_reraise_exceptions
+   push_reraise_exceptions()
 
 This helper function will cause exceptions from ``observe`` or
 ``on_trait_change`` to be re-raised. This setting can be reversed by
-:func:`~traits.testing.unittest_tools.teardown_test`:
+:func:`~traits.testing.unittest_tools.pop_reraise_exceptions`:
 
 .. code-block:: python
 
-   from traits.testing.api import teardown_test
-   teardown_test()
+   from traits.testing.api import pop_reraise_exceptions
+   pop_reraise_exceptions()
 
 Alternatively, you can modify the exception handling just for
 ``observe``:

--- a/docs/source/traits_user_manual/debugging.rst
+++ b/docs/source/traits_user_manual/debugging.rst
@@ -4,16 +4,19 @@
 Tips for debugging Traits
 =========================
 
+.. _debugging-change-handler-error:
 
 Re-raising exceptions in change handlers
 ========================================
 
 Traits will typically log (instead of raise) exceptions when an exception is
-encountered in a trait-change handler. This behavior is often preferred in
-applications, since you usually want to avoid critical failures in
-applications. However, when debugging these errors, the
+encountered in a trait-change handler (see :ref:`observe-notification`). This
+behavior is often preferred in applications, since you usually want to avoid
+critical failures in applications. However, when debugging these errors, the
 ``logging.Logger.exception`` only displays the tip of the traceback. For
-example, the following change handler raises an exception::
+example, the following change handler raises an exception:
+
+.. code-block:: python
 
    from traits.api import HasTraits, Int, observe
 
@@ -27,7 +30,9 @@ example, the following change handler raises an exception::
    c = Curmudgeon()
    c.number = 42
 
-The script exits normally. The exception is caught and logged::
+The script exits normally. The exception is caught and logged:
+
+.. code-block:: none
 
    Exception occurred in traits notification handler for event object: TraitChangeEvent(object=<__main__.Curmudgeon object at 0x7fed00525220>, name='number', old=1, new=42)
    Traceback (most recent call last):
@@ -38,25 +43,33 @@ The script exits normally. The exception is caught and logged::
 
 This logged exception, however, only contains the tip of the traceback. This
 makes debugging a bit difficult. You can force exceptions to be re-raised
-by calling :func:`~traits.testing.unittest_tools.setup_test`::
+by calling :func:`~traits.testing.unittest_tools.setup_test`:
+
+.. code-block:: python
 
    from traits.testing.api import setup_test
    setup_test()
 
 This helper function will cause exceptions from ``observe`` or
 ``on_trait_change`` to be re-raised. This setting can be reversed by
-:func:`~traits.testing.unittest_tools.teardown_test`::
+:func:`~traits.testing.unittest_tools.teardown_test`:
+
+.. code-block:: python
 
    from traits.testing.api import teardown_test
    teardown_test()
 
 Alternatively, you can modify the exception handling just for
-``observe``::
+``observe``:
+
+.. code-block:: python
 
    from traits.observation.api import push_exception_handler
    push_exception_handler(reraise_exceptions=True)
 
-Or just for ``on_trait_change``::
+Or just for ``on_trait_change``:
+
+.. code-block:: python
 
    from traits.api import push_exception_handler
    push_exception_handler(reraise_exceptions=True)
@@ -64,7 +77,9 @@ Or just for ``on_trait_change``::
 (For example, you could add this to the top of the original code block.)
 
 Re-running the original code example with the exception handler will now raise
-the following traceback::
+the following traceback:
+
+.. code-block:: none
 
    Traceback (most recent call last):
      File "curmudgeon.py", line 15, in <module>

--- a/docs/source/traits_user_manual/debugging.rst
+++ b/docs/source/traits_user_manual/debugging.rst
@@ -12,58 +12,70 @@ Traits will typically log (instead of raise) exceptions when an exception is
 encountered in a trait-change handler. This behavior is often preferred in
 applications, since you usually want to avoid critical failures in
 applications. However, when debugging these errors, the
-``logging.Logger.exception`` only displays the tip of the traceback. For example,
-the following code changes a ``constant``:
+``logging.Logger.exception`` only displays the tip of the traceback. For
+example, the following change handler raises an exception::
 
-.. code-block:: python
-
-   from traits.api import HasTraits, Int
+   from traits.api import HasTraits, Int, observe
 
    class Curmudgeon(HasTraits):
-       constant = Int(1)
-       def _constant_changed(self):
+       number = Int(1)
+
+       @observe("number")
+       def number_updated(self):
            raise ValueError()
 
    c = Curmudgeon()
-   c.constant = 42
+   c.number = 42
 
-The ``constant`` trait-change handler raises an exception that is caught and
-logged::
+The script exits normally. The exception is caught and logged::
 
-   Exception occurred in traits notification handler.
-   Please check the log file for details.
-   Exception occurred in traits notification handler for object:
-   <__main__.Curmudgeon object at 0x107603050>, trait: constant, old value: 0, new value: 42 
-     ...
-     File "curmudgeon.py", line 12, in _constant_changed
+   Exception occurred in traits notification handler for event object: TraitChangeEvent(object=<__main__.Curmudgeon object at 0x7fed00525220>, name='number', old=1, new=42)
+   Traceback (most recent call last):
+    ...
+   File "curmudgeon.py", line 8, in number_updated
        raise ValueError()
    ValueError
 
 This logged exception, however, only contains the tip of the traceback. This
 makes debugging a bit difficult. You can force exceptions to be re-raised
-by adding a custom exception handler:
+by calling :func:`~traits.testing.unittest_tools.setup_test`::
 
-.. code-block:: python
+   from traits.testing.api import setup_test
+   setup_test()
+
+This helper function will cause exceptions from ``observe`` or
+``on_trait_change`` to be re-raised. This setting can be reversed by
+:func:`~traits.testing.unittest_tools.teardown_test`::
+
+   from traits.testing.api import teardown_test
+   teardown_test()
+
+Alternatively, you can modify the exception handling just for
+``observe``::
+
+   from traits.observation.api import push_exception_handler
+   push_exception_handler(reraise_exceptions=True)
+
+Or just for ``on_trait_change``::
 
    from traits.api import push_exception_handler
    push_exception_handler(reraise_exceptions=True)
 
 (For example, you could add this to the top of the original code block.)
 
-Re-running the original code example with this custom handler will now raise
+Re-running the original code example with the exception handler will now raise
 the following traceback::
 
    Traceback (most recent call last):
      File "curmudgeon.py", line 15, in <module>
-       c.constant = 42
+       c.number = 42
      ...
-     File "curmudgeon.py", line 12, in _constant_changed
+     File "curmudgeon.py", line 12, in number_updated
        raise ValueError()
    ValueError
 
 Notice that this traceback has information about *where* we changed
-``constant``.  Note: This is a toy example; use ``Constant`` from
-``traits.api`` if you actually want a constant trait.
+``number``.
 
 
 Tracing Traits Change Events

--- a/docs/source/traits_user_manual/debugging.rst
+++ b/docs/source/traits_user_manual/debugging.rst
@@ -24,7 +24,7 @@ example, the following change handler raises an exception:
        number = Int(1)
 
        @observe("number")
-       def number_updated(self):
+       def number_updated(self, event):
            raise ValueError()
 
    c = Curmudgeon()

--- a/docs/source/traits_user_manual/debugging.rst
+++ b/docs/source/traits_user_manual/debugging.rst
@@ -30,9 +30,7 @@ example, the following change handler raises an exception:
    c = Curmudgeon()
    c.number = 42
 
-The script exits normally. The exception is caught and logged:
-
-.. code-block:: none
+The script exits normally. The exception is caught and logged::
 
    Exception occurred in traits notification handler for event object: TraitChangeEvent(object=<__main__.Curmudgeon object at 0x7fed00525220>, name='number', old=1, new=42)
    Traceback (most recent call last):
@@ -77,9 +75,7 @@ Or just for ``on_trait_change``:
 (For example, you could add this to the top of the original code block.)
 
 Re-running the original code example with the exception handler will now raise
-the following traceback:
-
-.. code-block:: none
+the following traceback::
 
    Traceback (most recent call last):
      File "curmudgeon.py", line 15, in <module>

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -244,7 +244,8 @@ The following expectations apply to any change handler:
 * No assumptions should be made about the order of which handlers are called
   for a given change event. A change event can have many change handlers.
 * No exceptions should be raised from a change handler. Any unexpected
-  exceptions will be captured and logged.
+  exceptions will be captured and logged. (See
+  :ref:`debugging-change-handler-error` on how to override this behavior).
 
 When the handler is invoked, it is given an **event** object which provides
 information about the change observed. The type and signature of *event*

--- a/traits/testing/api.py
+++ b/traits/testing/api.py
@@ -10,4 +10,6 @@
 
 from .doctest_tools import doctest_for_module  # noqa: F401
 from .nose_tools import deprecated, performance, skip  # noqa: F401
-from .unittest_tools import UnittestTools  # noqa: F401
+from .unittest_tools import (
+    setup_test, teardown_test, UnittestTools,  # noqa: F401
+)

--- a/traits/testing/api.py
+++ b/traits/testing/api.py
@@ -10,7 +10,7 @@
 
 from .doctest_tools import doctest_for_module  # noqa: F401
 from .nose_tools import deprecated, performance, skip  # noqa: F401
-from .unittest_tools import ( # noqa: F401
+from .unittest_tools import (  # noqa: F401
     pop_reraise_exceptions,
     push_reraise_exceptions,
     UnittestTools,

--- a/traits/testing/api.py
+++ b/traits/testing/api.py
@@ -10,6 +10,8 @@
 
 from .doctest_tools import doctest_for_module  # noqa: F401
 from .nose_tools import deprecated, performance, skip  # noqa: F401
-from .unittest_tools import (
-    setup_test, teardown_test, UnittestTools,  # noqa: F401
+from .unittest_tools import ( # noqa: F401
+    pop_reraise_exceptions,
+    push_reraise_exceptions,
+    UnittestTools,
 )

--- a/traits/testing/tests/test_unittest_tools.py
+++ b/traits/testing/tests/test_unittest_tools.py
@@ -448,6 +448,7 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
 
 
 class TestHelperMethod(unittest.TestCase):
+    """ Test setup_test and teardown_test helper functions. """
 
     def setUp(self):
         setup_test()

--- a/traits/testing/tests/test_unittest_tools.py
+++ b/traits/testing/tests/test_unittest_tools.py
@@ -20,8 +20,9 @@ from traits.api import (
     Int,
     List,
     on_trait_change,
+    observe,
 )
-from traits.testing.api import UnittestTools
+from traits.testing.api import UnittestTools, setup_test, teardown_test
 # unittest_tools provides a reference to unittest for historical reasons, and
 # downstream packages may still be doing "from traits.testing.unittest_tools
 # import unittest". We keep this import as-is (instead of doing a simple
@@ -444,3 +445,44 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
         with self.assertWarns(DeprecationWarning):
             with self._catch_warnings():
                 pass
+
+
+class TestHelperMethod(unittest.TestCase):
+
+    def setUp(self):
+        setup_test()
+        self.addCleanup(teardown_test)
+
+    def test_on_trait_change_error(self):
+        # Test error from on_trait_change is re-raised.
+        # Ideally, we should check there are no logging messages with
+        # assertNoLogs from Python 3.10
+
+        class A(HasTraits):
+            foo = Bool(False)
+
+            @on_trait_change("foo")
+            def _bad_handler(self):
+                raise ZeroDivisionError("Bad handler!")
+
+        obj = A()
+
+        with self.assertRaises(ZeroDivisionError):
+            obj.foo = True
+
+    def test_observe_error(self):
+        # Test error from observe is re-raised.
+        # Ideally, we should check there are no logging messages with
+        # assertNoLogs from Python 3.10
+
+        class A(HasTraits):
+            foo = Bool(False)
+
+            @observe("foo")
+            def _bad_handler(self, event):
+                raise ZeroDivisionError("Bad handler!")
+
+        obj = A()
+
+        with self.assertRaises(ZeroDivisionError):
+            obj.foo = True

--- a/traits/testing/tests/test_unittest_tools.py
+++ b/traits/testing/tests/test_unittest_tools.py
@@ -22,7 +22,11 @@ from traits.api import (
     on_trait_change,
     observe,
 )
-from traits.testing.api import UnittestTools, setup_test, teardown_test
+from traits.testing.api import (
+    pop_reraise_exceptions,
+    push_reraise_exceptions,
+    UnittestTools,
+)
 # unittest_tools provides a reference to unittest for historical reasons, and
 # downstream packages may still be doing "from traits.testing.unittest_tools
 # import unittest". We keep this import as-is (instead of doing a simple
@@ -448,11 +452,13 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
 
 
 class TestHelperMethod(unittest.TestCase):
-    """ Test setup_test and teardown_test helper functions. """
+    """ Test push_reraise_exceptions and pop_reraise_exceptions helper
+    functions.
+    """
 
     def setUp(self):
-        setup_test()
-        self.addCleanup(teardown_test)
+        push_reraise_exceptions()
+        self.addCleanup(pop_reraise_exceptions)
 
     def test_on_trait_change_error(self):
         # Test error from on_trait_change is re-raised.

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -8,8 +8,10 @@
 #
 # Thanks for using Enthought open source!
 
-""" Trait assert mixin class to simplify test implementation for Trait
-Classes.
+""" Tools for testing Traits classes using Python unittest framework.
+
+This includes a mixin class to simplify test implementation for
+Trait Classes, as well as helper functions that can be used with unittest.
 
 """
 
@@ -31,9 +33,40 @@ from traits.api import (
     Int,
     List,
     Str,
+    pop_exception_handler as on_trait_change_pop_exception,
     Property,
+    push_exception_handler as on_trait_change_push_exception,
+)
+from traits.observation.api import (
+    pop_exception_handler as observe_pop_exception,
+    push_exception_handler as observe_push_exception,
 )
 from traits.util.async_trait_wait import wait_for_condition
+
+
+def setup_test():
+    """ Set up exception handlers so that any exceptions from a change
+    handler given to ``on_trait_change`` or ``observe`` are re-raised and the
+    default logging behavior is silenced. Suitable to be used in
+    ``unittest.TestCase.setUp``.
+    """
+
+    # we will reraise, there is no need to log.
+    def ignore(*args):
+        pass
+
+    on_trait_change_push_exception(handler=ignore, reraise_exceptions=True)
+    observe_push_exception(handler=ignore, reraise_exceptions=True)
+
+
+def teardown_test():
+    """ Reverse the actions in ``setup_test``.
+
+    Suitable to be used in ``unittest.TestCase.tearDown`` or with
+    ``unittest.TestCase.addCleanup``.
+    """
+    observe_pop_exception()
+    on_trait_change_pop_exception()
 
 
 class _AssertTraitChangesContext(object):

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -44,7 +44,7 @@ from traits.observation.api import (
 from traits.util.async_trait_wait import wait_for_condition
 
 
-def setup_test():
+def push_reraise_exceptions():
     """ Set up exception handlers so that any exceptions from a change
     handler given to ``on_trait_change`` or ``observe`` are re-raised and the
     default logging behavior is silenced. Suitable to be used in
@@ -59,8 +59,8 @@ def setup_test():
     observe_push_exception(handler=ignore, reraise_exceptions=True)
 
 
-def teardown_test():
-    """ Reverse the actions in ``setup_test``.
+def pop_reraise_exceptions():
+    """ Reverse the actions in ``push_reraise_exceptions``.
 
     Suitable to be used in ``unittest.TestCase.tearDown`` or with
     ``unittest.TestCase.addCleanup``.

--- a/traits/testing/unittest_tools.py
+++ b/traits/testing/unittest_tools.py
@@ -49,6 +49,10 @@ def push_reraise_exceptions():
     handler given to ``on_trait_change`` or ``observe`` are re-raised and the
     default logging behavior is silenced. Suitable to be used in
     ``unittest.TestCase.setUp``.
+
+    See Also
+    --------
+    pop_reraise_exceptions : reverse the action of this function.
     """
 
     # we will reraise, there is no need to log.


### PR DESCRIPTION
Closes #1323

This PR adds `setup_test` and `teardown_test` helper functions so that one can set the `reraise_exceptions` more easily.
The handler is also overridden to silence logging: we are already raising.

User manual is updated too.

Presumably other tests in Traits can also use these functions, but that could be a separate PR too.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~Update type annotation hints in `traits-stubs`~ (testing module is not in the stub... it is a bit much to add this as part of this PR...)
