### PR TITLE
Expand the docstring of `HasTraits.trait_get()`

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1358,8 +1358,14 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         Parameters
         ----------
-        names : list of strings
-            A list of trait attribute names whose values are requested.
+        names : optional
+            List of positional arguments. Either trait attribute names as
+            string arguments or a single list or tuple of trait attribute
+            names whose values are requested.
+        metadata : optional
+            Dictionary of keyword–value pairs. Metadata information used to
+            find the traits to use, provided no positional arguments are
+            passed.
 
         Returns
         -------


### PR DESCRIPTION
Expand the docstring of `HasTraits.trait_get()`.

This follows the existing docstring style for positional and keyword arguments as seen here:
https://github.com/enthought/traits/blob/c97f3227f2190d42f4b5b99dfc3d44cb85a76487/traits/testing/unittest_tools.py#L260-L264

There are some alternative styles here: https://stackoverflow.com/questions/1137161/what-is-the-correct-way-to-document-a-kwargs-parameter

This PR closes issue #1297.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] Update User manual (`docs/source/traits_user_manual`)
- [x] Update type annotation hints in `traits-stubs` (I didn't actually make any changes because other `*names`, `*traits` and `**metadata` stubs are simply described as `_Any` too, but I'm happy to make them more specific in this PR)
