### PR TITLE
Fix an observe-decorated _name_changed method

### DIFF
--- a/docs/source/traits_user_manual/listening.rst
+++ b/docs/source/traits_user_manual/listening.rst
@@ -539,6 +539,17 @@ The arguments that are passed to the trait attribute change notification
 method depend on the method signature and on which type of static notification
 handler it is.
 
+.. note::
+    The :func:`~.on_trait_change` and :func:`~.observe` decorators nullify
+    the effect of special naming. A method that looks like::
+
+        @observe("foo")
+        def _foo_changed(self, event):
+            do_something_with(event)
+
+    will only be called once when ``foo`` changes, as a result of the
+    ``observe`` decorator.
+
 .. _attribute-specific-handler-signatures:
 
 Attribute-specific Handler Signatures

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -162,6 +162,7 @@ def _get_def(class_name, class_dict, bases, method):
         (result is not None)
         and is_unbound_method_type(result)
         and (getattr(result, "on_trait_change", None) is None)
+        and (getattr(result, "_observe_inputs", None) is None)
     ):
         return result
 
@@ -171,6 +172,7 @@ def _get_def(class_name, class_dict, bases, method):
             (result is not None)
             and is_unbound_method_type(result)
             and (getattr(result, "on_trait_change", None) is None)
+            and (getattr(result, "_observe_inputs", None) is None)
         ):
             return result
 

--- a/traits/tests/test_has_traits.py
+++ b/traits/tests/test_has_traits.py
@@ -604,6 +604,68 @@ class TestHasTraits(unittest.TestCase):
             {"foo": A.class_traits()["foo"]},
         )
 
+    def test_decorated_changed_method(self):
+        # xref: enthought/traits#527
+        # Traits should ignore the _changed magic naming.
+
+        events = []
+
+        class A(HasTraits):
+            foo = Int()
+
+            @on_trait_change("foo")
+            def _foo_changed(self, obj, name, old, new):
+                events.append((obj, name, old, new))
+
+        a = A()
+        a.foo = 23
+        self.assertEqual(
+            events,
+            [(a, "foo", 0, 23)],
+        )
+
+    def test_observed_changed_method(self):
+        events = []
+
+        class A(HasTraits):
+            foo = Int()
+
+            @observe("foo")
+            def _foo_changed(self, event):
+                events.append(event)
+
+        a = A()
+        a.foo = 23
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event.object, a)
+        self.assertEqual(event.name, "foo")
+        self.assertEqual(event.old, 0)
+        self.assertEqual(event.new, 23)
+
+    def test_decorated_changed_method_subclass(self):
+        # xref: enthought/traits#527
+        # Traits should ignore the _changed magic naming.
+
+        events = []
+
+        class A(HasTraits):
+            foo = Int()
+
+            @on_trait_change("foo")
+            def _foo_changed(self, obj, name, old, new):
+                events.append((obj, name, old, new))
+
+        class B(A):
+            pass
+
+        a = B()
+        a.foo = 23
+        self.assertEqual(
+            events,
+            [(a, "foo", 0, 23)],
+        )
+
 
 class TestObjectNotifiers(unittest.TestCase):
     """ Test calling object notifiers. """


### PR DESCRIPTION
This PR changes the behaviour of a method that's decorated with `observe` but also has the magic `_somename_changed` naming.

Prior to this PR, such a method would be registered twice by the Traits machinery, and called once with a `TraitChangeEvent` and once with the new value of the trait:

```python
>>> from traits.api import *
>>> class A(HasTraits):
...     foo = Int()
...     @observe("foo")
...     def _foo_changed(self, arg):
...         print(arg)
... 
>>> a = A()
>>> a.foo = 23  # Expect one call to `print`; get two calls.
23
TraitChangeEvent(object=<__main__.A object at 0x10ad14450>, name='foo', old=0, new=23)
```

With this PR, it will only be called once, with the `TraitChangeEvent`: the `observe` decorator supersedes and nullifies the magic naming. This is the same behaviour that's already present for `on_trait_change`:

```python
>>> from traits.api import *
>>> class A(HasTraits):
...     foo = Int()
...     @observe("foo")
...     def _foo_changed(self, arg):
...         print(arg)
... 
>>> a = A()
>>> a.foo = 23  # Get one call to `print`, as expected.
TraitChangeEvent(object=<__main__.A object at 0x1056994a0>, name='foo', old=0, new=23)
```

I don't think we need a deprecation period for the change in behaviour: I doubt that there's working code that *relies* on the method being called twice with different arguments for each call, so I think this qualifies as a bugfix.

The PR also adds tests that exercise the corresponding code for `on_trait_change`.

Closes #527