### PR TITLE
Deprecate the clean_filename and clean_timestamp utilities

### DIFF
--- a/traits/util/clean_strings.py
+++ b/traits/util/clean_strings.py
@@ -18,6 +18,7 @@ import datetime
 import keyword
 import re
 import unicodedata
+import warnings
 
 
 def clean_filename(name, replace_empty=""):
@@ -31,6 +32,9 @@ def clean_filename(name, replace_empty=""):
 
     This does not give a faithful representation of the original string:
     different input strings can result in the same output string.
+
+    .. deprecated:: 6.3.0
+        This function will be removed in a future version of Traits.
 
     Parameters
     ----------
@@ -48,6 +52,12 @@ def clean_filename(name, replace_empty=""):
         A filename-safe version of string.
 
     """
+    warnings.warn(
+        "clean_filename is deprecated and will eventually be removed",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     # Code is based on Django's slugify utility.
     # https://docs.djangoproject.com/en/1.9/_modules/django/utils/text/#slugify
     name = (
@@ -74,6 +84,9 @@ def clean_timestamp(dt=None, microseconds=False):
     * Microseconds are not displayed if the 'microseconds' parameter is
         False.
 
+    .. deprecated:: 6.3.0
+        This function will be removed in a future version of Traits.
+
     Parameters
     ----------
     dt : None or datetime.datetime
@@ -85,6 +98,12 @@ def clean_timestamp(dt=None, microseconds=False):
     -------
     A string timestamp.
     """
+    warnings.warn(
+        "clean_timestamp is deprecated and will eventually be removed",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if dt is None:
         dt = datetime.datetime.now()
     else:

--- a/traits/util/tests/test_clean_strings.py
+++ b/traits/util/tests/test_clean_strings.py
@@ -8,9 +8,10 @@
 #
 # Thanks for using Enthought open source!
 
+import datetime
 import unittest
 
-from traits.util.clean_strings import clean_filename
+from traits.util.clean_strings import clean_filename, clean_timestamp
 
 # Safe strings should only contain the following characters.
 LEGAL_CHARS = set("-0123456789_abcdefghijklmnopqrstuvwxyz")
@@ -26,22 +27,30 @@ class TestCleanStrings(unittest.TestCase):
             "^!+",
         ]
         for test_string in test_strings:
-            safe_string = clean_filename(test_string, "default-output")
+            with self.assertWarns(DeprecationWarning):
+                safe_string = clean_filename(test_string, "default-output")
             self.check_output(safe_string)
             self.assertEqual(safe_string, "default-output")
 
     def test_clean_filename_whitespace_handling(self):
         # Leading and trailing whitespace stripped.
-        self.assertEqual(clean_filename(" abc "), "abc")
-        self.assertEqual(clean_filename(" \t\tabc    \n"), "abc")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(clean_filename(" abc "), "abc")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(clean_filename(" \t\tabc    \n"), "abc")
+
         # Internal whitespace turned into hyphens.
-        self.assertEqual(clean_filename("well name"), "well-name")
-        self.assertEqual(clean_filename("well \n name"), "well-name")
-        self.assertEqual(clean_filename("well - name"), "well-name")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(clean_filename("well name"), "well-name")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(clean_filename("well \n name"), "well-name")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(clean_filename("well - name"), "well-name")
 
     def test_clean_filename_conversion_to_lowercase(self):
         test_string = "ABCdefGHI123"
-        safe_string = clean_filename(test_string)
+        with self.assertWarns(DeprecationWarning):
+            safe_string = clean_filename(test_string)
         self.assertEqual(safe_string, test_string.lower())
         self.check_output(safe_string)
 
@@ -51,7 +60,8 @@ class TestCleanStrings(unittest.TestCase):
             "a\u0308bc\u0327de\u0300f",
         ]
         for test_string in test_strings:
-            safe_string = clean_filename(test_string)
+            with self.assertWarns(DeprecationWarning):
+                safe_string = clean_filename(test_string)
             self.check_output(safe_string)
             self.assertEqual(safe_string, "abcdef")
 
@@ -62,8 +72,13 @@ class TestCleanStrings(unittest.TestCase):
             "".join(chr(n) for n in reversed(range(10000))),
         ]
         for test_string in test_strings:
-            safe_string = clean_filename(test_string)
+            with self.assertWarns(DeprecationWarning):
+                safe_string = clean_filename(test_string)
             self.check_output(safe_string)
+
+    def test_clean_timestamp_deprecation(self):
+        with self.assertWarns(DeprecationWarning):
+            clean_timestamp(datetime.datetime.now())
 
     def check_output(self, safe_string):
         """


### PR DESCRIPTION
The `clean_filename` and `clean_timestamp` utility functions have nothing to do with Traits and are not documented or exposed in any of the `api` modules; additionally, `clean_timestamp` has no tests. This PR deprecates those functions, so that they can be removed in Traits 7.0.0.

A check of ETS and private ETS-using projects that I have access to turned up no uses of either function.

Closes #1447.

**Checklist**
- [x] Tests
