### PR TITLE
Document HasTraits.traits excluding traits with name containing suffix "_items"

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2937,6 +2937,8 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
     def traits(self, **metadata):
         """Returns a dictionary containing the definitions of all of the trait
         attributes of this object that match the set of *metadata* criteria.
+        Note that any traits with a name containing the suffix "_items" are
+        always excluded.
 
         The keys of the returned dictionary are the trait attribute names, and
         the values are their corresponding trait definition objects.


### PR DESCRIPTION
closes #1327 

This PR simply adds one sentence to the docstring of `HasTraits.traits` mentioning that any trait with a suffix of "_items" will be excluded.

**Checklist**
- ~[ ] Tests~
- [x] Update API reference (`docs/source/traits_api_reference`)
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~
- ~[ ] Update type annotation hints in `traits-stubs`~
