### PR TITLE
Add workflow_dispatch trigger to cron job

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -1,6 +1,7 @@
 name: Test installation from PyPI
 
 on:
+  workflow_dispatch:
   schedule:
     # Run at 03:27 UTC on the 8th and 22nd of every month
     - cron: '27 3 8,22 * *'


### PR DESCRIPTION
It's helpful to be able to trigger all the CI cron jobs manually (e.g., when debugging). This PR adds the 'workflow_dispatch:' trigger to the Traits cron job.