### PR TITLE
Don't try to test wheels on Python 3.10 (yet)

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest


### PR DESCRIPTION
The wheels currently on PyPI don't support 3.10 out of the box. That will be fixed in the next release, but in the mean time the cron job is failing. This PR fixes that.