### PR TITLE
Add workflow for building and uploading wheels

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -1,0 +1,93 @@
+name: Publish release to PyPI
+
+on:
+  pull_request
+
+jobs:
+  build-sdist:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the release commit
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Python packages needed for sdist build and upload
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python -m pip install twine
+    - name: Build sdist
+      run: |
+        python setup.py sdist
+    - name: Publish sdist to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine check --strict dist/*.tar.gz
+        python -m twine upload dist/*.tar.gz
+
+  build-wheel-windows-macos:
+
+    strategy:
+      # Build on 32-bit and 64-bit Windows, and 64-bit macOS
+      matrix:
+        os: [windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-architecture: [x86, x64]
+        exclude:
+          - os: macos-latest
+            python-architecture: x86
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Check out the release commit
+      uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+    - name: Install Python packages needed for wheel build and upload
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python -m pip install twine wheel
+    - name: Build wheel
+      run: |
+        python -m pip wheel --no-deps -w ./dist .
+    - name: Publish wheels to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine check --strict dist/*.tar.gz
+        python -m twine upload dist/*.whl
+
+  build-wheel-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the release commit
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Python packages needed for wheel upload
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python -m pip install twine
+    - name: Build manylinux Python wheels
+      uses: RalfG/python-wheels-manylinux-build@v0.3.3
+      with:
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+    - name: Publish wheels to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine check --strict dist/*-manylinux*.whl
+        python -m twine upload dist/*-manylinux*.whl

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -1,7 +1,8 @@
 name: Publish release to PyPI
 
 on:
-  pull_request
+  release:
+    types: [published]
 
 jobs:
   build-sdist:
@@ -27,7 +28,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*.tar.gz
-        # python -m twine upload dist/*.tar.gz
+        python -m twine upload dist/*.tar.gz
 
   build-wheel-windows-macos:
 
@@ -64,7 +65,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*.whl
-        # python -m twine upload dist/*.whl
+        python -m twine upload dist/*.whl
 
   build-wheel-linux:
     runs-on: ubuntu-latest
@@ -90,4 +91,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*-manylinux*.whl
-        # python -m twine upload dist/*-manylinux*.whl
+        python -m twine upload dist/*-manylinux*.whl

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -63,7 +63,7 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python -m twine check --strict dist/*.tar.gz
+        python -m twine check --strict dist/*.whl
         python -m twine upload dist/*.whl
 
   build-wheel-linux:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -27,7 +27,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*.tar.gz
-        python -m twine upload dist/*.tar.gz
+        # python -m twine upload dist/*.tar.gz
 
   build-wheel-windows-macos:
 
@@ -64,7 +64,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*.whl
-        python -m twine upload dist/*.whl
+        # python -m twine upload dist/*.whl
 
   build-wheel-linux:
     runs-on: ubuntu-latest
@@ -90,4 +90,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*-manylinux*.whl
-        python -m twine upload dist/*-manylinux*.whl
+        # python -m twine upload dist/*-manylinux*.whl


### PR DESCRIPTION
This PR adds a workflow for automatically building and uploading source distribution and wheels to PyPI when a Traits release is published.

Still to do:

- [x] iterate on the workflow until it's working as far as the `twine upload` step. That step is expected to fail due to invalid permissions
- [x] change the workflow trigger so that it runs on publication of a release rather than on PR commits
- [x] provide valid permissions

# Notes

- On macOS, the Python builders we use have `MACOSX_DEPLOYMENT_TARGET=10.14`, so the wheels built won't work on macOS versions earlier than 10.14
- On Linux, we build manylinux1 and manylinux2010 wheels. That's probably good enough for now, but at some point in the future we'll likely also want manylinux2014 wheels.
- On Windows (and only on Windows), we build wheels for 32-bit Python as well as for 64-bit Python. I'm assuming that there's essentially zero demand for 32-bit wheels on Linux.
- No provision for ARM-based Macs yet.

Closes #357.