### PR TITLE
Remove unnecessary(?) method that's causing a deprecation warning

### DIFF
--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -75,10 +75,6 @@ class TraitDocumenter(ClassLevelDocumenter):
         """ Trait attributes have no members """
         pass
 
-    def add_content(self, more_content, no_docstring=False):
-        """ Never try to get a docstring from the trait."""
-        ClassLevelDocumenter.add_content(self, more_content, no_docstring=True)
-
     def import_object(self):
         """ Get the Trait object.
 


### PR DESCRIPTION
The `add_content` method in the `trait_documenter` Sphinx extension is causing a `DeprecationWarning`. It looks as though we don't need it, and this PR removes it.

In manual testing with a range of Sphinx versions from 1.8.5 onwards, after removing this method, I was unable to observe either documentation build failures or visible problems with the built documentation.

I'd be slightly happier if I understood why this code was there in the first place, but I've failed to discover the reason. @itziakos is the original author of this code, and may have some ideas.

It's also worth noting that since #1469, an attempt to access the `__doc__` attribute on a `CTrait` object will fail in the expected way, rather than potentially confusing Sphinx by returning `None`, so I can't think of any reason why we'd _need_ this override with Traits master branch, even if we did need it with earlier versions of Traits.

Fixes #1443.
