### PR TITLE
Fix repeated Property triggering in subclasses (#1587)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Traits CHANGELOG
 ================
 
+Release 6.3.2
+-------------
+
+Released: XXXX-XX-XX
+
+Traits 6.3.2 is a bugfix release.
+
+Fixes
+~~~~~
+
+* Fix that ``Property`` traits using ``observe`` metadata could be fired
+  twice in subclasses. (#1587)
+
+
 Release 6.3.1
 -------------
 

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -559,8 +559,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
 
             observer_states = getattr(value, "_observe_inputs", None)
             if observer_states is not None:
-                stack = observers.setdefault(name, [])
-                stack.extend(observer_states)
+                observers[name] = observer_states
 
         elif isinstance(value, property):
             class_traits[name] = generic_trait
@@ -613,9 +612,8 @@ def update_traits_class_dict(class_name, bases, class_dict):
 
         # Merge observer information:
         for name, states in base_dict[ObserverTraits].items():
-            if name not in class_traits and name not in class_dict:
-                stack = observers.setdefault(name, [])
-                stack.extend(states)
+            if (name not in class_traits) and (name not in class_dict):
+                observers[name] = states
 
         # Merge base traits:
         for name, value in base_dict.get(BaseTraits).items():
@@ -758,8 +756,7 @@ def update_traits_class_dict(class_name, bases, class_dict):
                 property_name=name,
                 cached=trait.cached,
             )
-            stack = observers.setdefault(name, [])
-            stack.append(observer_state)
+            observers[name] = [observer_state]
 
     # Add processed traits back into class_dict.
     class_dict[BaseTraits] = base_traits

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -25,6 +25,7 @@ from traits.api import (
     Int,
     List,
     observe,
+    Property,
     Set,
     Str,
     Undefined,
@@ -882,3 +883,26 @@ class TestObserveAnytrait(unittest.TestCase):
 
         # No additional events.
         self.assertEqual(len(events), 2)
+
+    def test_property_subclass_observe(self):
+        # Regression test for enthought/traits#1586
+        class Base(HasTraits):
+            bar = Int()
+
+            foo = Property(Int(), observe="bar")
+
+            def _get_foo(self):
+                return self.bar
+
+        class Derived(Base):
+            pass
+
+        events = []
+
+        obj = Derived(bar=3)
+        obj.observe(events.append, "foo")
+
+        # Changing bar should result in a single event.
+        self.assertEqual(len(events), 0)
+        obj.bar = 5
+        self.assertEqual(len(events), 1)


### PR DESCRIPTION
This PR backports the bugfix in #1587 (for #1586) to the 6.3 maintenance branch.