### PR TITLE
Don't hard-code class names in __repr__ implementations

### DIFF
--- a/traits/adaptation/adaptation_offer.py
+++ b/traits/adaptation/adaptation_offer.py
@@ -28,12 +28,13 @@ class AdaptationOffer(HasTraits):
     def __repr__(self):
         """ Return a string representation of the object. """
 
-        template = "<AdaptationOffer: '{from_}' -> '{to}'>"
+        template = "<{class_name}: '{from_}' -> '{to}'>"
 
+        class_name = self.__class__.__name__
         from_ = self.from_protocol_name
         to = self.to_protocol_name
 
-        return template.format(from_=from_, to=to)
+        return template.format(class_name=class_name, from_=from_, to=to)
 
     #### 'AdaptationOffer' protocol ###########################################
 

--- a/traits/adaptation/adaptation_offer.py
+++ b/traits/adaptation/adaptation_offer.py
@@ -28,13 +28,8 @@ class AdaptationOffer(HasTraits):
     def __repr__(self):
         """ Return a string representation of the object. """
 
-        template = "<{class_name}: '{from_}' -> '{to}'>"
-
-        class_name = self.__class__.__name__
-        from_ = self.from_protocol_name
-        to = self.to_protocol_name
-
-        return template.format(class_name=class_name, from_=from_, to=to)
+        return (f"<{self.__class__.__name__}: '{self.from_protocol_name}' "
+                f"-> '{self.to_protocol_name}'>")
 
     #### 'AdaptationOffer' protocol ###########################################
 

--- a/traits/adaptation/tests/test_adaptation_offer.py
+++ b/traits/adaptation/tests/test_adaptation_offer.py
@@ -56,3 +56,18 @@ class TestAdaptationOffer(unittest.TestCase):
         from traits.adaptation.tests.lazy_examples import IFoo
 
         self.assertIs(to_protocol, IFoo)
+
+    def test_adaptation_offer_str_representation(self):
+        """ test string representation of the AdaptationOffer class. """
+
+        class Foo:
+            pass
+
+        class Bar:
+            pass
+
+        desired_repr = ("<AdaptationOffer: 'test_adaptation_offer.Foo' "
+                        "-> 'test_adaptation_offer.Bar'>")
+        adaptation_offer = AdaptationOffer(from_protocol=Foo, to_protocol=Bar)
+        self.assertEqual(desired_repr, str(adaptation_offer))
+        self.assertEqual(desired_repr, repr(adaptation_offer))

--- a/traits/adaptation/tests/test_adaptation_offer.py
+++ b/traits/adaptation/tests/test_adaptation_offer.py
@@ -66,8 +66,10 @@ class TestAdaptationOffer(unittest.TestCase):
         class Bar:
             pass
 
-        desired_repr = ("<AdaptationOffer: 'test_adaptation_offer.Foo' "
-                        "-> 'test_adaptation_offer.Bar'>")
         adaptation_offer = AdaptationOffer(from_protocol=Foo, to_protocol=Bar)
+        desired_repr = "<AdaptationOffer: '{}' -> '{}'>".format(
+            adaptation_offer.from_protocol_name,
+            adaptation_offer.to_protocol_name
+        )
         self.assertEqual(desired_repr, str(adaptation_offer))
         self.assertEqual(desired_repr, repr(adaptation_offer))

--- a/traits/observation/_dict_change_event.py
+++ b/traits/observation/_dict_change_event.py
@@ -44,11 +44,10 @@ class DictChangeEvent:
 
     def __repr__(self):
         return (
-            "{event.__class__.__name__}("
-            "object={event.object!r}, "
-            "removed={event.removed!r}, "
-            "added={event.added!r}"
-            ")".format(event=self)
+            f"{self.__class__.__name__}("
+            f"object={self.object!r}, "
+            f"removed={self.removed!r}, "
+            f"added={self.added!r})"
         )
 
 

--- a/traits/observation/_list_change_event.py
+++ b/traits/observation/_list_change_event.py
@@ -39,12 +39,11 @@ class ListChangeEvent:
 
     def __repr__(self):
         return (
-            "{event.__class__.__name__}("
-            "object={event.object!r}, "
-            "index={event.index!r}, "
-            "removed={event.removed!r}, "
-            "added={event.added!r}"
-            ")".format(event=self)
+            f"{self.__class__.__name__}("
+            f"object={self.object!r}, "
+            f"index={self.index!r}, "
+            f"removed={self.removed!r}, "
+            f"added={self.added!r})"
         )
 
 

