### PR TITLE
Speed up on_trait_change, part III

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2670,10 +2670,10 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                     handler=ListenerHandler(handler),
                     wrapped_handler_ref=weakref.ref(lnw),
                     dispatch=dispatch,
+                    priority=priority,
                 ).listener
                 listener.trait_set(
                     type=lnw.type,
-                    priority=priority,
                     deferred=deferred,
                 )
                 lnw.listener = listener

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2658,11 +2658,14 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 if wrapper.equals(handler):
                     break
             else:
+                # The listener notify wrapper needs a reference to the
+                # listener, and the listener needs a (weak) reference to the
+                # wrapper. We first construct the wrapper with a listener of
+                # `None`, then construct the listener with its reference to the
+                # wrapper, then we replace the `None` listener with the correct
+                # one.
+                lnw = ListenerNotifyWrapper(handler, self, name, None, target)
                 listener = ListenerParser(name).listener
-                lnw = ListenerNotifyWrapper(
-                    handler, self, name, listener, target
-                )
-                listeners.append(lnw)
                 listener.trait_set(
                     handler=ListenerHandler(handler),
                     wrapped_handler_ref=weakref.ref(lnw),
@@ -2671,7 +2674,9 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                     priority=priority,
                     deferred=deferred,
                 )
+                lnw.listener = listener
                 listener.register(self)
+                listeners.append(lnw)
 
     # A synonym for 'on_trait_change'
     on_trait_event = on_trait_change

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2671,10 +2671,10 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                     wrapped_handler_ref=weakref.ref(lnw),
                     dispatch=dispatch,
                     priority=priority,
+                    deferred=deferred,
                 ).listener
                 listener.trait_set(
                     type=lnw.type,
-                    deferred=deferred,
                 )
                 lnw.listener = listener
                 listener.register(self)

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2665,9 +2665,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 # wrapper, then we replace the `None` listener with the correct
                 # one.
                 lnw = ListenerNotifyWrapper(handler, self, name, None, target)
