### PR TITLE
Remove mentions of `HasTraits.get()`

### DIFF
--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -1383,12 +1383,12 @@ case, you might clone an object and its trait attributes; allow the user to
 modify the clone; and then re-clone only the trait attributes back to the
 original object when the user commits changes.
 
-.. index:: set()
+.. index:: trait_set()
 
-.. _set:
+.. _trait_set:
 
-set()
-`````
+trait_set()
+```````````
 
 This method takes a list of keyword-value pairs, and sets the trait attribute
 corresponding to each keyword to the matching value. This shorthand is useful


### PR DESCRIPTION
Remove mentions of `HasTraits.get()`.
This PR closes issue #896.

There are a few other occurrences of `set()` functions:
- `threading.Event.set()` (unrelated)
- `set()` constructor (unrelated)
- implementation, test and Traits stubs for `HasTraits.set()` (scheduled to be removed, see #898)
- `TraitType.set()` used for property traits (unrelated)
- `Symbol.set()` and `WeakRef.set()` which are overwriting `TraitType.set()` (unrelated)

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] Update User manual (`docs/source/traits_user_manual`)
- [x] Update type annotation hints in `traits-stubs`
