### PR TITLE
Fix documentation build

### DIFF
--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip
-        python -m pip install Sphinx enthought_sphinx_theme
+        python -m pip install "Sphinx<4" enthought_sphinx_theme
     - name: Build HTML documentation with Sphinx
       run: |
         cd docs

--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -21,7 +21,8 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip
-        python -m pip install "Sphinx<4" enthought_sphinx_theme
+        python -m pip install Sphinx enthought_sphinx_theme
+        python -m pip install .
     - name: Build HTML documentation with Sphinx
       run: |
         cd docs

--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip
-        python -m pip install Sphinx enthought_sphinx_theme
+        python -m pip install "Sphinx<4" enthought_sphinx_theme
         python -m pip install .
     - name: Build HTML documentation with Sphinx
       run: |

--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .[docs]
+        python -m pip install Sphinx enthought_sphinx_theme
     - name: Build HTML documentation with Sphinx
       run: |
         cd docs


### PR DESCRIPTION
The documentation build is now picking up Sphinx 4.0.1, and is breaking as a result. We need to fix that, but short term we also need to pin Sphinx to a version < 4.0 so that other PRs (like #1461) can be merged.

I'm making this PR to both confirm the breakage independently of #1461, and to fix it. I'm expecting the doc build to fail until I pin Sphinx in a separate commit.