### PR TITLE
Fix more cases where the default_value_type is inferred unnecessarily

### DIFF
--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -13,6 +13,7 @@ import gc
 import sys
 import unittest
 
+from traits.constants import DefaultValue
 from traits.has_traits import (
     HasStrictTraits,
     HasTraits,
@@ -133,6 +134,9 @@ class RaisingValidator(TraitType):
     Used for testing propagation of that exception.
     """
     info_text = "bogus"
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     #: The default value for the trait:
     default_value = None

--- a/traits/tests/test_trait_types.py
+++ b/traits/tests/test_trait_types.py
@@ -36,6 +36,10 @@ class TraitTypesTest(unittest.TestCase):
         # Regression test for a bug in traits where the same _metadata
         # dictionary was shared between different trait types.
         class LazyProperty(TraitType):
+
+            #: The default value type to use.
+            default_value_type = DefaultValue.constant
+
             def get(self, obj, name):
                 return 1729
 

--- a/traits/tests/test_trait_types.py
+++ b/traits/tests/test_trait_types.py
@@ -70,16 +70,20 @@ class TraitTypesTest(unittest.TestCase):
         self.assertEqual(output.strip(), "Success")
 
     def test_default_value_in_init(self):
+
+        class MyTraitType(TraitType):
+            pass
+
         # Tests for the behaviour of the default_value argument
         # to TraitType.__init__.
-        trait_type = TraitType(default_value=23)
+        trait_type = MyTraitType(default_value=23)
         self.assertEqual(
             trait_type.get_default_value(),
             (DefaultValue.constant, 23),
         )
 
         # An explicit default value of None should work as expected.
-        trait_type = TraitType(default_value=None)
+        trait_type = MyTraitType(default_value=None)
         self.assertEqual(
             trait_type.get_default_value(),
             (DefaultValue.constant, None),
@@ -87,7 +91,7 @@ class TraitTypesTest(unittest.TestCase):
 
         # If no default is given, get_default_value() returns a value
         # of Undefined.
-        trait_type = TraitType()
+        trait_type = MyTraitType()
         self.assertEqual(
             trait_type.get_default_value(),
             (DefaultValue.constant, Undefined),
@@ -95,7 +99,7 @@ class TraitTypesTest(unittest.TestCase):
 
         # Similarly, if NoDefaultSpecified is given, get_default_value()
         # is Undefined.
-        trait_type = TraitType(default_value=NoDefaultSpecified)
+        trait_type = MyTraitType(default_value=NoDefaultSpecified)
         self.assertEqual(
             trait_type.get_default_value(),
             (DefaultValue.constant, Undefined),

--- a/traits/tests/test_union.py
+++ b/traits/tests/test_union.py
@@ -11,8 +11,8 @@
 import unittest
 
 from traits.api import (
-    Float, Instance, Int, List, Str, TraitError, TraitType, HasTraits, Union,
-    Type)
+    DefaultValue, Float, Instance, Int, List, Str, TraitError, TraitType,
+    HasTraits, Union, Type)
 
 
 class CustomClass(HasTraits):
@@ -20,6 +20,11 @@ class CustomClass(HasTraits):
 
 
 class CustomStrType(TraitType):
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
+    #: The default value.
     default_value = "a string value"
 
     def validate(self, obj, name, value):

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -857,6 +857,9 @@ class BaseType(TraitType):
     This is an abstract class and should not be directly instantiated.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     def validate(self, object, name, value):
         """ Validates that the value is a Python callable.
         """
@@ -925,6 +928,12 @@ class Function(TraitType):
         ``Instance(types.FunctionType)``.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
+    #: The default value for the trait type.
+    default_value = Undefined
+
     @deprecated("Function trait type has been deprecated. Use 'Callable' or "
                 "'Instance(types.FunctionType)' instead")
     def __init__(self):
@@ -948,6 +957,12 @@ class Method(TraitType):
         ``Instance(types.MethodType)``.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
+    #: The default value for the trait type.
+    default_value = Undefined
+
     @deprecated("Method trait type has been deprecated. Use 'Callable' or "
                 "'Instance(types.MethodType)' instead")
     def __init__(self):
@@ -963,6 +978,12 @@ class Method(TraitType):
 class Module(TraitType):
     """ A trait type whose value must be a module.
     """
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
+    #: The default value for the trait type.
+    default_value = Undefined
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.coerce, ModuleType)
@@ -4212,7 +4233,7 @@ class UUID(TraitType):
     def get_default_value(self):
         """ Return a Traits default value tuple for the trait.
 
-        This uses the _create_uuid method to generate the defualt value.
+        This uses the _create_uuid method to generate the default value.
         """
         return (
             DefaultValue.callable_and_args,


### PR DESCRIPTION
Another step towards #1538:

- Don't infer the default value type for `BaseType`, `Function`, `Method` and `Module`
- Fix some `TraitType` subclasses used in testing to avoid the inference
- Tangential fix: fix a place where `TraitType` was being used directly in tests. (In general, `TraitType` should be seen as an abstract base class, and should not be instantiated directly.)
