### PR TITLE
Fix errors on front page of user manual

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,7 +170,7 @@ if BUILD_DOCSET:
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "Traits {version} User Manual".format(version=version)
+html_title = "Traits {version} Documentation".format(version=version)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None

--- a/docs/source/traits_user_manual/intro.rst
+++ b/docs/source/traits_user_manual/intro.rst
@@ -10,10 +10,8 @@ repository <http://github.com/enthought/traits>`_. Additional documentation
 for the Traits package is available,
 including:
 
-* *Traits API Reference*
-* `TraitsUI User Manual
-  <http://docs.enthought.com/traitsui/traitsui_user_manual/index.html>`_
-* Traits Technical Notes
+* `Traits API Reference <https://docs.enthought.com/traits/traits_api_reference/index.html>`_
+* `Traits Technical Notes <https://docs.enthought.com/traits/changelog.html>`_
 
 What Are Traits?
 ----------------

--- a/docs/source/traits_user_manual/intro.rst
+++ b/docs/source/traits_user_manual/intro.rst
@@ -6,12 +6,9 @@ a special kind of type definition called a trait. This document introduces the
 concepts behind, and usage of, the Traits package.
 
 For more information on the Traits package, refer to the `Traits GitHub
-repository <http://github.com/enthought/traits>`_. Additional documentation
-for the Traits package is available,
-including:
-
-* `Traits API Reference <https://docs.enthought.com/traits/traits_api_reference/index.html>`_
-* `Traits Technical Notes <https://docs.enthought.com/traits/changelog.html>`_
+repository <http://github.com/enthought/traits>`_. For additional documentation
+on the Traits package, refer to the `Traits API Reference
+<https://docs.enthought.com/traits/traits_api_reference/index.html>`_
 
 What Are Traits?
 ----------------


### PR DESCRIPTION
fixes #1373 

This PR removes an unnecessary link to the TraitsUI user manual on the Intro page of the traits user manual.  It also adds links to the bullets for "Traits API Reference" and "Traits Technical Notes".  "Traits Technical Notes" is now linked to the changelog (I wasn't exactly sure what this was intended to be a reference to, this change should be confirmed by a reviewed)

Additionally, the buttons at the top of the page labels are changed.  The first button is now labelled "Traits 6.1 Documentation" as that is where that actually links to.  The second link comes from the title tag of individual pages (see: https://www.sphinx-doc.org/en/master/usage/configuration.html).  Building the docs and navigating to different pages the links seem to be labelled correctly now to the pages they actually link to.  

**Checklist**
- ~[ ] Tests~
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~
- [x] Update User manual (`docs/source/traits_user_manual`)
- ~[ ] Update type annotation hints in `traits-stubs`~
