### PR TITLE
Fix bug in handling of Union default value

### DIFF
--- a/traits/tests/test_union.py
+++ b/traits/tests/test_union.py
@@ -12,7 +12,7 @@ import unittest
 
 from traits.api import (
     Bytes, DefaultValue, Float, HasTraits, Instance, Int, List, Str,
-    TraitError, TraitType,Type, Union)
+    TraitError, TraitType, Type, Union)
 
 
 class CustomClass(HasTraits):

--- a/traits/tests/test_union.py
+++ b/traits/tests/test_union.py
@@ -11,8 +11,8 @@
 import unittest
 
 from traits.api import (
-    Bytes, DefaultValue, Float, HasTraits, Instance, Int, List, Str, TraitError, TraitType,
-    Type, Union)
+    Bytes, DefaultValue, Float, HasTraits, Instance, Int, List, Str,
+    TraitError, TraitType,Type, Union)
 
 
 class CustomClass(HasTraits):
@@ -209,8 +209,6 @@ class TestUnion(unittest.TestCase):
             has_union.trait("nested").default_value(),
             (DefaultValue.constant, ""),
         )
-
-
 
 
 if __name__ == '__main__':

--- a/traits/tests/test_union.py
+++ b/traits/tests/test_union.py
@@ -11,8 +11,8 @@
 import unittest
 
 from traits.api import (
-    Float, Instance, Int, List, Str, TraitError, TraitType, HasTraits, Union,
-    Type)
+    Bytes, DefaultValue, Float, HasTraits, Instance, Int, List, Str, TraitError, TraitType,
+    Type, Union)
 
 
 class CustomClass(HasTraits):
@@ -195,9 +195,22 @@ class TestUnion(unittest.TestCase):
         class HasUnionWithList(HasTraits):
             foo = Union(Int(23), Float)
 
+            nested = Union(Union(Str(), Bytes()), Union(Int(), Float(), None))
+
         has_union = HasUnionWithList()
         value = has_union.foo
         self.assertEqual(value, 23)
+
+        self.assertEqual(
+            has_union.trait("foo").default_value(),
+            (DefaultValue.constant, 23),
+        )
+        self.assertEqual(
+            has_union.trait("nested").default_value(),
+            (DefaultValue.constant, ""),
+        )
+
+
 
 
 if __name__ == '__main__':

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4028,7 +4028,7 @@ class Union(TraitType):
         if 'default_value' in metadata:
             default_value = metadata.pop("default_value")
         else:
-            first_default_value, first_default_value_type = (
+            first_default_value_type, first_default_value = (
                 self.list_ctrait_instances[0].default_value())
 
             if first_default_value_type == DefaultValue.constant:


### PR DESCRIPTION
The logic introduced in #1522 for handing dynamic defaults in `Union` traits was buggy. This PR fixes that logic and improves the test.

Closes #1533 .

**Checklist**
- [x] Tests
