### PR TITLE
Set IS_RELEASED to True for 6.3.1 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 6
 MINOR = 3
 MICRO = 1
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
Set IS_RELEASED to True in preparation for the 6.3.1 bugfix release.

Note: this PR will not be merged; it's opened for human and CI review, and will be closed after tagging its only commit for release.