### PR TITLE
Add 'factory' support for the Any trait type

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -278,7 +278,9 @@ the table.
 +------------------+----------------------------------------------------------+
 | Name             | Callable Signature                                       |
 +==================+==========================================================+
-| Any              | Any( [*value* = None, \*\*\ *metadata*] )                |
+| Any              | Any( [*default_value* = None, \*,                        |
+|                  | *factory* = None, *args* = (), *kw = {},                 |
+|                  | \*\*\ *metadata* )                                       |
 +------------------+----------------------------------------------------------+
 | Array            | Array( [*dtype* = None, *shape* = None, *value* = None,  |
 |                  | *typecode* = None, \*\*\ *metadata*] )                   |

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -279,7 +279,7 @@ the table.
 | Name             | Callable Signature                                       |
 +==================+==========================================================+
 | Any              | Any( [*default_value* = None, \*,                        |
-|                  | *factory* = None, *args* = (), *kw = {},                 |
+|                  | *factory* = None, *args* = (), *kw* = {},                 |
 |                  | \*\*\ *metadata* )                                       |
 +------------------+----------------------------------------------------------+
 | Array            | Array( [*dtype* = None, *shape* = None, *value* = None,  |

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -279,7 +279,7 @@ the table.
 | Name             | Callable Signature                                       |
 +==================+==========================================================+
 | Any              | Any( [*default_value* = None, \*,                        |
-|                  | *factory* = None, *args* = (), *kw* = {},                 |
+|                  | *factory* = None, *args* = (), *kw* = {},                |
 |                  | \*\*\ *metadata* )                                       |
 +------------------+----------------------------------------------------------+
 | Array            | Array( [*dtype* = None, *shape* = None, *value* = None,  |

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -42,7 +42,17 @@ _S = TypeVar("_S")
 
 _Trait = _Union[_TraitType[_S, _T], _Type[_TraitType[_S, _T]]]
 
-Any = _Any
+
+class Any(_TraitType[_Any, _Any]):
+    def __init__(
+        self,
+        default_value=...,
+        *,
+        factory: _CallableType = ...,
+        args: tuple = ...,
+        kw: dict = ...,
+        **metadata: _Any,
+    ) -> None: ...
 
 
 class _BaseInt(_TraitType[_T, int]):

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -46,7 +46,7 @@ _Trait = _Union[_TraitType[_S, _T], _Type[_TraitType[_S, _T]]]
 class Any(_TraitType[_Any, _Any]):
     def __init__(
         self,
-        default_value=...,
+        default_value: _Any = ...,
         *,
         factory: _CallableType = ...,
         args: tuple = ...,

--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -52,7 +52,8 @@ class Any(_TraitType[_Any, _Any]):
         args: tuple = ...,
         kw: dict = ...,
         **metadata: _Any,
-    ) -> None: ...
+    ) -> None:
+        ...
 
 
 class _BaseInt(_TraitType[_T, int]):

--- a/traits-stubs/traits_stubs_tests/examples/Any.py
+++ b/traits-stubs/traits_stubs_tests/examples/Any.py
@@ -52,9 +52,8 @@ class Foo:
 
 class Superclass(HasTraits):
     x = Any()
-    # y = Any()
 
 
 class Subclass(Superclass):
-    x = Instance(Foo)
+    x = Instance(Foo)  # E: assignment
     y = Int()

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -201,6 +201,13 @@ class Any(TraitType):
             will no longer be copied. If you need a per-instance default, use a
             ``_trait_name_default`` method to supply that default.
 
+    factory : callable, optional
+        A callable, that when called with *args* and
+        *kw*, returns the default value for the trait.
+    args : tuple, optional
+        Positional arguments (if any) for generating the default value.
+    kw : dictionary, optional
+        Keyword arguments (if any) for generating the default value.
     **metadata
         Metadata for the trait.
     """
@@ -214,7 +221,15 @@ class Any(TraitType):
     #: A description of the type of value this trait accepts:
     info_text = "any value"
 
-    def __init__(self, default_value=NoDefaultSpecified, **metadata):
+    def __init__(
+        self,
+        default_value=NoDefaultSpecified,
+        *,
+        factory=None,
+        args=(),
+        kw={},
+        **metadata
+    ):
         if isinstance(default_value, list):
             warnings.warn(
                 (
@@ -239,6 +254,17 @@ class Any(TraitType):
                 stacklevel=2,
             )
             self.default_value_type = DefaultValue.dict_copy
+
+        # Sanity check the parameters
+        if default_value is not NoDefaultSpecified and factory is not None:
+            raise TypeError(
+                "ambiguous defaults: both a default value and a default "
+                "value factory are specified"
+            )
+
+        if factory is not None:
+            self.default_value_type = DefaultValue.callable_and_args
+            default_value = (factory, args, kw)
 
         super().__init__(default_value, **metadata)
 


### PR DESCRIPTION
This PR adds `factory`, `args` and `kw` keyword-only arguments to the `Any` trait type initializer, allowing a default value for an `Any` trait to be specified via a factory, in much the same way as this already works for the `Instance` trait type.

The main goal is to provide a clean migration path for existing code using `Any({})` or `Any([])`. With Traits 6.3, such code will run into the deprecation introduced in #1532, and can now use `Any(factory=dict)` or `Any(factory=list)` as a suitable replacement that won't warn.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] Update User manual (`docs/source/traits_user_manual`)
- [x] Update type annotation hints in `traits-stubs`
