### PR TITLE
Support qt toolkit name for Qt5 and Qt4

### DIFF
--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -314,7 +314,7 @@ class ETSConfig(object):
                     self._kiva_backend = (
                         "quartz" if sys.platform == "darwin" else "image"
                     )
-                elif self.toolkit == "qt4":
+                elif self.toolkit.startswith("qt"):
                     self._kiva_backend = "image"
                 else:
                     self._kiva_backend = "image"

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -314,7 +314,7 @@ class ETSConfig(object):
                     self._kiva_backend = (
                         "quartz" if sys.platform == "darwin" else "image"
                     )
-                elif self.toolkit.startswith("qt"):
+                elif self.toolkit in ["qt4", "qt"]:
                     self._kiva_backend = "image"
                 else:
                     self._kiva_backend = "image"

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -221,6 +221,10 @@ class ETSConfigTestCase(unittest.TestCase):
         self.ETSConfig.toolkit = "qt4"
         self.assertEqual(self.ETSConfig.kiva_backend, "image")
 
+    def test_default_backend_for_qt5_toolkit(self):
+        self.ETSConfig.toolkit = "qt"
+        self.assertEqual(self.ETSConfig.kiva_backend, "image")
+
     def test_toolkit_explicit_kiva_backend(self):
         self.ETSConfig.toolkit = "wx.celiagg"
         self.assertEqual(self.ETSConfig.kiva_backend, "celiagg")


### PR DESCRIPTION
This PR updates `ETSConfig` to support the use of `qt` as the toolkit name for Qt4 and Qt5 instead of only supporting `qt4` as the toolkit name for Qt4. This is in line with similar changes we have made in other ETS packages e.g. traitsui, enable.

**Checklist**
- [x] Tests
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
