### PR TITLE
Fix typo in MetaHasTraits docstring

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -378,7 +378,7 @@ _HasTraits = None
 class MetaHasTraits(type):
     """ Controls the creation of HasTraits classes.
 
-    The heavy work is done by the `create_traits_meta_dict` function, which
+    The heavy work is done by the `update_traits_class_dict` function, which
     takes the ``class_dict`` dictionary of class members and extracts and
     processes the trait declarations in it. The trait declarations are then
     added back to the class dictionary and passed off to the __new__ method


### PR DESCRIPTION
This is a minor fix for a typo in the MetaHasTraits docstring. It references a "create_traits_meta_dict" function that does not seem to exist.