### PR TITLE
Use anytrait consistently

### DIFF
--- a/docs/source/traits_api_reference/trait_notifiers.rst
+++ b/docs/source/traits_api_reference/trait_notifiers.rst
@@ -13,7 +13,7 @@ Classes
     :members: _push_handler, _pop_handler, _handle_exception, _get_handlers,
         _check_lock, _log_exception
 
-.. autoclass:: StaticAnyTraitChangeNotifyWrapper
+.. autoclass:: StaticAnytraitChangeNotifyWrapper
 
 .. autoclass:: StaticTraitChangeNotifyWrapper
 

--- a/docs/source/traits_user_manual/listening.rst
+++ b/docs/source/traits_user_manual/listening.rst
@@ -494,7 +494,7 @@ To notify about changes to any trait attribute on a class, define a method
 named _anytrait_changed().
 
 .. index::
-   pair: examples; _any_trait_changed()
+   pair: examples; _anytrait_changed()
    pair: static notification; examples
 
 Both of these types of static trait attribute notification methods are

--- a/traits-stubs/traits-stubs/has_traits.pyi
+++ b/traits-stubs/traits-stubs/has_traits.pyi
@@ -16,7 +16,7 @@ from .ctraits import CHasTraits as CHasTraits
 from .trait_base import SequenceTypes as SequenceTypes, TraitsCache as TraitsCache, Undefined as Undefined, is_none as is_none, not_event as not_event, not_false as not_false
 from .trait_converters import check_trait as check_trait, mapped_trait_for as mapped_trait_for, trait_for as trait_for
 from .trait_errors import TraitError as TraitError
