### PR TITLE
Fix exception-swallowing behaviour of tuple validation

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3513,12 +3513,11 @@ validate_trait_tuple_check(
                 }
                 else {
                     aitem = itrait->validate(itrait, obj, name, bitem);
-                }
-
-                if (aitem == NULL) {
-                    PyErr_Clear();
-                    Py_XDECREF(tuple);
-                    return NULL;
+                    if (aitem == NULL) {
+                        PyErr_Clear();
+                        Py_XDECREF(tuple);
+                        return NULL;
+                    }
                 }
 
                 if (tuple != NULL) {

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3516,7 +3516,9 @@ validate_trait_tuple_check(
                 else {
                     aitem = itrait->validate(itrait, obj, name, bitem);
                     if (aitem == NULL) {
-                        PyErr_Clear();
+                        if (PyErr_ExceptionMatches(TraitError)) {
+                            PyErr_Clear();
+                        }
                         Py_XDECREF(tuple);
                         return NULL;
                     }
@@ -3560,7 +3562,7 @@ validate_trait_tuple(
 {
     PyObject *result = validate_trait_tuple_check(
         PyTuple_GET_ITEM(trait->py_validate, 1), obj, name, value);
-    if (result != NULL) {
+    if (result != NULL || PyErr_Occurred()) {
         return result;
     }
 
@@ -3917,7 +3919,7 @@ validate_trait_complex(
             case 9: /* Tuple item check: */
                 result = validate_trait_tuple_check(
                     PyTuple_GET_ITEM(type_info, 1), obj, name, value);
-                if (result != NULL) {
+                if (result != NULL || PyErr_Occurred()) {
                     return result;
                 }
 

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3484,9 +3484,11 @@ validate_trait_prefix_map(
 |  Verifies a Python value is a tuple of a specified type and content:
 +----------------------------------------------------------------------------*/
 
-/* There are three possible types of outcome for this function.
+/* Note: this function does not follow standard CPython error-handling rules.
+   There are three possible types of outcome for this function.
 
-   If validation fails, NULL is returned and no Python exception is set.
+   If validation fails, NULL is returned and no Python exception is set
+     (contrary to usual Python C-API conventions).
    If an unexpected exception occurs, NULL is returned and a Python exception
      is set.
    If validation succeeds, the validated object is returne.

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3484,6 +3484,14 @@ validate_trait_prefix_map(
 |  Verifies a Python value is a tuple of a specified type and content:
 +----------------------------------------------------------------------------*/
 
+/* There are three possible types of outcome for this function.
+
+   If validation fails, NULL is returned and no Python exception is set.
+   If an unexpected exception occurs, NULL is returned and a Python exception
+     is set.
+   If validation succeeds, the validated object is returne.
+*/
+
 static PyObject *
 validate_trait_tuple_check(
     PyObject *traits, has_traits_object *obj, PyObject *name, PyObject *value)

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3515,13 +3515,14 @@ validate_trait_tuple_check(
                 }
                 else {
                     aitem = itrait->validate(itrait, obj, name, bitem);
-                    if (aitem == NULL) {
-                        if (PyErr_ExceptionMatches(TraitError)) {
-                            PyErr_Clear();
-                        }
-                        Py_XDECREF(tuple);
-                        return NULL;
+                }
+
+                if (aitem == NULL) {
+                    if (PyErr_ExceptionMatches(TraitError)) {
+                        PyErr_Clear();
                     }
+                    Py_XDECREF(tuple);
+                    return NULL;
                 }
 
                 if (tuple != NULL) {

--- a/traits/tests/test_tuple.py
+++ b/traits/tests/test_tuple.py
@@ -12,7 +12,7 @@
 """
 import unittest
 
-from traits.api import BaseInt, HasTraits, Tuple
+from traits.api import BaseInt, Either, HasTraits, Int, Tuple
 from traits.tests.tuple_test_mixin import TupleTestMixin
 
 
@@ -37,6 +37,11 @@ class TupleTestCase(TupleTestMixin, unittest.TestCase):
         class A(HasTraits):
             foo = Tuple(BadInt(), BadInt())
 
+            bar = Either(Int, Tuple(BadInt(), BadInt()))
+
         a = A()
         with self.assertRaises(ZeroDivisionError):
             a.foo = (3, 5)
+
+        with self.assertRaises(ZeroDivisionError):
+            a.bar = (3, 5)

--- a/traits/tests/test_tuple.py
+++ b/traits/tests/test_tuple.py
@@ -12,10 +12,31 @@
 """
 import unittest
 
+from traits.api import BaseInt, HasTraits, Tuple
 from traits.tests.tuple_test_mixin import TupleTestMixin
-from traits.trait_types import Tuple
+
+
+class BadInt(BaseInt):
+    """ Test class used to simulate a Tuple item with bad validation.
+    """
+
+    # Describe the trait type
+    info_text = 'a bad integer'
+
+    def validate(self, object, name, value):
+        # Simulate a coding error in the validation method
+        return 1 / 0
 
 
 class TupleTestCase(TupleTestMixin, unittest.TestCase):
     def setUp(self):
         self.trait = Tuple
+
+    def test_unexpected_validation_exceptions_are_propagated(self):
+        # Regression test for enthought/traits#1389.
+        class A(HasTraits):
+            foo = Tuple(BadInt(), BadInt())
+
+        a = A()
+        with self.assertRaises(ZeroDivisionError):
+            a.foo = (3, 5)


### PR DESCRIPTION
This PR fixes tuple validation so that exceptions that occur when validating tuple subitems are propagated, instead of swallowed and ultimately turned into `TraitError`s.

Fixes #1389.

**Checklist**
- [x] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)  N/A
- [ ] Update User manual (`docs/source/traits_user_manual`)  N/A
- [ ] Update type annotation hints in `traits-stubs`  N/A
