### PR TITLE
Deprecate None values for Date, Datetime and Time trait types

### DIFF
--- a/docs/source/traits_api_reference/trait_types.rst
+++ b/docs/source/traits_api_reference/trait_types.rst
@@ -255,9 +255,12 @@ Traits
 .. autoclass:: Date
    :show-inheritance:
 
-.. autodata:: Datetime
+.. autoclass:: Datetime
+   :show-inheritance:
 
-.. autodata:: Time
+.. autoclass:: Time
+   :show-inheritance:
+
 
 Deprecated Traits
 -----------------

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -620,23 +620,31 @@ class Date(_TraitType[_OptionalDate, _OptionalDate]):
         ...
 
 
-class Datetime(_BaseInstance[datetime.datetime]):
+_OptionalDatetime = Optional[datetime.datetime]
+
+class Datetime(_TraitType[_OptionalDatetime, _OptionalDatetime]):
 
     # simplified signature
     def __init__(
             self,
             default_value: datetime.datetime = ...,
+            *,
+            allow_none: bool = ...,
             **metadata: _Any,
     ) -> None:
         ...
 
 
-class Time(_BaseInstance[datetime.time]):
+_OptionalDatetime = Optional[datetime.time]
+
+class Time(_TraitType[_OptionalTime, _OptionalTime]):
 
     # simplified signature
     def __init__(
             self,
             default_value: datetime.time = ...,
+            *,
+            allow_none: bool = ...,
             **metadata: _Any,
     ) -> None:
         ...

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -635,7 +635,7 @@ class Datetime(_TraitType[_OptionalDatetime, _OptionalDatetime]):
         ...
 
 
-_OptionalDatetime = Optional[datetime.time]
+_OptionalTime = Optional[datetime.time]
 
 class Time(_TraitType[_OptionalTime, _OptionalTime]):
 

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -623,8 +623,6 @@ class Date(_TraitType[_OptionalDate, _OptionalDate]):
 _OptionalDatetime = Optional[datetime.datetime]
 
 class Datetime(_TraitType[_OptionalDatetime, _OptionalDatetime]):
