### PR TITLE
Cache the result of the compile_expr function

### DIFF
--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -19,8 +19,12 @@ from traits.observation._named_trait_observer import NamedTraitObserver
 from traits.observation._observer_graph import ObserverGraph
 from traits.observation._set_item_observer import SetItemObserver
 
-# ObserverExpression is a public user interface for constructing ObserverGraph.
 
+#: Maximum number of parsed observer expressions stored in the LRU caches
+_OBSERVER_EXPRESSION_CACHE_MAXSIZE = 128
+
+
+# ObserverExpression is a public user interface for constructing ObserverGraph.
 
 class ObserverExpression:
     """
@@ -546,6 +550,7 @@ def trait(name, notify=True, optional=False):
     return SingleObserverExpression(observer)
 
 
+@functools.lru_cache(maxsize=_OBSERVER_EXPRESSION_CACHE_MAXSIZE)
 def compile_expr(expr):
     """ Compile an ObserverExpression to a list of ObserverGraphs.
 

--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -21,7 +21,7 @@ from traits.observation._set_item_observer import SetItemObserver
 
 
 #: Maximum number of parsed observer expressions stored in the LRU caches
-_OBSERVER_EXPRESSION_CACHE_MAXSIZE = 128
+_OBSERVER_EXPRESSION_CACHE_MAXSIZE = 256
 
 
 # ObserverExpression is a public user interface for constructing ObserverGraph.

--- a/traits/observation/observe.py
+++ b/traits/observation/observe.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 from traits.observation._observe import add_or_remove_notifiers
+from traits.observation.expression import compile_expr
 
 
 def dispatch_same(handler, event):
@@ -48,12 +49,9 @@ def observe(
         callback on a different thread. Default is to dispatch on the same
         thread.
     """
-    # Implicit interface: ``expression`` can be anything with a method
-    # ``_as_graphs`` that returns a list of ObserverGraph.
-
     apply_observers(
         object,
-        graphs=expression._as_graphs(),
+        graphs=compile_expr(expression),
         handler=handler,
         dispatcher=dispatcher,
         remove=remove,

--- a/traits/observation/parsing.py
+++ b/traits/observation/parsing.py
@@ -13,10 +13,8 @@ from functools import lru_cache
 from traits.observation import _generated_parser
 import traits.observation.expression as expression_module
 
-_LARK_PARSER = _generated_parser.Lark_StandAlone()
 
-#: Maximum number of parsed observer expressions stored in the LRU cache
-_OBSERVER_EXPRESSION_CACHE_MAXSIZE = 128
+_LARK_PARSER = _generated_parser.Lark_StandAlone()
 
 
 def _handle_series(trees, notify):
@@ -169,7 +167,7 @@ def _handle_tree(tree, notify):
     return handlers[tree.data](tree.children, notify)
 
 
-@lru_cache(maxsize=_OBSERVER_EXPRESSION_CACHE_MAXSIZE)
+@lru_cache(maxsize=expression_module._OBSERVER_EXPRESSION_CACHE_MAXSIZE)
 def parse(text):
     """ Top-level function for parsing user's text to an ObserverExpression.
 
@@ -195,7 +193,7 @@ def parse(text):
     return _handle_tree(tree, notify=True)
 
 
-@lru_cache(maxsize=_OBSERVER_EXPRESSION_CACHE_MAXSIZE)
+@lru_cache(maxsize=expression_module._OBSERVER_EXPRESSION_CACHE_MAXSIZE)
 def compile_str(text):
     """ Compile a mini-language string to a list of ObserverGraphs.
 


### PR DESCRIPTION
This PR adds an LRU cache for the `compile_expr` function, to eliminate unnecessary calls to `_as_graph`. I also made a one-line change in the `observe` function so that all expression compilation goes through `compile_expr`.

I've also boosted the size of the three parsing-related caches from 128 entries to 256.

I opted not to do a per-Expression-object caching of the result of the `_as_graphs` call (as [suggested](https://github.com/enthought/traits/pull/1516#issuecomment-916089926) in the #1516 discussion); it adds extra complication in that it makes the `Expression` objects mutable, and so introduces potential thread-safety concerns; in contrast, `lru_cache` has thread-safety provisions built in. There's benefit in keeping the `Expression` objects as simple immutable pure data structures - I'd rather not change that unless there's clear evidence that it's beneficial performance-wise.

No test changes or additions, because there are no observable behaviour changes.

Closes #1510 

See also #1516, #1517