### PR TITLE
Docstring grammar fix

### DIFF
--- a/traits/observation/parsing.py
+++ b/traits/observation/parsing.py
@@ -197,7 +197,7 @@ def parse(text):
 
 @lru_cache(maxsize=expression_module._OBSERVER_EXPRESSION_CACHE_MAXSIZE)
 def compile_str(text):
-    """ Compile a mini-language string to a list of ObserverGraphs.
+    """ Compile a mini-language string to a list of ObserverGraph objects.
 
     Parameters
     ----------


### PR DESCRIPTION
An insignificant fix to a docstring with the ulterior motive of triggering a new Read the Docs build
