### PR TITLE
Replace distutils.sysconfig.get_python_lib with sysconfig.get_path

### DIFF
--- a/traits/util/resource.py
+++ b/traits/util/resource.py
@@ -32,6 +32,7 @@ import sys
 
 from sysconfig import get_path
 
+
 def get_path(path):
     """ Returns an absolute path for the specified path.
 

--- a/traits/util/resource.py
+++ b/traits/util/resource.py
@@ -29,8 +29,7 @@
 import inspect
 import os
 import sys
-
-from sysconfig import get_path as _get_path
+import sysconfig
 
 
 def get_path(path):
@@ -145,7 +144,7 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
         # Setuptools was either not installed, or it failed to find the file.
         # First check to see if the package was installed using egginst by
         # looking for the file at: site-packages\\resource_path
-        full_path = os.path.join(_get_path('purelib'), resource_path)
+        full_path = os.path.join(sysconfig.get_path('purelib'), resource_path)
         if os.path.exists(full_path):
             if return_path:
                 return full_path

--- a/traits/util/resource.py
+++ b/traits/util/resource.py
@@ -30,8 +30,7 @@ import inspect
 import os
 import sys
 
-from distutils.sysconfig import get_python_lib
-
+from sysconfig import get_path
 
 def get_path(path):
     """ Returns an absolute path for the specified path.
@@ -144,8 +143,8 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
     except:
         # Setuptools was either not installed, or it failed to find the file.
         # First check to see if the package was installed using egginst by
-        # looking for the file at: site-packages\\resouce_path
-        full_path = os.path.join(get_python_lib(), resource_path)
+        # looking for the file at: site-packages\\resource_path
+        full_path = os.path.join(get_path('purelib'), resource_path)
         if os.path.exists(full_path):
             if return_path:
                 return full_path

--- a/traits/util/resource.py
+++ b/traits/util/resource.py
@@ -30,7 +30,7 @@ import inspect
 import os
 import sys
 
-from sysconfig import get_path
+from sysconfig import get_path as _get_path
 
 
 def get_path(path):
@@ -145,7 +145,7 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
         # Setuptools was either not installed, or it failed to find the file.
         # First check to see if the package was installed using egginst by
         # looking for the file at: site-packages\\resource_path
-        full_path = os.path.join(get_path('purelib'), resource_path)
+        full_path = os.path.join(_get_path('purelib'), resource_path)
         if os.path.exists(full_path):
             if return_path:
                 return full_path


### PR DESCRIPTION
Fixes https://github.com/enthought/traits/issues/1449

Removes the dependence on distutils, by replacing `distutils.sysconfig.get_python_lib` with `sysconfig.get_path`

`distutils.sysconfig.get_python_lib` with no flags defaults to `plat_specific=0, standard_lib=0`
https://github.com/pypa/distutils/blob/main/distutils/sysconfig.py

This is equivalent to `sysconfig.get_path('purelib')`
https://docs.python.org/3/library/sysconfig.html?highlight=purelib

**Checklist**
- [ n/a ] Tests
- [ n/a ] Update API reference (`docs/source/traits_api_reference`)
- [ n/a ] Update User manual (`docs/source/traits_user_manual`)
- [ n/a ] Update type annotation hints in `traits-stubs`
