### PR TITLE
Warn on a bad signature for an 'observe'-decorated function

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -845,24 +845,20 @@ def observe(expression, *, post_init=False, dispatch="same"):
         # Warn on a dubious handler signature. The handler should accept a call
         # that passes a single positional argument (conventionally named
         # "event") in addition to the usual "self".
+        handler_signature = inspect.signature(handler)
         try:
-            handler_signature = inspect.signature(handler)
-        except (ValueError, TypeError):
-            pass
-        else:
-            try:
-                handler_signature.bind("self", "event")
-            except TypeError:
-                warnings.warn(
-                    (
-                        "Dubious signature for observe-decorated method. "
-                        "The decorated method should be callable with a "
-                        "single positional argument in addition to 'self'. "
-                        "Did you forget to add an 'event' parameter?"
-                    ),
-                    UserWarning,
-                    stacklevel=2,
-                )
+            handler_signature.bind("self", "event")
+        except TypeError:
+            warnings.warn(
+                (
+                    "Dubious signature for observe-decorated method. "
+                    "The decorated method should be callable with a "
+                    "single positional argument in addition to 'self'. "
+                    "Did you forget to add an 'event' parameter?"
+                ),
+                UserWarning,
+                stacklevel=2,
+            )
 
         try:
             observe_inputs = handler._observe_inputs

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -839,10 +839,12 @@ def observe(expression, *, post_init=False, dispatch="same"):
         Parameters
         ----------
         handler : callable
-            Method of a subclass of HasTraits
+            Method of a subclass of HasTraits, with signature of the form
+            ``my_method(self, event)``.
         """
-        # Warn on a missing 'event' parameter in the handler. The handler
-        # should accept a call consisting of a single positional argument.
+        # Warn on a dubious handler signature. The handler should accept a call
+        # that passes a single positional argument (conventionally named
+        # "event") in addition to the usual "self".
         try:
             handler_signature = inspect.signature(handler)
         except (ValueError, TypeError):
@@ -853,10 +855,10 @@ def observe(expression, *, post_init=False, dispatch="same"):
             except TypeError:
                 warnings.warn(
                     (
-                        "Suspicious signature for observe-decorated method. "
-                        "The target method should be callable with a single "
-                        "positional parameter. Did you forget to add an "
-                        "'event' parameter?"
+                        "Dubious signature for observe-decorated method. "
+                        "The decorated method should be callable with a "
+                        "single positional argument in addition to 'self'. "
+                        "Did you forget to add an 'event' parameter?"
                     ),
                     UserWarning,
                     stacklevel=2,

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -841,6 +841,27 @@ def observe(expression, *, post_init=False, dispatch="same"):
         handler : callable
             Method of a subclass of HasTraits
         """
+        # Warn on a missing 'event' parameter in the handler. The handler
+        # should accept a call consisting of a single positional argument.
+        try:
+            handler_signature = inspect.signature(handler)
+        except (ValueError, TypeError):
+            pass
+        else:
+            try:
+                handler_signature.bind("self", "event")
+            except TypeError:
+                warnings.warn(
+                    (
+                        "Suspicious signature for observe-decorated method. "
+                        "The target method should be callable with a single "
+                        "positional parameter. Did you forget to add an "
+                        "'event' parameter?"
+                    ),
+                    UserWarning,
+                    stacklevel=2,
+                )
+
         try:
             observe_inputs = handler._observe_inputs
         except AttributeError:

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -69,6 +69,10 @@ class TestObserveDecorator(unittest.TestCase):
             call_count = Int(0)
 
             @observe("foo")
+            def _the_usual_signature(self, event):
+                self.call_count += 1
+
+            @observe("foo")
             def _method_with_extra_optional_args(self, event, frombicate=True):
                 self.call_count += 1
 
@@ -80,10 +84,14 @@ class TestObserveDecorator(unittest.TestCase):
             def _method_with_alternative_name(self, foo_change_event):
                 self.call_count += 1
 
