### PR TITLE
Fix a bad Instance trait declaration for a private lock

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,7 +65,7 @@ Features
 ~~~~~~~~
 
 * The ``Property`` trait type now supports the ``observe`` keyword. (#1175)
-* Add |= support to TraitDict for Python >= 3.9. (#1306)
+* Add ``|=`` support to TraitDict for Python 3.9 and later. (#1306)
 * Add casting keyword to numeric array types. (#547)
 * The Traits examples are now part of the Traits package, and so are
   contributed to ``etsdemo``. (#1275)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,19 +35,22 @@ Highlights of this release
 Detailed PR-by-PR changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-More than 60 PRs went into this release. The following people contributed
-changes for this release:
+More than 60 PRs went into this release. The following people contributed to
+this release:
 
-Aaron Ayres
-Alexandre Chabot-Leclerc
-Kit Choi
-Mark Dickinson
-Kevin Duff
-Matt Hancock
-Eric Prestat
-Poruri Sai Rahul
-Hugo van Kemenade
-Corran Webster
+* Aaron Ayres
+* Alexandre Chabot-Leclerc
+* Kit Choi
+* Mark Dickinson
+* Kevin Duff
+* Glen Granzow
+* Matt Hancock
+* Eric Prestat
+* Poruri Sai Rahul
+* Kuya Takami
+* Hugo van Kemenade
+* Aditya Vats
+* Corran Webster
 
 
 Performance
@@ -185,6 +188,7 @@ Build and development workflow changes
 * Make ``mypy`` an optional dependency. (#1289)
 * Speed up CI builds for Travis and Appveyor by caching the ``pip`` directory
   (now redundant). (#1241)
+* Add automated wheel and sdist building for Traits releases. (#1404, #1291)
 
 
 Release 6.1.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,192 @@
 Traits CHANGELOG
 ================
 
+Release 6.2.0
+-------------
+
+Released: 2021-01-XXX
+
+The Traits library is a foundational component of the Enthought Tool Suite. It
+provides observable, typed attributes for Python classes, making those classes
+suitable for event-driven dataflow programming and for immediate use as models
+for graphical user interfaces, like those provided by the TraitsUI library.
+
+Traits 6.2 is the latest feature release in the Traits 6 series, with several
+improvements and fixes over Traits 6.1.
+
+Highlights of this release
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* The Traits examples are now distributed as part of the Traits egg, and
+  are contributed to the ``etsdemo`` application. (The latter is currently
+  distributed as part of TraitsUI.)
+* Performance of the ``observe`` framework has been significantly improved.
+* It's no longer necessary to specify a trait comparison mode of
+  ``ComparisonMode.identity`` when using ``observe`` to observe items
+  in a ``List``, ``Dict`` or ``Set``.
+* Support for Python 3.5 has been dropped.
+* When importing from Traits, you should always import from one of the ``api``
+  modules (for example, ``traits.api``, ``traits.adaptation.api``, etc.) This
+  recommendation has now been made explicit in the documentation. If you find
+  something you need that's not available from one of the ``api`` modules,
+  please let the Traits developers know.
+
+
+Detailed PR-by-PR changes
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+More than 60 PRs went into this release. The following people contributed
+changes for this release:
+
+Aaron Ayres
+Alexandre Chabot-Leclerc
+Kit Choi
+Mark Dickinson
+Kevin Duff
+Matt Hancock
+Eric Prestat
+Poruri Sai Rahul
+Hugo van Kemenade
+Corran Webster
+
+
+Performance
+~~~~~~~~~~~
+
+* Parsing of the ``observe`` string was previously a performance bottleneck.
+  This has been fixed, by removing some redundant parsing calls and by caching
+  parsing results. (#1343, #1344, #1345)
+
+
+Features
+~~~~~~~~
+
+* The ``Property`` trait type now supports the ``observe`` keyword. (#1175)
+* Add |= support to TraitDict for Python >= 3.9. (#1306)
+* Add casting keyword to numeric array types. (#547)
+* The Traits examples are now part of the Traits package, and so are
+  contributed to ``etsdemo``. (#1275)
+* The Traits examples package now includes a beginner's tutorial. (#1061)
+
+
+Changes
+~~~~~~~
+
+* The ``NoDefaultSpecified`` constant (used as a default value for
+  the ``TraitType`` ``default_value`` argument) is now public, made
+  available from ``traits.api``. (#1384, #1380, #1378)
+* The deprecation of the ``TraitMap`` trait type has been reversed, because
+  there are existing uses of ``TraitMap`` that are hard to replace.
+  Nevertheless, it's still not recommended to use ``TraitMap`` in new code. Use
+  ``Map`` instead. (#1365)
+* An attempt to use ``PrefixList`` with an empty list, or ``PrefixMap`` or
+  ``Map`` with an empty dictionary, now raises ``ValueError``. As a result,
+  the default default value (which used to be ``None``) is always valid.
+  (#1351)
+* ``TraitListEvent`` arguments are now keyword only. (#1346)
+* It's no longer necessary to specify a trait comparison mode of
+  ``ComparisonMode.identity`` when using ``observe`` to observe items
+  in a ``List``, ``Dict`` or ``Set``. (#1165, #1328, #1240)
+
+
+Documentation
+~~~~~~~~~~~~~
+
+* Clarify that only the ``api`` modules should be used for imports. (#1387)
+* Update copyright header end years. (#1376)
+* Update contents of ``image_LICENSE.txt``. (#1362)
+* Remove mentions of the removed functions ``adapts`` and ``implements`` from
+  the examples and tutorial. (#1367)
+* Move Traits introduction description to ``index.rst``. (#1358)
+* Fix path to Enthought logo when building docset. (#1285)
+* Fix the ``trait_documenter`` extension to be less fragile. (#1247)
+* Various other minor improvements, typo fixes, and other documentation fixes.
+  (#1396, #1383, #1381, #1384, #1292, #1355, #1350, #1319, #1292)
+
+Deprecations
+~~~~~~~~~~~~
+
+* The ``Function`` and ``Method`` trait types are deprecated. Use
+  ``Callable`` or ``Instance`` instead. (#1399, #1397)
+* The ``edit`` parameter to ``configure_traits`` has been deprecated. (#1311)
+* The ``UnittestTools._catch_warnings`` function has been deprecated. (#1310)
+* The use of the ``CHECK_INTERFACES`` global variable for automated
+  interface checking has been deprecated. (#1231)
+
+
+Fixes
+~~~~~
+
+* Non-``TraitError`` exceptions raised during ``Tuple`` validation are now
+  propagated. Previously they were converted into ``TraitError``. (#1393)
+* Dynamic ``Range`` and ``Enum`` traits are now properly validated
+  when inside a container (for example ``Tuple`` or ``List``). Previously
+  no validation was performed. (#1388, #1392)
+* Remove the unused module-level constant ``traits.has_traits.EmptyList``.
+  (#1366)
+* Don't hard-code class names in ``__repr__`` implementations of
+  ``TraitListEvent``, ``TraitSetEvent`` and ``TraitDictEvent``. (#1335)
+* Don't notify on empty ``update``s of ``Dict`` traits. (#1308)
+* Fix exception raised when assigning a NumPy array to a ``List``
+  trait. (#1278)
+* Fix uses of deprecated ``logger.warn`` function. (#1283)
+
+
+Cleanup and other maintenance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Remove dead code. (#1281)
+* Update ``super`` usage to the usual Python 3 argument-less pattern. (#1280)
+* Remove per-import ``# noqa`` comments in ``api`` modules in favour of
+  per-file ignores in the ``flake8`` configuration. (#1269)
+* Remove out-of-date and non-functional coverage badge from README. (#1263)
+* Rename ``_i_observable`` module to ``i_observable``. (#1296)
+* Refactor and simplify method checks. (#1176)
+* Fix typo in optional_dependencies comment. (#1235)
+* Use ComparisonMode constants instead of magic numbers. (#1229)
+
+
+Test suite
+~~~~~~~~~~
+
+* Prevent test_enum failures if traitsui or GUI toolkit are not installed.
+  (#1349)
+* Other minor test fixes (typos in test names, etc.). (#1309)
+* Tests that require ``pkg_resources`` are skipped if ``setuptools`` is not
+  installed. (#1301)
+* Fix an order-dependency bug in the ``test_subclasses_weakref`` regression
+  test. (#1290)
+* Various additional or improved tests for existing code.
+  (#1359, #1336, #1330, #1248, #1225, #1208, #1209)
+
+
+Build and development workflow changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Traits now uses GitHub Actions for continuous integration. The Travis CI
+  and Appveyor configurations have been removed. (#1296, #1360)
+* CI runs are no longer based on EDM. (#878)
+* New CI run for the core test suite, without any optional dependencies.
+  (#1314)
+* Test Python 3.9 in the continuous integration (and drop tests for Python
+  3.5 and older). (#1326, #1313, , #1303)
+* Make ``traits.examples`` into a package. (#1348)
+* Make examples directories ``flake8``-clean. (#1353)
+* Fix examples packaging nit. (#1363)
+* Support ``-h`` for getting help in ``etstool.py``. (#1347)
+* Add ``shell`` command to ``etstool.py``. (#1293)
+* Use the ``flake8_ets`` package in place of the local ``copyright_header``
+  package.
+  The ``copyright_header`` package has been removed. (#1341)
+* Add script ``check_observe_timing.py`` to benchmark performance of
+  ``observe`` to compare with ``on_trait_change``. (#1331)
+* Correct the minimum Sphinx version in README. (#1216, #1320)
+* Restrict Sphinx version to avoid buggy versions. (#1276)
+* Make ``mypy`` an optional dependency. (#1289)
+* Speed up CI builds for Travis and Appveyor by caching the ``pip`` directory
+  (now redundant). (#1241)
+
+
 Release 6.1.1
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,8 +45,8 @@ this release:
 * Kevin Duff
 * Glen Granzow
 * Matt Hancock
+* Rahul Poruri
 * Eric Prestat
-* Poruri Sai Rahul
 * Kuya Takami
 * Hugo van Kemenade
 * Aditya Vats


### PR DESCRIPTION
This PR fixes a bad `Instance` declaration that effectively declared that a `_lock` trait could only be assigned a built-in function or method (and in particular, could not be assigned a lock).

I  _really_ wanted to rename the `events` trait to `_events` too as part of this PR, but I can't be absolutely sure that it's not being used elsewhere.  (And it is used in the tests, which isn't a great sign.)

No regression test, because I couldn't find a way to exercise the issue using only the public API, and I don't really want to add tests that test internal implementation details. However, if/when we deprecate `Instance(some_instance)`, this code will now fail to give a DeprecationWarning, where the code in master would have given such.

Fixes #1408.

**Checklist**
- [ ] Tests.  No test provided. Sorry.
- ~[ ] Update API reference (`docs/source/traits_api_reference`). N/A~
- ~[ ] Update User manual (`docs/source/traits_user_manual`). N/A~
- ~[ ] Update type annotation hints in `traits-stubs`. N/A~