--- a/traits/observation/_set_change_event.py
+++ b/traits/observation/_set_change_event.py
@@ -34,11 +34,10 @@ class SetChangeEvent:
 
     def __repr__(self):
         return (
-            "{event.__class__.__name__}("
-            "object={event.object!r}, "
-            "removed={event.removed!r}, "
-            "added={event.added!r}"
-            ")".format(event=self)
+            f"{self.__class__.__name__}("
+            f"object={self.object!r}, "
+            f"removed={self.removed!r}, "
+            f"added={self.added!r})"
         )
 
 

--- a/traits/tests/test_trait_dict_object.py
+++ b/traits/tests/test_trait_dict_object.py
@@ -15,7 +15,7 @@ import unittest
 from unittest import mock
 
 from traits.api import HasTraits
-from traits.trait_dict_object import TraitDict, TraitDictObject
+from traits.trait_dict_object import TraitDict, TraitDictEvent, TraitDictObject
 from traits.trait_errors import TraitError
 from traits.trait_types import Dict, Int, Str
 
@@ -433,3 +433,13 @@ class TestTraitDictObject(unittest.TestCase):
         tdo_unpickled.value_validator("1")
         tdo_unpickled.value_validator(1)
         tdo_unpickled.value_validator(True)
+
+
+class TestTraitDictEvent(unittest.TestCase):
+
+    def test_trait_dict_event_str_representation(self):
+        """ test string representation of the TraitDictEvent class. """
+        desired_repr = "TraitDictEvent(removed={}, added={}, changed={})"
+        trait_dict_event = TraitDictEvent()
+        self.assertEqual(desired_repr, str(trait_dict_event))
+        self.assertEqual(desired_repr, repr(trait_dict_event))

--- a/traits/tests/test_trait_dict_object.py
+++ b/traits/tests/test_trait_dict_object.py
@@ -443,3 +443,15 @@ class TestTraitDictEvent(unittest.TestCase):
         trait_dict_event = TraitDictEvent()
         self.assertEqual(desired_repr, str(trait_dict_event))
         self.assertEqual(desired_repr, repr(trait_dict_event))
+
+    def test_trait_dict_event_subclass_str_representation(self):
+        """ Test string representation of a subclass of the TraitDictEvent
+        class. """
+
+        class DifferentName(TraitDictEvent):
+            pass
+
+        desired_repr = "DifferentName(removed={}, added={}, changed={})"
+        differnt_name_subclass = DifferentName()
+        self.assertEqual(desired_repr, str(differnt_name_subclass))
+        self.assertEqual(desired_repr, repr(differnt_name_subclass))

--- a/traits/tests/test_trait_dict_object.py
+++ b/traits/tests/test_trait_dict_object.py
@@ -438,7 +438,7 @@ class TestTraitDictObject(unittest.TestCase):
 class TestTraitDictEvent(unittest.TestCase):
 
     def test_trait_dict_event_str_representation(self):
-        """ test string representation of the TraitDictEvent class. """
+        """ Test string representation of the TraitDictEvent class. """
         desired_repr = "TraitDictEvent(removed={}, added={}, changed={})"
         trait_dict_event = TraitDictEvent()
         self.assertEqual(desired_repr, str(trait_dict_event))

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -94,7 +94,7 @@ class TestTraitListEvent(unittest.TestCase):
         self.assertEqual(event.added, [])
 
     def test_trait_list_event_str_representation(self):
-        """ test string representation of the TraitListEvent class. """
+        """ Test string representation of the TraitListEvent class. """
         desired_repr = "TraitListEvent(index=0, removed=[], added=[])"
         trait_list_event = TraitListEvent()
         self.assertEqual(desired_repr, str(trait_list_event))

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -93,6 +93,13 @@ class TestTraitListEvent(unittest.TestCase):
         self.assertEqual(event.removed, [])
         self.assertEqual(event.added, [])
 
+    def test_trait_list_event_str_representation(self):
+        """ test string representation of the TraitListEvent class. """
+        desired_repr = "TraitListEvent(index=0, removed=[], added=[])"
+        trait_list_event = TraitListEvent()
+        self.assertEqual(desired_repr, str(trait_list_event))
+        self.assertEqual(desired_repr, repr(trait_list_event))
+
 
 class TestTraitList(unittest.TestCase):
 

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -100,6 +100,18 @@ class TestTraitListEvent(unittest.TestCase):
         self.assertEqual(desired_repr, str(trait_list_event))
         self.assertEqual(desired_repr, repr(trait_list_event))
 
