### PR TITLE
Bump version for development towards 6.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import setuptools
 # into the package source.
 MAJOR = 6
 MINOR = 3
-MICRO = 1
+MICRO = 2
 PRERELEASE = ""
 IS_RELEASED = False
 


### PR DESCRIPTION
The maint/6.3 branch is now open for development towards a possible 6.3.2 release. This PR bumps the version number accordingly.