### PR TITLE
Fix ListenerHandler race condition

### DIFF
--- a/traits/tests/test_traits_listener.py
+++ b/traits/tests/test_traits_listener.py
@@ -468,7 +468,7 @@ class TestListenerParser(unittest.TestCase):
                 self.value = value
 
             def square(self):
-                return self.value*self.value
+                return self.value * self.value
 
         a = A(7)
         listener_handler = traits_listener.ListenerHandler(a.square)

--- a/traits/tests/test_traits_listener.py
+++ b/traits/tests/test_traits_listener.py
@@ -18,9 +18,10 @@ import unittest
 
 from traits import traits_listener
 from traits.api import (
-    TraitError,
     pop_exception_handler,
     push_exception_handler,
+    TraitError,
+    Undefined,
 )
 
 
@@ -460,3 +461,35 @@ class TestListenerParser(unittest.TestCase):
             next=None,
         )
         self.assertEqual(parser.listener, expected)
+
+    def test_listener_handler_for_method(self):
+        class A:
+            def __init__(self, value):
+                self.value = value
+
+            def square(self):
+                return self.value*self.value
+
+        a = A(7)
+        listener_handler = traits_listener.ListenerHandler(a.square)
+        handler = listener_handler()
+        self.assertEqual(handler(), 49)
+
+        # listener_handler does not keep the object 'a' alive
+        del a, handler
+        handler = listener_handler()
+        self.assertEqual(handler, Undefined)
+
+    def test_listener_handler_for_function(self):
+
+        def square(value):
+            return value * value
+
+        listener_handler = traits_listener.ListenerHandler(square)
+        handler = listener_handler()
+        self.assertEqual(handler(9), 81)
+
+        # listener_handler *does* keep the 'square' function alive
+        del square, handler
+        handler = listener_handler()
+        self.assertEqual(handler(5), 25)

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -1194,6 +1194,23 @@ class ListenerNotifyWrapper(TraitChangeNotifyWrapper):
 
 
 class ListenerHandler(object):
+    """
+    Wrapper for trait change handlers that avoids strong references to methods.
+
+    For a bound method handler, this wrapper prevents us from holding a
+    strong reference to the object bound to that bound method. For other
+    callable handlers, we do keep a strong reference to the handler.
+
+    When called with no arguments, this object returns either the actual
+    handler, or Undefined if the handler no longer exists because the object
+    it was bound to has been garbage collected.
+
+    Parameters
+    ----------
+    handler : callable
+        Object to be called when the relevant trait or traits change.
+    """
+
     def __init__(self, handler):
         if isinstance(handler, MethodType):
             self.handler_ref = weakref.WeakMethod(handler)

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -1195,22 +1195,15 @@ class ListenerNotifyWrapper(TraitChangeNotifyWrapper):
 
 class ListenerHandler(object):
     def __init__(self, handler):
-        if type(handler) is MethodType:
-            object = handler.__self__
-            if object is not None:
-                self.object = weakref.ref(object, self.listener_deleted)
-                self.name = handler.__name__
-
-                return
-
-        self.handler = handler
+        if isinstance(handler, MethodType):
+            self.handler_ref = weakref.WeakMethod(handler)
+        else:
+            self.handler = handler
 
     def __call__(self):
         result = getattr(self, "handler", None)
         if result is not None:
             return result
-
-        return getattr(self.object(), self.name)
-
-    def listener_deleted(self, ref):
-        self.handler = Undefined
+        else:
+            handler = self.handler_ref()
+            return Undefined if handler is None else handler


### PR DESCRIPTION
Fixes #1494.

I've added a couple of unit tests for `ListenerHandler`, testing the two main use-cases (methods and functions as handlers). I don't have a regression test for the race condition - the race condition exists, but is almost impossible to reproduce programmatically.
