### PR TITLE
Deprecate allowing datetime.datetime instances as values for Date traits

### DIFF
--- a/traits/tests/test_date.py
+++ b/traits/tests/test_date.py
@@ -73,20 +73,13 @@ class TestDate(unittest.TestCase):
         message = str(exception_context.exception)
         self.assertIn("must be a date or None, but", message)
 
-    def test_assign_datetime(self):
-        # By default, datetime instances are permitted.
-        test_datetime = datetime.datetime(1975, 2, 13)
-        obj = HasDateTraits()
-        obj.simple_date = test_datetime
-        self.assertEqual(obj.simple_date, test_datetime)
-
     def test_assign_none(self):
         obj = HasDateTraits(simple_date=UNIX_EPOCH)
         self.assertIsNotNone(obj.simple_date)
         obj.simple_date = None
         self.assertIsNone(obj.simple_date)
 
-    def test_allow_datetime_false(self):
+    def test_assign_datetime_with_allow_datetime_false(self):
         test_datetime = datetime.datetime(1975, 2, 13)
         obj = HasDateTraits()
         with self.assertRaises(TraitError) as exception_context:
@@ -94,11 +87,30 @@ class TestDate(unittest.TestCase):
         message = str(exception_context.exception)
         self.assertIn("must be a non-datetime date or None, but", message)
 
-    def test_allow_datetime_true(self):
+    def test_assign_datetime_with_allow_datetime_true(self):
         test_datetime = datetime.datetime(1975, 2, 13)
         obj = HasDateTraits()
         obj.datetime_allowed = test_datetime
         self.assertEqual(obj.datetime_allowed, test_datetime)
+
+    def test_assign_datetime_with_allow_datetime_not_given(self):
+        # For traits where "allow_datetime" is not specified, a
+        # DeprecationWarning should be issued on assignment of datetime.
+        test_datetime = datetime.datetime(1975, 2, 13)
+        obj = HasDateTraits()
+        with self.assertWarns(DeprecationWarning) as warnings_cm:
+            # Note: the warning depends on the type, not the value; this case
+            # should warn even though the time component of the datetime is
+            # zero.
+            obj.simple_date = test_datetime
+        self.assertEqual(obj.simple_date, test_datetime)
+
+        _, _, this_module = __name__.rpartition(".")
+        self.assertIn(this_module, warnings_cm.filename)
+        self.assertIn(
+            "datetime instances will no longer be accepted",
+            str(warnings_cm.warning),
+        )
 
     def test_allow_none_false(self):
         obj = HasDateTraits(none_prohibited=UNIX_EPOCH)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4263,7 +4263,7 @@ class Date(TraitType):
     Use ``Date(allow_datetime=False)`` to exclude this possibility.
 
     .. deprecated:: 6.3.0
-        In the future, :cls:`datetime.datetime` instances will not be valid
+        In the future, :class:`datetime.datetime` instances will not be valid
         values for this trait type unless "allow_datetime=True" is explicitly
         given.
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4314,7 +4314,8 @@ class Date(TraitType):
                         "In the future, datetime.datetime instances will no "
                         "longer be accepted by this trait type. To accept "
                         "datetimes and silence this warning, use "
-                        "Date(allow_datetime=True) or Union(Datetime(), Date())."
+                        "Date(allow_datetime=True) or "
+                        "Union(Datetime(), Date())."
                     ),
                     DeprecationWarning,
                     stacklevel=2,

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4314,7 +4314,7 @@ class Date(TraitType):
                         "In the future, datetime.datetime instances will no "
                         "longer be accepted by this trait type. To accept "
                         "datetimes and silence this warning, use "
-                        "Date(allow_datetime=True) or Union(Datetime, Date)."
+                        "Date(allow_datetime=True) or Union(Datetime(), Date())."
                     ),
                     DeprecationWarning,
                     stacklevel=2,


### PR DESCRIPTION
This PR paves the way for eventually making it illegal to pass a `datetime.datetime` instance to a `Date` trait:

- Change the default for `allow_datetime` to `None` rather than `True`
- If `allow_datetime` is not supplied and the user tries to assign a `datetime.datetime` value to a `Date` trait, a `DeprecationWarning` is issued. In the future (ideally in Traits 7.0), a `TraitError` will be raised.

Rationale: right now, `Date` allows any value that's an instance of the Python std. lib. `datetime.date` class. Somewhat surprisingly, Python's `datetime.datetime` is a subclass of `datetime.date`. But in typical uses for the `Date` trait, we really do want to specify a date and not a datetime.

Users who do want to allow datetimes in addition to date can modify their code in a number of ways to avoid the warning: for example, using `Union(Datetime(), Date())`, `Instance(datetime.date)`, or `Date(allow_datetime=True)`.

Users can also opt in to the future behaviour right now by using `Date(allow_datetime=False)`.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)  (docstring updated)
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~ N/A
- [ ] ~Update type annotation hints in `traits-stubs`~  N/A (the default for `allow_datetime` has changed, but that default isn't recorded in the stub)
