### PR TITLE
Remove restriction on Sphinx version

### DIFF
--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip
-        python -m pip install "Sphinx<4" enthought_sphinx_theme
+        python -m pip install Sphinx enthought_sphinx_theme
         python -m pip install .
     - name: Build HTML documentation with Sphinx
       run: |


### PR DESCRIPTION
This PR reverts the Sphinx version pin introduced in #1462: it should no longer be necessary since #1463 was fixed.

Undoes the effects of #1462.
