### PR TITLE
Bypass default_value_type inference for remaining TraitType subclasses

### DIFF
--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -1125,6 +1125,9 @@ class Disallow(TraitType):
     #: Defines the CTrait type to use for this trait:
     ctrait_type = TraitKind.disallow
 
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
+
 
 # Create a singleton instance as the trait:
 Disallow = Disallow()
@@ -1216,6 +1219,9 @@ class Delegate(TraitType):
 
     #: Defines the CTrait type to use for this trait:
     ctrait_type = TraitKind.delegate
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     #: The standard metadata for the trait:
     metadata = {"type": "delegate", "transient": False}
@@ -3861,6 +3867,9 @@ class Event(TraitType):
     trait : a trait
         The type of value that can be assigned to the event.
     """
+
+    #: The default value type to use.
+    default_value_type = DefaultValue.constant
 
     def __init__(self, trait=None, **metadata):
         metadata["type"] = "event"


### PR DESCRIPTION
This PR completes the removal of `default_value_type` inference for the remaining `TraitType` subclasses that still use it: `Delegate`, `Event` and `Disallow`. I wanted to use a type of `DefaultValue.disallow` for these instead of `DefaultValue.constant`, but that caused issues in TraitsUI `ViewSubElement`, here: https://github.com/enthought/traitsui/blob/114b29131c1fe92eb945bf1118574f1732b3fa15/traitsui/view_element.py#L184. That code relies on being able to call `default_value_for` and get a meaningful result for any trait.

After this PR, the `_infer_default_value_type` function in `trait_type.py` is only exercised by a single test.