### PR TITLE
Make accessing dunder-names on a CTrait object an AttributeError

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2971,14 +2971,15 @@ trait_traverse(trait_object *trait, visitproc visit, void *arg)
 }
 
 /*-----------------------------------------------------------------------------
-|  Handles the 'getattr' operation on a 'CTrait' instance:
+|  Identify double underscore names like "__qualname__" and "__package__".
+|
+|  Returns 1 if name starts and ends with "__", else 0. Returns -1 with
+|  an exception set on failure.
 +----------------------------------------------------------------------------*/
 
-/* Return 1 if name starts and ends with "__", else 0. Return -1 with
-   an exception set on failure. */
-
 static int
-is_dunder_name(PyObject *name) {
+is_dunder_name(PyObject *name)
+{
     Py_ssize_t name_length;
     int kind;
     void *data;
@@ -2999,6 +3000,9 @@ is_dunder_name(PyObject *name) {
     );
 }
 
+/*-----------------------------------------------------------------------------
+|  Handles the 'getattr' operation on a 'CTrait' instance:
++----------------------------------------------------------------------------*/
 
 static PyObject *
 trait_getattro(trait_object *obj, PyObject *name)

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3014,7 +3014,6 @@ trait_getattro(trait_object *obj, PyObject *name)
     if (value != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError)) {
         return value;
     }
-    PyErr_Clear();
 
     /* The attribute lookup failed. For backwards compatibility, we return
        `None` in this case, *except* for attribute names that start and end
@@ -3022,17 +3021,14 @@ trait_getattro(trait_object *obj, PyObject *name)
        to the interpreter, and `None` may not be a valid value, so we allow the
        exception to propagate. */
 
-    is_dunder = is_dunder_name(name);
-    if (is_dunder < 0) {
+    if (is_dunder_name(name)) {
+        /* Either we have a double-underscore name, or the is_dunder_name
+           call itself failed; either way, propagate the current exception. */
         return NULL;
-    }
-    else if (is_dunder) {
-        /* Retry the attribute lookup so that we get the correct exception
-           message. */
-        return PyObject_GenericGetAttr((PyObject *)obj, name);
     }
     else {
         /* Not a __dunder__ name; invent an attribute value of `None`. */
+        PyErr_Clear();
         Py_RETURN_NONE;
     }
 }

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2974,18 +2974,63 @@ trait_traverse(trait_object *trait, visitproc visit, void *arg)
 |  Handles the 'getattr' operation on a 'CTrait' instance:
 +----------------------------------------------------------------------------*/
 
+/* Return 1 if name starts and ends with "__", else 0. Return -1 with
+   an exception set on failure. */
+
+static int
+is_dunder_name(PyObject *name) {
+    Py_ssize_t name_length;
+    int kind;
+    void *data;
+
+    if (PyUnicode_READY(name) < 0) {
+        return -1;
+    }
+
+    name_length = PyUnicode_GET_LENGTH(name);
+    kind = PyUnicode_KIND(name);
+    data = PyUnicode_DATA(name);
+    return (
+        (name_length >= 2)
+        && (PyUnicode_READ(kind, data, 0) == '_')
+        && (PyUnicode_READ(kind, data, 1) == '_')
+        && (PyUnicode_READ(kind, data, name_length - 2) == '_')
+        && (PyUnicode_READ(kind, data, name_length - 1) == '_')
+    );
+}
+
+
 static PyObject *
 trait_getattro(trait_object *obj, PyObject *name)
 {
-    PyObject *value = PyObject_GenericGetAttr((PyObject *)obj, name);
+    PyObject *value;
+    int is_dunder;
+
+    value = PyObject_GenericGetAttr((PyObject *)obj, name);
     if (value != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError)) {
         return value;
     }
-
     PyErr_Clear();
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    /* The attribute lookup failed. For backwards compatibility, we return
+       `None` in this case, *except* for attribute names that start and end
+       with a double underscore. Those attribute names may have special meaning
+       to the interpreter, and `None` may not be a valid value, so we allow the
+       exception to propagate. */
+
+    is_dunder = is_dunder_name(name);
+    if (is_dunder < 0) {
+        return NULL;
+    }
+    else if (is_dunder) {
+        /* Retry the attribute lookup so that we get the correct exception
+           message. */
+        return PyObject_GenericGetAttr((PyObject *)obj, name);
+    }
+    else {
+        /* Not a __dunder__ name; invent an attribute value of `None`. */
+        Py_RETURN_NONE;
+    }
 }
 
 /*-----------------------------------------------------------------------------

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -308,8 +308,32 @@ class TestCTrait(unittest.TestCase):
         self.assertEqual(foo.bar_changed[0], "baz")
 
     def test_failed_attribute_access(self):
+        # Double-underscore names are special-cased.
+        non_dunder_names = [
+            "non_existent",
+            "__non_existent",
+            "non_existent__",
+            "__a__b_",
+            "_",
+        ]
+
+        dunder_names = [
+            "__package__",
+            "__a__",
+            "____",
+            "___",
+            "__",
+        ]
+
         ctrait = CTrait(0)
-        self.assertIsNone(ctrait.non_existent)
+        for name in non_dunder_names:
+            with self.subTest(name=name):
+                self.assertIsNone(getattr(ctrait, name))
+
+        for name in dunder_names:
+            with self.subTest(name=name):
+                with self.assertRaises(AttributeError):
+                    getattr(ctrait, name)
 
     def test_exception_from_attribute_access(self):
         # Regression test for enthought/traits#946.

--- a/traits/tests/test_ctraits.py
+++ b/traits/tests/test_ctraits.py
@@ -313,6 +313,7 @@ class TestCTrait(unittest.TestCase):
             "non_existent",
             "__non_existent",
             "non_existent__",
+            "_non_existent_",
             "__a__b_",
             "_",
         ]


### PR DESCRIPTION
This PR changes attribute lookups on `CTrait` objects to raise `AttributeError` for names beginning and ending with a double underscore, and for which the normal attribute lookup rules don't return anything. Previously, those attribute lookups would return `None`, and this broke napoleon, which expected that a lookup of `__qualname__` on a `CTrait` object would either raise or return a string.

Attribute lookups for names that _don't_ begin and end with a double underscore are unchanged.

No documentation  update: it's not currently documented that arbitrary attribute accesses on a `CTrait` object return `None`, and I'm not sure that I really want it to be - it's not a "feature" of Traits that I'd want to encourage people to rely on.

Fixes #1463.

**Checklist**
- [x] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)
- [ ] Update User manual (`docs/source/traits_user_manual`)
- [ ] Update type annotation hints in `traits-stubs`
