### PR TITLE
Extend PyPI test workflow to wheels

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -52,3 +52,50 @@ jobs:
       with:
         working-directory: testdir
         run: python -m unittest discover -v traits
+
+  test-pypi-wheel:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-architecture: [x86, x64]
+        exclude:
+        - os: macos-latest
+          python-architecture: x86
+        - os: ubuntu-latest
+          python-architecture: x86
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Install Linux packages for Qt 5 support
+      run: |
+        sudo apt-get update
+        sudo apt-get install qt5-default
+        sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-icccm4
+        sudo apt-get install libxcb-image0
+        sudo apt-get install libxcb-keysyms1
+        sudo apt-get install libxcb-randr0
+        sudo apt-get install libxcb-render-util0
+        sudo apt-get install libxcb-xinerama0
+      if: runner.os == 'Linux'
+    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+    - name: Install prerequisites
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+    - name: Install Traits and test dependencies from PyPI wheel
+      run: |
+        python -m pip install --only-binary :all: traits[test]
+    - name: Create clean test directory
+      run: |
+        mkdir testdir
+    - name: Test Traits package
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        working-directory: testdir
+        run: python -m unittest discover -v traits


### PR DESCRIPTION
We already have a cron-based workflow that checks that the Traits tests pass with all the latest packages from PyPI; that workflow installs from the PyPI sdist.

This PR extends that workflow to also test wheels.

The goal is for Traits users not to need to compile anything; for that reason, we attempt to ensure that _everything_ is installed from wheels by using the `--only-binary` flag to `pip`. We may need to relax this requirement if some of the test dependencies don't have wheels available (NumPy would be the most likely candidate for this).

I'll temporarily adjust the trigger for this PR to be on pull request, so that we can verify that it works. Then I'll put the cron trigger back before merging.