-                listener = ListenerParser(name).listener
-                listener.trait_set(
+                listener = ListenerParser(
+                    name,
                     handler=ListenerHandler(handler),
+                ).listener
+                listener.trait_set(
                     wrapped_handler_ref=weakref.ref(lnw),
                     type=lnw.type,
                     dispatch=dispatch,

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2668,9 +2668,9 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 listener = ListenerParser(
                     name,
                     handler=ListenerHandler(handler),
+                    wrapped_handler_ref=weakref.ref(lnw),
                 ).listener
                 listener.trait_set(
-                    wrapped_handler_ref=weakref.ref(lnw),
                     type=lnw.type,
                     dispatch=dispatch,
                     priority=priority,

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2669,10 +2669,10 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                     name,
                     handler=ListenerHandler(handler),
                     wrapped_handler_ref=weakref.ref(lnw),
+                    dispatch=dispatch,
                 ).listener
                 listener.trait_set(
                     type=lnw.type,
-                    dispatch=dispatch,
                     priority=priority,
                     deferred=deferred,
                 )

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -2672,10 +2672,8 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                     dispatch=dispatch,
                     priority=priority,
                     deferred=deferred,
+                    handler_type=lnw.type,
                 ).listener
-                listener.trait_set(
-                    type=lnw.type,
-                )
                 lnw.listener = listener
                 listener.register(self)
                 listeners.append(lnw)

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -126,9 +126,6 @@ def not_event(value):
 
 class ListenerBase(HasPrivateTraits):
 
-    # The handler to be called when any listened to trait is changed:
-    # handler = Any
-
     # The dispatch mechanism to use when invoking the handler:
     # dispatch = Str
 
@@ -498,12 +495,6 @@ class ListenerItem(ListenerBase):
 
     # -- Event Handlers -------------------------------------------------------
 
-    def _handler_changed(self, handler):
-        """ Handles the **handler** trait being changed.
-        """
-        if self.next is not None:
-            self.next.handler = handler
-
     def _wrapped_handler_ref_changed(self, wrapped_handler_ref):
         """ Handles the 'wrapped_handler_ref' trait being changed.
         """
@@ -861,9 +852,6 @@ ListProperty = Property(fget=_get_value, fset=_set_value)
 
 class ListenerGroup(ListenerBase):
 
-    #: The handler to be called when any listened-to trait is changed
-    handler = Property
-
     #: A weakref 'wrapped' version of 'handler':
     wrapped_handler_ref = Property
 
@@ -892,12 +880,6 @@ class ListenerGroup(ListenerBase):
     items = List(ListenerBase)
 
     # -- Property Implementations ---------------------------------------------
-
-    def _set_handler(self, handler):
-        if self._handler is None:
-            self._handler = handler
-            for item in self.items:
-                item.handler = handler
 
     def _set_wrapped_handler_ref(self, wrapped_handler_ref):
         if self._wrapped_handler_ref is None:
@@ -993,7 +975,7 @@ class ListenerParser:
 
     # -- object Method Overrides ----------------------------------------------
 
-    def __init__(self, text):
+    def __init__(self, text, handler=None):
         #: The text being parsed.
         self.text = text
 
@@ -1002,6 +984,9 @@ class ListenerParser:
 
         #: The current parse index within the string.
         self.index = 0
+
+        #: The handler to be called when any listened-to trait is changed.
+        self.handler = handler
 
         #: The parsed listener.
         self.listener = self.parse()
@@ -1027,7 +1012,11 @@ class ListenerParser:
             return ListenerItem(
                 name=match.group(1),
                 notify=match.group(2) == ".",
-                next=ListenerItem(name=match.group(3)),
+                next=ListenerItem(
+                    name=match.group(3),
+                    handler=self.handler,
+                ),
+                handler=self.handler,
             )
 
         return self.parse_group(EOS)
@@ -1066,7 +1055,10 @@ class ListenerParser:
             if name != "":
                 c = self.next
 
-            result = ListenerItem(name=name)
+            result = ListenerItem(
+                name=name,
+                handler=self.handler,
+            )
 
             if c in "+-":
                 result.name += "*"

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -495,12 +495,6 @@ class ListenerItem(ListenerBase):
 
     # -- Event Handlers -------------------------------------------------------
 
-    def _wrapped_handler_ref_changed(self, wrapped_handler_ref):
-        """ Handles the 'wrapped_handler_ref' trait being changed.
-        """
-        if self.next is not None:
-            self.next.wrapped_handler_ref = wrapped_handler_ref
-
     def _dispatch_changed(self, dispatch):
         """ Handles the **dispatch** trait being changed.
         """
@@ -852,9 +846,6 @@ ListProperty = Property(fget=_get_value, fset=_set_value)
 
 class ListenerGroup(ListenerBase):
 
-    #: A weakref 'wrapped' version of 'handler':
-    wrapped_handler_ref = Property
-
     #: The dispatch mechanism to use when invoking the handler:
     dispatch = Property
 
@@ -880,12 +871,6 @@ class ListenerGroup(ListenerBase):
     items = List(ListenerBase)
 
     # -- Property Implementations ---------------------------------------------
-
-    def _set_wrapped_handler_ref(self, wrapped_handler_ref):
-        if self._wrapped_handler_ref is None:
-            self._wrapped_handler_ref = wrapped_handler_ref
-            for item in self.items:
-                item.wrapped_handler_ref = wrapped_handler_ref
 
     def _set_dispatch(self, dispatch):
         if self._dispatch is None:
@@ -975,7 +960,7 @@ class ListenerParser:
 
     # -- object Method Overrides ----------------------------------------------
 
-    def __init__(self, text, handler=None):
+    def __init__(self, text, handler=None, wrapped_handler_ref=None):
         #: The text being parsed.
         self.text = text
 
@@ -987,6 +972,9 @@ class ListenerParser:
 
         #: The handler to be called when any listened-to trait is changed.
         self.handler = handler
+
+        #: A weakref 'wrapped' version of 'handler':
+        self.wrapped_handler_ref = wrapped_handler_ref
 
         #: The parsed listener.
         self.listener = self.parse()
@@ -1015,8 +1003,10 @@ class ListenerParser:
                 next=ListenerItem(
                     name=match.group(3),
                     handler=self.handler,
+                    wrapped_handler_ref=self.wrapped_handler_ref,
                 ),
                 handler=self.handler,
+                wrapped_handler_ref=self.wrapped_handler_ref,
             )
 
         return self.parse_group(EOS)
@@ -1058,6 +1048,7 @@ class ListenerParser:
             result = ListenerItem(
                 name=name,
                 handler=self.handler,
+                wrapped_handler_ref=self.wrapped_handler_ref,
             )
 
             if c in "+-":

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -126,10 +126,6 @@ def not_event(value):
 
 class ListenerBase(HasPrivateTraits):
 