+    def test_trait_list_event_subclass_str_representation(self):
+        """ Test string representation of a subclass of the TraitListEvent
+        class. """
+
+        class DifferentName(TraitListEvent):
+            pass
+
+        desired_repr = "DifferentName(index=0, removed=[], added=[])"
+        different_name_subclass = DifferentName()
+        self.assertEqual(desired_repr, str(different_name_subclass))
+        self.assertEqual(desired_repr, repr(different_name_subclass))
+
 
 class TestTraitList(unittest.TestCase):
 

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -521,7 +521,7 @@ class TestTraitSetObject(unittest.TestCase):
 class TestTraitSetEvent(unittest.TestCase):
 
     def test_trait_set_event_str_representation(self):
-        """ test string representation of the TraitSetEvent class. """
+        """ Test string representation of the TraitSetEvent class. """
         desired_repr = "TraitSetEvent(removed=set(), added=set())"
         trait_set_event = TraitSetEvent()
         self.assertEqual(desired_repr, str(trait_set_event))

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -526,3 +526,15 @@ class TestTraitSetEvent(unittest.TestCase):
         trait_set_event = TraitSetEvent()
         self.assertEqual(desired_repr, str(trait_set_event))
         self.assertEqual(desired_repr, repr(trait_set_event))
+
+    def test_trait_set_event_subclass_str_representation(self):
+        """ Test string representation of a subclass of the TraitSetEvent
+        class. """
+
+        class DifferentName(TraitSetEvent):
+            pass
+
+        desired_repr = "DifferentName(removed=set(), added=set())"
+        different_name_subclass = DifferentName()
+        self.assertEqual(desired_repr, str(different_name_subclass))
+        self.assertEqual(desired_repr, repr(different_name_subclass))

--- a/traits/tests/test_trait_set_object.py
+++ b/traits/tests/test_trait_set_object.py
@@ -14,7 +14,7 @@ from unittest import mock
 from traits.api import HasTraits, Set, Str
 from traits.trait_base import _validate_everything
 from traits.trait_errors import TraitError
-from traits.trait_set_object import TraitSet
+from traits.trait_set_object import TraitSet, TraitSetEvent
 from traits.trait_types import _validate_int
 
 
@@ -516,3 +516,13 @@ class TestTraitSetObject(unittest.TestCase):
 
         # then
         notifier.assert_not_called()
+
+
+class TestTraitSetEvent(unittest.TestCase):
+
+    def test_trait_set_event_str_representation(self):
+        """ test string representation of the TraitSetEvent class. """
+        desired_repr = "TraitSetEvent(removed=set(), added=set())"
+        trait_set_event = TraitSetEvent()
+        self.assertEqual(desired_repr, str(trait_set_event))
+        self.assertEqual(desired_repr, repr(trait_set_event))

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -53,8 +53,12 @@ class TraitDictEvent(object):
         self.changed = changed
 
     def __repr__(self):
