### PR TITLE
Bump version for continued development towards Traits 6.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import setuptools
 # together with information from the version control system, and then injected
 # into the package source.
 MAJOR = 6
-MINOR = 3
+MINOR = 4
 MICRO = 0
 PRERELEASE = ""
 IS_RELEASED = False


### PR DESCRIPTION
This PR bumps the version on the main branch; the main branch now targets the Traits 6.4.0 release (or possibly Traits 7.0.0).
