### PR TITLE
Fix trait selection by metadata

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -3041,7 +3041,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         result = {}
         for name, trait in traits.items():
             for meta_name, meta_eval in metadata.items():
-                if not meta_eval(getattr(trait, meta_name)):
+                if not meta_eval(getattr(trait, meta_name, None)):
                     break
             else:
                 result[name] = trait
@@ -3090,7 +3090,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         for name, trait in cls.__base_traits__.items():
             for meta_name, meta_eval in metadata.items():
-                if not meta_eval(getattr(trait, meta_name)):
+                if not meta_eval(getattr(trait, meta_name, None)):
                     break
             else:
                 result[name] = trait

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -564,6 +564,25 @@ class TestHasTraits(unittest.TestCase):
         self.assertEqual(A().foo, "")
         self.assertEqual(B().foo, 0)
 
+    def test_traits_method_with_dunder_metadata(self):
+        # Regression test for enthought/envisage#430
+        class A(HasTraits):
+            foo = Int(__extension_point__=True)
+            bar = Int(__extension_point__=False)
+            baz = Int()
+
+        a = A(foo=3, bar=4, baz=5)
+
+        self.assertEqual(
+            a.traits(__extension_point__=True),
+            {"foo": a.trait("foo")},
+        )
+
+        self.assertEqual(
+            A.class_traits(__extension_point__=True),
+            {"foo": A.class_traits()["foo"]},
+        )
+
 
 class TestObjectNotifiers(unittest.TestCase):
     """ Test calling object notifiers. """


### PR DESCRIPTION
PR #1469 made accessing nonexistent double-underscore-named attributes on a cTrait instance an `AttributeError`. Unfortunately, Envisage uses a metadata attribute `__extension_point__` to identify extension points, and the filtering facilities of `HasTraits.traits` and `HasTraits.class_traits` fail as a result.

This PR fixes calls like `hastraits_obj.traits(__extension_point=True__)` and `hastraits_obj.class_traits(__extension_point__=True)` so that they no longer fail with an `AttributeError`.

Motivated by enthought/envisage#430, but may not fix it completely.