-from .trait_notifiers import ExtendedTraitChangeNotifyWrapper as ExtendedTraitChangeNotifyWrapper, FastUITraitChangeNotifyWrapper as FastUITraitChangeNotifyWrapper, NewTraitChangeNotifyWrapper as NewTraitChangeNotifyWrapper, StaticAnyTraitChangeNotifyWrapper as StaticAnyTraitChangeNotifyWrapper, StaticTraitChangeNotifyWrapper as StaticTraitChangeNotifyWrapper, TraitChangeNotifyWrapper as TraitChangeNotifyWrapper
+from .trait_notifiers import ExtendedTraitChangeNotifyWrapper as ExtendedTraitChangeNotifyWrapper, FastUITraitChangeNotifyWrapper as FastUITraitChangeNotifyWrapper, NewTraitChangeNotifyWrapper as NewTraitChangeNotifyWrapper, StaticAnytraitChangeNotifyWrapper as StaticAnytraitChangeNotifyWrapper, StaticTraitChangeNotifyWrapper as StaticTraitChangeNotifyWrapper, TraitChangeNotifyWrapper as TraitChangeNotifyWrapper
 from .trait_types import Any as Any, Bool as Bool, Disallow as Disallow, Event as Event, Python as Python
 from .traits import ForwardProperty as ForwardProperty, Property as Property, Trait as Trait, generic_trait as generic_trait
 from .util.deprecated import deprecated as deprecated

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -41,7 +41,7 @@ from .trait_notifiers import (
     ExtendedTraitChangeNotifyWrapper,
     FastUITraitChangeNotifyWrapper,
     NewTraitChangeNotifyWrapper,
-    StaticAnyTraitChangeNotifyWrapper,
+    StaticAnytraitChangeNotifyWrapper,
     StaticTraitChangeNotifyWrapper,
     TraitChangeNotifyWrapper,
     ui_dispatch,
@@ -89,7 +89,7 @@ class AbstractViewElement(abc.ABC):
 # Constants
 
 WrapperTypes = (
-    StaticAnyTraitChangeNotifyWrapper,
+    StaticAnytraitChangeNotifyWrapper,
     StaticTraitChangeNotifyWrapper,
 )
 
@@ -652,7 +652,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
     # it can be attached to all traits in the class:
     anytrait = _get_def(class_name, class_dict, bases, "_anytrait_changed")
     if anytrait is not None:
-        anytrait = StaticAnyTraitChangeNotifyWrapper(anytrait)
+        anytrait = StaticAnytraitChangeNotifyWrapper(anytrait)
 
         # Save it in the prefix traits dictionary so that any dynamically
         # created traits (e.g. 'prefix traits') can re-use it:

--- a/traits/tests/test_traits_listener.py
+++ b/traits/tests/test_traits_listener.py
@@ -47,8 +47,8 @@ def assert_listener_item_equal(test_case, item1, item2, msg=None):
         msg=get_msg("metadata_defined", msg),
     )
     test_case.assertEqual(
-        item1.is_any_trait, item2.is_any_trait,
-        msg=get_msg("is_any_trait", msg),
+        item1.is_anytrait, item2.is_anytrait,
+        msg=get_msg("is_anytrait", msg),
     )
     test_case.assertEqual(
         item1.dispatch, item2.dispatch,
@@ -97,7 +97,7 @@ class TestListenerParser(unittest.TestCase):
             name="some_trait_name",
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -114,7 +114,7 @@ class TestListenerParser(unittest.TestCase):
         common_traits = dict(
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -140,7 +140,7 @@ class TestListenerParser(unittest.TestCase):
         common_traits = dict(
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             is_list_handler=False,
             type=traits_listener.ANY_LISTENER,
@@ -174,7 +174,7 @@ class TestListenerParser(unittest.TestCase):
         common_traits = dict(
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -242,7 +242,7 @@ class TestListenerParser(unittest.TestCase):
             name="prefix",
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -260,7 +260,7 @@ class TestListenerParser(unittest.TestCase):
             name="prefix*",
             metadata_name="foo",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -269,7 +269,7 @@ class TestListenerParser(unittest.TestCase):
         )
         self.assertEqual(parser.listener, expected)
 
-    def test_parse_is_any_trait_plus(self):
+    def test_parse_is_anytrait_plus(self):
         text = "+"
         parser = traits_listener.ListenerParser(text=text)
 
@@ -277,7 +277,7 @@ class TestListenerParser(unittest.TestCase):
             name="*",
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -286,7 +286,7 @@ class TestListenerParser(unittest.TestCase):
         )
         self.assertEqual(parser.listener, expected)
 
-    def test_parse_is_any_trait_minus(self):
+    def test_parse_is_anytrait_minus(self):
         text = "-"
         parser = traits_listener.ListenerParser(text=text)
 
@@ -294,7 +294,7 @@ class TestListenerParser(unittest.TestCase):
             name="*",
             metadata_name="",
             metadata_defined=False,    # the effect of '-'
-            is_any_trait=True,         # the effect of '-'
+            is_anytrait=True,         # the effect of '-'
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -311,7 +311,7 @@ class TestListenerParser(unittest.TestCase):
             name="foo*",
             metadata_name="",
             metadata_defined=False,    # the effect of '-'
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -328,7 +328,7 @@ class TestListenerParser(unittest.TestCase):
             name="*",
             metadata_name="foo",
             metadata_defined=False,    # the effect of '-'
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -346,7 +346,7 @@ class TestListenerParser(unittest.TestCase):
         common_traits = dict(
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -377,7 +377,7 @@ class TestListenerParser(unittest.TestCase):
         common_traits = dict(
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -416,7 +416,7 @@ class TestListenerParser(unittest.TestCase):
         common_traits = dict(
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=False,
@@ -452,7 +452,7 @@ class TestListenerParser(unittest.TestCase):
             name="foo",
             metadata_name="",
             metadata_defined=True,
-            is_any_trait=False,
+            is_anytrait=False,
             dispatch="",
             notify=True,
             is_list_handler=True,    # the effect of '[]'

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -361,7 +361,7 @@ class AbstractStaticChangeNotifyWrapper(object):
         return False
 
 
-class StaticAnyTraitChangeNotifyWrapper(AbstractStaticChangeNotifyWrapper):
+class StaticAnytraitChangeNotifyWrapper(AbstractStaticChangeNotifyWrapper):
 
     # The wrapper is called with the full set of argument, and we need to
     # create a tuple with the arguments that need to be sent to the event

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -208,9 +208,9 @@ class ListenerItem(ListenerBase):
     #: be deferred until the associated trait is first read or set?
     deferred = Bool(False)
 
-    #: Is this an 'any_trait' change listener, or does it create explicit
+    #: Is this an 'anytrait' change listener, or does it create explicit
     #: listeners for each individual trait?
-    is_any_trait = Bool(False)
+    is_anytrait = Bool(False)
 
     #: Is the associated handler a special list handler that handles both
     #: 'foo' and 'foo_items' events by receiving a list of 'deleted' and
@@ -250,7 +250,7 @@ class ListenerItem(ListenerBase):
     name = %r,
     metadata_name = %r,
     metadata_defined = %r,
-    is_any_trait = %r,
+    is_anytrait = %r,
     dispatch = %r,
     notify = %r,
     is_list_handler = %r,
@@ -261,7 +261,7 @@ class ListenerItem(ListenerBase):
             self.name,
             self.metadata_name,
             self.metadata_defined,
-            self.is_any_trait,
+            self.is_anytrait,
             self.dispatch,
             self.notify,
             self.is_list_handler,
@@ -283,7 +283,7 @@ class ListenerItem(ListenerBase):
         last = name[-1:]
         if last == "*":
             # Handle the special case of an 'anytrait' change listener:
-            if self.is_any_trait:
+            if self.is_anytrait:
                 try:
                     self.active[new] = [("", ANYTRAIT_LISTENER)]
                     return self._register_anytrait(new, "", False)
@@ -1086,12 +1086,12 @@ class ListenerParser:
                 if metadata != "":
                     cn = self.skip_ws
 
-                result.is_any_trait = (
+                result.is_anytrait = (
                     (c == "-") and (name == "") and (metadata == "")
                 )
                 c = cn
 
-                if result.is_any_trait and (
+                if result.is_anytrait and (
                     not (
                         (c == terminator)
                         or ((c == ",") and (terminator == "]"))


### PR DESCRIPTION
The existing anytrait-handling machinery sometimes spells related objects and names using `any_trait` and sometimes using `anytrait`. The user-facing portion is always spelled `anytrait`; this PR changes related internal occurrences of `any_trait` to `anytrait`.

Includes one actual fix to a documentation index entry.
