### PR TITLE
Add GitHub Workflow badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 Traits: observable typed attributes for Python classes
 ======================================================
 
+.. image:: https://github.com/enthought/traits/workflows/Tests/badge.svg
+   :target: https://github.com/enthought/traits
+
 http://docs.enthought.com/traits
 
 The Traits project is at the center of all Enthought Tool Suite development


### PR DESCRIPTION
Not sure if Traits wants any of the badges here or not, please feel free to close as unwanted.

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
