### PR TITLE
Fix minor package_data nit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -331,9 +331,9 @@ setuptools.setup(
     },
     ext_modules=[setuptools.Extension("traits.ctraits", ["traits/ctraits.c"])],
     package_data={
-        "traits": [
-            "examples/introduction/*",
-            "examples/introduction/*/*",
+        "traits.examples": [
+            "introduction/*",
+            "introduction/*/*",
         ],
         "traits.tests": [
             "test-data/historical-pickles/README",


### PR DESCRIPTION
This PR fixes a minor `setup.py` nit: `package_data` should be listed by package. So now that `traits.examples` is a package, we can adjust the `package_data` listing accordingly.

xref: #1348, #1358

**Checklist**
- [ ] Tests N/A, but needs manual testing
- [ ] Update API reference (`docs/source/traits_api_reference`) N/A
- [ ] Update User manual (`docs/source/traits_user_manual`) N/A
- [ ] Update type annotation hints in `traits-stubs` N/A
