### PR TITLE
Add configuration file for Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,4 +8,5 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements: docs
+      extra_requirements:
+        - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@
 version: 2
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,4 +6,6 @@ version: 2
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements: docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx>=2.1.0
+enthought-sphinx-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-Sphinx>=2.1.0
-enthought-sphinx-theme


### PR DESCRIPTION
This PR adds a basic configuration file for Read the Docs. This file was sufficient to get the RtD build passing. See https://traits.readthedocs.io/en/docs-readthedocs-config/ for the documentation built from this branch.