### PR TITLE
Fix validation of dynamic Enum inside a Tuple

### DIFF
--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -336,7 +336,6 @@ class EnumTestCase(unittest.TestCase):
             #: Sequence of those digits
             digit_sequence = List(Enum(values="digits"))
 
-
         model = HasEnumInList(digits={-1, 0, 1})
         model.digit_sequence = [-1, 0, 1, 1]
         with self.assertRaises(TraitError):

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -12,8 +12,7 @@ import enum
 import unittest
 
 from traits.api import (
-    Any, BaseEnum, Enum, HasTraits, Int, List, Property, Set,
-    TraitError, Tuple)
+    Any, BaseEnum, Enum, HasTraits, Int, List, Property, TraitError, Tuple)
 from traits.etsconfig.api import ETSConfig
 from traits.testing.optional_dependencies import requires_traitsui
 
@@ -327,19 +326,6 @@ class EnumTestCase(unittest.TestCase):
         with self.assertRaises(TraitError):
             model.year_and_month = 1986, 13
 
-    def test_dynamic_enum_in_list(self):
-        # Another regression test for #1385.
-        class HasEnumInList(HasTraits):
-            #: Valid digits
-            digits = Set(Int)
-
-            #: Sequence of those digits
-            digit_sequence = List(Enum(values="digits"))
-
-        model = HasEnumInList(digits={-1, 0, 1})
-        model.trinary_int = [-1, 0, 1, 1]
-        with self.assertRaises(TraitError):
-            model.trinary_int = [-1, 0, 2, 1]
 
 @requires_traitsui
 @unittest.skipIf(is_null, "GUI toolkit not available")

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -12,7 +12,8 @@ import enum
 import unittest
 
 from traits.api import (
-    Any, BaseEnum, Enum, HasTraits, Int, List, Property, TraitError, Tuple)
+    Any, BaseEnum, Enum, HasTraits, Int, List, Property, Set, TraitError,
+    Tuple)
 from traits.etsconfig.api import ETSConfig
 from traits.testing.optional_dependencies import requires_traitsui
 
@@ -325,6 +326,21 @@ class EnumTestCase(unittest.TestCase):
         self.assertEqual(model.year_and_month, (1974, 8))
         with self.assertRaises(TraitError):
             model.year_and_month = 1986, 13
+
+    def test_dynamic_enum_in_list(self):
+        # Another regression test for #1385.
+        class HasEnumInList(HasTraits):
+            #: Valid digits
+            digits = Set(Int)
+
+            #: Sequence of those digits
+            digit_sequence = List(Enum(values="digits"))
+
+
+        model = HasEnumInList(digits={-1, 0, 1})
+        model.digit_sequence = [-1, 0, 1, 1]
+        with self.assertRaises(TraitError):
+            model.digit_sequence = [-1, 0, 2, 1]
 
 
 @requires_traitsui

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -12,7 +12,7 @@ import enum
 import unittest
 
 from traits.api import (
-    Any, BaseEnum, Enum, HasTraits, List, Property, TraitError)
+    Any, BaseEnum, Enum, HasTraits, Int, List, Property, TraitError, Tuple)
 from traits.etsconfig.api import ETSConfig
 from traits.testing.optional_dependencies import requires_traitsui
 
@@ -307,6 +307,24 @@ class EnumTestCase(unittest.TestCase):
         with self.assertRaises(TraitError):
             obj.slow_enum = "perhaps"
         self.assertEqual(obj.slow_enum, "no")
