### PR TITLE
Setup slack notifications for cron jobs

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -54,6 +54,34 @@ jobs:
         working-directory: testdir
         run: python -m unittest discover -v traits
 
+  notify-on-sdist-failure:
+    needs: test-pypi-sdist
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-sdist-success:
+    needs: test-pypi-sdist
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
   test-pypi-wheel:
     strategy:
       matrix:
@@ -100,3 +128,31 @@ jobs:
       with:
         working-directory: testdir
         run: python -m unittest discover -v traits
+
+  notify-on-wheel-failure:
+    needs: test-pypi-wheel
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-wheel-success:
+    needs: test-pypi-wheel
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -54,34 +54,6 @@ jobs:
         working-directory: testdir
         run: python -m unittest discover -v traits
 
-  notify-on-sdist-failure:
-    needs: test-pypi-sdist
-    if: failure()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack channel on failure
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
-          status: FAILED
-          color: danger
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
-
-  notify-on-sdist-success:
-    needs: test-pypi-sdist
-    if: success()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack channel on success
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
-          status: SUCCESS
-          color: good
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
-
   test-pypi-wheel:
     strategy:
       matrix:
@@ -129,8 +101,8 @@ jobs:
         working-directory: testdir
         run: python -m unittest discover -v traits
 
-  notify-on-wheel-failure:
-    needs: test-pypi-wheel
+  notify-on-failure:
+    needs: [test-pypi-sdist, test-pypi-wheel]
     if: failure()
     runs-on: ubuntu-latest
     steps:
@@ -143,8 +115,8 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
 
-  notify-on-wheel-success:
-    needs: test-pypi-wheel
+  notify-on-success:
+    needs: [test-pypi-sdist, test-pypi-wheel]
     if: success()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR sets up slack notifications for the cron jobs in this repository. I manually triggered the cron jobs on this branch to check that the slack notifications were fired as expected. Ref https://github.com/enthought/traits/actions/runs/1027333124.

This is one more step towards https://github.com/enthought/ets/issues/65

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
