### PR TITLE
Add test for the use case of Trait with mapping and callable

### DIFF
--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -565,7 +565,7 @@ def str_cast_to_int(object, name, value):
     return len(value)
 
 
-# Suppress DeprecationWarning from TraitPrefixMap instantiation.
+# Suppress DeprecationWarning from TraitMap instantiation.
 with warnings.catch_warnings():
     warnings.filterwarnings(action="ignore", category=DeprecationWarning)
 

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -600,7 +600,6 @@ class TestTraitWithMappingAndCallable(unittest.TestCase):
 
         # the value is not 'white' any more.
         self.assertEqual(obj.value, 5)
-        # it is a mapped trait because there is a mapping.
         self.assertEqual(obj.value_, 5)
 
     def test_trait_set_value_use_callable(self):
@@ -609,7 +608,6 @@ class TestTraitWithMappingAndCallable(unittest.TestCase):
         # The value is not 'red' any more.
         # the callable is used, not the mapping.
         self.assertEqual(obj.value, 3)
-        # it is a mapped trait because there is a mapping.
         self.assertEqual(obj.value_, 3)
 
     def test_trait_set_value_use_mapping(self):
@@ -617,7 +615,6 @@ class TestTraitWithMappingAndCallable(unittest.TestCase):
 
         # Now this uses the mapping, and the value is the original one.
         self.assertEqual(obj.value, (0, 0, 0))
-        # it is a mapped trait because there is a mapping.
         self.assertEqual(obj.value_, 999)
 
 

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -565,13 +565,17 @@ def str_cast_to_int(object, name, value):
     return len(value)
 
 
-class TraitWithMappingAndCallable(HasTraits):
+# Suppress DeprecationWarning from TraitPrefixMap instantiation.
+with warnings.catch_warnings():
+    warnings.filterwarnings(action="ignore", category=DeprecationWarning)
 
-    value = Trait(
-        "white",
-        {"white": 0, "red": 1, (0, 0, 0): 999},
-        str_cast_to_int,
-    )
+    class TraitWithMappingAndCallable(HasTraits):
+
+        value = Trait(
+            "white",
+            {"white": 0, "red": 1, (0, 0, 0): 999},
+            str_cast_to_int,
+        )
 
 
 class TestTraitWithMappingAndCallable(unittest.TestCase):

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -557,11 +557,11 @@ class PrefixMapTest(AnyTraitTest):
 # This test a combination of Trait, a default, a mapping and a function
 
 def str_cast_to_int(object, name, value):
-    """ A function that validates the value is a str and then convert
+    """ A function that validates the value is a str and then converts
     it to an int using its length.
     """
     if not isinstance(value, str):
-        raise TraitError("Not an string!")
+        raise TraitError("Not a string!")
     return len(value)
 
 


### PR DESCRIPTION
Motivated by #1258, this PR adds a few tests that exercise the scenario where migration from TraitMap to Map is hard.

The difficulty here is that `Trait` can take a number of things, and when a mapping and a callable are given to it, it makes the trait a mapped trait because there is a mapping.  And when the callable is used for validation (and transformation), both the key value and the mapped value are the same. But when the callable fails, the mapping is used and the key value is not the same as the mapped value.

If we migrate to Map, then the key value would be different from the mapped value. If we use Union to combine them together, then the mapped trait is gone.  

I still haven't figured out a migration solution for this scenario that does not involve just reimplement a TraitType that does all these things, but maybe that's what downstream projects have to do if they need to keep these strange behaviour alive, so that Traits can deprecate TraitMap and Trait.

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
