### PR TITLE
Fix a handler signature in a test

### DIFF
--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -187,7 +187,7 @@ class TestCreateTraitsMetaDict(unittest.TestCase):
         # Given
         @observe(trait("value"), post_init=True, dispatch="ui")
         @observe("name")
-        def handler(event):
+        def handler(self, event):
             pass
 
         class_name = "MyClass"


### PR DESCRIPTION
This PR fixes a bad handler signature in a test. The bad signature was detected by the code in PR #1529.
