### PR TITLE
Add errors for PrefixList, PrefixMap, and Map with empty lists/dicts

### DIFF
--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -200,6 +200,10 @@ class TestMap(unittest.TestCase):
         self.assertEqual(p.married_, 1)
         self.assertEqual(p.default_calls, 1)
 
+    def test_empty_map(self):
+        with self.assertRaises(TypeError):
+            Map({})
+
     def test_notification(self):
 
         preferences = Preferences()

--- a/traits/tests/test_map.py
+++ b/traits/tests/test_map.py
@@ -201,7 +201,7 @@ class TestMap(unittest.TestCase):
         self.assertEqual(p.default_calls, 1)
 
     def test_empty_map(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             Map({})
 
     def test_notification(self):

--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -88,8 +88,8 @@ class TestPrefixList(unittest.TestCase):
 
     def test_values_is_empty(self):
         # it doesn't make sense to use a PrefixList with an empty list, so make
-        # sure we raise a TypeError
-        with self.assertRaises(TypeError):
+        # sure we raise a ValueError
+        with self.assertRaises(ValueError):
             PrefixList([])
 
     def test_pickle_roundtrip(self):

--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -86,6 +86,12 @@ class TestPrefixList(unittest.TestCase):
             "got 'zero'."
         )
 
+    def test_values_is_empty(self):
+        # it doesn't make sense to use a PrefixList with an empty list, so make
+        # sure we raise a TypeError
+        with self.assertRaises(TypeError):
+            PrefixList([])
+
     def test_pickle_roundtrip(self):
         class A(HasTraits):
             foo = PrefixList(["zero", "one", "two"], default_value="one")

--- a/traits/tests/test_prefix_map.py
+++ b/traits/tests/test_prefix_map.py
@@ -209,6 +209,10 @@ class TestPrefixMap(unittest.TestCase):
         with self.assertRaises(TraitError):
             reconstituted.validate(p, "married", "ye")
 
+    def test_empty_map(self):
+        with self.assertRaises(TypeError):
+            PrefixMap({})
+
     def test_pickle_shadow_trait(self):
         class Person(HasTraits):
             married = PrefixMap({"yes": 1, "yeah": 1, "no": 0, "nah": 0},

--- a/traits/tests/test_prefix_map.py
+++ b/traits/tests/test_prefix_map.py
@@ -210,7 +210,7 @@ class TestPrefixMap(unittest.TestCase):
             reconstituted.validate(p, "married", "ye")
 
     def test_empty_map(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             PrefixMap({})
 
     def test_pickle_shadow_trait(self):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2601,7 +2601,7 @@ class PrefixList(TraitType):
         else:
             raise ValueError(
                 "The iterable of legal string values can not be empty."
-        )
+            )
 
         super().__init__(default, **metadata)
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2599,7 +2599,7 @@ class PrefixList(TraitType):
         elif self.values:
             default = self.values[0]
         else:
-            raise TypeError(
+            raise ValueError(
                 "The iterable of legal string values can not be empty."
         )
 
@@ -2932,7 +2932,7 @@ class Map(TraitType):
             if len(self.map) > 0:
                 default_value = next(iter(self.map))
             else:
-                raise TypeError(
+                raise ValueError(
                     "The dictionary of valid values can not be empty."
                 )
 
@@ -3017,7 +3017,7 @@ class PrefixMap(TraitType):
             if len(self.map) > 0:
                 default_value = next(iter(self.map))
             else:
-                raise TypeError(
+                raise ValueError(
                     "The dictionary of valid values can not be empty."
                 )
         else:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2934,7 +2934,7 @@ class Map(TraitType):
             else:
                 raise ValueError(
                     "The dictionary of valid values can not be empty."
-                )
+                ) from None
 
         super().__init__(default_value, **metadata)
 
@@ -3019,7 +3019,7 @@ class PrefixMap(TraitType):
             else:
                 raise ValueError(
                     "The dictionary of valid values can not be empty."
-                )
+                ) from None
         else:
             default_value = self.value_for(default_value)
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2598,6 +2598,10 @@ class PrefixList(TraitType):
             default = self.value_for(default)
         elif self.values:
             default = self.values[0]
+        else:
+            raise TypeError(
+                "The iterable of legal string values can not be empty."
+        )
 
         super().__init__(default, **metadata)
 
@@ -2925,7 +2929,12 @@ class Map(TraitType):
         try:
             default_value = metadata.pop("default_value")
         except KeyError:
-            default_value = next(iter(self.map))
+            if len(self.map) > 0:
+                default_value = next(iter(self.map))
+            else:
+                raise TypeError(
+                    "The dictionary of valid values can not be empty."
+                )
 
         super().__init__(default_value, **metadata)
 
@@ -3005,7 +3014,12 @@ class PrefixMap(TraitType):
         try:
             default_value = metadata.pop("default_value")
         except KeyError:
-            default_value = next(iter(self.map))
+            if len(self.map) > 0:
+                default_value = next(iter(self.map))
+            else:
+                raise TypeError(
+                    "The dictionary of valid values can not be empty."
+                )
         else:
             default_value = self.value_for(default_value)
 


### PR DESCRIPTION
fixes #1191

`PrefixList`, previously if no default was given and the given list of strings was empty, had a default default value of `None`.  In this PR, if the given list to `PrefixList` is empty an error is raised.  Likewise, if `Map` or `PrefixMap` are fed empty dicts a `ValueError` is also raised.  Previously, for `Map` and `PrefixMap` if an empty dictionary was given, it would raise a `StopIteration` exception.  In this PR that is changed to a `ValueError` with a message explicitly specifying that the dictionary of valid values can not be empty.  

Additionally, this PR adds trivial tests to ensure errors are raised when empty lists/dictionaries are used. 

**Checklist**
- [x] Tests
~- [ ] Update API reference (`docs/source/traits_api_reference`)~
~- [ ] Update User manual (`docs/source/traits_user_manual`)~
~- [ ] Update type annotation hints in `traits-stubs`~