### PR TITLE
Support -h for getting help

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -82,6 +82,11 @@ from contextlib import contextmanager
 
 import click
 
+# Ensure that "-h" is supported for getting help. 
+CONTEXT_SETTINGS = dict(
+    help_option_names=["-h", "--help"],
+)
+
 # Dependencies common to all configurations.
 common_dependencies = {
     "configobj",
@@ -140,7 +145,7 @@ verbose_option = click.option(
 )
 
 
-@click.group()
+@click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
     """
     Developer and CI support commands for Traits.

--- a/etstool.py
+++ b/etstool.py
@@ -82,7 +82,7 @@ from contextlib import contextmanager
 
 import click
 
-# Ensure that "-h" is supported for getting help. 
+# Ensure that "-h" is supported for getting help.
 CONTEXT_SETTINGS = dict(
     help_option_names=["-h", "--help"],
 )


### PR DESCRIPTION
(For @achabotl)

Currently, `python -m etstool --help` works for getting help but `python -m etstool -h` does not. This breaks user expectations when working with a command line application. This PR makes `-h` work as expected.


**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
