### PR TITLE
POC: Don't infer the default value type for TraitType subclasses

### DIFF
--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -175,6 +175,9 @@ class TraitType(BaseTraitHandler):
     #: The default value for the trait type.
     default_value = Undefined
 
+    #: The default value type for the trait type.
+    default_value_type = DefaultValue.constant
+
     #: The metadata for the trait.
     metadata = {}
 
@@ -254,13 +257,7 @@ class TraitType(BaseTraitHandler):
             as described above.
 
         """
-        dv = self.default_value
-        dvt = self.default_value_type
-        if dvt < 0:
-            dvt = _infer_default_value_type(dv)
-            self.default_value_type = dvt
-
-        return (dvt, dv)
+        return (self.default_value_type, self.default_value)
 
     def clone(self, default_value=NoDefaultSpecified, **metadata):
         """ Copy, optionally modifying default value and metadata.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -49,7 +49,6 @@ from .trait_type import (
 from .traits import (
     Trait,
     _TraitMaker,
-    _InstanceArgs,
 )
 from .util.deprecated import deprecated
 from .util.import_symbol import import_symbol
@@ -3375,7 +3374,8 @@ class BaseInstance(BaseClass):
                 if (len(args) > 0) or (len(kw) > 0):
                     raise TraitError("'factory' must be callable")
             else:
-                value = _InstanceArgs(factory, args, kw)
+                value = (self.create_default_value, (factory, *args), kw)
+                self.default_value_type = DefaultValue.callable_and_args
 
         self.default_value = value
 
@@ -3417,10 +3417,10 @@ class BaseInstance(BaseClass):
             self.validate_failed(object, name, value)
         else:
             result = self.default_value
-            if isinstance(result, _InstanceArgs):
+            if self.default_value_type == DefaultValue.callable_and_args:
                 return result[0](*result[1], **result[2])
             else:
-                return result
+                return self.default_value
 
     def info(self):
         """ Returns a description of the trait.
@@ -3440,25 +3440,6 @@ class BaseInstance(BaseClass):
             return result + " or None"
 
         return result
-
-    def get_default_value(self):
-        """ Returns a tuple of the form: ( default_value_type, default_value )
-            which describes the default value for this trait.
-        """
-        dv = self.default_value
-        dvt = self.default_value_type
-        if dvt < 0:
-            if not isinstance(dv, _InstanceArgs):
-                return super().get_default_value()
-
-            self.default_value_type = dvt = DefaultValue.callable_and_args
-            self.default_value = dv = (
-                self.create_default_value,
-                dv.args,
-                dv.kw,
-            )
-
-        return (dvt, dv)
 
     def clone(self, default_value=NoDefaultSpecified, **metadata):
         """ Copy, optionally modifying default value and metadata. """


### PR DESCRIPTION
This is a draft PR that simplifies the default value handling for `TraitType` subclasses: it eliminates the code that infers the default value type based on the default value, and instead forces a _default_ `default_value_type` of `DefaultValue.constant`. This is the right default value type for the vast majority of `TraitType` subclasses. Notable exceptions are the `Any` trait, where we may still want to do some inference for lists and dicts (mostly for backwards compatibility), and `Instance`, where the `default_value_type` will often be `DefaultValue.callable_with_args`.

Note that this will potentially affect third-party `TraitType` subclasses as well. It's technically a backwards incompatible change, and as such we may want to defer it until Traits 7.0.

Once this PR goes in, the `_infer_default_value_type` function can move to `traits.py`, which is the only place that it's used.

Changes in detail:
- Change `TraitType.default_value_type` from `DefaultValue.unspecified` to `DefaultValue.constant`
- Remove a now unused default_value_type inference branch from `TraitType.get_default_value`
- Set `default_value_type` eagerly in `BaseInstance.__init__` instead of changing `self.default_value` and `self.default_value_type` on the first call to `self.get_default_value`.
- Remove the `BaseInstance.get_default_value` override, which is now redundant.

Still to do:
- [ ] Add tests for the `Any` trait with a mutable default value; fix so that those tests pass
- [ ] Consider deprecating the behaviour of `Any` with a mutable default value
- [ ] Add tests that exercise the `if self.default_value_type == DefaultValue.callable_and_args:` branch in `BaseInstance.validate`. (There are no such tests at the moment.)