### PR TITLE
Fix documentation build due to class being name shadowed by a singleton

### DIFF
--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -73,7 +73,7 @@ class NoDefaultSpecified(object):
     pass
 
 
-NoDefaultSpecified = NoDefaultSpecified()
+no_default_specified = NoDefaultSpecified()
 
 
 class TraitType(BaseTraitHandler):
@@ -173,7 +173,7 @@ class TraitType(BaseTraitHandler):
     #: The metadata for the trait.
     metadata = {}
 
-    def __init__(self, default_value=NoDefaultSpecified, **metadata):
+    def __init__(self, default_value=no_default_specified, **metadata):
         """ TraitType initializer
 
         This is the only method normally called directly by client code.
@@ -183,7 +183,7 @@ class TraitType(BaseTraitHandler):
         Override this method whenever a different method signature or a
         validated default value is needed.
         """
-        if default_value is not NoDefaultSpecified:
+        if default_value is not no_default_specified:
             self.default_value = default_value
 
         if len(metadata) > 0:
@@ -257,7 +257,7 @@ class TraitType(BaseTraitHandler):
 
         return (dvt, dv)
 
-    def clone(self, default_value=NoDefaultSpecified, **metadata):
+    def clone(self, default_value=no_default_specified, **metadata):
         """ Copy, optionally modifying default value and metadata.
 
         Clones the contents of this object into a new instance of the same
@@ -294,7 +294,7 @@ class TraitType(BaseTraitHandler):
 
         new._metadata.update(metadata)
 
-        if default_value is not NoDefaultSpecified:
+        if default_value is not no_default_specified:
             new.default_value = default_value
             if self.validate is not None:
                 try:


### PR DESCRIPTION
Fix #1377

The singleton instance name is the same as its type name. This is confusing sphinx, and is causing the following error with Sphinx 3.4.1 while building doc:

```
reading sources... [ 51%] traits_api_reference/trait_type                                                                                                                                                                                 
Exception occurred:
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/sphinx/util/typing.py", line 160, in _restify_py37
    return ':obj:`%s.%s`' % (cls.__module__, cls.__name__)
AttributeError: 'NoDefaultSpecified' object has no attribute '__name__'
The full traceback has been saved in /var/folders/_6/bw6pnpwx3pzfvhd20ffcpyjm0000gn/T/sphinx-err-4260mu_5.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [html] Error 2
```

**Checklist**
- ~Tests~
- ~Update API reference (`docs/source/traits_api_reference`)~
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
