### PR TITLE
Bump version for 6.3.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 6
 MINOR = 3
 MICRO = 0
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This PR targets the new maint/6.3 branch, and bumps the version number for the Traits 6.3.0 release. I plan to tag the merge commit for this PR as 6.3.0.