### PR TITLE
Remove warning about TraitsDoc

### DIFF
--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -49,12 +49,6 @@ class TraitDocumenter(ClassLevelDocumenter):
 
     To use the documenter, append the module path in the extension
     attribute of the `conf.py`.
-
-    .. warning::
-
-        Using the TraitDocumenter in conjunction with TraitsDoc is not
-        advised.
-
     """
 
     # ClassLevelDocumenter interface #####################################


### PR DESCRIPTION
This PR removes a potentially confusing warning about TraitsDoc, which is now ancient history.

From some historical code diving and searching, TraitsDoc here refers to a single file `traitsdoc.py` which contained a Sphinx extension; the file was typically copied directly into the `docs` directory of projects that needed it. `traits.util.trait_documenter` is the official "right way" to do this.

**Checklist**
- [ ] ~Tests~ Not applicable
- [x] Update API reference (`docs/source/traits_api_reference`)
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~ Not needed - TraitsDoc not referred to from the user manual
- [ ] ~Update type annotation hints in `traits-stubs`~  Not applicable
