### PR TITLE
Bypass default_value_type inference for Constant

### DIFF
--- a/traits/tests/test_constant.py
+++ b/traits/tests/test_constant.py
@@ -52,3 +52,23 @@ class TestConstantTrait(unittest.TestCase):
 
         self.assertEqual(obj.c_atr_1, [1, 2, 3, 4, 5, 6])
         self.assertEqual(obj.c_atr_2, {"a": 1, "b": 2, "c": 3})
+
+    def test_mutate_affects_all_instances(self):
+        # Mutable values are allowed for the 'Constant' trait because it's
+        # impractical to do otherwise - many things are mutable but not
+        # intended to be mutated, and there's no practical way to test for
+        # "not-intended-to-be-mutated". Nevertheless, actually mutating the
+        # value for 'Constant' is inadvisable in practice, despite the
+        # existence of this test.
+        class TestClass(HasTraits):
+            c_atr = Constant([1, 2, 3, 4, 5])
+
+        obj1 = TestClass()
+        obj2 = TestClass()
+
+        # Mutate obj2; check that obj1 is affected.
+        obj2.c_atr.append(6)
+        self.assertEqual(obj1.c_atr, [1, 2, 3, 4, 5, 6])
+
+        # Check directly that both refer to the same object.
+        self.assertIs(obj1.c_atr, obj2.c_atr)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1045,6 +1045,9 @@ class Constant(TraitType):
         Trait metadata for the trait.
     """
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
     #: Defines the CTrait type to use for this trait:
     ctrait_type = TraitKind.constant
 


### PR DESCRIPTION
[Part of #1538]

This PR bypasses default_value_type inference for the `Constant` trait type. It also adds tests to check that default values are shared. Those tests reflect the behaviour both prior and post PR - the PR shouldn't change the behaviour here.