### PR TITLE
reset currentmodule to traits.has_traits so Property Factory function is correctly documented

### DIFF
--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -1117,6 +1117,7 @@ Property Factory Function
 
 The Property() function has the following signature:
 
+.. currentmodule:: traits.has_traits
 .. function:: Property( [fget=None, fset=None, fvalidate=None, force=False, handler=None, trait=None, **metadata] )
 
 All parameters are optional, including the *fget* "getter", *fvalidate*


### PR DESCRIPTION
fixes #149 

This PR simply makes a 1 line addition to the documentation by resetting `currentmodule` to `traits.has_traits` instead of `traits.adaptation.api` so that the Property Factory Function is correctly documented.  After building the docs this is what you now see:

<img width="896" alt="Screen Shot 2020-11-13 at 3 02 10 PM" src="https://user-images.githubusercontent.com/36972686/99121086-98f45f80-25c1-11eb-9742-6b0f2d6006c7.png">

Excuse the highlighted "Property" in the screenshot.

**Checklist**
~- [ ] Tests~
~- [ ] Update API reference (`docs/source/traits_api_reference`)~
~- [ ] Update User manual (`docs/source/traits_user_manual`)~
~- [ ] Update type annotation hints in `traits-stubs`~
