### PR TITLE
Re-include NumPy as a test dependency on Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -309,7 +309,7 @@ setuptools.setup(
             "flake8",
             "flake8-ets",
             "mypy",
-            "numpy; python_version<'3.10'",
+            "numpy",
             "pyface",
             "PySide2; python_version<'3.10'",
             "setuptools",


### PR DESCRIPTION
We were excluding NumPy as a test dependency for Python 3.10 because PyPI wheels weren't yet available on all platforms we were testing on. Those wheels are now available, so the restriction can be removed.