### PR TITLE
Add Travis CI macOS / Python 3.8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,11 @@ jobs:
       os: osx
       osx_image: xcode11.5
       language: shell
-    - name: "Python 3.8 on macOS"
+    - name: "Python 3.8 on macOS (XCode 12.2)"
+      os: osx
+      osx_image: xcode12.2
+      language: shell
+    - name: "Python 3.8 on macOS (XCode 12.0.1)"
       os: osx
       osx_image: xcode12
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       language: shell
     - name: "Python 3.8 on macOS"
       os: osx
-      osx_image: xcode12.2
+      osx_image: xcode12
       language: shell
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ jobs:
       os: osx
       osx_image: xcode11.5
       language: shell
+    - name: "Python 3.8 on macOS"
+      os: osx
+      osx_image: xcode12.2
+      language: shell
 
 install:
   - python3 --version


### PR DESCRIPTION
This is an experimental PR, motivated by issue #1337. Travis CI has XCode 12.2 available, and I want to see if the "Unsupported architecture" compilation bug with XCode 12.1 persists with XCode 12.2.
