### PR TITLE
Limit, document, test and deprecate default_value_type inference for 'Any'

### DIFF
--- a/traits/tests/test_any.py
+++ b/traits/tests/test_any.py
@@ -14,16 +14,39 @@ Tests for the "Any" trait type.
 
 import unittest
 
+from traits.has_traits import HasTraits
 from traits.trait_types import Any
 
 
 class TestAny(unittest.TestCase):
-    def test_deprecated_list_default(self):
+    def test_list_default(self):
         message_pattern = r"a default value of type 'list'.* will be shared"
         with self.assertWarnsRegex(DeprecationWarning, message_pattern):
-            Any([])
+            class A(HasTraits):
+                foo = Any([])
 
-    def test_deprecated_dict_default(self):
+        # Test the current (but deprecated) copying behaviour
+        a = A()
+        b = A()
+        self.assertEqual(a.foo, [])
+        self.assertEqual(b.foo, [])
+
+        a.foo.append(35)
+        self.assertEqual(a.foo, [35])
+        self.assertEqual(b.foo, [])
+
+    def test_dict_default(self):
         message_pattern = r"a default value of type 'dict'.* will be shared"
         with self.assertWarnsRegex(DeprecationWarning, message_pattern):
-            Any({})
+            class A(HasTraits):
+                foo = Any({})
+
+        # Test the current (but deprecated) copying behaviour
+        a = A()
+        b = A()
+        self.assertEqual(a.foo, {})
+        self.assertEqual(b.foo, {})
+
+        a.foo["color"] = "red"
+        self.assertEqual(a.foo, {"color": "red"})
+        self.assertEqual(b.foo, {})

--- a/traits/tests/test_any.py
+++ b/traits/tests/test_any.py
@@ -1,0 +1,29 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tests for the "Any" trait type.
+"""
+
+import unittest
+
+from traits.trait_types import Any
+
+
+class TestAny(unittest.TestCase):
+    def test_deprecated_list_default(self):
+        message_pattern = r"a default value of type 'list'.* will be shared"
+        with self.assertWarnsRegex(DeprecationWarning, message_pattern):
+            Any([])
+
+    def test_deprecated_dict_default(self):
+        message_pattern = r"a default value of type 'dict'.* will be shared"
+        with self.assertWarnsRegex(DeprecationWarning, message_pattern):
+            Any({})

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -190,11 +190,43 @@ class Any(TraitType):
     """ A trait type whose value can be anything.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     #: The default value for the trait:
     default_value = None
 
     #: A description of the type of value this trait accepts:
     info_text = "any value"
+
+    def __init__(self, default_value=NoDefaultSpecified, **metadata):
+        # Backwards compatibility
+        if isinstance(default_value, list):
+            warnings.warn(
+                (
+                    "In the future, a default value of type 'list' in an Any "
+                    "trait will be shared between all instances. For a "
+                    "per-instance default, use a default method for this "
+                    "trait. "
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.default_value_type = DefaultValue.list_copy
+        elif isinstance(default_value, dict):
+            warnings.warn(
+                (
+                    "In the future, a default value of type 'dict' in an Any "
+                    "trait will be shared between all instances. For a "
+                    "per-instance default, use a default method for this "
+                    "trait. "
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.default_value_type = DefaultValue.dict_copy
+
+        super().__init__(default_value, **metadata)
 
 
 class BaseInt(TraitType):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -188,6 +188,22 @@ def _validate_float(value):
 
 class Any(TraitType):
     """ A trait type whose value can be anything.
+
+    Parameters
+    ----------
+    default_value : object, optional
+        The default value for the trait. If this is an instance of either
+        :class:`list` or :class:`dict` then a copy of the default value
+        is made for each instance. Otherwise, the default is shared between
+        all instances.
+
+        .. deprecated:: 6.3.0
+            In a future version of Traits, a ``list`` or ``dict`` default value
+            will no longer be copied. If you need a per-instance default, use a
+            ``_trait_name_default`` method to supply that default.
+
+    **metadata
+        Metadata for the trait.
     """
 
     #: The default value type to use.

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -216,7 +216,6 @@ class Any(TraitType):
     info_text = "any value"
 
     def __init__(self, default_value=NoDefaultSpecified, **metadata):
-        # Backwards compatibility
         if isinstance(default_value, list):
             warnings.warn(
                 (

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -221,7 +221,7 @@ class Any(TraitType):
                 (
                     "In the future, a default value of type 'list' in an Any "
                     "trait will be shared between all instances. For a "
-                    "per-instance default, use a default method for this "
+                    "per-instance default, define a default method for this "
                     "trait. "
                 ),
                 DeprecationWarning,
@@ -233,7 +233,7 @@ class Any(TraitType):
                 (
                     "In the future, a default value of type 'dict' in an Any "
                     "trait will be shared between all instances. For a "
-                    "per-instance default, use a default method for this "
+                    "per-instance default, define a default method for this "
                     "trait. "
                 ),
                 DeprecationWarning,


### PR DESCRIPTION
The `Any` trait type currently goes through the normal inference for `default_value_type`. The only cases where this inference is likely to produce something other than `DefaultValue.constant` are traits of the form `Any(some_list)` or `Any(some_dict)`. In those cases, we end up with `DefaultValue.list_copy` and `DefaultValue.dict_copy` respectively. This means that the default is copied for each `HasTraits` instance, so we end up with a per-instance non-shared default instead of a per-class shared default value.

This PR moves the inference from the `TraitType` base class to `Any.__init__`, and deprecates the use of the `DefaultValue.list_copy` and `DefaultValue.dict_copy` default value types. The intent is to use `DefaultValue.constant` consistently in Traits >= 7.0.

Rationale for the deprecation: the inference is already inconsistent in that it special-cases `list` and `dict` instances but not `set` instances. We could extend to `set` (at some cost - we'd need a new `DefaultValue` enum member and extra handling in `ctraits.c`), but that misses other mutable types, and just as with default values for Python functions, there's no realistic way that we can determine when a default value should be copied and when it shouldn't. The only sensible behaviour for Traits here is to follow Python's lead and not make copies when not explicitly asked to. If there are worries that this is a common failure mode, we could look into static analysis checking as a solution.

I suspect that patterns of the form `Any(some_list)` or `Any(some_dict)` are rather rare in real code; nevertheless, it seems prudent to have a deprecation period and only make the change in Traits 7.0.

I did a search of Traits-using codebases available to me (both public and private) for the regex pattern `"= Any\("`. After discarding one false positive, I was left with 878 hits, most of which were simply `Any()`. The rest included:

- 2 occurrences of `Any( [1, 2, 3 ] )` or `Any([1, 2, 3])` in the traits documentation.
- 2 cases of `Any( [] )`, in blockcanvas
- 23 occurrences of `Any( {} )` or `Any({})`, split between TraitsUI and blockcanvas, and 6 of `Any(dict())`, all in blockcanvas and codetools
- no other cases that would be affected by this change.

The TraitsUI cases should be looked at; the rest are in outdated code and unlikely to be problematic.


