### PR TITLE
Make TraitListEvent arguments keyword only

### DIFF
--- a/traits/tests/test_trait_dict_list_set_event.py
+++ b/traits/tests/test_trait_dict_list_set_event.py
@@ -42,6 +42,10 @@ class TestTraitEvent(unittest.TestCase):
         self.assertEqual(repr(event), event_str)
         self.assertIsInstance(eval(repr(event)), TraitListEvent)
 
+    def test_list_event_kwargs_only(self):
+        with self.assertRaises(TypeError):
+            TraitListEvent(slice(0, 3, 2), [1, 3], [4, 5])
+
     def test_dict_event_kwargs_only(self):
         with self.assertRaises(TypeError):
             TraitDictEvent({}, {'black': 0}, {'blue': 2})

--- a/traits/tests/test_trait_list_object.py
+++ b/traits/tests/test_trait_list_object.py
@@ -77,7 +77,7 @@ def list_item_validator(item):
 
 class TestTraitListEvent(unittest.TestCase):
     def test_creation(self):
-        event = TraitListEvent(2, [3], [4])
+        event = TraitListEvent(index=2, removed=[3], added=[4])
         self.assertEqual(event.index, 2)
         self.assertEqual(event.removed, [3])
         self.assertEqual(event.added, [4])

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -42,7 +42,7 @@ class TraitListEvent(object):
         this is an empty list.
     """
 
-    def __init__(self, index=0, removed=None, added=None):
+    def __init__(self, *, index=0, removed=None, added=None):
         self.index = index
 
         if removed is None:
@@ -616,7 +616,7 @@ class TraitListObject(TraitList):
             # See enthought/traits#25, enthought/traits#281
             return
 
-        event = TraitListEvent(index, removed, added)
+        event = TraitListEvent(index=index, removed=removed, added=added)
         items_event = self.trait.items_event()
         object.trait_items_event(self.name_items, event, items_event)
 


### PR DESCRIPTION
fixes #1035 

This PR makes the `TraitListEvent` arguments keyword only to match what is done for `TraitSetEvent` and `TraitDictEvent`, and for safety.

**Checklist**
- [x] Tests
~- [ ] Update API reference (`docs/source/traits_api_reference`)~
~- [ ] Update User manual (`docs/source/traits_user_manual`)~
~- [ ] Update type annotation hints in `traits-stubs`~
