### PR TITLE
Replace use of "Either" with "Union"

### DIFF
--- a/traits/tests/test_callable.py
+++ b/traits/tests/test_callable.py
@@ -14,7 +14,6 @@ import unittest
 from traits.api import (
     BaseCallable,
     Callable,
-    Either,
     HasTraits,
     Int,
     Str,
@@ -58,13 +57,13 @@ class Unbool:
 class MyCallable(HasTraits):
     value = Callable()
 
-    callable_or_str = Either(Callable, Str)
+    callable_or_str = Union(Callable, Str)
 
-    old_callable_or_str = Either(OldCallable, Str)
+    old_callable_or_str = Union(OldCallable, Str)
 
-    bad_allow_none = Either(Callable(allow_none=Unbool()), Str)
+    bad_allow_none = Union(Callable(allow_none=Unbool()), Str)
 
-    non_none_callable_or_str = Either(Callable(allow_none=False), Str)
+    non_none_callable_or_str = Union(Callable(allow_none=False), Str)
 
 
 class MyBaseCallable(HasTraits):

--- a/traits/tests/test_float.py
+++ b/traits/tests/test_float.py
@@ -14,7 +14,9 @@ Tests for the Float trait type.
 """
 import unittest
 
-from traits.api import BaseFloat, Either, Float, HasTraits, Str, TraitError
+from traits.api import (
+    BaseFloat, Either, Float, HasTraits, Str, TraitError, Union,
+)
 from traits.testing.optional_dependencies import numpy, requires_numpy
 
 
@@ -48,9 +50,9 @@ class FloatModel(HasTraits):
 class BaseFloatModel(HasTraits):
     value = BaseFloat
 
-    value_or_none = Either(None, BaseFloat)
+    value_or_none = Union(None, BaseFloat)
 
-    float_or_text = Either(Float, Str)
+    float_or_text = Union(Float, Str)
 
 
 class CommonFloatTests(object):

--- a/traits/tests/test_float_range.py
+++ b/traits/tests/test_float_range.py
@@ -16,11 +16,11 @@ import unittest
 
 from traits.api import (
     BaseRange,
-    Either,
     HasTraits,
     Instance,
     Range,
     TraitError,
+    Union,
 )
 from traits.testing.optional_dependencies import numpy, requires_numpy
 
@@ -89,14 +89,14 @@ def RangeCompound(*args, **kwargs):
     """
     Compound trait including a Range.
     """
-    return Either(impossible, Range(*args, **kwargs))
+    return Union(impossible, Range(*args, **kwargs))
 
 
 def BaseRangeCompound(*args, **kwargs):
     """
     Compound trait including a BaseRange.
     """
-    return Either(impossible, BaseRange(*args, **kwargs))
+    return Union(impossible, BaseRange(*args, **kwargs))
 
 
 ModelWithRange = ModelFactory("ModelWithRange", RangeFactory=Range)

--- a/traits/tests/test_integer.py
+++ b/traits/tests/test_integer.py
@@ -17,7 +17,7 @@ import decimal
 import sys
 import unittest
 
-from traits.api import Either, HasTraits, Int, CInt, TraitError
+from traits.api import HasTraits, Int, CInt, TraitError, Union
 from traits.testing.optional_dependencies import numpy, requires_numpy
 
 
@@ -26,7 +26,7 @@ class A(HasTraits):
 
     convertible = CInt
 
-    convertible_or_none = Either(None, CInt)
+    convertible_or_none = Union(None, CInt)
 
 
 class IntegerLike(object):

--- a/traits/tests/test_integer_range.py
+++ b/traits/tests/test_integer_range.py
@@ -16,11 +16,11 @@ import unittest
 
 from traits.api import (
     BaseRange,
-    Either,
     HasTraits,
     Instance,
     Range,
     TraitError,
+    Union,
 )
 from traits.testing.optional_dependencies import numpy, requires_numpy
 
@@ -89,14 +89,14 @@ def RangeCompound(*args, **kwargs):
     """
     Compound trait including a Range.
     """
-    return Either(impossible, Range(*args, **kwargs))
+    return Union(impossible, Range(*args, **kwargs))
 
 
 def BaseRangeCompound(*args, **kwargs):
     """
     Compound trait including a BaseRange.
     """
-    return Either(impossible, BaseRange(*args, **kwargs))
+    return Union(impossible, BaseRange(*args, **kwargs))
 
 
 ModelWithRange = ModelFactory("ModelWithRange", RangeFactory=Range)

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -26,7 +26,6 @@ from traits.trait_types import (
     Bool,
     DelegatesTo,
     Dict,
-    Either,
     Instance,
     Int,
     List,
@@ -258,7 +257,7 @@ class TestRegression(unittest.TestCase):
         # Regression test for enthought/traits#376.
 
         class MultiArrayDataSource(HasTraits):
-            data = Either(None, Array)
+            data = Union(None, Array)
 
         b = MultiArrayDataSource(data=numpy.array([1, 2]))  # noqa: F841
         # The following line was necessary to trigger the bug: the previous
@@ -296,7 +295,7 @@ class TestRegression(unittest.TestCase):
         class A(HasTraits):
             foo = RaisingValidator()
 
-            bar = Either(None, RaisingValidator())
+            bar = Union(None, RaisingValidator())
 
         a = A()
         with self.assertRaises(ZeroDivisionError):

--- a/traits/tests/test_tuple.py
+++ b/traits/tests/test_tuple.py
@@ -12,7 +12,7 @@
 """
 import unittest
 
-from traits.api import BaseInt, Either, HasTraits, Int, Tuple
+from traits.api import BaseInt, HasTraits, Int, Tuple, Union
 from traits.tests.tuple_test_mixin import TupleTestMixin
 
 
@@ -37,7 +37,7 @@ class TupleTestCase(TupleTestMixin, unittest.TestCase):
         class A(HasTraits):
             foo = Tuple(BadInt(), BadInt())
 
-            bar = Either(Int, Tuple(BadInt(), BadInt()))
+            bar = Union(Int, Tuple(BadInt(), BadInt()))
 
         a = A()
         with self.assertRaises(ZeroDivisionError):

--- a/traits/trait_numeric.py
+++ b/traits/trait_numeric.py
@@ -416,7 +416,7 @@ class ArrayOrNone(CArray):
     """ A coercing trait whose value may be either a NumPy array or None.
 
     This trait is designed to avoid the comparison issues with numpy arrays
-    that can arise from the use of constructs like Either(None, Array).
+    that can arise from the use of constructs like Union(None, Array).
 
     The default value is None.
     """


### PR DESCRIPTION
`Either` hasn't been officially deprecated but the current best practice is to use `Union` instead of `Either` so these changes are a small step in the right direction.

Note that most of the uses are in the testsuite. Note that this PR doesn't remove all uses of `Either` in the `traits` package - there are two more uses in the testsuite which have been ignored.

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
