### PR TITLE
Rework PrefixList

### DIFF
--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -60,15 +60,26 @@ class TestPrefixList(unittest.TestCase):
             a.foo = "abc"
 
     def test_invalid_default(self):
-        with self.assertRaises(TraitError) as exception_context:
+        with self.assertRaises(ValueError):
             class A(HasTraits):
                 foo = PrefixList(["zero", "one", "two"], default_value="uno")
 
-        self.assertIn(
-            "The value of a PrefixList trait must be 'zero' or 'one' or 'two' "
-            "(or any unique prefix), but a value of 'uno'",
-            str(exception_context.exception),
-        )
+    def test_invalid_default_corner_case(self):
+        with self.assertRaises(ValueError):
+
+            # In this case the default is "abc", which is invalid because
+            # it's not a unique prefix.
+            class A(HasTraits):
+                foo = PrefixList(["abc", "abcd", "e"])
+
+    def test_invalid_value_corner_case(self):
+        class A(HasTraits):
+            foo = PrefixList(["abcd", "abc", "e"])
+
+        a = A()
+        self.assertEqual(a.foo, "abcd")
+        with self.assertRaises(TraitError):
+            a.foo = "abc"
 
     def test_values_not_sequence(self):
         # Defining values with this signature is not supported

--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -31,7 +31,7 @@ class TestPrefixList(unittest.TestCase):
         with self.assertRaises(TraitError) as exception_context:
             a.foo = ''
         self.assertIn(
-            "The 'foo' trait of an A instance must be 'zero' or 'one' or 'two'"
+            "The 'foo' trait of an A instance must be 'one' or 'two' or 'zero'"
             " (or any unique prefix), but a value of ''",
             str(exception_context.exception),
         )
@@ -64,22 +64,16 @@ class TestPrefixList(unittest.TestCase):
             class A(HasTraits):
                 foo = PrefixList(["zero", "one", "two"], default_value="uno")
 
-    def test_invalid_default_corner_case(self):
-        with self.assertRaises(ValueError):
-
-            # In this case the default is "abc", which is invalid because
-            # it's not a unique prefix.
-            class A(HasTraits):
-                foo = PrefixList(["abc", "abcd", "e"])
-
-    def test_invalid_value_corner_case(self):
+    def test_one_legal_value_is_prefix_of_another(self):
         class A(HasTraits):
             foo = PrefixList(["abcd", "abc", "e"])
 
         a = A()
         self.assertEqual(a.foo, "abcd")
-        with self.assertRaises(TraitError):
-            a.foo = "abc"
+        # Okay because "abc" is identical to one of the elements of the
+        # list of legal values.
+        a.foo = "abc"
+        self.assertEqual(a.foo, "abc")
 
     def test_values_not_sequence(self):
         # Defining values with this signature is not supported

--- a/traits/tests/test_prefix_list.py
+++ b/traits/tests/test_prefix_list.py
@@ -103,6 +103,10 @@ class TestPrefixList(unittest.TestCase):
         with self.assertRaises(ValueError):
             PrefixList([])
 
+    def test_values_is_empty_with_default(self):
+        with self.assertRaises(ValueError):
+            PrefixList([], default_value="one")
+
     def test_pickle_roundtrip(self):
         class A(HasTraits):
             foo = PrefixList(["zero", "one", "two"], default_value="one")

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2842,7 +2842,7 @@ class PrefixList(TraitType):
         """
         Return the unique string completion for a given string prefix.
 
-        Finds the unique string in "values" which starts with "prefix".
+        Finds the unique string in "self.values" which starts with "prefix".
         If there is no such string, or there are multiple matches, raises
         ValueError.
 


### PR DESCRIPTION
This PR reworks and tidies up the `PrefixList` class, fixing a couple of minor bugs along the way.

Detailed changes:

- a bad default in the trait definition now raises `ValueError` rather than `TraitError`
- the caching of previous completions has been removed. If we really need it it can be re-introduced in a more thread-safe way than before
- validation errors no longer give a confusing chained traceback

Fixes #1155, and the problems described in the already-closed issue #1561.

EDIT: Description updated - the original PR also attempted to fix #1562, but #1562 wasn't a valid bug.