### PR TITLE
Bump version number for 6.2.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 6
 MINOR = 2
 MICRO = 0
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This is the final preparation step for the 6.2.0 release: change the `IS_RELEASED` portion of the version structure from `False` to `True`.

Making this a draft PR because I want the CI to run, but I don't intend to merge this into the `maint/6.2` branch: instead, once CI signs off and I've done other testing, I'll tag this commit as the release commit.