### PR TITLE
Remove unused variable

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3008,7 +3008,6 @@ static PyObject *
 trait_getattro(trait_object *obj, PyObject *name)
 {
     PyObject *value;
-    int is_dunder;
 
     value = PyObject_GenericGetAttr((PyObject *)obj, name);
     if (value != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError)) {


### PR DESCRIPTION
The `is_dunder` variable was left unused after a late refactor in #1469 (see https://github.com/enthought/traits/pull/1469/commits/a132475ef49798ec4490a91b33056b5f4d11cd4a); this PR removes it.