### PR TITLE
Fix deprecation of Function and Method

### DIFF
--- a/traits/tests/test_trait_types.py
+++ b/traits/tests/test_trait_types.py
@@ -112,9 +112,21 @@ class TraitTypesTest(unittest.TestCase):
 
 class TestDeprecatedTraitTypes(unittest.TestCase):
     def test_function_deprecated(self):
+        def some_function():
+            pass
+
         with self.assertWarnsRegex(DeprecationWarning, "Function trait type"):
             Function()
+        with self.assertWarnsRegex(DeprecationWarning, "Function trait type"):
+            Function(some_function, washable=True)
 
     def test_method_deprecated(self):
+
+        class A:
+            def some_method(self):
+                pass
+
         with self.assertWarnsRegex(DeprecationWarning, "Method trait type"):
             Method()
+        with self.assertWarnsRegex(DeprecationWarning, "Method trait type"):
+            Method(A().some_method, gluten_free=False)

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1010,8 +1010,8 @@ class Function(TraitType):
 
     @deprecated("Function trait type has been deprecated. Use 'Callable' or "
                 "'Instance(types.FunctionType)' instead")
-    def __init__(self):
-        super().__init__()
+    def __init__(self, default_value=NoDefaultSpecified, **metadata):
+        super().__init__(default_value=default_value, **metadata)
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.coerce, FunctionType)
@@ -1039,8 +1039,8 @@ class Method(TraitType):
 
     @deprecated("Method trait type has been deprecated. Use 'Callable' or "
                 "'Instance(types.MethodType)' instead")
-    def __init__(self):
-        super().__init__()
+    def __init__(self, default_value=NoDefaultSpecified, **metadata):
+        super().__init__(default_value=default_value, **metadata)
 
     #: The C-level fast validator to use:
     fast_validate = (ValidateTrait.coerce, MethodType)


### PR DESCRIPTION
The `Function` and `Method` trait types were deprecated in #1397 and #1399 (respectively), but the `__init__` method introduced wasn't general enough - it prevented uses of `Function` and `Method` with a default value or with metadata. This PR fixes that.