+
+    def test_enum_in_tuple(self):
+        # Regression test for #1385. The previous implementation of Enum
+        # did no validation until trait-set time, but for an Enum inside
+        # a Tuple, the inner traits are never set.
+
+        class HasEnumInTuple(HasTraits):
+            #: List of valid month numbers.
+            months = List(Int, value=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+
+            #: (Year, month) pairs.
+            year_and_month = Tuple(Int(), Enum(values='months'))
+
+        model = HasEnumInTuple()
+        model.year_and_month = (1974, 8)
+        self.assertEqual(model.year_and_month, (1974, 8))
+        with self.assertRaises(TraitError):
+            model.year_and_month = 1986, 13
 
 
 @requires_traitsui

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -12,7 +12,8 @@ import enum
 import unittest
 
 from traits.api import (
-    Any, BaseEnum, Enum, HasTraits, Int, List, Property, TraitError, Tuple)
+    Any, BaseEnum, Enum, HasTraits, Int, List, Property, Set,
+    TraitError, Tuple)
 from traits.etsconfig.api import ETSConfig
 from traits.testing.optional_dependencies import requires_traitsui
 
@@ -308,7 +309,7 @@ class EnumTestCase(unittest.TestCase):
             obj.slow_enum = "perhaps"
         self.assertEqual(obj.slow_enum, "no")
 
-    def test_enum_in_tuple(self):
+    def test_dynamic_enum_in_tuple(self):
         # Regression test for #1385. The previous implementation of Enum
         # did no validation until trait-set time, but for an Enum inside
         # a Tuple, the inner traits are never set.
@@ -326,6 +327,19 @@ class EnumTestCase(unittest.TestCase):
         with self.assertRaises(TraitError):
             model.year_and_month = 1986, 13
 
+    def test_dynamic_enum_in_list(self):
+        # Another regression test for #1385.
+        class HasEnumInList(HasTraits):
+            #: Valid digits
+            digits = Set(Int)
+
+            #: Sequence of those digits
+            digit_sequence = List(Enum(values="digits"))
+
+        model = HasEnumInList(digits={-1, 0, 1})
+        model.trinary_int = [-1, 0, 1, 1]
+        with self.assertRaises(TraitError):
+            model.trinary_int = [-1, 0, 2, 1]
 
 @requires_traitsui
 @unittest.skipIf(is_null, "GUI toolkit not available")

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2075,15 +2075,13 @@ class BaseEnum(TraitType):
         return value
 
     def _set(self, object, name, value):
-        """ Sets the current value of a dynamic range trait.
+        """ Sets the current value of a dynamic enum trait.
         """
-        if safe_contains(value, xgetattr(object, self.name)):
-            self.set_value(object, name, value)
-        else:
-            self.error(object, name, value)
+        value = self._validate(object, name, value)
+        self.set_value(object, name, value)
 
     def _validate(self, object, name, value):
-        """ Validate the specified value.
+        """ Validate a value for a dynamic enum trait.
         """
         if safe_contains(value, xgetattr(object, self.name)):
             return value

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1976,7 +1976,8 @@ class BaseEnum(TraitType):
         if self.name is not None:
             # Dynamic enumeration
             self.values = None
-            self.get, self.set, self.validate = self._get, self._set, None
+            self.get, self.set, self.validate = (
+                self._get, self._set, self._validate)
             if nargs == 0:
                 super().__init__(**metadata)
             elif nargs == 1:
@@ -2078,6 +2079,14 @@ class BaseEnum(TraitType):
         """
         if safe_contains(value, xgetattr(object, self.name)):
             self.set_value(object, name, value)
+        else:
+            self.error(object, name, value)
+
+    def _validate(self, object, name, value):
+        """ Validate the specified value.
+        """
+        if safe_contains(value, xgetattr(object, self.name)):
+            return value
         else:
             self.error(object, name, value)
 


### PR DESCRIPTION
This PR fixes validation of dynamic enumerations inside a Tuple. Previously, for the dynamic case of an `Enum`, no validation was performed until trait-set time. This PR changes the logic so that the validate method (which the Tuple uses for its item validation) is no longer None.

This fixes the issue originally reported in #1385. There are other issues identified in the #1385 comments that still need to be fixed (or have new issues opened) before #1385 can be closed.

**Checklist**
- [x] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)  N/A
- [ ] Update User manual (`docs/source/traits_user_manual`)  N/A
- [ ] Update type annotation hints in `traits-stubs`  N/A
