### PR TITLE
Fix Traits introduction description not being visible on etsdemo

### DIFF
--- a/traits/examples/introduction/index.rst
+++ b/traits/examples/introduction/index.rst
@@ -1,4 +1,3 @@
-"""
 Introduction to Traits
 ======================
 
@@ -15,4 +14,3 @@ for **Validation**, **Initialization**, **Documentation**,
 **Observation** and **Visualization**.  This tutorial is designed
 to introduce the basics of Traits, but also to explain *why* you
 might want to use Traits in your own code.
-"""


### PR DESCRIPTION
Closes #1357

This PR moves the `__init__.py` file to an `index.rst`. Now the description is visible on etsdemo:
![Screenshot 2020-11-17 at 10 23 33](https://user-images.githubusercontent.com/3673984/99379693-e83bd800-28c0-11eb-9933-6619561d5e3e.png)

This does NOT _close_ #1356 (one can still import `traits.examples.introduction` for it is still considered a 'namespace package'?).

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
