### PR TITLE
Add __slots__ to key observation classes

### DIFF
--- a/traits/observation/_dict_item_observer.py
+++ b/traits/observation/_dict_item_observer.py
@@ -31,6 +31,8 @@ class DictItemObserver:
         parser, where the source container type is ambiguous.
     """
 
+    __slots__ = ("notify", "optional")
+
     def __init__(self, *, notify, optional):
         self.notify = notify
         self.optional = optional

--- a/traits/observation/_filtered_trait_observer.py
+++ b/traits/observation/_filtered_trait_observer.py
@@ -37,6 +37,8 @@ class FilteredTraitObserver:
         also be hashable.
     """
 
+    __slots__ = ("notify", "filter")
+
     def __init__(self, notify, filter):
         self.notify = notify
         self.filter = filter

--- a/traits/observation/_list_item_observer.py
+++ b/traits/observation/_list_item_observer.py
@@ -31,6 +31,8 @@ class ListItemObserver:
         parser, where the source container type is ambiguous.
     """
 
+    __slots__ = ("notify", "optional")
+
     def __init__(self, *, notify, optional):
         self.notify = notify
         self.optional = optional

--- a/traits/observation/_metadata_filter.py
+++ b/traits/observation/_metadata_filter.py
@@ -27,6 +27,8 @@ class MetadataFilter:
         Name of the metadata to filter traits with.
     """
 
+    __slots__ = ("metadata_name",)
+
     def __init__(self, metadata_name):
         self.metadata_name = metadata_name
 

--- a/traits/observation/_named_trait_observer.py
+++ b/traits/observation/_named_trait_observer.py
@@ -28,6 +28,8 @@ class NamedTraitObserver:
     on an instance of HasTraits.
     """
 
+    __slots__ = ("name", "notify", "optional")
+
     def __init__(self, *, name, notify, optional):
         """ Initializer.
         Once this observer is defined, it should not be mutated.

--- a/traits/observation/_observer_graph.py
+++ b/traits/observation/_observer_graph.py
@@ -59,6 +59,8 @@ class ObserverGraph:
         If not all children are unique.
     """
 
+    __slots__ = ("node", "children")
+
     def __init__(self, *, node, children=None):
 
         if children is not None and len(set(children)) != len(children):

--- a/traits/observation/_set_item_observer.py
+++ b/traits/observation/_set_item_observer.py
@@ -31,6 +31,8 @@ class SetItemObserver:
         parser, where the source container type is ambiguous.
     """
 
+    __slots__ = ("notify", "optional")
+
     def __init__(self, *, notify, optional):
         self.notify = notify
         self.optional = optional

--- a/traits/observation/tests/test_dict_item_observer.py
+++ b/traits/observation/tests/test_dict_item_observer.py
@@ -58,6 +58,13 @@ class TestDictItemObserverEqualHash(unittest.TestCase):
         self.assertEqual(observer1, observer2)
         self.assertEqual(hash(observer1), hash(observer2))
 
+    def test_slots(self):
+        observer = DictItemObserver(notify=True, optional=False)
+        with self.assertRaises(AttributeError):
+            observer.__dict__
+        with self.assertRaises(AttributeError):
+            observer.__weakref__
+
 
 class CustomDict(dict):
     # This is a dict, but not an observable

--- a/traits/observation/tests/test_filtered_trait_observer.py
+++ b/traits/observation/tests/test_filtered_trait_observer.py
@@ -96,6 +96,16 @@ class TestFilteredTraitObserverEqualHash(unittest.TestCase):
         imposter.filter = filter_func
         self.assertNotEqual(observer1, imposter)
 
+    def test_slots(self):
+        observer = FilteredTraitObserver(
+            notify=True,
+            filter=DummyFilter(return_value=True),
+        )
+        with self.assertRaises(AttributeError):
+            observer.__dict__
+        with self.assertRaises(AttributeError):
+            observer.__weakref__
+
 
 class Dummy(HasTraits):
 

--- a/traits/observation/tests/test_list_item_observer.py
+++ b/traits/observation/tests/test_list_item_observer.py
@@ -46,6 +46,13 @@ class TestListItemObserverEqualHash(unittest.TestCase):
         self.assertEqual(observer1, observer2)
         self.assertEqual(hash(observer1), hash(observer2))
 
+    def test_slots(self):
+        observer = ListItemObserver(notify=True, optional=False)
+        with self.assertRaises(AttributeError):
+            observer.__dict__
+        with self.assertRaises(AttributeError):
+            observer.__weakref__
+
 
 class CustomList(list):
     pass

--- a/traits/observation/tests/test_metadata_filter.py
+++ b/traits/observation/tests/test_metadata_filter.py
@@ -74,6 +74,13 @@ class TestMetadataFilter(unittest.TestCase):
         imposter.metadata_name = "name"
         self.assertNotEqual(imposter, filter1)
 
+    def test_slots(self):
+        filter = MetadataFilter(metadata_name="name")
+        with self.assertRaises(AttributeError):
+            filter.__dict__
+        with self.assertRaises(AttributeError):
+            filter.__weakref__
+
     def test_repr_value(self):
         metadata_filter = MetadataFilter(
             metadata_name="name",

--- a/traits/observation/tests/test_named_trait_observer.py
+++ b/traits/observation/tests/test_named_trait_observer.py
@@ -67,6 +67,13 @@ class TestNamedTraitObserverEqualHash(unittest.TestCase):
         imposter.optional = True
         self.assertNotEqual(observer, imposter)
 
+    def test_slots(self):
+        observer = NamedTraitObserver(name="foo", notify=True, optional=True)
+        with self.assertRaises(AttributeError):
+            observer.__dict__
+        with self.assertRaises(AttributeError):
+            observer.__weakref__
+
 
 class TestObserverGraphIntegrateNamedTraitObserver(unittest.TestCase):
     """ Test integrating ObserverGraph with NamedTraitObserver as nodes.

--- a/traits/observation/tests/test_observer_graph.py
+++ b/traits/observation/tests/test_observer_graph.py
@@ -94,3 +94,10 @@ class TestObserverGraph(unittest.TestCase):
 
         self.assertEqual(
             str(exception_cm.exception), "Not all children are unique.")
+
+    def test_slots(self):
+        graph = ObserverGraph(node=1)
+        with self.assertRaises(AttributeError):
+            graph.__dict__
+        with self.assertRaises(AttributeError):
+            graph.__weakref__

--- a/traits/observation/tests/test_set_item_observer.py
+++ b/traits/observation/tests/test_set_item_observer.py
@@ -61,6 +61,13 @@ class TestSetItemObserverEqualHash(unittest.TestCase):
         self.assertEqual(observer1, observer2)
         self.assertEqual(hash(observer1), hash(observer2))
 
+    def test_slots(self):
+        observer = SetItemObserver(notify=True, optional=False)
+        with self.assertRaises(AttributeError):
+            observer.__dict__
+        with self.assertRaises(AttributeError):
+            observer.__weakref__
+
 
 class CustomSet(set):
     # This is a set, but not an observable


### PR DESCRIPTION
This PR adds `__slots__` to seven key classes related to the observe machinery, namely the `ObserverGraph` and all the objects that it has references to in normal use.

This is a partial fix for #1511. We probably want to add `__slots__` to the various expression classes too, though that will have a smaller benefit.
