### PR TITLE
Fix issues with tutorial CSS

### DIFF
--- a/traits/examples/introduction/default.css
+++ b/traits/examples/introduction/default.css
@@ -1,36 +1,36 @@
 body { background-color: #FFFFFF; }
 
-h1 { font-family: Arial; 
-     font-size: 14pt;
-     color: #303030;
-     background-color: #FCD062;
-     padding-top: 3px; 
+h1 { font-family: Arial;
+     font-size: 18pt;
+     color: #272a32;
+     background-color: #8fbfde;
+     padding-top: 3px;
      padding-left:8px;
-     padding-bottom: 3px; 
+     padding-bottom: 3px;
      padding-right: 8px; }
 
 h2 { font-family: Arial;
-     font-size: 12pt;
-     color: #303030;
-     background-color: #FCD062;
-     padding-top: 3px; 
+     font-size: 14pt;
+     color: #272a32;
+     background-color: #8fbfde;
+     padding-top: 3px;
      padding-left:8px;
-     padding-bottom: 3px; 
+     padding-bottom: 3px;
      padding-right: 8px; }
 
-pre { border: 1px solid #A0A0A0; 
-      background-color: #FDF7E7; 
+pre { border: 1px solid #4488c7;
+      background-color: #eaeaea;
       padding: 4px; }
-      
-dl { border: 1px solid #A0A0A0;
-     background-color: #FDF7E7;
+
+dl { border: 1px solid #272a32;
+     background-color: #eaeaea;
      padding-top: 4px;
      padding-bottom: 6px;
      padding-left: 8px;
      padding-right: 8px; }
-      
+
 dl dl { border: 0px solid #A0A0A0; }
-     
+
 dt { font-family: Arial;
      font-weight: bold;
 


### PR DESCRIPTION
This fixes the distinct colours in the code samples, plus switches from the orange color scheme to a more usual Enthought blue.

This is a follow on from #1419 and should fix #1420.

<img src="https://user-images.githubusercontent.com/600761/105471438-a3eb0080-5c92-11eb-94b9-69eaacc6349b.png" height=50% width=50% />
