### PR TITLE
Fix docstring to observe's dispatcher callable

### DIFF
--- a/traits/observation/_observe.py
+++ b/traits/observation/_observe.py
@@ -33,7 +33,7 @@ def add_or_remove_notifiers(
         This is typically an instance of HasTraits seen by the user as the
         "owner" of the observer.
     dispatcher : callable(callable, event)
-        Callable for dispatching the user-defined handler, i.e. dispatching
+        Callable for dispatching the user-defined handler, e.g. dispatching
         callback on a different thread.
     remove : boolean
         If true, notifiers are being removed.

--- a/traits/observation/observe.py
+++ b/traits/observation/observe.py
@@ -43,9 +43,10 @@ def observe(
         Its type and content depends on the change.
     remove : boolean, optional
         If true, remove notifiers. i.e. unobserve the traits.
-    dispatcher : callable(callable, event)
-        Callable for dispatching the user-defined handler, i.e. dispatching
-        callback on a different thread.
+    dispatcher : callable(callable, event), optional
+        Callable for dispatching the user-defined handler, e.g. dispatching
+        callback on a different thread. Default is to dispatch on the same
+        thread.
     """
     # Implicit interface: ``expression`` can be anything with a method
     # ``_as_graphs`` that returns a list of ObserverGraph.


### PR DESCRIPTION
This PR fixes the docstring of the `dispatcher` argument on `traits.observation.api.observe` (not the decorator!).

The mention of dispatching onto a different thread is merely an example, the "i.e." is misleading.
This PR fixes that and also clarifies the default behavior.

**Checklist**
- ~Tests~
- [x] Update API reference (`docs/source/traits_api_reference`)
- ~Update User manual (`docs/source/traits_user_manual`)~
- ~Update type annotation hints in `traits-stubs`~
