### PR TITLE
Fix occurrences of Any(some_list) in docs

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -988,7 +988,7 @@ on a HasTraits object to get a reference to a specific trait, and then access
 the metadata attribute::
 
     # metadata.py --- Example of accessing trait metadata attributes
-    from traits.api import HasTraits, Int, List, Float, \
+    from traits.api import HasTraits, Int, List, Float, Str, \
                                      Instance, Any, TraitType
 
     class Foo( HasTraits ): pass
@@ -997,7 +997,7 @@ the metadata attribute::
         i = Int(99)
         lf = List(Float)
         foo = Instance( Foo, () )
-        any = Any( [1, 2, 3 ] )
+        any = Any( "123" )
 
     t = Test()
 
@@ -1022,11 +1022,11 @@ the metadata attribute::
     print(t.trait( 'foo' ).is_trait_type( Instance ))  # True
     print(t.trait( 'foo' ).is_trait_type( List  ))     # False
 
-    print(t.trait( 'any' ).default)                    # [1, 2, 3]
-    print(t.trait( 'any' ).default_kind)               # list
+    print(t.trait( 'any' ).default)                    # 123
+    print(t.trait( 'any' ).default_kind)               # value
     print(t.trait( 'any' ).inner_traits)               # ()
     print(t.trait( 'any' ).is_trait_type( Any ))       # True
-    print(t.trait( 'any' ).is_trait_type( List ))      # False
+    print(t.trait( 'any' ).is_trait_type( Str ))       # False
 
 .. rubric:: Footnotes
 .. [2] Most callable predefined traits are classes, but a few are functions.

--- a/examples/tutorials/doc_examples/examples/metadata.py
+++ b/examples/tutorials/doc_examples/examples/metadata.py
@@ -11,7 +11,8 @@
 # metadata.py --- Example of accessing trait metadata attributes
 
 # --[Imports]------------------------------------------------------------------
-from traits.api import HasTraits, Int, List, Float, Instance, Any, TraitType
+from traits.api import (
+    HasTraits, Int, List, Float, Instance, Any, Str, TraitType)
 
 
 # --[Code]---------------------------------------------------------------------
@@ -23,7 +24,7 @@ class Test(HasTraits):
     i = Int(99)
     lf = List(Float)
     foo = Instance(Foo, ())
-    any = Any([1, 2, 3])
+    any = Any("123")
 
 
 # --[Example*]-----------------------------------------------------------------
@@ -51,8 +52,8 @@ print(t.trait("foo").inner_traits)  # ()
 print(t.trait("foo").is_trait_type(Instance))  # True
 print(t.trait("foo").is_trait_type(List))  # False
 
-print(t.trait("any").default)  # [1, 2, 3]
-print(t.trait("any").default_kind)  # list
+print(t.trait("any").default)  # 123
+print(t.trait("any").default_kind)  # value
 print(t.trait("any").inner_traits)  # ()
 print(t.trait("any").is_trait_type(Any))  # True
-print(t.trait("any").is_trait_type(List))  # False
+print(t.trait("any").is_trait_type(Str))  # False


### PR DESCRIPTION
A belated followup to #1532: fix occurrences of `Any(some_list)` from the documentation.
