### PR TITLE
Fix a DeprecationWarning from a test

### DIFF
--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -56,7 +56,7 @@ class CustomCollection:
 
 
 class EnumListExample(HasTraits):
-    values = Any(['foo', 'bar', 'baz'])
+    values = List(['foo', 'bar', 'baz'])
 
     value = Enum(['foo', 'bar', 'baz'])
 


### PR DESCRIPTION
Following #1532, this PR fixes an instance of the `DeprecationWarning` from one of the tests. This warning doesn't usually show up in the test run, because it's triggered at import time rather than during the test run. However, it can be seen when running the tests under `python -Wd -m unittest`.