-
-    # simplified signature
     def __init__(
             self,
             default_value: datetime.datetime = ...,
@@ -638,8 +636,6 @@ class Datetime(_TraitType[_OptionalDatetime, _OptionalDatetime]):
 _OptionalTime = Optional[datetime.time]
 
 class Time(_TraitType[_OptionalTime, _OptionalTime]):
-
-    # simplified signature
     def __init__(
             self,
             default_value: datetime.time = ...,

--- a/traits-stubs/traits_stubs_tests/examples/Datetime.py
+++ b/traits-stubs/traits_stubs_tests/examples/Datetime.py
@@ -9,16 +9,16 @@
 # Thanks for using Enthought open source!
 
 import datetime
-from traits.api import HasTraits, Datetime, Int
+
+from traits.api import Datetime, HasTraits
 
 
 class TestClass(HasTraits):
     t = Datetime()
-    x = Int()
 
 
 obj = TestClass()
-obj.t = "sometime-string"
+obj.t = "sometime-string"  # E: assignment
 obj.t = datetime.datetime.now()
 
 obj.t = 9  # E: assignment

--- a/traits-stubs/traits_stubs_tests/examples/Time.py
+++ b/traits-stubs/traits_stubs_tests/examples/Time.py
@@ -9,17 +9,17 @@
 # Thanks for using Enthought open source!
 
 import datetime
-from traits.api import HasTraits, Time, Int
+
+from traits.api import HasTraits, Time
 
 
 class TestClass(HasTraits):
     t = Time()
-    x = Int()
 
 
 obj = TestClass()
-obj.t = datetime.time()
-obj.t = "sometime-string"
-obj.t = datetime.datetime()  # E: assignment, call-arg
+obj.t = datetime.time(11, 12, 13)
+obj.t = "sometime-string"  # E: assignment
+obj.t = datetime.datetime(2020, 1, 1)  # E: assignment
 obj.t = 9  # E: assignment
 obj.t = []  # E: assignment

--- a/traits/tests/test_date.py
+++ b/traits/tests/test_date.py
@@ -73,11 +73,32 @@ class TestDate(unittest.TestCase):
         message = str(exception_context.exception)
         self.assertIn("must be a date or None, but", message)
 
-    def test_assign_none(self):
+    def test_assign_none_with_allow_none_not_given(self):
         obj = HasDateTraits(simple_date=UNIX_EPOCH)
         self.assertIsNotNone(obj.simple_date)
-        obj.simple_date = None
+        with self.assertWarns(DeprecationWarning) as warnings_cm:
+            obj.simple_date = None
         self.assertIsNone(obj.simple_date)
+
+        _, _, this_module = __name__.rpartition(".")
+        self.assertIn(this_module, warnings_cm.filename)
+        self.assertIn(
+            "None will no longer be accepted",
+            str(warnings_cm.warning),
+        )
+
+    def test_assign_none_with_allow_none_false(self):
+        obj = HasDateTraits(none_prohibited=UNIX_EPOCH)
+        with self.assertRaises(TraitError) as exception_context:
+            obj.none_prohibited = None
+        message = str(exception_context.exception)
+        self.assertIn("must be a date, but", message)
+
+    def test_assign_none_with_allow_none_true(self):
+        obj = HasDateTraits(none_allowed=UNIX_EPOCH)
+        self.assertIsNotNone(obj.none_allowed)
+        obj.none_allowed = None
+        self.assertIsNone(obj.none_allowed)
 
     def test_assign_datetime_with_allow_datetime_false(self):
         test_datetime = datetime.datetime(1975, 2, 13)
@@ -111,19 +132,6 @@ class TestDate(unittest.TestCase):
             "datetime instances will no longer be accepted",
             str(warnings_cm.warning),
         )
-
-    def test_allow_none_false(self):
-        obj = HasDateTraits(none_prohibited=UNIX_EPOCH)
-        with self.assertRaises(TraitError) as exception_context:
-            obj.none_prohibited = None
-        message = str(exception_context.exception)
-        self.assertIn("must be a date, but", message)
-
-    def test_allow_none_true(self):
-        obj = HasDateTraits(none_allowed=UNIX_EPOCH)
-        self.assertIsNotNone(obj.none_allowed)
-        obj.none_allowed = None
-        self.assertIsNone(obj.none_allowed)
 
     def test_allow_none_false_allow_datetime_false(self):
         obj = HasDateTraits(strict=UNIX_EPOCH)

--- a/traits/tests/test_date.py
+++ b/traits/tests/test_date.py
@@ -73,20 +73,13 @@ class TestDate(unittest.TestCase):
         message = str(exception_context.exception)
         self.assertIn("must be a date or None, but", message)
 
-    def test_assign_datetime(self):
-        # By default, datetime instances are permitted.
-        test_datetime = datetime.datetime(1975, 2, 13)
-        obj = HasDateTraits()
-        obj.simple_date = test_datetime
-        self.assertEqual(obj.simple_date, test_datetime)
-
     def test_assign_none(self):
         obj = HasDateTraits(simple_date=UNIX_EPOCH)
         self.assertIsNotNone(obj.simple_date)
         obj.simple_date = None
         self.assertIsNone(obj.simple_date)
 
-    def test_allow_datetime_false(self):
+    def test_assign_datetime_with_allow_datetime_false(self):
         test_datetime = datetime.datetime(1975, 2, 13)
         obj = HasDateTraits()
         with self.assertRaises(TraitError) as exception_context:
@@ -94,11 +87,30 @@ class TestDate(unittest.TestCase):
         message = str(exception_context.exception)
         self.assertIn("must be a non-datetime date or None, but", message)
 
-    def test_allow_datetime_true(self):
+    def test_assign_datetime_with_allow_datetime_true(self):
         test_datetime = datetime.datetime(1975, 2, 13)
         obj = HasDateTraits()
         obj.datetime_allowed = test_datetime
         self.assertEqual(obj.datetime_allowed, test_datetime)
+
+    def test_assign_datetime_with_allow_datetime_not_given(self):
+        # For traits where "allow_datetime" is not specified, a
+        # DeprecationWarning should be issued on assignment of datetime.
+        test_datetime = datetime.datetime(1975, 2, 13)
+        obj = HasDateTraits()
+        with self.assertWarns(DeprecationWarning) as warnings_cm:
+            # Note: the warning depends on the type, not the value; this case
+            # should warn even though the time component of the datetime is
+            # zero.
+            obj.simple_date = test_datetime
+        self.assertEqual(obj.simple_date, test_datetime)
+
+        _, _, this_module = __name__.rpartition(".")
+        self.assertIn(this_module, warnings_cm.filename)
+        self.assertIn(
+            "datetime instances will no longer be accepted",
+            str(warnings_cm.warning),
+        )
 
     def test_allow_none_false(self):
         obj = HasDateTraits(none_prohibited=UNIX_EPOCH)

--- a/traits/tests/test_datetime.py
+++ b/traits/tests/test_datetime.py
@@ -73,20 +73,28 @@ class TestDatetime(unittest.TestCase):
         self.assertIn("must be a datetime or None, but", message)
         self.assertIsNone(obj.simple_datetime)
 
-    def test_assign_none(self):
+    def test_assign_none_with_allow_none_not_given(self):
         obj = HasDatetimeTraits(simple_datetime=UNIX_EPOCH)
         self.assertIsNotNone(obj.simple_datetime)
-        obj.simple_datetime = None
+        with self.assertWarns(DeprecationWarning) as warnings_cm:
+            obj.simple_datetime = None
         self.assertIsNone(obj.simple_datetime)
 
-    def test_allow_none_false(self):
+        _, _, this_module = __name__.rpartition(".")
+        self.assertIn(this_module, warnings_cm.filename)
+        self.assertIn(
+            "None will no longer be accepted",
+            str(warnings_cm.warning),
+        )
+
+    def test_assign_none_with_allow_none_false(self):
         obj = HasDatetimeTraits(none_prohibited=UNIX_EPOCH)
         with self.assertRaises(TraitError) as exception_context:
             obj.none_prohibited = None
         message = str(exception_context.exception)
         self.assertIn("must be a datetime, but", message)
 
-    def test_allow_none_true(self):
+    def test_assign_none_with_allow_none_true(self):
         obj = HasDatetimeTraits(none_allowed=UNIX_EPOCH)
         self.assertIsNotNone(obj.none_allowed)
         obj.none_allowed = None

--- a/traits/tests/test_time.py
+++ b/traits/tests/test_time.py
@@ -73,20 +73,28 @@ class TestDatetime(unittest.TestCase):
         self.assertIn("must be a time or None, but", message)
         self.assertIsNone(obj.simple_time)
 
-    def test_assign_none(self):
+    def test_assign_none_with_allow_none_not_given(self):
         obj = HasTimeTraits(simple_time=UNIX_EPOCH)
         self.assertIsNotNone(obj.simple_time)
-        obj.simple_time = None
+        with self.assertWarns(DeprecationWarning) as warnings_cm:
+            obj.simple_time = None
         self.assertIsNone(obj.simple_time)
 
-    def test_allow_none_false(self):
+        _, _, this_module = __name__.rpartition(".")
+        self.assertIn(this_module, warnings_cm.filename)
+        self.assertIn(
+            "None will no longer be accepted",
+            str(warnings_cm.warning),
+        )
+
+    def test_assign_none_with_allow_none_false(self):
         obj = HasTimeTraits(none_prohibited=UNIX_EPOCH)
         with self.assertRaises(TraitError) as exception_context:
             obj.none_prohibited = None
         message = str(exception_context.exception)
         self.assertIn("must be a time, but", message)
 
-    def test_allow_none_true(self):
+    def test_assign_none_with_allow_none_true(self):
         obj = HasTimeTraits(none_allowed=UNIX_EPOCH)
         self.assertIsNotNone(obj.none_allowed)
         obj.none_allowed = None

--- a/traits/tests/test_time.py
+++ b/traits/tests/test_time.py
@@ -44,7 +44,7 @@ class HasTimeTraits(HasStrictTraits):
     none_allowed = Time(allow_none=True)
 
 
-class TestDatetime(unittest.TestCase):
+class TestTime(unittest.TestCase):
     def test_default(self):
         obj = HasTimeTraits()
         self.assertEqual(obj.simple_time, None)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4339,7 +4339,8 @@ class Date(TraitType):
                         "In the future, datetime.datetime instances will no "
                         "longer be accepted by this trait type. To accept "
                         "datetimes and silence this warning, use "
-                        "Date(allow_datetime=True) or Union(Datetime, Date)."
+                        "Date(allow_datetime=True) or "
+                        "Union(Datetime(), Date())."
                     ),
                     DeprecationWarning,
                     stacklevel=2,

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4263,7 +4263,7 @@ class Date(TraitType):
     Use ``Date(allow_datetime=False)`` to exclude this possibility.
 
     .. deprecated:: 6.3.0
