### PR TITLE
Add lru_cache on parse for observe to speed up instantiation time

### DIFF
--- a/traits/observation/parsing.py
+++ b/traits/observation/parsing.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 import contextlib
-from functools import reduce, lru_cache
+from functools import lru_cache, reduce
 import operator
 
 from traits.observation import _generated_parser

--- a/traits/observation/parsing.py
+++ b/traits/observation/parsing.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 import contextlib
-from functools import reduce
+from functools import reduce, lru_cache
 import operator
 
 from traits.observation import _generated_parser
@@ -254,6 +254,7 @@ def _handle_tree(tree, default_notifies=None):
         tree.children, default_notifies=default_notifies)
 
 
+@lru_cache(maxsize=128)
 def parse(text):
     """ Top-level function for parsing user's text to an ObserverExpression.
 


### PR DESCRIPTION
related to #1316 

**Checklist**
~- [ ] Tests~
~- [ ] Update API reference (`docs/source/traits_api_reference`)~
~- [ ] Update User manual (`docs/source/traits_user_manual`)~
~- [ ] Update type annotation hints in `traits-stubs`~

This is an alternate approach to what is done in #1343.  Here rather than moving the parsing logic into the decorator, we simply cache the results of parsing so that if many instantiations are done, we don't need to re-parse the expression every time.  This solution gives a comparable decrease in case (2) time to instantaite, without increasing the time it takes to construct the class (1). See benchmark reports with `n=100000` below:

On master:

<details>

Given a subclass of HasTraits with a trait defined, e.g. name = Str(),
compare having a method with no decorator to one that is decorated with
`@on_trait_change("name")`, one decorated with `@observe("name")`, and one
with `@observe(trait('name'))`.

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for reassigning the trait to a new value.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 8.84740   1.00 (2): 0.14315   1.00 (3): 0.00659   1.00
`@on_trait_change('name')` -
(1): 9.19530   1.04 (2): 0.71941   5.03 (3): 0.00672   1.02
`@observe('name')` -
(1): 8.91179   1.01 **(2): 6.65963  46.52** (3): 0.00647   0.98
`@observe(trait('name'))` -
(1): 9.09999   1.03 (2): 2.89405  20.22 (3): 0.00676   1.03

--------------------------------------------------------------------------------

Given a subclass of HasTraits with a trait referring to an instance of
HasTraits, e.g. child = Instance(AnotherClass) where AnotherClass has a
name trait, compare having a method with no decorator to one that is
decorated with @on_trait_change("child.name"), one decorated with
@observe("child.name"), and one with
@observe(trait('child').trait('name')).

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for reassigning child to a new value.
(4) Time for reassigning child.name to a new value.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 9.43381   1.00 (2): 0.28772   1.00 (3): 0.14178   1.00 (4): 0.00701   1.00
`@on_trait_change('child.name')` -
(1): 9.43325   1.00 (2): 9.59384  33.34 (3): 2.50125  17.64 (4): 0.00989   1.41
`@observe('child.name')` -
(1): 9.53141   1.01 **(2): 16.08950  55.92** (3): 6.59454  46.51 (4): 0.00783   1.12
`@observe(trait('child').trait('name'))` -
(1): 10.35650   1.10 (2): 7.84243  27.26 (3): 6.84757  48.30 (4): 0.00743   1.06

--------------------------------------------------------------------------------

Given a subclass of HasTraits with a trait that is defined as Property
that depends on a simple trait, compare having the Property be defined
as `Property()`, `Property(depends_on="name")`, `Property(observe="name")`,
and `Property(observe=trait('name'))`. (Note that this is a feature
currently available on master only).

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for changing the trait being depended-on / observed.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 14.54505   1.00 (2): 0.13050   1.00 (3): 0.00500   1.00
`depends_on='name'` -
(1): 14.24326   0.98 (2): 6.05126  46.37 (3): 0.00699   1.40
`observe='name'` -
(1): 14.86066   1.02 **(2): 6.35408  48.69** (3): 0.00582   1.16
`observe=trait('name')` -
(1): 15.03425   1.03 (2): 2.80149  21.47 (3): 0.00625   1.25

--------------------------------------------------------------------------------

Identical to the simple property case only using the `@cached_property`
decorator on the property's getter method.

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for changing the trait being depended-on / observed.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 14.31380   1.00 (2): 0.12962   1.00 (3): 0.00494   1.00
`depends_on='name'` -
(1): 14.46543   1.01 (2): 12.26901  94.66 (3): 0.00716   1.45
`observe='name'` -
(1): 16.66431   1.16 **(2): 6.47019  49.92** (3): 0.00660   1.34
`observe=trait('name')` -
(1): 16.14596   1.13 (2): 3.07010  23.69 (3): 0.00633   1.28

--------------------------------------------------------------------------------

Given a subclass of HasTraits with a trait that is defined as Property
that depends on an extended trait, compare having the Property be
defined as `Property()`, `Property(depends_on="child.name")`,
`Property(observe="child.name")`, and
`Property(observe=trait('child').trait('name'))`. (Note that this is a
feature currently available on master only).

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for reassigning child to a new value.
(4) Time for reassigning child.name to a new value.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 16.51180   1.00 (2): 0.29474   1.00 (3): 0.13879   1.00 (4): 0.00637   1.00
`depends_on='child.name'` -
(1): 15.35540   0.93 (2): 9.91735  33.65 (3): 2.11387  15.23 (4): 0.00843   1.32
`observe='child.name'` -
(1): 15.38781   0.93 **(2): 15.66122  53.14** (3): 6.44849  46.46 (4): 0.00780   1.22
`observe=trait('child').trait('name')` -
(1): 16.48509   1.00 (2): 7.87570  26.72 (3): 6.81021  49.07 (4): 0.00761   1.19

--------------------------------------------------------------------------------

Identical to the extended property case only using the `@cached_property`
decorator on the property's getter method.

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for reassigning child to a new value.
(4) Time for reassigning child.name to a new value.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 15.64841   1.00 (2): 0.27936   1.00 (3): 0.13353   1.00 (4): 0.00595   1.00
`depends_on='child.name'` -
(1): 15.42324   0.99 (2): 20.08643  71.90 (3): 4.19624  31.43 (4): 0.01049   1.76
`observe='child.name'` -
(1): 16.19206   1.03 **(2): 15.96901  57.16** (3): 6.68527  50.07 (4): 0.00805   1.35
`observe=trait('child').trait('name')` -
(1): 16.36513   1.05 (2): 7.72487  27.65 (3): 6.68223  50.04 (4): 0.00738   1.24

--------------------------------------------------------------------------------

</details>

On this branch:


<details>


Given a subclass of HasTraits with a trait defined, e.g. name = Str(),
compare having a method with no decorator to one that is decorated with
`@on_trait_change("name")`, one decorated with `@observe("name")`, and one
with `@observe(trait('name'))`.

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for reassigning the trait to a new value.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 8.17364   1.00 (2): 0.12738   1.00 (3): 0.00683   1.00
`@on_trait_change('name')` -
(1): 8.83223   1.08 (2): 0.74051   5.81 (3): 0.00617   0.90
`@observe('name')` -
(1): 8.87711   1.09 **(2): 3.05000  23.94** (3): 0.00700   1.02
`@observe(trait('name'))` -
(1): 9.21969   1.13 (2): 2.97178  23.33 (3): 0.00632   0.93

--------------------------------------------------------------------------------

Given a subclass of HasTraits with a trait referring to an instance of
HasTraits, e.g. child = Instance(AnotherClass) where AnotherClass has a
name trait, compare having a method with no decorator to one that is
decorated with `@on_trait_change("child.name")`, one decorated with
`@observe("child.name")`, and one with
`@observe(trait('child').trait('name'))`.

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for reassigning child to a new value.
(4) Time for reassigning child.name to a new value.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
 control -
(1): 9.48384   1.00 (2): 0.28387   1.00 (3): 0.12588   1.00 (4): 0.00628   1.00
`@on_trait_change('child.name')` -
(1): 9.63600   1.02 (2): 9.65629  34.02 (3): 2.60447  20.69 (4): 0.00977   1.55
`@observe('child.name')` -
(1): 9.63945   1.02 **(2): 8.05027  28.36** (3): 6.76104  53.71 (4): 0.00859   1.37
`@observe(trait('child').trait('name'))` -
(1): 10.45232   1.10 (2): 8.45396  29.78 (3): 7.92926  62.99 (4): 0.00750   1.19

--------------------------------------------------------------------------------

Given a subclass of HasTraits with a trait that is defined as Property
that depends on a simple trait, compare having the Property be defined
as `Property()`, `Property(depends_on="name")`, `Property(observe="name")`,
and `Property(observe=trait('name'))`. (Note that this is a feature
currently available on master only).

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for changing the trait being depended-on / observed.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 14.50994   1.00 (2): 0.13294   1.00 (3): 0.00452   1.00
`depends_on='name'` -
(1): 14.42461   0.99 (2): 6.18670  46.54 (3): 0.00623   1.38
`observe='name'` -
(1): 15.31489   1.06 **(2): 2.93529  22.08** (3): 0.00556   1.23
`observe=trait('name')` -
(1): 15.02808   1.04 (2): 2.90651  21.86 (3): 0.00618   1.37

--------------------------------------------------------------------------------

Identical to the simple property case only using the `@cached_property`
decorator on the property's getter method.

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for changing the trait being depended-on / observed.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 14.41725   1.00 (2): 0.12930   1.00 (3): 0.00509   1.00
`depends_on='name'` -
(1): 14.60439   1.01 (2): 12.38442  95.78 (3): 0.00686   1.35
`observe='name'` -
(1): 15.16266   1.05 **(2): 2.93375  22.69** (3): 0.00617   1.21
`observe=trait('name')` -
(1): 15.26573   1.06 (2): 2.85343  22.07 (3): 0.00622   1.22

--------------------------------------------------------------------------------

Given a subclass of HasTraits with a trait that is defined as Property
that depends on an extended trait, compare having the Property be
defined as `Property()`, `Property(depends_on="child.name")`,
`Property(observe="child.name")`, and
`Property(observe=trait('child').trait('name'))`. (Note that this is a
feature currently available on master only).

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for reassigning child to a new value.
(4) Time for reassigning child.name to a new value.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 15.36892   1.00 (2): 0.27916   1.00 (3): 0.13284   1.00 (4): 0.00653   1.00
`depends_on='child.name'` -
(1): 15.43856   1.00 (2): 10.26390  36.77 (3): 2.20055  16.57 (4): 0.00879   1.35
`observe='child.name'` -
(1): 16.02348   1.04 **(2): 7.97794  28.58** (3): 6.91317  52.04 (4): 0.00817   1.25
`observe=trait('child').trait('name')` -
(1): 16.53586   1.08 (2): 7.83010  28.05 (3): 6.83465  51.45 (4): 0.00754   1.15

--------------------------------------------------------------------------------

Identical to the extended property case only using the `@cached_property`
decorator on the property's getter method.

The timing we are interested in:
(1) Time to import the module, i.e. the class construction.
(2) Time to instantiate the HasTraits object.
(3) Time for reassigning child to a new value.
(4) Time for reassigning child.name to a new value.

Times are reported as:
(#): absolute_time  relative_time_to_control
        
control -
(1): 15.75994   1.00 (2): 0.27890   1.00 (3): 0.13005   1.00 (4): 0.00641   1.00
`depends_on='child.name'` -
(1): 15.57283   0.99 (2): 20.48732  73.46 (3): 4.33380  33.32 (4): 0.00860   1.34
`observe='child.name'` -
(1): 16.04158   1.02 **(2): 8.01820  28.75** (3): 6.89069  52.99 (4): 0.00805   1.26
`observe=trait('child').trait('name')` -
(1): 16.58640   1.05 (2): 7.91414  28.38 (3): 6.77448  52.09 (4): 0.00772   1.21

--------------------------------------------------------------------------------

</details>