### PR TITLE
Style fixes in trait_types.pyi

### DIFF
--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -14,7 +14,6 @@ from typing import (
     Any as _Any,
     Callable as _CallableType,
     Dict as _DictType,
-    Generic as Generic,
     List as _ListType,
     Optional,
     Sequence as _Sequence,
@@ -605,8 +604,8 @@ class WeakRef(Instance):
         ...
 
 
-
 _OptionalDate = Optional[datetime.date]
+
 
 class Date(_TraitType[_OptionalDate, _OptionalDate]):
     def __init__(
@@ -622,6 +621,7 @@ class Date(_TraitType[_OptionalDate, _OptionalDate]):
 
 _OptionalDatetime = Optional[datetime.datetime]
 
+
 class Datetime(_TraitType[_OptionalDatetime, _OptionalDatetime]):
     def __init__(
             self,
@@ -634,6 +634,7 @@ class Datetime(_TraitType[_OptionalDatetime, _OptionalDatetime]):
 
 
 _OptionalTime = Optional[datetime.time]
+
 
 class Time(_TraitType[_OptionalTime, _OptionalTime]):
     def __init__(


### PR DESCRIPTION
This PR fixes some IDE complaints in `trait_types.pyi`: it removes an unused import ("Generic") and fixes some line-spacing issues.
