### PR TITLE
Add tests to show observer handlers are gone when a simple trait is removed

### DIFF
--- a/traits/observation/tests/test_named_trait_observer.py
+++ b/traits/observation/tests/test_named_trait_observer.py
@@ -452,7 +452,7 @@ class TestNamedTraitObserverTraitAdded(unittest.TestCase):
 
         # sanity check, the handler is called when the trait changes.
         foo.value1 += 1
-        self.assertEqual(handler.call_count, 1)
+        handler.assert_called_once()
         handler.reset_mock()
 
         # when

--- a/traits/observation/tests/test_named_trait_observer.py
+++ b/traits/observation/tests/test_named_trait_observer.py
@@ -434,6 +434,36 @@ class TestNamedTraitObserverTraitAdded(unittest.TestCase):
         foo.value += 1
         self.assertEqual(handler.call_count, 0)
 
+    def test_remove_trait_then_add_trait_again(self):
+        # Test a scenario where a trait exists when the observer is hooked,
+        # but then the trait is removed, and then added back again, the
+        # observer is gone, because the CTrait is gone.
+
+        # given
+        # the trait exists, we can set optional to false.
+        graph = create_graph(
+            create_observer(name="value1", notify=True, optional=False),
+        )
+        handler = mock.Mock()
+        foo = ClassWithTwoValue()
+        call_add_or_remove_notifiers(
+            object=foo, graph=graph, handler=handler, remove=False)
+
+        # sanity check, the handler is called when the trait changes.
+        foo.value1 += 1
+        self.assertEqual(handler.call_count, 1)
+        handler.reset_mock()
+
+        # when
+        # remove the trait and then add it back
+        foo.remove_trait("value1")
+        foo.add_trait("value1", Int())
+
+        # then
+        # the handler is gone
+        foo.value1 += 1
+        self.assertEqual(handler.call_count, 0)
+
     def test_notifier_trait_added_distinguished(self):
         # Add two observers, both will have their own additional trait_added
         # observer. When one is removed, the other one is not affected.

--- a/traits/observation/tests/test_named_trait_observer.py
+++ b/traits/observation/tests/test_named_trait_observer.py
@@ -462,7 +462,7 @@ class TestNamedTraitObserverTraitAdded(unittest.TestCase):
         # then
         # the handler is gone with the instance trait.
         foo.value1 += 1
-        self.assertEqual(handler.call_count, 0)
+        handler.assert_not_called()
 
         # when
         # Add the trait back...
@@ -472,7 +472,7 @@ class TestNamedTraitObserverTraitAdded(unittest.TestCase):
         # won't bring the handler back, because the 'value1' is defined as a
         # class trait, trait_added is not fired when it is added.
         foo.value1 += 1
-        self.assertEqual(handler.call_count, 0)
+        handler.assert_not_called()
 
     def test_add_trait_remove_trait_then_add_trait_again(self):
         # Test a scenario when a trait is added, then removed, then added back.
@@ -489,7 +489,7 @@ class TestNamedTraitObserverTraitAdded(unittest.TestCase):
 
         foo.add_trait("new_value", Int())
         foo.new_value += 1
-        self.assertEqual(handler.call_count, 1)
+        handler.assert_called_once()
         handler.reset_mock()
 
         # when
@@ -501,7 +501,7 @@ class TestNamedTraitObserverTraitAdded(unittest.TestCase):
         # the handler is now back! The trait was not defined on the class,
         # so the last 'add_trait' fires a trait_added event.
         foo.new_value += 1
-        self.assertEqual(handler.call_count, 1)
+        handler.assert_called_once()
 
     def test_notifier_trait_added_distinguished(self):
         # Add two observers, both will have their own additional trait_added


### PR DESCRIPTION
Motivation: Earlier when I was looking into what we could do to optimize `observe` (e.g. #1343), I noticed that the code path for supporting `trait_added` takes a significant amount of time (relatively speaking), and I started wondering if that observer graph for supported `trait_added` is actually redundant when the trait is present (which is the majority of use case).

This PR simply adds the tests to demonstrate and preserve the existing behaviour when an existing trait is removed and added back, whether the handlers are still around.

This block of code is relevant:
https://github.com/enthought/traits/blob/d0b94558ed8f7005057228c9a01c52a59c6f4544/traits/has_traits.py#L2816-L2818
If a trait had been defined as a class trait, trait_added will not be fired even if the instance trait was removed and then added back (🤯 ).

I believe the observer graph for trait_added is indeed redundant when the trait exists already. However, fixing #1047 will change that story and affect what we could optimize around this functionality. 

**Checklist**
- [x] Tests
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
