### PR TITLE
Run core tests on 3.10-dev

### DIFF
--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.9]
+        python-version: [3.6, 3.9, 3.10-dev]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Extend the core traits tests workflow to also run on Python 3.10, so that we get alerted early to problems with the upcoming Python release.
