### PR TITLE
WIP: Include Python 3.10 in wheel builds.

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -1,8 +1,7 @@
 name: Publish release to PyPI
 
 on:
-  release:
-    types: [published]
+  pull_request
 
 jobs:
   build-sdist:
@@ -88,7 +87,7 @@ jobs:
     - name: Publish wheels to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_PASSWORD: "bogus"
       run: |
         python -m twine check --strict dist/*-manylinux*.whl
         python -m twine upload dist/*-manylinux*.whl

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -27,7 +27,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*.tar.gz
-        python -m twine upload dist/*.tar.gz
+        # python -m twine upload dist/*.tar.gz
 
   build-wheel-windows-macos:
 
@@ -64,7 +64,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*.whl
-        python -m twine upload dist/*.whl
+        # python -m twine upload dist/*.whl
 
   build-wheel-linux:
     runs-on: ubuntu-latest
@@ -80,14 +80,18 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install twine
-    - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.3.3
+    - name: Build manylinux2010 Python wheels
+      uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2010_x86_64
+      with:
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
+    - name: Build manylinux2014 Python wheels
+      uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2014_x86_64
       with:
         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
     - name: Publish wheels to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: "bogus"
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m twine check --strict dist/*-manylinux*.whl
-        python -m twine upload dist/*-manylinux*.whl
+        # python -m twine upload dist/*-manylinux*.whl

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.8
     - name: Install Python packages needed for sdist build and upload
       run: |
         python -m pip install --upgrade pip setuptools
@@ -36,7 +36,7 @@ jobs:
       # Build on 32-bit and 64-bit Windows, and 64-bit macOS
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.2]
         python-architecture: [x86, x64]
         exclude:
           - os: macos-latest
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.8
     - name: Install Python packages needed for wheel upload
       run: |
         python -m pip install --upgrade pip setuptools
@@ -84,7 +84,7 @@ jobs:
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.3.3
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
     - name: Publish wheels to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
In anticipation of the Traits 6.3 release, this PR updates the wheel building workflow to add Python 3.10 wheels.

We also standardize on Python 3.8 rather than Python 3.9 for the sdist build and the Linux host Python used to run Twine. (I plan another PR that standardises on Python 3.8 for all other non-Python-specific CI - style checks, documentation builds.)

Note:
- The first commit is the one we want
- The second commit makes this PR testable, by replacing the trigger with "pull_request", and using a dummy password that should ensure that nothing's actually uploaded to PyPI

Once the PR looks like it's working, I'll revert that second commit and mark the PR as ready for review.