### PR TITLE
Fix dynamic range in container Trait

### DIFF
--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -107,11 +107,11 @@ class RangeTestCase(unittest.TestCase):
 
 
         model = HasRangeInTuple(low=0, high=48)
-        model.hours = (40, "fred")
-        self.assertEqual(model.hours, (40, "fred"))
+        model.hours_and_name = (40, "fred")
+        self.assertEqual(model.hours_and_name, (40, "fred"))
         with self.assertRaises(TraitError):
             # First argument out or range; should raise.
-            model.hours = (50, "george")
+            model.hours_and_name = (50, "george")
 
     def test_dynamic_range_in_list(self):
         # Another regression test for #1391.

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -10,7 +10,7 @@
 
 import unittest
 
-from traits.api import HasTraits, Int, Range, Str, TraitError
+from traits.api import HasTraits, Int, List, Range, Str, TraitError, Tuple
 
 
 class WithFloatRange(HasTraits):
@@ -97,3 +97,34 @@ class RangeTestCase(unittest.TestCase):
         with self.assertRaises(TraitError):
             obj.r = obj.high
         self.assertEqual(obj.r, 5)
+
+    def test_dynamic_range_in_tuple(self):
+        # Regression test for #1391
+        class HasRangeInTuple(HasTraits):
+            low = Int()
+            high = Int()
+            hours_and_name = Tuple(Range(low="low", high="high"), Str)
+
+
+        model = HasRangeInTuple(low=0, high=48)
+        model.hours = (40, "fred")
+        self.assertEqual(model.hours, (40, "fred"))
+        with self.assertRaises(TraitError):
+            # First argument out or range; should raise.
+            model.hours = (50, "george")
+
+    def test_dynamic_range_in_list(self):
+        # Another regression test for #1391.
+        class HasEnumInList(HasTraits):
+            #: Valid digit range
+            low = Int()
+
+            high = Int()
+
+            #: Sequence of digits
+            digit_sequence = List(Range(low="low", high="high"))
+
+        model = HasEnumInList(low=-1, high=1)
+        model.digit_sequence = [-1, 0, 1, 1]
+        with self.assertRaises(TraitError):
+            model.digit_sequence = [-1, 0, 2, 1]

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -105,7 +105,6 @@ class RangeTestCase(unittest.TestCase):
             high = Int()
             hours_and_name = Tuple(Range(low="low", high="high"), Str)
 
-
         model = HasRangeInTuple(low=0, high=48)
         model.hours_and_name = (40, "fred")
         self.assertEqual(model.hours_and_name, (40, "fred"))

--- a/traits/tests/test_range.py
+++ b/traits/tests/test_range.py
@@ -114,7 +114,7 @@ class RangeTestCase(unittest.TestCase):
 
     def test_dynamic_range_in_list(self):
         # Another regression test for #1391.
-        class HasEnumInList(HasTraits):
+        class HasRangeInList(HasTraits):
             #: Valid digit range
             low = Int()
 
@@ -123,7 +123,7 @@ class RangeTestCase(unittest.TestCase):
             #: Sequence of digits
             digit_sequence = List(Range(low="low", high="high"))
 
-        model = HasEnumInList(low=-1, high=1)
+        model = HasRangeInList(low=-1, high=1)
         model.digit_sequence = [-1, 0, 1, 1]
         with self.assertRaises(TraitError):
             model.digit_sequence = [-1, 0, 2, 1]

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1633,7 +1633,8 @@ class BaseRange(TraitType):
             if high is not None:
                 high = int(high)
         else:
-            self.get, self.set, self.validate = self._get, self._set, None
+            self.get, self.set, self.validate = (
+                self._get, self._set, self._validate)
             self._vtype = None
             self._type_desc = "a number"
 
@@ -1764,14 +1765,19 @@ class BaseRange(TraitType):
     def _set(self, object, name, value):
         """ Sets the current value of a dynamic range trait.
         """
+        value = self._validate(object, name, value)
+        self._set_value(object, name, value)
+
+    def _validate(self, object, name, value):
+        """ Validate a value for a dynamic range trait.
+        """
         if not isinstance(value, str):
             try:
                 low = eval(self._low)
                 high = eval(self._high)
                 if (low is None) and (high is None):
                     if isinstance(value, RangeTypes):
-                        self._set_value(object, name, value)
-                        return
+                        return value
                 else:
                     new_value = self._typed_value(value, low, high)
                     if (
@@ -1783,8 +1789,7 @@ class BaseRange(TraitType):
                         or (self._exclude_high and (high > new_value))
                         or ((not self._exclude_high) and (high >= new_value))
                     ):
-                        self._set_value(object, name, new_value)
-                        return
+                        return new_value
             except:
                 pass
 


### PR DESCRIPTION
This PR implements `r.validate` on a dynamic `BaseRange` instance `r`, so that the trait knows how to do validation. Previously, all validation was done at trait-set time, so a standalone dynamic `Range` trait would be validated correctly, but a dynamic `Range` inside a `List` or `Tuple`  (or other container) wouldn't be validated at all.

Fixes #1391.

**Checklist**
- [x] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`) N/A
- [ ] Update User manual (`docs/source/traits_user_manual`) N/A
- [ ] Update type annotation hints in `traits-stubs`  N/A
