### PR TITLE
Bump version number for continued feature development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import setuptools
 # together with information from the version control system, and then injected
 # into the package source.
 MAJOR = 6
-MINOR = 2
+MINOR = 3
 MICRO = 0
 PRERELEASE = ""
 IS_RELEASED = False


### PR DESCRIPTION
The master branch is now targeting the next feature release of Traits, which will presumably be 6.3.0 (though it could end up being retargeted to 7.0.0). This PR bumps the version number accordingly.

I'll make the release maintenance branch after this PR is merged, from the commit preceding this one.

~Not to be merged until after #1405 has gone in.~  (Update: #1405 is in.)

