### PR TITLE
Update to GitHub Actions CI configurations

### DIFF
--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -6,6 +6,15 @@ name: Core tests
 on:
   pull_request
 
+env:
+  PYTHONUNBUFFERED: 1
+
+concurrency:
+  # This should have the effect of cancelling CI runs for
+  # existing commits when a new commit is pushed to the PR.
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   core:
     strategy:

--- a/.github/workflows/run-style-checks.yml
+++ b/.github/workflows/run-style-checks.yml
@@ -3,6 +3,15 @@ name: Style check
 on:
   pull_request
 
+env:
+  PYTHONUNBUFFERED: 1
+
+concurrency:
+  # This should have the effect of cancelling CI runs for
+  # existing commits when a new commit is pushed to the PR.
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   style:
     strategy:

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -3,6 +3,15 @@ name: Tests
 on:
   pull_request
 
+env:
+  PYTHONUNBUFFERED: 1
+
+concurrency:
+  # This should have the effect of cancelling CI runs for
+  # existing commits when a new commit is pushed to the PR.
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -3,6 +3,15 @@ name: Doc build
 on:
   pull_request
 
+env:
+  PYTHONUNBUFFERED: 1
+
+concurrency:
+  # This should have the effect of cancelling CI runs for
+  # existing commits when a new commit is pushed to the PR.
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     strategy:

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -6,6 +6,9 @@ on:
     # Run at 03:27 UTC on the 8th and 22nd of every month
     - cron: '27 3 8,22 * *'
 
+env:
+  PYTHONUNBUFFERED: 1
+
 jobs:
   test-pypi-sdist:
     strategy:


### PR DESCRIPTION
This PR does two things

- sets `PYTHONUNBUFFERED` environment variable to `True` on all jobs except for the PyPI upload job.
- sets up `concurrency` so that existing CI runs are cancelled when a new commit is pushed to a PR branch. This is done only for the jobs that are run on PRs.

First step towards https://github.com/enthought/ets/issues/71

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
