### PR TITLE
Make NoDefaultSpecified and no_default_specified private

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Traits CHANGELOG
 ================
 
+Upcoming release X.Y.Z
+----------------------
+
+Removals
+~~~~~~~~
+* Make ``NoDefaultSpecified`` private and remove it from the public API.(#1380)
+
+
 Release 6.1.1
 -------------
 

--- a/docs/source/traits_api_reference/trait_type.rst
+++ b/docs/source/traits_api_reference/trait_type.rst
@@ -7,8 +7,6 @@
 Classes
 -------
 
-.. autoclass:: NoDefaultSpecified
-
 .. autoclass:: TraitType
 
 Private Functions

--- a/traits-stubs/traits-stubs/trait_type.pyi
+++ b/traits-stubs/traits-stubs/trait_type.pyi
@@ -14,11 +14,6 @@ from .base_trait_handler import BaseTraitHandler as BaseTraitHandler
 
 trait_types: Dict[str, int]
 
-
-class NoDefaultSpecified:
-    ...
-
-
 _Accepts = TypeVar('_Accepts')
 
 _Stores = TypeVar('_Stores')

--- a/traits/tests/test_readonly.py
+++ b/traits/tests/test_readonly.py
@@ -1,0 +1,48 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tests for the ReadOnly trait type.
+
+"""
+import unittest
+
+from traits.api import (
+    HasTraits,
+    ReadOnly,
+    TraitError,
+)
+
+
+class ObjectWithReadOnlyText(HasTraits):
+    """ A dummy object that set the readonly trait in __init__
+
+    There exists such usage in TraitsUI.
+    """
+
+    text = ReadOnly()
+
+    def __init__(self, text, **traits):
+        self.text = text
+        super(ObjectWithReadOnlyText, self).__init__(**traits)
+
+
+class TestReadOnlyTrait(unittest.TestCase):
+    """ Test ReadOnly TraitType. """
+
+    def test_set_readonly_trait_in_init(self):
+
+        obj = ObjectWithReadOnlyText(text="ABC")
+        self.assertEqual(obj.text, "ABC")
+
+        with self.assertRaises(TraitError):
+            obj.text = "XYZ"
+
+        self.assertEqual(obj.text, "ABC")

--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -69,11 +69,11 @@ def _read_only(object, name, value):
 
 
 # Create a singleton object for use in the TraitType constructor:
-class NoDefaultSpecified(object):
+class _NoDefaultSpecified(object):
     pass
 
 
-no_default_specified = NoDefaultSpecified()
+_no_default_specified = _NoDefaultSpecified()
 
 
 class TraitType(BaseTraitHandler):
@@ -173,7 +173,7 @@ class TraitType(BaseTraitHandler):
     #: The metadata for the trait.
     metadata = {}
 
-    def __init__(self, default_value=no_default_specified, **metadata):
+    def __init__(self, default_value=_no_default_specified, **metadata):
         """ TraitType initializer
 
         This is the only method normally called directly by client code.
@@ -183,7 +183,7 @@ class TraitType(BaseTraitHandler):
         Override this method whenever a different method signature or a
         validated default value is needed.
         """
-        if default_value is not no_default_specified:
+        if default_value is not _no_default_specified:
             self.default_value = default_value
 
         if len(metadata) > 0:
@@ -257,7 +257,7 @@ class TraitType(BaseTraitHandler):
 
         return (dvt, dv)
 
-    def clone(self, default_value=no_default_specified, **metadata):
+    def clone(self, default_value=_no_default_specified, **metadata):
         """ Copy, optionally modifying default value and metadata.
 
         Clones the contents of this object into a new instance of the same
@@ -294,7 +294,7 @@ class TraitType(BaseTraitHandler):
 
         new._metadata.update(metadata)
 
-        if default_value is not no_default_specified:
+        if default_value is not _no_default_specified:
             new.default_value = default_value
             if self.validate is not None:
                 try:


### PR DESCRIPTION
Closes #1379

This PR fixes the issue by making `NoDefaultSpecified` and `no_default_specified` private by naming convention. We believe they are not (actively) used outside of traits. If they are indeed used, this PR will at least make those breakage fail in a more obvious and trackable fashion, and we will get to know why and how it gets used internally, and then we can fix the breakage accordingly.

Note that if I change this line to `if True:`:
https://github.com/enthought/traits/blob/a68bc501fddef1a7091c8748ed61d4793007a658/traits/trait_type.py#L297
I would get a test failure for the test that involves TraitsUI:
```
======================================================================
ERROR: test_create_editor (traits.tests.test_enum.TestGui)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traits/traits/tests/test_enum.py", line 320, in test_create_editor
    with UITester().create_ui(obj):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py", line 117, in __enter__
    return next(self.gen)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/testing/tester/ui_tester.py", line 88, in create_ui
    ui = object.edit_traits(**ui_kwargs)
  File "/Users/kchoi/Work/ETS/traits/traits/has_traits.py", line 1736, in edit_traits
    return view.ui(
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/view.py", line 462, in ui
    ui.ui(parent, kind)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/ui.py", line 244, in ui
    self.rebuild(self, parent)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/qt4/toolkit.py", line 163, in ui_live
    ui_live.ui_live(ui, parent)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/qt4/ui_live.py", line 43, in ui_live
    _ui_dialog(ui, parent, BaseDialog.NONMODAL)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/qt4/ui_live.py", line 65, in _ui_dialog
    BaseDialog.display_ui(ui, parent, style)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/qt4/ui_base.py", line 278, in display_ui
    ui.owner.init(ui, parent, style)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/qt4/ui_live.py", line 225, in init
    self.add_contents(panel(ui), bbox)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/qt4/ui_panel.py", line 253, in panel
    content = ui._groups
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/ui.py", line 832, in _get__groups
    shadow_group = self.view.content.get_shadow(self)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/group.py", line 288, in get_shadow
    content.append(value.get_shadow(ui))
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/group.py", line 297, in get_shadow
    return ShadowGroup(shadow=self, content=content, groups=groups)
  File "/Users/kchoi/Work/ETS/py39-venv/traits-env/lib/python3.9/site-packages/traitsui/group.py", line 546, in __init__
    self.shadow = shadow
traits.trait_errors.TraitError: Cannot modify the read only 'shadow' attribute of a 'ShadowGroup' object.
```
Instead of relying on this test which really belonged to TraitsUI, I added another one that would fail for the same reason.

Ideally there should be a test for `TraitType.clone`, but I struggle to understand how it is supposed to be used.  From what I saw, it is predominantly used by `TraitType.__call__` and `_TraitMaker`. The former is used in the metaclass and the latter is used by `Trait`... both are quite complex. Eventually I decided this can be an exercise for another day, the existing usage in TraitsUI deserves a test in Traits anyway and it would provide the protection we needed for the code we changed here.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- ~Update User manual (`docs/source/traits_user_manual`)~ : This NoDefaultSpecified is not mentioned in the user manual
- [x] Update type annotation hints in `traits-stubs`