-        return "TraitDictEvent(removed={!r}, added={!r}, changed={!r})".format(
-            self.removed, self.added, self.changed
+        return (
+            "{event.__class__.__name__}("
+            "removed={event.removed!r}, "
+            "added={event.added!r}, "
+            "changed={event.changed!r}"
+            ")".format(event=self)
         )
 
 

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -54,11 +54,10 @@ class TraitDictEvent(object):
 
     def __repr__(self):
         return (
-            "{event.__class__.__name__}("
-            "removed={event.removed!r}, "
-            "added={event.added!r}, "
-            "changed={event.changed!r}"
-            ")".format(event=self)
+            f"{self.__class__.__name__}("
+            f"removed={self.removed!r}, "
+            f"added={self.added!r}, "
+            f"changed={self.changed!r})"
         )
 
 

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -54,8 +54,12 @@ class TraitListEvent(object):
         self.added = added
 
     def __repr__(self):
-        return "TraitListEvent(index={!r}, removed={!r}, added={!r})".format(
-            self.index, self.removed, self.added
+        return (
+            "{event.__class__.__name__}("
+            "index={event.index!r}, "
+            "removed={event.removed!r}, "
+            "added={event.added!r}"
+            ")".format(event=self)
         )
 
 

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -55,11 +55,10 @@ class TraitListEvent(object):
 
     def __repr__(self):
         return (
-            "{event.__class__.__name__}("
-            "index={event.index!r}, "
-            "removed={event.removed!r}, "
-            "added={event.added!r}"
-            ")".format(event=self)
+            f"{self.__class__.__name__}("
+            f"index={self.index!r}, "
+            f"removed={self.removed!r}, "
+            f"added={self.added!r})"
         )
 
 

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -48,10 +48,9 @@ class TraitSetEvent(object):
 
     def __repr__(self):
         return (
-            "{event.__class__.__name__}("
-            "removed={event.removed!r}, "
-            "added={event.added!r}"
-            ")".format(event=self)
+            f"{self.__class__.__name__}("
+            f"removed={self.removed!r}, "
+            f"added={self.added!r})"
         )
 
 

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -47,8 +47,11 @@ class TraitSetEvent(object):
         self.added = added
 
     def __repr__(self):
-        return "TraitSetEvent(removed={!r}, added={!r})".format(
-            self.removed, self.added
+        return (
+            "{event.__class__.__name__}("
+            "removed={event.removed!r}, "
+            "added={event.added!r}"
+            ")".format(event=self)
         )
 
 

--- a/traits/util/tests/test_weakidddict.py
+++ b/traits/util/tests/test_weakidddict.py
@@ -130,3 +130,10 @@ class TestWeakIDDict(unittest.TestCase):
         desired_repr = "<WeakIDDict at 0x{0:x}>".format(id(weak_id_dict))
         self.assertEqual(desired_repr, str(weak_id_dict))
         self.assertEqual(desired_repr, repr(weak_id_dict))
+
+    def test_weak_id_key_dict_str_representation(self):
+        """ test string representation of the WeakIDKeyDict class. """
+        weak_id_key_dict = WeakIDKeyDict()
+        desired_repr = "<WeakIDKeyDict at 0x{0:x}>".format(id(weak_id_key_dict))
+        self.assertEqual(desired_repr, str(weak_id_key_dict))
+        self.assertEqual(desired_repr, repr(weak_id_key_dict))

--- a/traits/util/tests/test_weakidddict.py
+++ b/traits/util/tests/test_weakidddict.py
@@ -123,3 +123,10 @@ class TestWeakIDDict(unittest.TestCase):
         self.assertEqual(len(wd), 1)
         del values[0:2]
         self.assertEqual(len(wd), 0)
+
+    def test_weak_id_dict_str_representation(self):
+        """ test string representation of the WeakIDDict class. """
+        weak_id_dict = WeakIDDict()
+        desired_repr = "<WeakIDDict at 0x{0:x}>".format(id(weak_id_dict))
+        self.assertEqual(desired_repr, str(weak_id_dict))
+        self.assertEqual(desired_repr, repr(weak_id_dict))

--- a/traits/util/tests/test_weakidddict.py
+++ b/traits/util/tests/test_weakidddict.py
@@ -134,6 +134,6 @@ class TestWeakIDDict(unittest.TestCase):
     def test_weak_id_key_dict_str_representation(self):
         """ test string representation of the WeakIDKeyDict class. """
         weak_id_key_dict = WeakIDKeyDict()
-        desired_repr = "<WeakIDKeyDict at 0x{0:x}>".format(id(weak_id_key_dict))
+        desired_repr = f"<WeakIDKeyDict at 0x{id(weak_id_key_dict):x}>"
         self.assertEqual(desired_repr, str(weak_id_key_dict))
         self.assertEqual(desired_repr, repr(weak_id_key_dict))

--- a/traits/util/weakiddict.py
+++ b/traits/util/weakiddict.py
@@ -43,7 +43,9 @@ class WeakIDDict(MutableMapping):
             self.update(dict)
 
     def __repr__(self):
-        return "<WeakIDDict at 0x{0:x}>".format(id(self))
+        return "<{self.__class__.__name__} at 0x{0:x}>".format(
+            id(self), self=self
+        )
 
     def __delitem__(self, key):
         del self.data[id(key)]

--- a/traits/util/weakiddict.py
+++ b/traits/util/weakiddict.py
@@ -43,9 +43,7 @@ class WeakIDDict(MutableMapping):
             self.update(dict)
 
     def __repr__(self):
-        return "<{self.__class__.__name__} at 0x{0:x}>".format(
-            id(self), self=self
-        )
+        return f"<{self.__class__.__name__} at 0x{id(self):x}>"
 
     def __delitem__(self, key):
         del self.data[id(key)]


### PR DESCRIPTION
fixes #1333 

This PR simply updates repr implementations in a few classes to use `self.__class__.__name__` rather than hardcoding the class name, and adds simple tests.  Namely, it updates the `TraitListEvent`, `TraitDictEvent`, and `TraitSetEvent` classes as well as the `AdaptationOffer` and `WeakIDDict` classes.

**Checklist**
- [x] Tests
~- [ ] Update API reference (`docs/source/traits_api_reference`)~
~- [ ] Update User manual (`docs/source/traits_user_manual`)~
~- [ ] Update type annotation hints in `traits-stubs`~
