### PR TITLE
Backwards compatibility fix: make `PrefixMap._map` available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,21 @@
 Traits CHANGELOG
 ================
 
+Release 6.3.1
+-------------
+
+Released: 2021-10-12
+
+Traits 6.3.1 is a bugfix release, fixing an incompatibility between
+Traits 6.3.0 and Mayavi <= 4.7.3.
+
+Fixes
+~~~~~
+
+* Make ``PrefixMap._map`` available again, for compatibility with Mayavi.
+  (#1578)
+
+
 Release 6.3.0
 -------------
 

--- a/traits/tests/test_prefix_map.py
+++ b/traits/tests/test_prefix_map.py
@@ -236,3 +236,12 @@ class TestPrefixMap(unittest.TestCase):
         default_value_callable = reconstituted.default_value()[1]
 
         self.assertEqual(default_value_callable(p), 1)
+
+    def test_existence_of__map(self):
+        # This test can be removed once Mayavi no longer depends on the
+        # existence of the _map attribute.
+        # xref: enthought/traits#1577
+        # xref: enthought/mayavi#1094
+
+        prefix_map = PrefixMap({"yes": 1, "yeah": 1, "no": 0, "nah": 0})
+        self.assertEqual(prefix_map._map["yes"], "yes")

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3294,6 +3294,13 @@ class PrefixMap(TraitType):
         if not map:
             raise ValueError("map must be nonempty")
         self.map = map
+        # Provide backwards compatibility for Mayavi, which currently
+        # subclasses PrefixMap and depends on the existence of the _map
+        # attribute. This attribute can be removed as soon as RevPrefixMap in
+        # Mayavi has been fixed.
+        # xref: enthought/traits#1577
+        # xref: enthought/mayavi#1094
+        self._map = {value: value for value in map}
 
         if default_value is not None:
             default_value = self._complete_value(default_value)


### PR DESCRIPTION
This PR makes `PrefixMap._map` available again (following its removal in #1564), to avoid breaking Mayavi.

**Checklist**
- [x] Tests

Closes #1577.