### PR TITLE
Refactor ListenerParser to be a plain old Python class

### DIFF
--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -953,35 +953,28 @@ class ListenerGroup(ListenerBase):
             item.unregister(old)
 
 
-class ListenerParser(HasPrivateTraits):
+class ListenerParser:
 
-    #: The string being parsed
-    text = Str
+    # -- object Method Overrides ----------------------------------------------
 
-    #: The length of the string being parsed.
-    len_text = Int
+    def __init__(self, text):
+        #: The text being parsed.
+        self.text = text
 
-    #: The current parse index within the string
-    index = Int
+        #: The length of the string being parsed.
+        self.len_text = len(self.text)
 
-    #: The next character from the string being parsed
-    next = Property
+        #: The current parse index within the string.
+        self.index = 0
 
-    #: The next Python attribute name within the string:
-    name = Property
-
-    #: The next non-whitespace character
-    skip_ws = Property
-
-    #: Backspaces to the last character processed
-    backspace = Property
-
-    #: The ListenerBase object resulting from parsing **text**
-    listener = Instance(ListenerBase)
+        #: The parsed listener.
+        self.listener = self.parse()
 
     # -- Property Implementations ---------------------------------------------
 
-    def _get_next(self):
+    @property
+    def next(self):
+        """The next character from the string being parsed."""
         index = self.index
         self.index += 1
         if index >= self.len_text:
@@ -989,16 +982,22 @@ class ListenerParser(HasPrivateTraits):
 
         return self.text[index]
 
-    def _get_backspace(self):
+    @property
+    def backspace(self):
+        """Backspaces to the last character processed."""
         self.index = max(0, self.index - 1)
 
-    def _get_skip_ws(self):
+    @property
+    def skip_ws(self):
+        """The next non-whitespace character."""
         while True:
             c = self.next
             if c not in whitespace:
                 return c
 
-    def _get_name(self):
+    @property
+    def name(self):
+        """The next Python attribute name within the string."""
         match = name_pat.match(self.text, self.index - 1)
         if match is None:
             return ""
@@ -1006,12 +1005,6 @@ class ListenerParser(HasPrivateTraits):
         self.index = match.start(2)
 
         return match.group(1)
-
-    # -- object Method Overrides ----------------------------------------------
-
-    def __init__(self, text="", **traits):
-        self.text = text
-        super().__init__(**traits)
 
     # -- Private Methods ------------------------------------------------------
 
@@ -1150,13 +1143,6 @@ class ListenerParser(HasPrivateTraits):
         raise TraitError(
             "%s at column %d of '%s'" % (msg, self.index, self.text)
         )
-
-    # -- Event Handlers -------------------------------------------------------
-
-    def _text_changed(self):
-        self.index = 0
-        self.len_text = len(self.text)
-        self.listener = self.parse()
 
 
 class ListenerNotifyWrapper(TraitChangeNotifyWrapper):

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -22,7 +22,7 @@ from .constants import DefaultValue
 from .has_traits import HasPrivateTraits
 from .trait_base import Undefined, Uninitialized
 from .traits import Property
-from .trait_types import Str, Int, Bool, Instance, List, Enum, Any
+from .trait_types import Str, Bool, Instance, List, Enum, Any
 from .trait_errors import TraitError
 from .trait_notifiers import TraitChangeNotifyWrapper
 from .util.weakiddict import WeakIDKeyDict

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -955,21 +955,6 @@ class ListenerGroup(ListenerBase):
 
 class ListenerParser:
 
-    # -- object Method Overrides ----------------------------------------------
-
-    def __init__(self, text):
-        #: The text being parsed.
-        self.text = text
-
-        #: The length of the string being parsed.
-        self.len_text = len(self.text)
-
-        #: The current parse index within the string.
-        self.index = 0
-
-        #: The parsed listener.
-        self.listener = self.parse()
-
     # -- Property Implementations ---------------------------------------------
 
     @property
@@ -1005,6 +990,21 @@ class ListenerParser:
         self.index = match.start(2)
 
         return match.group(1)
+
+    # -- object Method Overrides ----------------------------------------------
+
+    def __init__(self, text):
+        #: The text being parsed.
+        self.text = text
+
+        #: The length of the string being parsed.
+        self.len_text = len(self.text)
+
+        #: The current parse index within the string.
+        self.index = 0
+
+        #: The parsed listener.
+        self.listener = self.parse()
 
     # -- Private Methods ------------------------------------------------------
 


### PR DESCRIPTION
This PR refactors the `ListenerParser` to turn it into a plain old Python class, rather than a `HasTraits` class.

This was mostly motivated by performance; this is only a small part of the performance story, but it is a part, and it's easy to fix. The overall goal is to speed up the creation of Traits listeners, since that was proving a bottleneck in some large Traits-using applications. This PR speeds up parsing of listener text strings like "foo.bar[]".

The behaviour of the old class also didn't make a lot of sense: in the `__init__` method, there was a line `self.text = text`, prior to calling the superclass `__init__`. That `self.text = text` assignment triggered the `_text_changed` method, which then did all the parsing. That meant that _all_ of the parsing had already taken place, and the `listener` trait set, before the `super().__init__(**traits)` call took place, making that superclass call entirely redundant. The trait-change dispatch to the `_text_changed` method was showing up as significant (not huge, but significant) in profiling.

This was motivated by #1489: we still have a lot of old Delegate-based code around (particularly in TraitsUI), and so speeding up that code should provide a quick win for downstream code.