### PR TITLE
Make NoDefaultSpecified public

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,6 @@
 Traits CHANGELOG
 ================
 
-Upcoming release X.Y.Z
-----------------------
-
-Removals
-~~~~~~~~
-* Make ``NoDefaultSpecified`` private and remove it from the public API.(#1380)
-
-
 Release 6.1.1
 -------------
 

--- a/docs/source/traits_api_reference/trait_type.rst
+++ b/docs/source/traits_api_reference/trait_type.rst
@@ -7,7 +7,7 @@
 Classes
 -------
 
-.. autoclass:: NoDefaultSpecified
+.. autodata:: NoDefaultSpecified
 
 .. autoclass:: TraitType
 

--- a/docs/source/traits_api_reference/trait_type.rst
+++ b/docs/source/traits_api_reference/trait_type.rst
@@ -7,6 +7,8 @@
 Classes
 -------
 
+.. autoclass:: NoDefaultSpecified
+
 .. autoclass:: TraitType
 
 Private Functions

--- a/docs/source/traits_user_manual/custom.rst
+++ b/docs/source/traits_user_manual/custom.rst
@@ -67,6 +67,16 @@ property, depending on the specific methods and class constants that you define.
 A trait type uses a validate() method, while a trait property uses get() and
 set() methods.
 
+The :class:`~.TraitType` initializer provides an optional argument
+``default_value`` to support easy setting of the default value of the trait
+type. The default value for that argument is :data:`~.NoDefaultSpecified`: we
+don't follow the common Python idiom of using ``None`` to represent no default
+here, since for many trait types ``None`` may be a valid default value. When
+subclassing :class:`~.TraitType` and overriding or extending its ``__init__``
+method, it's recommended to re-use the singleton :data:`~.NoDefaultSpecified`
+if you need a way to indicate that no default value was specified.
+
+
 .. index: trait type; defining
 
 .. _defining-a-trait-type:
@@ -148,7 +158,7 @@ In order for the property to trigger notifications you must call either:
 * object.trait_property_changed(name, old, value) to not cache the value.
 * self.set_value(object, name, value) to cache the value.
 
-Likewise if the property will not be read only the get method must use 
+Likewise if the property will not be read only the get method must use
 self.get_value(object, name) in order to behave correctly.
 
 The following example demonstrates the use of a property trait to set temperature::

--- a/traits-stubs/traits-stubs/trait_type.pyi
+++ b/traits-stubs/traits-stubs/trait_type.pyi
@@ -14,6 +14,11 @@ from .base_trait_handler import BaseTraitHandler as BaseTraitHandler
 
 trait_types: Dict[str, int]
 
+
+class NoDefaultSpecified:
+    ...
+
+
 _Accepts = TypeVar('_Accepts')
 
 _Stores = TypeVar('_Stores')

--- a/traits-stubs/traits-stubs/trait_type.pyi
+++ b/traits-stubs/traits-stubs/trait_type.pyi
@@ -14,7 +14,6 @@ from .base_trait_handler import BaseTraitHandler as BaseTraitHandler
 
 trait_types: Dict[str, int]
 
-
 _Accepts = TypeVar('_Accepts')
 
 _Stores = TypeVar('_Stores')

--- a/traits-stubs/traits-stubs/trait_type.pyi
+++ b/traits-stubs/traits-stubs/trait_type.pyi
@@ -15,10 +15,6 @@ from .base_trait_handler import BaseTraitHandler as BaseTraitHandler
 trait_types: Dict[str, int]
 
 
-class NoDefaultSpecified:
-    ...
-
-
 _Accepts = TypeVar('_Accepts')
 
 _Stores = TypeVar('_Stores')

--- a/traits/api.py
+++ b/traits/api.py
@@ -196,7 +196,7 @@ from .has_traits import (
 
 from .base_trait_handler import BaseTraitHandler
 from .trait_handler import TraitHandler
-from .trait_type import TraitType
+from .trait_type import TraitType, NoDefaultSpecified
 from .trait_handlers import (
     TraitCoerceType,
     TraitCastType,

--- a/traits/tests/test_trait_types.py
+++ b/traits/tests/test_trait_types.py
@@ -19,8 +19,8 @@ import shutil
 import subprocess
 import unittest
 
-from traits.trait_type import TraitType
-from traits.trait_types import Float
+from traits.api import (
+    DefaultValue, Float, NoDefaultSpecified, TraitType, Undefined)
 from traits.testing.optional_dependencies import requires_numpy
 
 
@@ -61,3 +61,35 @@ class TraitTypesTest(unittest.TestCase):
             shutil.rmtree(tmpdir)
 
         self.assertEqual(output.strip(), "Success")
+
+    def test_default_value_in_init(self):
+        # Tests for the behaviour of the default_value argument
+        # to TraitType.__init__.
+        trait_type = TraitType(default_value=23)
+        self.assertEqual(
+            trait_type.get_default_value(),
+            (DefaultValue.constant, 23),
+        )
+
+        # An explicit default value of None should work as expected.
+        trait_type = TraitType(default_value=None)
+        self.assertEqual(
+            trait_type.get_default_value(),
+            (DefaultValue.constant, None),
+        )
+
+        # If no default is given, get_default_value() returns a value
+        # of Undefined.
+        trait_type = TraitType()
+        self.assertEqual(
+            trait_type.get_default_value(),
+            (DefaultValue.constant, Undefined),
+        )
+
+        # Similarly, if NoDefaultSpecified is given, get_default_value()
+        # is Undefined.
+        trait_type = TraitType(default_value=NoDefaultSpecified)
+        self.assertEqual(
+            trait_type.get_default_value(),
+            (DefaultValue.constant, Undefined),
+        )

--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -73,7 +73,7 @@ class NoDefaultSpecified(object):
     pass
 
 
-no_default_specified = NoDefaultSpecified()
+NoDefaultSpecified = NoDefaultSpecified()
 
 
 class TraitType(BaseTraitHandler):
@@ -173,7 +173,7 @@ class TraitType(BaseTraitHandler):
     #: The metadata for the trait.
     metadata = {}
 
-    def __init__(self, default_value=no_default_specified, **metadata):
+    def __init__(self, default_value=NoDefaultSpecified, **metadata):
         """ TraitType initializer
 
         This is the only method normally called directly by client code.
@@ -183,7 +183,7 @@ class TraitType(BaseTraitHandler):
         Override this method whenever a different method signature or a
         validated default value is needed.
         """
-        if default_value is not no_default_specified:
+        if default_value is not NoDefaultSpecified:
             self.default_value = default_value
 
         if len(metadata) > 0:
@@ -257,7 +257,7 @@ class TraitType(BaseTraitHandler):
 
         return (dvt, dv)
 
-    def clone(self, default_value=no_default_specified, **metadata):
+    def clone(self, default_value=NoDefaultSpecified, **metadata):
         """ Copy, optionally modifying default value and metadata.
 
         Clones the contents of this object into a new instance of the same
@@ -294,7 +294,7 @@ class TraitType(BaseTraitHandler):
 
         new._metadata.update(metadata)
 
-        if default_value is not no_default_specified:
+        if default_value is not NoDefaultSpecified:
             new.default_value = default_value
             if self.validate is not None:
                 try:

--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -68,12 +68,17 @@ def _read_only(object, name, value):
     )
 
 
-# Create a singleton object for use in the TraitType constructor:
-class NoDefaultSpecified(object):
-    pass
+class _NoDefaultSpecifiedType(object):
+    """
+    An instance of this class is used to provide the singleton object
+    ``NoDefaultSpecified`` for use in the TraitType constructor.
+    """
 
 
-NoDefaultSpecified = NoDefaultSpecified()
+#: Singleton object that can be passed for the ``default_value`` argument
+#: in the :class:`TraitType` constructor, to indicate that no default value
+#: was specified.
+NoDefaultSpecified = _NoDefaultSpecifiedType()
 
 
 class TraitType(BaseTraitHandler):

--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -69,11 +69,11 @@ def _read_only(object, name, value):
 
 
 # Create a singleton object for use in the TraitType constructor:
-class _NoDefaultSpecified(object):
+class NoDefaultSpecified(object):
     pass
 
 
-_no_default_specified = _NoDefaultSpecified()
+no_default_specified = NoDefaultSpecified()
 
 
 class TraitType(BaseTraitHandler):
@@ -173,7 +173,7 @@ class TraitType(BaseTraitHandler):
     #: The metadata for the trait.
     metadata = {}
 
-    def __init__(self, default_value=_no_default_specified, **metadata):
+    def __init__(self, default_value=no_default_specified, **metadata):
         """ TraitType initializer
 
         This is the only method normally called directly by client code.
@@ -183,7 +183,7 @@ class TraitType(BaseTraitHandler):
         Override this method whenever a different method signature or a
         validated default value is needed.
         """
-        if default_value is not _no_default_specified:
+        if default_value is not no_default_specified:
             self.default_value = default_value
 
         if len(metadata) > 0:
@@ -257,7 +257,7 @@ class TraitType(BaseTraitHandler):
 
         return (dvt, dv)
 
-    def clone(self, default_value=_no_default_specified, **metadata):
+    def clone(self, default_value=no_default_specified, **metadata):
         """ Copy, optionally modifying default value and metadata.
 
         Clones the contents of this object into a new instance of the same
@@ -294,7 +294,7 @@ class TraitType(BaseTraitHandler):
 
         new._metadata.update(metadata)
 
-        if default_value is not _no_default_specified:
+        if default_value is not no_default_specified:
             new.default_value = default_value
             if self.validate is not None:
                 try:


### PR DESCRIPTION
We recently made `NoDefaultSpecified` private. In hindsight, that was the wrong thing to do, for various reasons:

- It's part of the signature of `TraitType` (specifically, it's the default value for the optional `default_value` argument), which is a public class that's designed to be subclassed. As such, it's a little odd to have the value private.
- The rationale for making it private was questionable: the immediate need was to fix the doc build, but the doc build only needed to be fixed by fixing the documentation itself.
- There's an open issue (#1041) to do the opposite: make `NoDefaultSpecified` truly public by adding it to `traits.api`.

This PR:
- Reverts PRs #1380 and #1378 (but keeps the extra test added in #1380)
- Renames the `NoDefaultSpecified` _class_, to avoid confusion (note that prior to #1378 and #1380, the class was immediately shadowed, so it was never publicly available)
- Adds the `NoDefaultSpecified` _instance_ to `traits.api`
- Adds tests that verify that passing a `default_value` argument of `NoDefaultSpecified` has the expected behaviour.
- Fixes the documentation to document `NoDefaultSpecified` using the `.. autodata` Sphinx directive instead of the incorrect `.. autoclass`. (This was the cause of the documentation build breakage observed in #1377.)

Closes #1041.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] Update User manual (`docs/source/traits_user_manual`)
- [x] Update type annotation hints in `traits-stubs`
