### PR TITLE
Remove unnecessary unittest.main blocks

### DIFF
--- a/traits/tests/test_none.py
+++ b/traits/tests/test_none.py
@@ -31,7 +31,3 @@ class TestCaseNoneTrait(unittest.TestCase):
         with self.assertRaises(ValueError):
             class TestClass(HasTraits):
                 none_trait = _NoneTrait(default_value=[])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/traits/tests/test_union.py
+++ b/traits/tests/test_union.py
@@ -214,7 +214,3 @@ class TestUnion(unittest.TestCase):
             has_union.trait("nested").default_value(),
             (DefaultValue.constant, ""),
         )
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Drive-by cleanup: some time ago we removed all the `if __name__ == "__main__"` blocks from test modules; it appears a couple have crept back in. This PR removes them.
