### PR TITLE
Deprecate MetaHasTraits.add_listener and MetaHasTraits.remove_listener

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -417,13 +417,21 @@ class MetaHasTraits(type):
 
         If the class name is the empty string then the listener will be called
         when *any* class is created.
+
+        .. deprecated:: 6.3.0
         """
+        warnings.warn("add_listener is deprecated", DeprecationWarning, stacklevel=2)
+
         MetaHasTraits._listeners.setdefault(class_name, []).append(listener)
 
     @classmethod
     def remove_listener(cls, listener, class_name=""):
         """ Removes a class creation listener.
+
+        .. deprecated:: 6.3.0
         """
+        warnings.warn("remove_listener is deprecated", DeprecationWarning, stacklevel=2)
+
         MetaHasTraits._listeners[class_name].remove(listener)
 
 

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -420,7 +420,9 @@ class MetaHasTraits(type):
 
         .. deprecated:: 6.3.0
         """
-        warnings.warn("add_listener is deprecated", DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            "add_listener is deprecated", DeprecationWarning, stacklevel=2
+        )
 
         MetaHasTraits._listeners.setdefault(class_name, []).append(listener)
 
@@ -430,7 +432,9 @@ class MetaHasTraits(type):
 
         .. deprecated:: 6.3.0
         """
-        warnings.warn("remove_listener is deprecated", DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            "remove_listener is deprecated", DeprecationWarning, stacklevel=2
+        )
 
         MetaHasTraits._listeners[class_name].remove(listener)
 

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -61,9 +61,13 @@ class TestMetaHasTraits(unittest.TestCase):
         def listener(cls):
             pass
 
-        with self.assertWarnsRegex(DeprecationWarning, "add_listener is deprecated"):
+        with self.assertWarnsRegex(
+            DeprecationWarning, "add_listener is deprecated"
+        ):
             MetaHasTraits.add_listener(listener)
-        with self.assertWarnsRegex(DeprecationWarning, "remove_listener is deprecated"):
+        with self.assertWarnsRegex(
+            DeprecationWarning, "remove_listener is deprecated"
+        ):
             MetaHasTraits.remove_listener(listener)
 
 

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -26,6 +26,7 @@ from traits.has_traits import (
     SingletonHasTraits,
     SingletonHasStrictTraits,
     SingletonHasPrivateTraits,
+    MetaHasTraits,
 )
 from traits.ctrait import CTrait
 from traits.observation.api import (
@@ -53,6 +54,17 @@ def _dummy_setter(self, value):
 
 def _dummy_validator(self, value):
     pass
+
+
+class TestMetaHasTraits(unittest.TestCase):
+    def test_add_listener_and_remove_listener_deprecated(self):
+        def listener(cls):
+            pass
+
+        with self.assertWarnsRegex(DeprecationWarning, "add_listener is deprecated"):
+            MetaHasTraits.add_listener(listener)
+        with self.assertWarnsRegex(DeprecationWarning, "remove_listener is deprecated"):
+            MetaHasTraits.remove_listener(listener)
 
 
 class TestCreateTraitsMetaDict(unittest.TestCase):


### PR DESCRIPTION
Closes #1549.

**Checklist**
- [x] Tests
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~ N/A
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~ N/A
- [ ] ~Update type annotation hints in `traits-stubs`~ N/A
