### PR TITLE
Deprecate find_resource and store_resource

### DIFF
--- a/traits/util/resource.py
+++ b/traits/util/resource.py
@@ -30,6 +30,7 @@ import inspect
 import os
 import sys
 import sysconfig
+import warnings
 
 
 def get_path(path):
@@ -90,6 +91,8 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
     find/open the resource, find_resource will use the sys.path[0] to find the
     resource if alt_path is defined.
 
+    .. deprecated:: 6.3.0
+
     Parameters
     ----------
     project : str
@@ -116,6 +119,11 @@ def find_resource(project, resource_path, alt_path=None, return_path=False):
         will be the full path to the resource. If the file is not found or
         cannot be opened, None is returned.
     """
+    warnings.warn(
+        "find_resource is deprecated. Use importlib.resources instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     try:
         # Get the image using the pkg_resources resource_stream module, which
@@ -178,7 +186,15 @@ def store_resource(project, resource_path, filename):
         argument (filename) is the name of the file which will be created,
         or overwritten if it already exists.
         The return value in always None.
+
+        .. deprecated:: 6.3.0
     """
+    warnings.warn(
+        "store_resource is deprecated. Use importlib.resources instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     fi = find_resource(project, resource_path)
     if fi is None:
         raise RuntimeError(

--- a/traits/util/tests/test_resource.py
+++ b/traits/util/tests/test_resource.py
@@ -33,4 +33,3 @@ class TestResource(unittest.TestCase):
                     os.path.join("traits", "__init__.py"),
                     os.path.join(tmpdir, "just_testing.py"),
                 )
-                breakpoint()

--- a/traits/util/tests/test_resource.py
+++ b/traits/util/tests/test_resource.py
@@ -1,0 +1,36 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Tests for traits.util.resource. """
+
+import os
+import tempfile
+import unittest
+
+from traits.util.resource import find_resource, store_resource
+
+
+class TestResource(unittest.TestCase):
+    def test_find_resource_deprecated(self):
+        with self.assertWarns(DeprecationWarning):
+            find_resource(
+                "traits",
+                os.path.join("traits", "__init__.py"),
+            )
+
+    def test_store_resource_deprecated(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertWarns(DeprecationWarning):
+                store_resource(
+                    "traits",
+                    os.path.join("traits", "__init__.py"),
+                    os.path.join(tmpdir, "just_testing.py"),
+                )
+                breakpoint()


### PR DESCRIPTION
This PR deprecates `traits.util.resource.find_resource` and `traits.util.resource.store_resource`. New code should use `importlib.resources` or its fallback `importlib_resources` instead.

The only existing uses of `find_resource` I could find either in ETS projects or internal Enthought projects were in Chaco example code. There appear to be no uses of `store_resource` in current code.

Related: enthought/chaco#657.

Closes #1500.
