### PR TITLE
Cache calls to compile_str

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -827,6 +827,8 @@ def observe(expression, *, post_init=False, dispatch="same"):
     HasTraits.observe
     """
 
+    graphs = _compile_expression(expression)
+
     def observe_decorator(handler):
         """ Create input arguments for HasTraits.observe and attach the input
         to the callable.
@@ -844,8 +846,6 @@ def observe(expression, *, post_init=False, dispatch="same"):
         except AttributeError:
             observe_inputs = []
             handler._observe_inputs = observe_inputs
-
-        graphs = _compile_expression(expression)
 
         observe_input = dict(
             graphs=graphs,

--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -19,8 +19,6 @@ from traits.observation._named_trait_observer import NamedTraitObserver
 from traits.observation._observer_graph import ObserverGraph
 from traits.observation._set_item_observer import SetItemObserver
 
-_graph_version_count = 0
-
 # ObserverExpression is a public user interface for constructing ObserverGraph.
 
 
@@ -261,10 +259,6 @@ class ObserverExpression:
         -------
         graphs : list of ObserverGraph
         """
-        global _graph_version_count
-        _graph_version_count += 1
-        print("_as_graphs_call_count:", _graph_version_count)
-
         return self._create_graphs(branches=[])
 
     def _create_graphs(self, branches):

--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -19,6 +19,8 @@ from traits.observation._named_trait_observer import NamedTraitObserver
 from traits.observation._observer_graph import ObserverGraph
 from traits.observation._set_item_observer import SetItemObserver
 
+_graph_version_count = 0
+
 # ObserverExpression is a public user interface for constructing ObserverGraph.
 
 
@@ -259,6 +261,10 @@ class ObserverExpression:
         -------
         graphs : list of ObserverGraph
         """
+        global _graph_version_count
+        _graph_version_count += 1
+        print("_as_graphs_call_count:", _graph_version_count)
+
         return self._create_graphs(branches=[])
 
     def _create_graphs(self, branches):

--- a/traits/observation/parsing.py
+++ b/traits/observation/parsing.py
@@ -195,7 +195,7 @@ def parse(text):
     return _handle_tree(tree, notify=True)
 
 
-# @lru_cache(maxsize=_OBSERVER_EXPRESSION_CACHE_MAXSIZE)
+@lru_cache(maxsize=_OBSERVER_EXPRESSION_CACHE_MAXSIZE)
 def compile_str(text):
     """ Compile a mini-language string to a list of ObserverGraphs.
 

--- a/traits/observation/parsing.py
+++ b/traits/observation/parsing.py
@@ -195,6 +195,7 @@ def parse(text):
     return _handle_tree(tree, notify=True)
 
 
+# @lru_cache(maxsize=_OBSERVER_EXPRESSION_CACHE_MAXSIZE)
 def compile_str(text):
     """ Compile a mini-language string to a list of ObserverGraphs.
 


### PR DESCRIPTION
This PR adds an LRU cache to the `compile_str` function that compiles an observe mini-language expression in text form to a collection of `ObserverGraphs`.

In testing on a medium-sided Traits-using application, this reduced the number of calls to `ObserverExpression._as_graphs` from `221` to `90` at application startup time.

The PR also hoiks compilation of the expression provided to an `observe` decorator up a level: in code like:

```
@observe("foo:bar.baz")
def _some_method(self, event):
    ...
```

compilation currently (in main) occurs when `observe("foo:bar.baz")` is applied to the `_some_method` function. With this PR, it occurs as part of the `observe("foo:bar:baz")` call instead. This will rarely make a difference to real code, but it does allow the possibility of sharing observe-decorators without incurring multiple compilations:

```
observe_all_updates = observe("children:items:updated")

@observe_all_updates
def _some_method(self, event):
    ...

@observe_all_updates
def some_other_method(self, event):
    ...
```

Note: caching compilation of `ObserverExpressions` to graphs isn't useful: equality for `ObserverExpressions` is based on the conversion to graphs, so a conforming hash function would also need to be based on `_as_graphs`, so would perform the exact same operation that's being cached.

No tests, because there should be no perceptible change in behaviour other than performance. (Though it *would* make sense to develop a benchmark test suite at some point.)