### PR TITLE
Prevent test_enum failures if traitsui or GUI toolkit are not installed

### DIFF
--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -14,18 +14,9 @@ import unittest
 from traits.api import (
     Any, BaseEnum, Enum, HasTraits, List, Property, TraitError)
 from traits.etsconfig.api import ETSConfig
-from traits.testing.optional_dependencies import pyface, requires_traitsui
+from traits.testing.optional_dependencies import requires_traitsui
 
-is_qt = ETSConfig.toolkit.startswith('qt')
-
-if pyface is not None and is_qt:
-    from pyface.toolkit import toolkit_object
-
-    GuiTestAssistant = toolkit_object(
-        "util.gui_test_assistant:GuiTestAssistant")
-else:
-    class GuiTestAssistant:
-        pass
+is_null = ETSConfig.toolkit == 'null'
 
 
 class FooEnum(enum.Enum):
@@ -319,16 +310,12 @@ class EnumTestCase(unittest.TestCase):
 
 
 @requires_traitsui
-@unittest.skipIf(not is_qt, "GUI toolkit not available")
-class TestGui(GuiTestAssistant, unittest.TestCase):
+@unittest.skipIf(is_null, "GUI toolkit not available")
+class TestGui(unittest.TestCase):
 
     def test_create_editor(self):
-        obj = EnumCollectionGUIExample()
+        from traitsui.testing.api import UITester
 
-        # Create a UI window
-        ui = obj.edit_traits()
-        try:
-            self.gui.process_events()
-        finally:
-            with self.delete_widget(ui.control):
-                ui.dispose()
+        obj = EnumCollectionGUIExample()
+        with UITester().create_ui(obj):
+            pass

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -13,10 +13,15 @@ import unittest
 
 from traits.api import (
     Any, BaseEnum, Enum, HasTraits, List, Property, TraitError)
+from traits.etsconfig.api import ETSConfig
 from traits.testing.optional_dependencies import pyface, requires_traitsui
 
-if pyface is not None:
-    GuiTestAssistant = pyface.toolkit.toolkit_object(
+is_qt = ETSConfig.toolkit.startswith('qt')
+
+if pyface is not None and is_qt:
+    from pyface.toolkit import toolkit_object
+
+    GuiTestAssistant = toolkit_object(
         "util.gui_test_assistant:GuiTestAssistant")
 else:
     class GuiTestAssistant:
@@ -314,6 +319,7 @@ class EnumTestCase(unittest.TestCase):
 
 
 @requires_traitsui
+@unittest.skipIf(not is_qt, "GUI toolkit not available")
 class TestGui(GuiTestAssistant, unittest.TestCase):
 
     def test_create_editor(self):


### PR DESCRIPTION
Fixes #1266 

In this PR I first simply broke `pyface.toolkit.toolkit_object` up into `from pyface.toolkit import toolkit_object` and then called `toolkit_object`.  This fixed the `AttributeError: module 'pyface' has no attribute 'toolkit'` error mentioned in the issue.  Currently `GUITestAssistant` is only implemented on Qt, so I also added an `is_qt` check before trying to get `GUITestAssistant` via `toolkit_object`, and I also skipped the test that needs `qt` if `qt` is not available.  This may or may not be the right solution as the code is basically coped over from https://github.com/enthought/traitsui/blob/770e94346e06dc70909f125ba7237edce90872da/traitsui/tests/_tools.py#L50-L54

The tests no longer failed if pyface is installed but traitsui is not, or if traitsui/pyface are installed by pyside2 (or pyqt5) is not.

**Checklist**
~- [ ] Tests~
~- [ ] Update API reference (`docs/source/traits_api_reference`)~
~- [ ] Update User manual (`docs/source/traits_user_manual`)~
~- [ ] Update type annotation hints in `traits-stubs`~
