### PR TITLE
Deprecate the Symbol trait type

### DIFF
--- a/traits/tests/test_trait_types.py
+++ b/traits/tests/test_trait_types.py
@@ -23,8 +23,9 @@ from traits.api import (
     DefaultValue,
     Float,
     Function,
-    NoDefaultSpecified,
     Method,
+    NoDefaultSpecified,
+    Symbol,
     TraitType,
     Undefined
 )
@@ -118,3 +119,7 @@ class TestDeprecatedTraitTypes(unittest.TestCase):
     def test_method_deprecated(self):
         with self.assertWarnsRegex(DeprecationWarning, "Method trait type"):
             Method()
+
+    def test_symbol_deprecated(self):
+        with self.assertWarnsRegex(DeprecationWarning, "Symbol trait type"):
+            Symbol("random:random")

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4216,7 +4216,15 @@ class Symbol(TraitType):
 
     The value returned by the trait is the actual object that this string
     refers to.  The value is cached, so any calls are only evaluated once.
+
+    .. deprecated:: 6.3.0
+        This trait type is deprecated, and will be removed in a future
+        version of Traits.
     """
+
+    @deprecated("The Symbol trait type has been deprecated.")
+    def __init__(self, default_value=NoDefaultSpecified, **metadata):
+        super().__init__(default_value=default_value, **metadata)
 
     #: A description of the type of value this trait accepts:
     info_text = (


### PR DESCRIPTION
This PR deprecates the `Symbol` trait type, which was untested, unused in code that I have access to (with one exception, where it can be easily replaced), and has some slightly dangerous eval-based semantics. It's also not really a good fit for a trait, since it involves neither validation nor notification.

- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- ~[ ] Update User manual (`docs/source/traits_user_manual`)~ N/A
- ~[ ] Update type annotation hints in `traits-stubs`~ N/A
