### PR TITLE
Include Python 3.10 in install-from-pypi tests

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest


### PR DESCRIPTION
Now that wheels for Traits 6.3 have been uploaded to PyPI, this PR re-adds Python 3.10 as a target for testing those wheels. This undoes the effects of #1572.