### PR TITLE
Change File and Directory trait descriptions to take into account the 'exists' flag.

### DIFF
--- a/traits/tests/test_directory.py
+++ b/traits/tests/test_directory.py
@@ -19,6 +19,8 @@ from traits.api import BaseDirectory, Directory, HasTraits, TraitError
 class ExampleModel(HasTraits):
     path = Directory(exists=True)
 
+    new_path = Directory(exists=False)
+
 
 class ExistsBaseDirectory(HasTraits):
     path = BaseDirectory(value=pathlib.Path(gettempdir()), exists=True)
@@ -122,3 +124,16 @@ class TestBaseDirectory(unittest.TestCase):
         foo.path = pathlib.Path("!!!")
 
         self.assertIsInstance(foo.path, str)
+
+    def test_info_text(self):
+        example_model = ExampleModel()
+        with self.assertRaises(TraitError) as exc_cm:
+            example_model.path = 47
+        self.assertIn("a string or os.PathLike object", str(exc_cm.exception))
+        self.assertIn(
+            "referring to an existing directory", str(exc_cm.exception))
+
+        with self.assertRaises(TraitError) as exc_cm:
+            example_model.new_path = 47
+        self.assertIn("a string or os.PathLike object", str(exc_cm.exception))
+        self.assertNotIn("exist", str(exc_cm.exception))

--- a/traits/tests/test_file.py
+++ b/traits/tests/test_file.py
@@ -19,6 +19,8 @@ from traits.testing.optional_dependencies import requires_traitsui
 class ExampleModel(HasTraits):
     file_name = File(exists=True)
 
+    new_file_name = File(exists=False)
+
 
 class FastExampleModel(HasTraits):
     file_name = File()
@@ -65,6 +67,18 @@ class FileTestCase(unittest.TestCase):
     def test_fast(self):
         example_model = FastExampleModel(file_name=__file__)
         example_model.path = "."
+
+    def test_info_text(self):
+        example_model = ExampleModel()
+        with self.assertRaises(TraitError) as exc_cm:
+            example_model.file_name = 47
+        self.assertIn("a string or os.PathLike object", str(exc_cm.exception))
+        self.assertIn("referring to an existing file", str(exc_cm.exception))
+
+        with self.assertRaises(TraitError) as exc_cm:
+            example_model.new_file_name = 47
+        self.assertIn("a string or os.PathLike object", str(exc_cm.exception))
+        self.assertNotIn("exist", str(exc_cm.exception))
 
 
 class TestCreateEditor(unittest.TestCase):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1360,9 +1360,6 @@ class BaseFile(BaseStr):
         not.
     """
 
-    #: A description of the type of value this trait accepts:
-    info_text = "a filename or object implementing the os.PathLike interface"
-
     def __init__(
         self,
         value="",
@@ -1399,6 +1396,13 @@ class BaseFile(BaseStr):
             return validated_value
 
         self.error(object, name, value)
+
+    def info(self):
+        """ Return a description of the type of value this trait accepts. """
+        description = "a string or os.PathLike object"
+        if self.exists:
+            description += " referring to an existing file"
+        return description
 
     def create_editor(self):
         from traitsui.editors.file_editor import FileEditor
@@ -1498,10 +1502,6 @@ class BaseDirectory(BaseStr):
         not.
     """
 
-    #: A description of the type of value this trait accepts:
-    info_text = ("a directory name or an object implementing "
-                 "the os.PathLike interface")
-
     def __init__(
         self, value="", auto_set=False, entries=0, exists=False, **metadata
     ):
@@ -1530,6 +1530,13 @@ class BaseDirectory(BaseStr):
             return validated_value
 
         self.error(object, name, value)
+
+    def info(self):
+        """ Return a description of the type of value this trait accepts. """
+        description = "a string or os.PathLike object"
+        if self.exists:
+            description += " referring to an existing directory"
+        return description
 
     def create_editor(self):
         from traitsui.editors.directory_editor import DirectoryEditor


### PR DESCRIPTION
This PR customises the trait description for the `File` and `Directory` trait types to take into account whether `exists` was true or not.

For the `File` trait, the description has changed from "a filename or object implementing the os.PathLike interface" to "a string or os.PathLike object" in the normal case and "a string or os.PathLike object referring to an existing file" for the `File(exists=True)` case. The changes for `Directory` are analogous.

Before:

```python
>>> from traits.api import Directory, File, HasStrictTraits
>>> class A(HasStrictTraits):
...     home_dir = Directory(exists=True)
...     config_file = File(exists=True)
... 
>>> a = A()
>>> a.home_dir = 47
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 1524, in validate
    validated_value = super().validate(
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 350, in validate
    self.error(object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/base_trait_handler.py", line 74, in error
    raise TraitError(
traits.trait_errors.TraitError: The 'home_dir' trait of an A instance must be a directory name or an object implementing the os.PathLike interface, but a value of 47 <class 'int'> was specified.
>>> a.config_file = 47
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 1395, in validate
    validated_value = super().validate(object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 350, in validate
    self.error(object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/base_trait_handler.py", line 74, in error
    raise TraitError(
traits.trait_errors.TraitError: The 'config_file' trait of an A instance must be a filename or object implementing the os.PathLike interface, but a value of 47 <class 'int'> was specified.
```

After:

```python
>>> from traits.api import Directory, File, HasStrictTraits
>>> class A(HasStrictTraits):
...     home_dir = Directory(exists=True)
...     config_file = File(exists=True)
... 
>>> a = A()
>>> a.home_dir = 47
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 1524, in validate
    validated_value = super().validate(
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 350, in validate
    self.error(object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/base_trait_handler.py", line 74, in error
    raise TraitError(
traits.trait_errors.TraitError: The 'home_dir' trait of an A instance must be a string or os.PathLike object referring to an existing directory, but a value of 47 <class 'int'> was specified.
>>> a.config_file = 47
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 1392, in validate
    validated_value = super().validate(object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/trait_types.py", line 350, in validate
    self.error(object, name, value)
  File "/Users/mdickinson/Enthought/ETS/traits/traits/base_trait_handler.py", line 74, in error
    raise TraitError(
traits.trait_errors.TraitError: The 'config_file' trait of an A instance must be a string or os.PathLike object referring to an existing file, but a value of 47 <class 'int'> was specified.
```

Fixes #1439 

@nicolasap-dm: Do you have bandwidth for a quick review?


**Checklist**
- [x] Tests
- ~[ ] Update API reference (`docs/source/traits_api_reference`)  N/A~
- ~[ ] Update User manual (`docs/source/traits_user_manual`)   N/A~
- ~[ ] Update type annotation hints in `traits-stubs`  N/A~
