### PR TITLE
Speed up on_trait_change, part II

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2658,11 +2658,14 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 if wrapper.equals(handler):
                     break
             else:
+                # The listener notify wrapper needs a reference to the
+                # listener, and the listener needs a (weak) reference to the
+                # wrapper. We first construct the wrapper with a listener of
+                # `None`, then construct the listener with its reference to the
+                # wrapper, then we replace the `None` listener with the correct
+                # one.
+                lnw = ListenerNotifyWrapper(handler, self, name, None, target)
                 listener = ListenerParser(name).listener
-                lnw = ListenerNotifyWrapper(
-                    handler, self, name, listener, target
-                )
-                listeners.append(lnw)
                 listener.trait_set(
                     handler=ListenerHandler(handler),
                     wrapped_handler_ref=weakref.ref(lnw),
@@ -2671,7 +2674,9 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                     priority=priority,
                     deferred=deferred,
                 )
+                lnw.listener = listener
                 listener.register(self)
+                listeners.append(lnw)
 
     # A synonym for 'on_trait_change'
     on_trait_event = on_trait_change

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2665,9 +2665,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 # wrapper, then we replace the `None` listener with the correct
                 # one.
                 lnw = ListenerNotifyWrapper(handler, self, name, None, target)
-                listener = ListenerParser(name).listener
-                listener.trait_set(
+                listener = ListenerParser(
+                    name,
                     handler=ListenerHandler(handler),
+                ).listener
+                listener.trait_set(
                     wrapped_handler_ref=weakref.ref(lnw),
                     type=lnw.type,
                     dispatch=dispatch,

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2668,9 +2668,9 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 listener = ListenerParser(
                     name,
                     handler=ListenerHandler(handler),
+                    wrapped_handler_ref=weakref.ref(lnw),
                 ).listener
                 listener.trait_set(
-                    wrapped_handler_ref=weakref.ref(lnw),
                     type=lnw.type,
                     dispatch=dispatch,
                     priority=priority,

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2669,10 +2669,10 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                     name,
                     handler=ListenerHandler(handler),
                     wrapped_handler_ref=weakref.ref(lnw),
+                    dispatch=dispatch,
                 ).listener
                 listener.trait_set(
                     type=lnw.type,
-                    dispatch=dispatch,
                     priority=priority,
                     deferred=deferred,
                 )

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -126,9 +126,6 @@ def not_event(value):
 
 class ListenerBase(HasPrivateTraits):
 
-    # The handler to be called when any listened to trait is changed:
-    # handler = Any
-
     # The dispatch mechanism to use when invoking the handler:
     # dispatch = Str
 
@@ -498,12 +495,6 @@ class ListenerItem(ListenerBase):
 
     # -- Event Handlers -------------------------------------------------------
 
-    def _handler_changed(self, handler):
-        """ Handles the **handler** trait being changed.
-        """
-        if self.next is not None:
-            self.next.handler = handler
-
     def _wrapped_handler_ref_changed(self, wrapped_handler_ref):
         """ Handles the 'wrapped_handler_ref' trait being changed.
         """
@@ -861,9 +852,6 @@ ListProperty = Property(fget=_get_value, fset=_set_value)
 
 class ListenerGroup(ListenerBase):
 
-    #: The handler to be called when any listened-to trait is changed
-    handler = Property
-
     #: A weakref 'wrapped' version of 'handler':
     wrapped_handler_ref = Property
 
@@ -892,12 +880,6 @@ class ListenerGroup(ListenerBase):
     items = List(ListenerBase)
 
     # -- Property Implementations ---------------------------------------------
-
-    def _set_handler(self, handler):
-        if self._handler is None:
-            self._handler = handler
-            for item in self.items:
-                item.handler = handler
 
     def _set_wrapped_handler_ref(self, wrapped_handler_ref):
         if self._wrapped_handler_ref is None:
@@ -993,7 +975,7 @@ class ListenerParser:
 
     # -- object Method Overrides ----------------------------------------------
 
-    def __init__(self, text):
+    def __init__(self, text, handler=None):
         #: The text being parsed.
         self.text = text
 
@@ -1002,6 +984,9 @@ class ListenerParser:
 
         #: The current parse index within the string.
         self.index = 0
+
+        #: The handler to be called when any listened-to trait is changed.
+        self.handler = handler
 
         #: The parsed listener.
         self.listener = self.parse()
@@ -1027,7 +1012,11 @@ class ListenerParser:
             return ListenerItem(
                 name=match.group(1),
                 notify=match.group(2) == ".",
-                next=ListenerItem(name=match.group(3)),
+                next=ListenerItem(
+                    name=match.group(3),
+                    handler=self.handler,
+                ),
+                handler=self.handler,
             )
 
         return self.parse_group(EOS)
@@ -1066,7 +1055,10 @@ class ListenerParser:
             if name != "":
                 c = self.next
 
-            result = ListenerItem(name=name)
+            result = ListenerItem(
+                name=name,
+                handler=self.handler,
+            )
 
             if c in "+-":
                 result.name += "*"

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -495,12 +495,6 @@ class ListenerItem(ListenerBase):
 
     # -- Event Handlers -------------------------------------------------------
 
-    def _wrapped_handler_ref_changed(self, wrapped_handler_ref):
-        """ Handles the 'wrapped_handler_ref' trait being changed.
-        """
-        if self.next is not None:
-            self.next.wrapped_handler_ref = wrapped_handler_ref
-
     def _dispatch_changed(self, dispatch):
         """ Handles the **dispatch** trait being changed.
         """
@@ -852,9 +846,6 @@ ListProperty = Property(fget=_get_value, fset=_set_value)
 
 class ListenerGroup(ListenerBase):
 
-    #: A weakref 'wrapped' version of 'handler':
-    wrapped_handler_ref = Property
-
     #: The dispatch mechanism to use when invoking the handler:
     dispatch = Property
 
@@ -880,12 +871,6 @@ class ListenerGroup(ListenerBase):
     items = List(ListenerBase)
 
     # -- Property Implementations ---------------------------------------------
-
-    def _set_wrapped_handler_ref(self, wrapped_handler_ref):
-        if self._wrapped_handler_ref is None:
-            self._wrapped_handler_ref = wrapped_handler_ref
-            for item in self.items:
-                item.wrapped_handler_ref = wrapped_handler_ref
 
     def _set_dispatch(self, dispatch):
         if self._dispatch is None:
@@ -975,7 +960,7 @@ class ListenerParser:
 
     # -- object Method Overrides ----------------------------------------------
 
-    def __init__(self, text, handler=None):
+    def __init__(self, text, handler=None, wrapped_handler_ref=None):
         #: The text being parsed.
         self.text = text
 
@@ -987,6 +972,9 @@ class ListenerParser:
 
         #: The handler to be called when any listened-to trait is changed.
         self.handler = handler
+
+        #: A weakref 'wrapped' version of 'handler':
+        self.wrapped_handler_ref = wrapped_handler_ref
 
         #: The parsed listener.
         self.listener = self.parse()
@@ -1015,8 +1003,10 @@ class ListenerParser:
                 next=ListenerItem(
                     name=match.group(3),
                     handler=self.handler,
+                    wrapped_handler_ref=self.wrapped_handler_ref,
                 ),
                 handler=self.handler,
+                wrapped_handler_ref=self.wrapped_handler_ref,
             )
 
         return self.parse_group(EOS)
@@ -1058,6 +1048,7 @@ class ListenerParser:
             result = ListenerItem(
                 name=name,
                 handler=self.handler,
+                wrapped_handler_ref=self.wrapped_handler_ref,
             )
 
             if c in "+-":


### PR DESCRIPTION
Context: This PR follows on from #1490. It's part of a larger effort to identify and ameliorate performance bottlenecks in the on_trait_change, while not changing the `on_trait_change` behaviour.

This PR changes the way that `ListenerItem`s are initialised. Previously, in the `on_trait_change` method:

* a `ListenerParser` created a tree of `ListenerBase` instances (`ListenerItem`s and `ListenerGroup`s),
* then the `handler`, `wrapped_handler_ref` and `dispatch` traits were set on the root node of the tree
* and static trait-change handlers took care of propagating those changes down the tree

Those static trait-change handlers are one cause of slowness in a large Traits-using system.

With this PR, the `ListenerParser` takes care of provisioning all the `ListenerItem`s at creation time, instead of propagating the changes down after `ListenerItem` creation.

This PR gets us partway to making the `ListenerItem` and `ListenerGroup` classes not need to be traited classes at all. I plan to make at least one more PR to complete that process.

This PR should be reviewable commit by commit: all tests should pass at each commit.