### PR TITLE
Replace equality definition on ObserverExpression

### DIFF
--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -282,10 +282,6 @@ class SingleObserverExpression(ObserverExpression):
             and self._observer == other._observer
         )
 
-    def __repr__(self):
-        formatted_args = [f"observer={self._observer!r}"]
-        return f"{self.__class__.__name__}({', '.join(formatted_args)})"
-
     def _create_graphs(self, branches):
         return [
             ObserverGraph(node=self._observer, children=branches),
@@ -319,13 +315,6 @@ class SeriesObserverExpression(ObserverExpression):
             and self._second == other._second
         )
 
-    def __repr__(self):
-        formatted_args = [
-            f"first={self._first!r}",
-            f"second={self._second!r}",
-        ]
-        return f"{self.__class__.__name__}({', '.join(formatted_args)})"
-
     def _create_graphs(self, branches):
         branches = self._second._create_graphs(branches=branches)
         return self._first._create_graphs(branches=branches)
@@ -357,13 +346,6 @@ class ParallelObserverExpression(ObserverExpression):
             and self._left == other._left
             and self._right == other._right
         )
-
-    def __repr__(self):
-        formatted_args = [
-            f"left={self._left!r}",
-            f"right={self._right!r}",
-        ]
-        return f"{self.__class__.__name__}({', '.join(formatted_args)})"
 
     def _create_graphs(self, branches):
         left_graphs = self._left._create_graphs(branches=branches)

--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -34,18 +34,6 @@ class ObserverExpression:
 
     __slots__ = ()
 
-    def __eq__(self, other):
-        """ Return true if the other value is an ObserverExpression with
-        equivalent content.
-
-        Returns
-        -------
-        bool
-        """
-        if type(other) is not type(self):
-            return False
-        return self._as_graphs() == other._as_graphs()
-
     def __or__(self, expression):
         """ Create a new expression that matches this expression OR
         the given expression.
@@ -280,14 +268,27 @@ class SingleObserverExpression(ObserverExpression):
     """ Container of ObserverExpression for wrapping a single observer.
     """
 
-    __slots__ = ("observer",)
+    __slots__ = ("_observer",)
 
     def __init__(self, observer):
-        self.observer = observer
+        self._observer = observer
+
+    def __hash__(self):
+        return hash((type(self).__name__, self._observer))
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self._observer == other._observer
+        )
+
+    def __repr__(self):
+        formatted_args = [f"observer={self._observer!r}"]
+        return f"{self.__class__.__name__}({', '.join(formatted_args)})"
 
     def _create_graphs(self, branches):
         return [
-            ObserverGraph(node=self.observer, children=branches),
+            ObserverGraph(node=self._observer, children=branches),
         ]
 
 
@@ -307,6 +308,23 @@ class SeriesObserverExpression(ObserverExpression):
     def __init__(self, first, second):
         self._first = first
         self._second = second
+
+    def __hash__(self):
+        return hash((type(self).__name__, self._first, self._second))
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self._first == other._first
+            and self._second == other._second
+        )
+
+    def __repr__(self):
+        formatted_args = [
+            f"first={self._first!r}",
+            f"second={self._second!r}",
+        ]
+        return f"{self.__class__.__name__}({', '.join(formatted_args)})"
 
     def _create_graphs(self, branches):
         branches = self._second._create_graphs(branches=branches)
@@ -329,6 +347,23 @@ class ParallelObserverExpression(ObserverExpression):
     def __init__(self, left, right):
         self._left = left
         self._right = right
+
+    def __hash__(self):
+        return hash((type(self).__name__, self._left, self._right))
+
+    def __eq__(self, other):
+        return (
+            type(self) is type(other)
+            and self._left == other._left
+            and self._right == other._right
+        )
+
+    def __repr__(self):
+        formatted_args = [
+            f"left={self._left!r}",
+            f"right={self._right!r}",
+        ]
+        return f"{self.__class__.__name__}({', '.join(formatted_args)})"
 
     def _create_graphs(self, branches):
         left_graphs = self._left._create_graphs(branches=branches)

--- a/traits/observation/tests/test_expression.py
+++ b/traits/observation/tests/test_expression.py
@@ -660,13 +660,14 @@ class TestObserverExpressionSetItem(unittest.TestCase):
         )
 
 
-class TestObserverExpressionEquality(unittest.TestCase):
-    """ Test ObserverExpression.__eq__ """
+class TestObserverExpressionEqualityAndHashing(unittest.TestCase):
+    """ Test ObserverExpression.__eq__ and ObserverExpression.__hash__. """
 
     def test_trait_equality(self):
         expr1 = create_expression(1)
         expr2 = create_expression(1)
         self.assertEqual(expr1, expr2)
+        self.assertEqual(hash(expr1), hash(expr2))
 
     def test_join_equality_with_then(self):
         # The following all result in the same graphs
@@ -677,6 +678,13 @@ class TestObserverExpressionEquality(unittest.TestCase):
         combined2 = expr1.then(expr2)
 
         self.assertEqual(combined1, combined2)
+        self.assertEqual(hash(combined1), hash(combined2))
+
+    def test_equality_of_parallel_expressions(self):
+        expr1 = create_expression(1) | create_expression(2)
+        expr2 = create_expression(1) | create_expression(2)
+        self.assertEqual(expr1, expr2)
+        self.assertEqual(hash(expr1), hash(expr2))
 
     def test_equality_different_type(self):
         expr = create_expression(1)

--- a/traits/observation/tests/test_parsing.py
+++ b/traits/observation/tests/test_parsing.py
@@ -177,10 +177,11 @@ class TestParsingGeneral(unittest.TestCase):
 
         actual = parse("[a:[b.[c:d]]]")
         expected = (
-            trait("a", notify=False)
-            .trait("b")
-            .trait("c", notify=False)
-            .trait("d")
+            trait("a", notify=False).then(
+                trait("b").then(
+                    trait("c", notify=False).then(trait("d"))
+                )
+            )
         )
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
The current `ObserverExpression` implements equality via `_as_graphs`, I suspect purely as a convenience for testing purposes. This PR replaces that equality check with a simple structural equality. It also:

- makes all expressions hashable, to make caching easier
- adds convenience `__repr__` implementations
- renames the `observer` attribute to `_observer`, for consistency with the other expression classes, to emphasize that it's not used outside this module, and to discourage users from modifying the value
- fixes one (recently-introduced) test