### PR TITLE
Make allow_none functional in the `Date` trait type

### DIFF
--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -252,7 +252,8 @@ Traits
 .. autoclass:: WeakRef
    :show-inheritance:
 
-.. autodata:: Date
+.. autoclass:: Date
+   :show-inheritance:
 
 .. autodata:: Datetime
 

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -613,7 +613,7 @@ class Date(_TraitType[_OptionalDate, _OptionalDate]):
             self,
             default_value: datetime.date = ...,
             allow_datetime: bool = ...,
-            allow_none: bool = ...
+            allow_none: bool = ...,
             **metadata: _Any,
     ) -> None:
         ...

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -605,12 +605,14 @@ class WeakRef(Instance):
         ...
 
 
-class Date(_BaseInstance[datetime.date]):
 
-    # simplified signature
+_OptionalDate = Optional[datetime.date]
+
+class Date(_TraitType[_OptionalDate, _OptionalDate]):
     def __init__(
             self,
             default_value: datetime.date = ...,
+            allow_datetime: bool = False,
             **metadata: _Any,
     ) -> None:
         ...

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -612,7 +612,8 @@ class Date(_TraitType[_OptionalDate, _OptionalDate]):
     def __init__(
             self,
             default_value: datetime.date = ...,
-            allow_datetime: bool = False,
+            allow_datetime: bool = ...,
+            allow_none: bool = ...
             **metadata: _Any,
     ) -> None:
         ...

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -612,6 +612,7 @@ class Date(_TraitType[_OptionalDate, _OptionalDate]):
     def __init__(
             self,
             default_value: datetime.date = ...,
+            *,
             allow_datetime: bool = ...,
             allow_none: bool = ...,
             **metadata: _Any,

--- a/traits-stubs/traits_stubs_tests/examples/Date.py
+++ b/traits-stubs/traits_stubs_tests/examples/Date.py
@@ -20,8 +20,8 @@ class TestClass(HasTraits):
 obj = TestClass()
 obj.t = datetime.datetime.now()
 obj.t = datetime.datetime.now().date()
-obj.t = "sometime-string"
 
 obj.t = datetime.datetime.now().time()  # E: assignment
+obj.t = "sometime-string"  # E: assignment
 obj.t = 9  # E: assignment
 obj.t = []  # E: assignment

--- a/traits-stubs/traits_stubs_tests/examples/Date.py
+++ b/traits-stubs/traits_stubs_tests/examples/Date.py
@@ -18,8 +18,9 @@ class TestClass(HasTraits):
 
 
 obj = TestClass()
-obj.t = datetime.datetime.now()
 obj.t = datetime.datetime.now().date()
+obj.t = datetime.datetime.now()
+obj.t = None
 
 obj.t = datetime.datetime.now().time()  # E: assignment
 obj.t = "sometime-string"  # E: assignment

--- a/traits/tests/test_date.py
+++ b/traits/tests/test_date.py
@@ -87,3 +87,11 @@ class TestDate(unittest.TestCase):
         trait = obj.base_trait("epoch")
         editor_factory = trait.get_editor()
         self.assertIsInstance(editor_factory, traitsui.api.DateEditor)
+
+    def test_disallow_datetime(self):
+        test_datetime = datetime.datetime(1975, 2, 13)
+        obj = HasDateTraits()
+        with self.assertRaises(TraitError) as exception_context:
+            obj.expiry = test_datetime
+        message = str(exception_context.exception)
+        self.assertIn("must be a non-datetime date or None", message)

--- a/traits/tests/test_date.py
+++ b/traits/tests/test_date.py
@@ -1,0 +1,89 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tests for the Date trait type.
+"""
+
+import datetime
+import unittest
+
+from traits.testing.optional_dependencies import requires_traitsui, traitsui
+
+from traits.api import Date, HasStrictTraits, TraitError
+
+
+#: Unix epoch date.
+UNIX_EPOCH = datetime.date(1970, 1, 1)
+
+#: Windows NT epoch
+NT_EPOCH = datetime.date(1600, 1, 1)
+
+
+class HasDateTraits(HasStrictTraits):
+    #: Cake expiry date
+    expiry = Date(allow_datetime=False)
+
+    #: Datetime allowed!
+    solstice = Date(allow_datetime=True)
+
+    #: Date with default
+    epoch = Date(UNIX_EPOCH)
+
+    #: Date with default spelled out explicitly using the keyword.
+    alternative_epoch = Date(default_value=NT_EPOCH)
+
+
+class TestDate(unittest.TestCase):
+    def test_default(self):
+        obj = HasDateTraits()
+        self.assertEqual(obj.epoch, UNIX_EPOCH)
+        self.assertEqual(obj.alternative_epoch, NT_EPOCH)
+        self.assertEqual(obj.expiry, None)
+
+    def test_assign_a_date(self):
+        test_date = datetime.date(1975, 2, 13)
+        obj = HasDateTraits()
+        obj.expiry = test_date
+        self.assertEqual(obj.expiry, test_date)
+
+    def test_assign_not_a_date(self):
+        obj = HasDateTraits()
+        with self.assertRaises(TraitError):
+            obj.expiry = "1975-2-13"
+
+    def test_info_text(self):
+        obj = HasDateTraits()
+        with self.assertRaises(TraitError) as exception_context:
+            obj.solstice = "1975-2-13"
+        message = str(exception_context.exception)
+        self.assertIn("must be a date or None", message)
+
+    def test_assign_none(self):
+        # This is a test for the current behaviour. There may be an argument
+        # for optionally disallowing None. Note that specifying
+        # allow_none=False in the trait definition does not work as expected.
+        obj = HasDateTraits(expiry=UNIX_EPOCH)
+        obj.expiry = None
+        self.assertIsNone(obj.expiry)
+
+    def test_assign_a_datetime_legacy(self):
+        # Legacy case: by default, datetime instances are permitted.
+        test_datetime = datetime.datetime(1975, 2, 13)
+        obj = HasDateTraits()
+        obj.solstice = test_datetime
+        self.assertEqual(obj.solstice, test_datetime)
+
+    @requires_traitsui
+    def test_get_editor(self):
+        obj = HasDateTraits()
+        trait = obj.base_trait("epoch")
+        editor_factory = trait.get_editor()
+        self.assertIsInstance(editor_factory, traitsui.api.DateEditor)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4238,8 +4238,54 @@ class WeakRef(Instance):
         self.klass = klass
 
 
-#: A trait type for datetime.date instances.
-Date = BaseInstance(datetime.date, editor=date_editor)
+class Date(TraitType):
+    """ A trait type whose value must be a date.
+
+    The value must be an instance of :class:`datetime.date`. Note that
+    :class:`datetime.datetime` is a subclass of :class:`datetime.date`, so
+    by default instances of :class:`datetime.datetime` are also permitted.
+    Use ``Date(allow_datetime=False)`` to exclude this possibility.
+
+    Parameters
+    ----------
+    default_value : datetime.date, optional
+        The default value for this trait. If no default is provided, the
+        default is ``None``.
+    allow_datetime : bool, optional
+        If ``False``, instances of ``datetime.datetime`` are not valid
+        values for this Trait. The default is ``True``.
+    **metadata: dict
+        Additional metadata.
+    """
+
+    def __init__(self, default_value=None, *, allow_datetime=True, **metadata):
+        super().__init__(default_value, **metadata)
+        self.allow_datetime = allow_datetime
+
+    def validate(self, object, name, value):
+        """ Check that the given value is valid date for this trait.
+        """
+        if value is None:
+            return value
+        if isinstance(value, datetime.date):
+            if self.allow_datetime or not isinstance(value, datetime.datetime):
+                return value
+
+        self.error(object, name, value)
+
+    def info(self):
+        """
+        Return text description of this trait.
+        """
+        if self.allow_datetime:
+            return "a date or None"
+        else:
+            return "a non-datetime date or None"
+
+    def create_editor(self):
+        """ Create default editor factory for this trait.
+        """
+        return date_editor()
 
 
 #: A trait type for datetime.datetime instances.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4254,18 +4254,29 @@ class Date(TraitType):
     allow_datetime : bool, optional
         If ``False``, instances of ``datetime.datetime`` are not valid
         values for this Trait. The default is ``True``.
+    allow_none : bool, optional
+        If ``False``, it's not permitted to assign ``None`` to this trait.
+        The default is ``True``.
     **metadata: dict
         Additional metadata.
     """
 
-    def __init__(self, default_value=None, *, allow_datetime=True, **metadata):
+    def __init__(
+        self,
+        default_value=None,
+        *,
+        allow_datetime=True,
+        allow_none=True,
+        **metadata,
+    ):
         super().__init__(default_value, **metadata)
         self.allow_datetime = allow_datetime
+        self.allow_none = allow_none
 
     def validate(self, object, name, value):
         """ Check that the given value is valid date for this trait.
         """
-        if value is None:
+        if value is None and self.allow_none:
             return value
         if isinstance(value, datetime.date):
             if self.allow_datetime or not isinstance(value, datetime.datetime):
@@ -4277,10 +4288,9 @@ class Date(TraitType):
         """
         Return text description of this trait.
         """
-        if self.allow_datetime:
-            return "a date or None"
-        else:
-            return "a non-datetime date or None"
+        datetime_qualifier = "" if self.allow_datetime else " non-datetime"
+        none_qualifier = " or None" if self.allow_none else ""
+        return f"a{datetime_qualifier} date{none_qualifier}"
 
     def create_editor(self):
         """ Create default editor factory for this trait.


### PR DESCRIPTION
This PR makes it possible to prevent assignment of `None` to a `Date` trait. (As usual, it doesn't prevent a _default_ value of `None`.)

Note that before the recently-merged PR #1429, `Date` was an instance of `BaseInstance`, and so in theory should already have allowed and respected `allow_none`. But a different bug (#495) means that `allow_none` was not respected. So this PR actually introduces a change in behaviour (effectively a bugfix) for anyone already doing: `foo = Date(allow_none=False)`: before this PR, assignment of `None` would still have been permitted for such a trait declaration. After this PR, it won't be.

In detail, we:

- Add a new parameter `allow_none` to `Date`, defaulting to `True` for backwards compatibility reasons
- Prevent assignment of `None` if `allow_none` is `False`
- Add some unit tests.


**Checklist**
- [x] Tests
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~ N/A
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~ N/A
- [x] Update type annotation hints in `traits-stubs`