-    # Does the handler go at the beginning (True) or end (False) of the
-    # notification handlers list?
-    # priority = Bool( False )
-
     # The next level (if any) of ListenerBase object to be called when any of
     # our listened to traits is changed:
     # next = Instance( ListenerBase )
@@ -490,14 +486,6 @@ class ListenerItem(ListenerBase):
                 "incompatible with a change to an intermediate trait"
             )
 
-    # -- Event Handlers -------------------------------------------------------
-
-    def _priority_changed(self, priority):
-        """ Handles the **priority** trait being changed.
-        """
-        if self.next is not None:
-            self.next.priority = priority
-
     # -- Private Methods ------------------------------------------------------
 
     def _register_anytrait(self, object, name, remove):
@@ -837,10 +825,6 @@ ListProperty = Property(fget=_get_value, fset=_set_value)
 
 class ListenerGroup(ListenerBase):
 
-    #: Does the handler go at the beginning (True) or end (False) of the
-    #: notification handlers list?
-    priority = ListProperty
-
     #: The next level (if any) of ListenerBase object to be called when any of
     #: this object's listened-to traits is changed
     next = ListProperty
@@ -941,7 +925,13 @@ class ListenerParser:
     # -- object Method Overrides ----------------------------------------------
 
     def __init__(
-        self, text, handler=None, wrapped_handler_ref=None, dispatch=""
+        self,
+        text,
+        *,
+        handler=None,
+        wrapped_handler_ref=None,
+        dispatch="",
+        priority=False,
     ):
         #: The text being parsed.
         self.text = text
@@ -960,6 +950,10 @@ class ListenerParser:
 
         #: The dispatch mechanism to use when invoking the handler.
         self.dispatch = dispatch
+
+        #: Does the handler go at the beginning (True) or end (False) of the
+        #: notification handlers list?
+        self.priority = priority
 
         #: The parsed listener.
         self.listener = self.parse()
@@ -990,10 +984,12 @@ class ListenerParser:
                     handler=self.handler,
                     wrapped_handler_ref=self.wrapped_handler_ref,
                     dispatch=self.dispatch,
+                    priority=self.priority,
                 ),
                 handler=self.handler,
                 wrapped_handler_ref=self.wrapped_handler_ref,
                 dispatch=self.dispatch,
+                priority=self.priority,
             )
 
         return self.parse_group(EOS)
@@ -1037,6 +1033,7 @@ class ListenerParser:
                 handler=self.handler,
                 wrapped_handler_ref=self.wrapped_handler_ref,
                 dispatch=self.dispatch,
+                priority=self.priority,
             )
 
             if c in "+-":

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -984,7 +984,7 @@ class ListenerParser:
                     priority=self.priority,
                     # Bug-for-bug compatibility with old behaviour: don't
                     # propagate the 'deferred' or 'handler_type' values for the
-                    # child item.
+                    # child item. Ref: enthought/traits#537.
                     deferred=False,
                     type=ANY_LISTENER,
                 ),
@@ -1112,6 +1112,7 @@ class ListenerParser:
             result.notify = c == "."
             # Bug-for-bug compatibility with old behaviour: don't propagate the
             # 'deferred' or 'handler_type' values for the child item.
+            # Ref: enthought/traits#537.
             next = self.parse_item(
                 terminator=terminator,
                 deferred=False,


### PR DESCRIPTION
~[PR against branch for #1491, for ease of review]~

This PR continues the work in #1491, removing more after-the-fact trait setting in the `ListenerItem` and `ListenerGroup`.

It addresses the three traits `priority`, `deferred` and `type` on the `ListenerItem`. With this PR, the need for the `trait_set` operation after creating the listener is completely removed.

Handling `priority` is straightforward, and the approach taken is similar to the approach taken in #1491: the `priority` value is stored on the `ListenerParser`, and injected into the `ListenerItem` objects as they're created.

The other two traits can't be handled in the same way, since their value differs depending on where in the listener tree we are.  Instead, we pass the `type` and `deferred` values through the parsing machinery via the `parse`, `parse_item` and `parse_group` function calls.

(It's quite possible that the `deferred` and `type` values aren't actually being set correctly on child items, but the goal of this PR is not to fix that: we just want to speed things up without changing user observable behaviour. We've tried to change the behaviour before and ended up with failures on Traits-using projects. See #537.)
