### PR TITLE
Raise ValueError on parse failure

### DIFF
--- a/traits/observation/parsing.py
+++ b/traits/observation/parsing.py
@@ -288,6 +288,15 @@ def parse(text):
     Returns
     -------
     expression : ObserverExpression
+
+    Raises
+    ------
+    ValueError
+        If the text is not a valid observe expression.
     """
-    tree = _LARK_PARSER.parse(text)
+    try:
+        tree = _LARK_PARSER.parse(text)
+    except _generated_parser.LarkError as parser_exception:
+        raise ValueError(f"Invalid expression: {text!r}") from parser_exception
+
     return _handle_tree(tree)

--- a/traits/observation/tests/test_parsing.py
+++ b/traits/observation/tests/test_parsing.py
@@ -147,3 +147,18 @@ class TestParsingItems(unittest.TestCase):
             | set_items(notify=False, optional=True)
         ).trait("attr")
         self.assertEqual(actual, expected)
+
+
+class TestParsingGeneral(unittest.TestCase):
+
+    def test_parse_error(self):
+        invalid_expressions = [
+            "a:",
+            "**",
+            ".",
+            "",
+        ]
+        for expression in invalid_expressions:
+            with self.subTest(expression=expression):
+                with self.assertRaises(ValueError):
+                    parse(expression)


### PR DESCRIPTION
This PR updates the `parse` method in `traits.observation.api` to raise `ValueError` instead of `LarkError`. The `LarkError` exception is an implementation detail that users should be shielded from - we may replace the lark-based parser with some other parser in the future, and users shouldn't have to change their code in that case.

I made this change because I found myself wanting to writing tests to check that particular expressions were invalid, and neither of `self.assertRaises(LarkError)` nor `self.assertRaises(Exception)` seemed like a palatable option for those tests.

Fixes #1504.