### PR TITLE
Revert the deprecation of TraitMap

### DIFF
--- a/docs/source/traits_api_reference/trait_handlers.rst
+++ b/docs/source/traits_api_reference/trait_handlers.rst
@@ -19,6 +19,9 @@ Classes
 
 .. autoclass:: TraitCompound
 
+.. autoclass:: TraitMap
+
+
 Private Functions
 -----------------
 
@@ -44,7 +47,4 @@ and may be removed in a future version of Traits.
 
 .. autoclass:: TraitPrefixList
 
-.. autoclass:: TraitMap
-
 .. autoclass:: TraitPrefixMap
-

--- a/traits/tests/test_deprecated_handlers.py
+++ b/traits/tests/test_deprecated_handlers.py
@@ -14,7 +14,6 @@ import warnings
 from traits.api import (
     TraitDict,
     TraitList,
-    TraitMap,
     TraitPrefixList,
     TraitPrefixMap,
     TraitTuple,
@@ -28,7 +27,6 @@ class TestTraitHandlerDeprecatedWarnings(unittest.TestCase):
             "TraitDict": TraitDict,
             "TraitList": TraitList,
             "TraitTuple": TraitTuple,
-            "TraitMap": lambda: TraitMap({}),
             "TraitPrefixList": lambda: TraitPrefixList("one", "two"),
             "TraitPrefixMap": lambda: TraitPrefixMap({}),
         }

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -475,12 +475,8 @@ class EnumTest(AnyTraitTest):
     _bad_values = [0, "zero", 4, None]
 
 
-# Suppress DeprecationWarning from (implicit) TraitMap instantiation
-with warnings.catch_warnings():
-    warnings.filterwarnings(action="ignore", category=DeprecationWarning)
-
-    class MappedTrait(HasTraits):
-        value = Trait("one", {"one": 1, "two": 2, "three": 3})
+class MappedTrait(HasTraits):
+    value = Trait("one", {"one": 1, "two": 2, "three": 3})
 
 
 class MappedTest(AnyTraitTest):
@@ -565,17 +561,13 @@ def str_cast_to_int(object, name, value):
     return len(value)
 
 
-# Suppress DeprecationWarning from TraitMap instantiation.
-with warnings.catch_warnings():
-    warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+class TraitWithMappingAndCallable(HasTraits):
 
-    class TraitWithMappingAndCallable(HasTraits):
-
-        value = Trait(
-            "white",
-            {"white": 0, "red": 1, (0, 0, 0): 999},
-            str_cast_to_int,
-        )
+    value = Trait(
+        "white",
+        {"white": 0, "red": 1, (0, 0, 0): 999},
+        str_cast_to_int,
+    )
 
 
 class TestTraitWithMappingAndCallable(unittest.TestCase):

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -668,8 +668,6 @@ class TraitMap(TraitHandler):
 
     is_mapped = True
 
-    @deprecated(_WARNING_FORMAT_STR.format(
-        handler="TraitMap", replacement="Map"))
     def __init__(self, map):
         self.map = map
         self.fast_validate = (ValidateTrait.map, map)


### PR DESCRIPTION
The deprecation of `TraitMap` in #974 was premature: Traits itself still uses `TraitMap` internally (through `Trait`), and the difficulty of removing that usage demonstrates that there isn't an obvious replacement.

This PR undoes the deprecation of `TraitMap`. Note that `TraitPrefixList` and `TraitPrefixMap` remain deprecated: those classes are not used internally, and `PrefixList` and `PrefixMap` should provide a reasonable replacement.

See also #1336.

Closes #1258.

**Checklist**
- [x] Tests (relevant test updated)
- [x] Update API reference (`docs/source/traits_api_reference`)
- [ ] Update User manual (`docs/source/traits_user_manual`) - not applicable
- [ ] Update type annotation hints in `traits-stubs` - not applicable
