### PR TITLE
Add missing CSS file for the 'introduction' tutorial

### DIFF
--- a/traits/examples/introduction/default.css
+++ b/traits/examples/introduction/default.css
@@ -1,36 +1,36 @@
 body { background-color: #FFFFFF; }
 
-h1 { font-family: Arial;
+h1 { font-family: Arial; 
      font-size: 14pt;
      color: #303030;
      background-color: #FCD062;
-     padding-top: 3px;
+     padding-top: 3px; 
      padding-left:8px;
-     padding-bottom: 3px;
+     padding-bottom: 3px; 
      padding-right: 8px; }
 
 h2 { font-family: Arial;
      font-size: 12pt;
      color: #303030;
      background-color: #FCD062;
-     padding-top: 3px;
+     padding-top: 3px; 
      padding-left:8px;
-     padding-bottom: 3px;
+     padding-bottom: 3px; 
      padding-right: 8px; }
 
-pre { border: 1px solid #A0A0A0;
-      background-color: #FDF7E7;
+pre { border: 1px solid #A0A0A0; 
+      background-color: #FDF7E7; 
       padding: 4px; }
-
+      
 dl { border: 1px solid #A0A0A0;
      background-color: #FDF7E7;
      padding-top: 4px;
      padding-bottom: 6px;
      padding-left: 8px;
      padding-right: 8px; }
-
+      
 dl dl { border: 0px solid #A0A0A0; }
-
+     
 dt { font-family: Arial;
      font-weight: bold;
 

--- a/traits/examples/introduction/default.css
+++ b/traits/examples/introduction/default.css
@@ -1,0 +1,37 @@
+body { background-color: #FFFFFF; }
+
+h1 { font-family: Arial;
+     font-size: 14pt;
+     color: #303030;
+     background-color: #FCD062;
+     padding-top: 3px;
+     padding-left:8px;
+     padding-bottom: 3px;
+     padding-right: 8px; }
+
+h2 { font-family: Arial;
+     font-size: 12pt;
+     color: #303030;
+     background-color: #FCD062;
+     padding-top: 3px;
+     padding-left:8px;
+     padding-bottom: 3px;
+     padding-right: 8px; }
+
+pre { border: 1px solid #A0A0A0;
+      background-color: #FDF7E7;
+      padding: 4px; }
+
+dl { border: 1px solid #A0A0A0;
+     background-color: #FDF7E7;
+     padding-top: 4px;
+     padding-bottom: 6px;
+     padding-left: 8px;
+     padding-right: 8px; }
+
+dl dl { border: 0px solid #A0A0A0; }
+
+dt { font-family: Arial;
+     font-weight: bold;
+
+dd { padding-bottom: 10px; }


### PR DESCRIPTION
After the move of the tutorial into the `traits/examples` subpackage, the `default.css` file was no longer being picked up. This PR makes a copy of that file in `traits/examples/introduction`. That _seems_ to work, but it's not clear to me whether this is the place that the `etsdemo` app expects CSS files to be.

<img width="1001" alt="Screenshot 2021-01-21 at 16 55 09" src="https://user-images.githubusercontent.com/662003/105383839-77d76d00-5c09-11eb-824b-f5990b067c81.png">

I've checked that the CSS file also ends up in the source distribution.

@corranwebster Please could you check that this has the desired effect?

Fixes #1418.
