### PR TITLE
row_factory should be a callable for TableEditors 

### DIFF
--- a/traits/editor_factories.py
+++ b/traits/editor_factories.py
@@ -148,7 +148,11 @@ def _instance_handler_factory(handler):
     if isinstance(handler, TraitInstance):
         return handler.aClass
     elif isinstance(handler, BaseInstance):
-        return handler.default_value
+        result = handler.default_value
+        if isinstance(result, tuple):
+            return lambda : result[0](*result[1], **result[2])
+        else:
+            return result
     else:
         msg = "handler should be TraitInstance or BaseInstance, but got {}"
         raise ValueError(msg.format(repr(handler)))

--- a/traits/editor_factories.py
+++ b/traits/editor_factories.py
@@ -150,7 +150,8 @@ def _instance_handler_factory(handler):
     elif isinstance(handler, BaseInstance):
         result = handler.default_value
         if isinstance(result, tuple):
-            return lambda: result[0](*result[1], **result[2])
+            default_value_getter, args, kwargs = result
+            return lambda: default_value_getter(*args, **kwargs)
         else:
             return result
     else:

--- a/traits/editor_factories.py
+++ b/traits/editor_factories.py
@@ -150,7 +150,7 @@ def _instance_handler_factory(handler):
     elif isinstance(handler, BaseInstance):
         result = handler.default_value
         if isinstance(result, tuple):
-            return lambda : result[0](*result[1], **result[2])
+            return lambda: result[0](*result[1], **result[2])
         else:
             return result
     else:

--- a/traits/editor_factories.py
+++ b/traits/editor_factories.py
@@ -143,13 +143,13 @@ def _expects_hastraits_instance(handler):
 def _instance_handler_factory(handler):
     """ Get the instance factory of an Instance or TraitInstance
     """
-    from traits.api import BaseInstance, TraitInstance
+    from traits.api import BaseInstance, DefaultValue, TraitInstance
 
     if isinstance(handler, TraitInstance):
         return handler.aClass
     elif isinstance(handler, BaseInstance):
         result = handler.default_value
-        if isinstance(result, tuple):
+        if handler.default_value_type == DefaultValue.callable_and_args:
             default_value_getter, args, kwargs = result
             return lambda: default_value_getter(*args, **kwargs)
         else:

--- a/traits/tests/test_editor_factories.py
+++ b/traits/tests/test_editor_factories.py
@@ -211,7 +211,7 @@ class TestListEditor(unittest.TestCase):
     # regression test for enthought/traitsui#1539
     def test_list_editor_list_instance_row_factory(self):
         trait = List(Instance(HasTraits, kw={}))
-        editor = list_editor(trait, trait)
+        editor = trait.create_editor()
         self.assertIsInstance(editor, traitsui.api.TableEditor)
         if editor.row_factory is not None:
             self.assertTrue(callable(editor.row_factory))

--- a/traits/tests/test_editor_factories.py
+++ b/traits/tests/test_editor_factories.py
@@ -207,3 +207,11 @@ class TestListEditor(unittest.TestCase):
         trait = List(Instance(HasTraits))
         editor = list_editor(trait, trait)
         self.assertIsInstance(editor, traitsui.api.TableEditor)
+
+    # regression test for enthought/traitsui#1539
+    def test_list_editor_list_instance_row_factory(self):
+        trait = List(Instance(HasTraits, kw={}))
+        editor = list_editor(trait, trait)
+        self.assertIsInstance(editor, traitsui.api.TableEditor)
+        if editor.row_factory is not None:
+            self.assertTrue(callable(editor.row_factory))


### PR DESCRIPTION
**Checklist**
- [x] Tests
- ~[ ] Update API reference (`docs/source/traits_api_reference`)~
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~
- ~[ ] Update type annotation hints in `traits-stubs`~


This PR fixes https://github.com/enthought/traitsui/issues/1539
The `row_factory` for a `TableEditor` should be a callable if it is not None, see:
https://github.com/enthought/traitsui/blob/7a6d46ad10ea6c6b5a8dcc3b4939a9670c2a52ad/traitsui/editors/table_editor.py#L291-L296

Previously there was a case in which we used an `Instance` trait's `default_value`.  ~However, there is a situation in which this is an instance of `_InstanceArgs`, see:~
~https://github.com/enthought/traits/blob/2b62cd9b39bcb9e4998eeab0b32a4e3127b3df66/traits/trait_types.py#L3353-L3356~
EDIT: This was not correct, it was actually just a tuple coming from https://github.com/enthought/traits/blob/5f2effc0254570dfa7736d8bf53eb224c9877c57/traits/trait_types.py#L3420-L3437 where `dv` was an `_InstanceArgs` instance.  The tuple is of the form `(self.create_default_value, dv.args, dv.kw)` so ultimately we still do want to have a change similar to the one shown below:

This PR avoids that problem scenario by checking and making the necessary adjustment if needed.  Similar to what is done here:
https://github.com/enthought/traits/blob/2b62cd9b39bcb9e4998eeab0b32a4e3127b3df66/traits/trait_types.py#L3394-L3399