### PR TITLE
Don't infer the default value type when it's clear from context

### DIFF
--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -207,6 +207,9 @@ class BaseInt(TraitType):
     #: The function to use for evaluating strings to this type:
     evaluate = int
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     #: The default value for the trait:
     default_value = 0
 
@@ -248,6 +251,9 @@ class BaseFloat(TraitType):
 
     #: The function to use for evaluating strings to this type:
     evaluate = float
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     #: The default value for the trait:
     default_value = 0.0
@@ -293,6 +299,9 @@ class BaseComplex(TraitType):
     #: The function to use for evaluating strings to this type:
     evaluate = complex
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     #: The default value for the trait:
     default_value = 0.0 + 0.0j
 
@@ -332,6 +341,9 @@ class Complex(BaseComplex):
 class BaseStr(TraitType):
     """ A trait type whose value must be a string.
     """
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     #: The default value for the trait:
     default_value = ""
@@ -389,6 +401,9 @@ class BaseBytes(TraitType):
     """ A trait type whose value must be a bytestring.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     #: The default value for the trait:
     default_value = b""
 
@@ -435,6 +450,9 @@ class BaseBool(TraitType):
 
     #: The function to use for evaluating strings to this type:
     evaluate = bool
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     #: The default value for the trait:
     default_value = False
@@ -647,6 +665,9 @@ class String(TraitType):
         A Python regular expression that the string must match.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     def __init__(
         self, value="", minlen=0, maxlen=sys.maxsize, regex="", **metadata
     ):
@@ -824,6 +845,9 @@ class BaseCallable(TraitType):
     #: The standard metadata for the trait:
     metadata = {"copy": "ref"}
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     #: The default value for the trait:
     default_value = None
 
@@ -869,6 +893,9 @@ class BaseType(TraitType):
 class This(BaseType):
     """ A trait type whose value must be an instance of the defining class.
     """
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.self_type,)
@@ -983,6 +1010,9 @@ class Python(TraitType):
 
     #: The standard metadata for the trait:
     metadata = {"type": "python"}
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     #: The default value for the trait:
     default_value = Undefined
@@ -1273,6 +1303,9 @@ class Expression(TraitType):
     The compiled form of a valid expression is stored as the mapped value of
     the trait.
     """
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     #: The default value for the trait:
     default_value = "0"
@@ -1614,6 +1647,9 @@ class BaseRange(TraitType):
     exclude_high : bool
         Indicates whether the high end of the range is exclusive.
     """
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     def __init__(
         self,
@@ -2010,6 +2046,9 @@ class BaseEnum(TraitType):
         None.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     def __init__(self, *args, values=None, **metadata):
         self.name = values
 
@@ -2267,6 +2306,9 @@ class BaseTuple(TraitType):
         element.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     def __init__(self, *types, **metadata):
         if len(types) == 0:
             self.init_fast_validate(ValidateTrait.coerce, tuple, None, list)
@@ -2301,7 +2343,6 @@ class BaseTuple(TraitType):
                 dvt == DefaultValue.constant for dvt in child_default_types
             )
             if constant_default:
-                self.default_value_type = DefaultValue.constant
                 default_value = tuple(child_defaults)
             else:
                 self.default_value_type = DefaultValue.callable
@@ -3033,6 +3074,9 @@ class Map(TraitType):
             trait attribute.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     is_mapped = True
 
     def __init__(self, map, **metadata):
@@ -3117,6 +3161,10 @@ class PrefixMap(TraitType):
         trait attribute, and whose corresponding values are the values for
         the shadow trait attribute.
     """
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     is_mapped = True
 
     def __init__(self, map, **metadata):
@@ -4000,6 +4048,9 @@ class Union(TraitType):
     first trait will be used.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     def __init__(self, *traits, **metadata):
         self.list_ctrait_instances = []
 
@@ -4032,7 +4083,6 @@ class Union(TraitType):
                 self.list_ctrait_instances[0].default_value())
 
             if first_default_value_type == DefaultValue.constant:
-                self.default_value_type = DefaultValue.constant
                 default_value = first_default_value
             else:
                 self.default_value_type = DefaultValue.callable
@@ -4334,6 +4384,9 @@ class Date(TraitType):
         Additional metadata.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     def __init__(
         self,
         default_value=None,
@@ -4432,6 +4485,9 @@ class Datetime(TraitType):
         Additional metadata.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     def __init__(
         self,
         default_value=None,
@@ -4505,6 +4561,9 @@ class Time(TraitType):
     **metadata: dict
         Additional metadata.
     """
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     def __init__(
         self,

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1034,6 +1034,9 @@ class ReadOnly(TraitType):
     # Defines the CTrait type to use for this trait:
     ctrait_type = TraitKind.read_only
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     #: The default value for the trait:
     default_value = Undefined
 


### PR DESCRIPTION
The `TraitType` base class currently has a `default_value_type` of `DefaultValue.unspecified`; as a result, most `TraitType` subclasses do a collection of `isinstance` checks at trait type instantiation time, in order to infer the appropriate default value type to use.

But for most concrete trait types, the appropriate `default_value_type` is already known (and in almost all cases it's `DefaultValue.constant`).

This PR overrides `default_value_type` for most of the concrete trait types. There are some trait types that are messier (notably `Any` and `Instance`, and I'm deferring those for a separate PR. Eventually, I'd like to be able to ensure that we're never using the default value type inference for `TraitType` subclasses and relegate that code to the old `TraitHandler`s. The wider goal is to rationalise and fix the default value handling across all `TraitType` subclasses.

Strictly speaking, this is a behaviour change. However, the cases where the behaviour does change are fairly obscure and seem unlikely to turn up in production code. For example, after:

```python
class A(HasTraits):
    foo = Int([])  # not a very likely default value
```

with this PR, the default value ends up being shared between instances (which isn't exactly an unfamiliar situation to Python programmers):

```python
>>> a = A()
>>> a.foo
[]
>>> a.foo.append(3)
>>> b = A()
>>> b.foo
[3]
```

Prior to this PR, the inference would have determined that the appropriate `default_value_type` was `DefaultValue.list_copy` and a new list would have been generated for each instance:

```python
>>> a = A()
>>> a.foo
[]
>>> a.foo.append(3)
>>> b = A()
>>> b.foo
[]
```
