### PR TITLE
Remove unnecessary 'noqa' markers

### DIFF
--- a/traits/adaptation/api.py
+++ b/traits/adaptation/api.py
@@ -8,11 +8,11 @@
 #
 # Thanks for using Enthought open source!
 
-from .adapter import Adapter, PurePythonAdapter  # noqa: F401
+from .adapter import Adapter, PurePythonAdapter
 
-from .adaptation_error import AdaptationError  # noqa: F401
+from .adaptation_error import AdaptationError
 
-from .adaptation_manager import (  # noqa: F401
+from .adaptation_manager import (
     adapt,
     AdaptationManager,
     get_global_adaptation_manager,
@@ -25,4 +25,4 @@ from .adaptation_manager import (  # noqa: F401
     supports_protocol,
 )
 
-from .adaptation_offer import AdaptationOffer  # noqa: F401
+from .adaptation_offer import AdaptationOffer

--- a/traits/etsconfig/api.py
+++ b/traits/etsconfig/api.py
@@ -8,4 +8,4 @@
 #
 # Thanks for using Enthought open source!
 
-from .etsconfig import ETSConfig, ETSToolkitError  # noqa: F401
+from .etsconfig import ETSConfig, ETSToolkitError

--- a/traits/observation/api.py
+++ b/traits/observation/api.py
@@ -8,12 +8,12 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.observation.exception_handling import (     # noqa: F401
+from traits.observation.exception_handling import (
     pop_exception_handler,
     push_exception_handler,
 )
 
-from traits.observation.expression import (   # noqa: F401
+from traits.observation.expression import (
     dict_items,
     list_items,
     match,
@@ -22,8 +22,8 @@ from traits.observation.expression import (   # noqa: F401
     trait,
 )
 
-from traits.observation.observe import (   # noqa: F401
+from traits.observation.observe import (
     dispatch_same,
     observe,
 )
-from traits.observation.parsing import parse     # noqa: F401
+from traits.observation.parsing import parse

--- a/traits/testing/api.py
+++ b/traits/testing/api.py
@@ -8,6 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-from .doctest_tools import doctest_for_module  # noqa: F401
-from .nose_tools import deprecated, performance, skip  # noqa: F401
-from .unittest_tools import UnittestTools  # noqa: F401
+from .doctest_tools import doctest_for_module
+from .nose_tools import deprecated, performance, skip
+from .unittest_tools import UnittestTools

--- a/traits/util/api.py
+++ b/traits/util/api.py
@@ -8,6 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-from .deprecated import deprecated  # noqa: F401
-from .event_tracer import record_events  # noqa: F401
-from .import_symbol import import_symbol  # noqa: F401
+from .deprecated import deprecated
+from .event_tracer import record_events
+from .import_symbol import import_symbol


### PR DESCRIPTION
This is a drive-by cleanup PR that removes unnecessary "#  noqa: F401" comments from `api.py` files. We already have a [per-file-ignores setting](https://github.com/enthought/traits/blob/b343ea87a02c74f9b74c16efe6a02bd3d883eccb/setup.cfg#L4) in our `setup.cfg` for this.