### PR TITLE
Remove an unused module-level constant

### DIFF
--- a/traits-stubs/traits-stubs/has_traits.pyi
+++ b/traits-stubs/traits-stubs/has_traits.pyi
@@ -35,7 +35,6 @@ ViewTraits: str
 InstanceTraits: str
 DefaultTraitsView: str
 CantHaveDefaultValue: _Any
-EmptyList: _Any
 DeferredCopy: _Any
 extended_trait_pat: _Any
 any_trait: _Any

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -110,9 +110,6 @@ DefaultTraitsView = "traits_view"
 # Trait types which cannot have default values
 CantHaveDefaultValue = ("event", "delegate", "constant")
 
-# An empty list
-EmptyList = []
-
 # The trait types that should be copied last when doing a 'copy_traits':
 DeferredCopy = ("delegate", "property")
 


### PR DESCRIPTION
The only internal use of `EmptyList` disappeared at some point between Traits 4.3.0 and Traits 4.4.0.

This change will break external code that's doing `from traits.has_traits import EmptyList`. I'm finding it hard to care much about that.

**Checklist**
- [ ] Tests - n/a
- [ ] Update API reference (`docs/source/traits_api_reference`) - n/a
- [ ] Update User manual (`docs/source/traits_user_manual`) - n/a
- [x] Update type annotation hints in `traits-stubs` 