-        In the future, :cls:`datetime.datetime` instances will not be valid
+        In the future, :class:`datetime.datetime` instances will not be valid
         values for this trait type unless "allow_datetime=True" is explicitly
         given.
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4366,12 +4366,152 @@ class Date(TraitType):
         return date_editor()
 
 
-#: A trait type for datetime.datetime instances.
-Datetime = BaseInstance(datetime.datetime, editor=datetime_editor)
+class Datetime(TraitType):
+    """ A trait type whose value must be a datetime.
+
+    The value must be an instance of :class:`datetime.datetime`.
+
+    .. deprecated:: 6.3.0
+        In the future, ``None`` will not be a valid value for this trait type
+        unless "allow_none=True" is explicitly given.
+
+    Parameters
+    ----------
+    default_value : datetime.datetime, optional
+        The default value for this trait. If no default is provided, the
+        default is ``None``.
+    allow_none : bool, optional
+        If ``False``, it's not permitted to assign ``None`` to this trait.
+        If ``True``, ``None`` instances are permitted. If this argument is
+        not given, ``None`` instances will be accepted but a
+        ``DeprecationWarning`` will be issued; in some future verison of
+        Traits, ``None`` may no longer be permitted.
+    **metadata: dict
+        Additional metadata.
+    """
+
+    def __init__(
+        self,
+        default_value=None,
+        *,
+        allow_none=None,
+        **metadata,
+    ):
+        super().__init__(default_value, **metadata)
+        self.allow_none = allow_none
+
+    def validate(self, object, name, value):
+        """ Check that the given value is valid datetime for this trait.
+        """
+        if value is None:
+            if self.allow_none:
+                return value
+            elif self.allow_none is None:
+                warnings.warn(
+                    (
+                        "In the future, None will no longer be accepted by "
+                        "this trait type. To allow None and silence this "
+                        "warning, use Datetime(allow_none=True)."
+                    ),
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return value
+
+        elif isinstance(value, datetime.datetime):
+            return value
+
+        self.error(object, name, value)
+
+    def info(self):
+        """
+        Return text description of this trait.
+        """
+        if self.allow_none or self.allow_none is None:
+            none_qualifier = " or None"
+        else:
+            none_qualifier = ""
+
+        return f"a datetime{none_qualifier}"
+
+    def create_editor(self):
+        """ Create default editor factory for this trait.
+        """
+        return datetime_editor()
 
 
-#: A trait type for datetime.time instances.
-Time = BaseInstance(datetime.time, editor=time_editor)
+class Time(TraitType):
+    """ A trait type whose value must be a time.
+
+    The value must be an instance of :class:`datetime.time`.
+
+    .. deprecated:: 6.3.0
+        In the future, ``None`` will not be a valid value for this trait type
+        unless "allow_none=True" is explicitly given.
+
+    Parameters
+    ----------
+    default_value : datetime.time, optional
+        The default value for this trait. If no default is provided, the
+        default is ``None``.
+    allow_none : bool, optional
+        If ``False``, it's not permitted to assign ``None`` to this trait.
+        If ``True``, ``None`` instances are permitted. If this argument is
+        not given, ``None`` instances will be accepted but a
+        ``DeprecationWarning`` will be issued; in some future verison of
+        Traits, ``None`` may no longer be permitted.
+    **metadata: dict
+        Additional metadata.
+    """
+
+    def __init__(
+        self,
+        default_value=None,
+        *,
+        allow_none=None,
+        **metadata,
+    ):
+        super().__init__(default_value, **metadata)
+        self.allow_none = allow_none
+
+    def validate(self, object, name, value):
+        """ Check that the given value is valid time for this trait.
+        """
+        if value is None:
+            if self.allow_none:
+                return value
+            elif self.allow_none is None:
+                warnings.warn(
+                    (
+                        "In the future, None will no longer be accepted by "
+                        "this trait type. To allow None and silence this "
+                        "warning, use Time(allow_none=True)."
+                    ),
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return value
+
+        elif isinstance(value, datetime.time):
+            return value
+
+        self.error(object, name, value)
+
+    def info(self):
+        """
+        Return text description of this trait.
+        """
+        if self.allow_none or self.allow_none is None:
+            none_qualifier = " or None"
+        else:
+            none_qualifier = ""
+
+        return f"a time{none_qualifier}"
+
+    def create_editor(self):
+        """ Create default editor factory for this trait.
+        """
+        return time_editor()
 
 
 # Predefined, reusable trait instances

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4315,7 +4315,7 @@ class Date(TraitType):
                 warnings.warn(
                     (
                         "In the future, None will no longer be accepted by "
-                        "this trait type. To accept None and silence this "
+                        "this trait type. To allow None and silence this "
                         "warning, use Date(allow_none=True)."
                     ),
                     DeprecationWarning,


### PR DESCRIPTION
This PR builds on #1441 to also deprecate acceptance of `None` values for `Date` traits. While I think this is the right way to go, ~this does introduce a discrepancy with the `Datetime` and `Time` classes, where `None` is still accepted by default with no deprecation warning issued.~

Update: the PR has been extended to cover `Datetime` and `Time` classes; this required realising the `Datetime` and `Time` trait types (so that they're no longer instances of `BaseInstance`).

Closes #1438

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)  (relevant docstrings updated)
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~ N/A
- [x] Update type annotation hints in `traits-stubs`