+            @observe("foo")
+            def _optional_second_argument(self, event=None):
+                self.call_count += 1
+
         a = A()
         self.assertEqual(a.call_count, 0)
         a.foo = 23
-        self.assertEqual(a.call_count, 3)
+        self.assertEqual(a.call_count, 5)
 
 
 class Student(HasTraits):

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -37,6 +37,20 @@ from traits.observation.api import (
 )
 
 
+class TestObserveDecorator(unittest.TestCase):
+    """ General tests for the observe decorator. """
+
+    def test_warning_on_handler_with_bad_signature(self):
+        message_regex = "should be callable with a single positional parameter"
+        with self.assertWarnsRegex(UserWarning, message_regex):
+            class A(HasTraits):
+                foo = Int()
+
+                @observe("foo")
+                def _do_something_when_foo_changes(self):
+                    pass
+
+
 class Student(HasTraits):
     """ Model for testing list + post_init (enthought/traits#275) """
 

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -42,6 +42,7 @@ class TestObserveDecorator(unittest.TestCase):
 
     def test_warning_on_handler_with_bad_signature(self):
         message_regex = "should be callable with a single positional argument"
+
         with self.assertWarnsRegex(UserWarning, message_regex):
             class A(HasTraits):
                 foo = Int()
@@ -49,6 +50,40 @@ class TestObserveDecorator(unittest.TestCase):
                 @observe("foo")
                 def _do_something_when_foo_changes(self):
                     pass
+
+        with self.assertWarnsRegex(UserWarning, message_regex):
+            class A(HasTraits):
+                foo = Int()
+
+                @observe("foo")
+                def _do_something_when_foo_changes(self, **kwargs):
+                    pass
+
+    def test_decorated_method_signatures(self):
+        # Test different handler signatures for compatibility with
+        # observe decorator.
+
+        class A(HasTraits):
+            foo = Int()
+
+            call_count = Int(0)
+
+            @observe("foo")
+            def _method_with_extra_optional_args(self, event, frombicate=True):
+                self.call_count += 1
+
+            @observe("foo")
+            def _method_with_star_args(self, *args):
+                self.call_count += 1
+
+            @observe("foo")
+            def _method_with_alternative_name(self, foo_change_event):
+                self.call_count += 1
+
+        a = A()
+        self.assertEqual(a.call_count, 0)
+        a.foo = 23
+        self.assertEqual(a.call_count, 3)
 
 
 class Student(HasTraits):

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -52,7 +52,7 @@ class TestObserveDecorator(unittest.TestCase):
                     pass
 
         with self.assertWarnsRegex(UserWarning, message_regex):
-            class A(HasTraits):
+            class B(HasTraits):
                 foo = Int()
 
                 @observe("foo")

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -41,7 +41,7 @@ class TestObserveDecorator(unittest.TestCase):
     """ General tests for the observe decorator. """
 
     def test_warning_on_handler_with_bad_signature(self):
-        message_regex = "should be callable with a single positional parameter"
+        message_regex = "should be callable with a single positional argument"
         with self.assertWarnsRegex(UserWarning, message_regex):
             class A(HasTraits):
                 foo = Int()


### PR DESCRIPTION
This PR adds a runtime warning for an observe-decorated method whose signature is incompatible with 'observe'.

I'm in two minds about whether this is a good idea - it's unnecessary runtime overhead, but on the other hand that runtime overhead should be small and will typically only apply at import time.

One the other hand, forgetting the `event` parameter is a very common mistake with `observe`-decorated methods, especially since the event-less signature is compatible with `on_trait_change`.

I haven't extended the fix to dynamic applications of `observe`: `a.observe(handler, expression)`; that does seem like a case where we don't want the extra runtime overhead, since there may be many hidden calls to `observe` in a codebase, but occurrences of the `observe` decorator are limited in comparison.

Closes #1428.

**Checklist**
- [x] Tests
