### PR TITLE
Make Complex trait type validation duck-typed.

### DIFF
--- a/traits/constants.py
+++ b/traits/constants.py
@@ -109,6 +109,9 @@ class ValidateTrait(IntEnum):
     #: A callable check.
     callable = 22
 
+    #: A complex number check.
+    complex_number = 23
+
 
 class ComparisonMode(IntEnum):
     """ Comparison mode.

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3377,7 +3377,7 @@ as_float(PyObject *value)
 */
 
 static PyObject *
-number_to_complex(PyObject *value)
+validate_complex_number(PyObject *value)
 {
     Py_complex value_as_complex;
 
@@ -3396,9 +3396,9 @@ number_to_complex(PyObject *value)
 }
 
 static PyObject *
-_ctraits_number_to_complex(PyObject *self, PyObject *value)
+_ctraits_validate_complex_number(PyObject *self, PyObject *value)
 {
-    return number_to_complex(value);
+    return validate_complex_number(value);
 }
 
 /*-----------------------------------------------------------------------------
@@ -3445,7 +3445,7 @@ validate_trait_complex_number(
     trait_object *trait, has_traits_object *obj, PyObject *name,
     PyObject *value)
 {
-    PyObject *result = number_to_complex(value);
+    PyObject *result = validate_complex_number(value);
     /* A TypeError represents a type validation failure, and should be
        re-raised as a TraitError. Other exceptions should be propagated. */
     if (result == NULL && PyErr_ExceptionMatches(PyExc_TypeError)) {
@@ -4228,7 +4228,7 @@ validate_trait_complex(
                 /* A TypeError indicates that we don't have a match.
                    Clear the error and continue with the next item
                    in the complex sequence. */
-                result = number_to_complex(value);
+                result = validate_complex_number(value);
                 if (result == NULL
                     && PyErr_ExceptionMatches(PyExc_TypeError)) {
                     PyErr_Clear();
@@ -5639,8 +5639,8 @@ _ctraits_ctrait(PyObject *self, PyObject *args)
 
 
 PyDoc_STRVAR(
-    _ctraits_number_to_complex_doc,
-    "_number_to_complex(number)\n"
+    _ctraits_validate_complex_number_doc,
+    "_validate_complex_number(number)\n"
     "\n"
     "Return *number* converted to a complex number. Raise TypeError if \n"
     "conversion is not possible.\n"
@@ -5654,8 +5654,8 @@ static PyMethodDef ctraits_methods[] = {
      PyDoc_STR("_adapt(adaptation_function)")},
     {"_ctrait", (PyCFunction)_ctraits_ctrait, METH_VARARGS,
      PyDoc_STR("_ctrait(CTrait_class)")},
-    {"_number_to_complex", (PyCFunction)_ctraits_number_to_complex, METH_O,
-     _ctraits_number_to_complex_doc},
+    {"_validate_complex_number", (PyCFunction)_ctraits_validate_complex_number, METH_O,
+     _ctraits_validate_complex_number_doc},
     {NULL, NULL},
 };
 

--- a/traits/tests/test_complex.py
+++ b/traits/tests/test_complex.py
@@ -1,0 +1,175 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tests for the Complex trait type.
+"""
+
+import unittest
+
+from traits.api import BaseComplex, Complex, Either, HasTraits, TraitError
+from traits.testing.optional_dependencies import numpy, requires_numpy
+
+
+class IntegerLike:
+    def __init__(self, value):
+        self._value = value
+
+    def __index__(self):
+        return self._value
+
+
+# Python versions < 3.8 don't support conversion of something with __index__
+# to complex.
+try:
+    complex(IntegerLike())
+except TypeError:
+    complex_accepts_index = False
+else:
+    complex_accepts_index = True
+
+
+class FloatLike:
+    def __init__(self, value):
+        self._value = value
+
+    def __float__(self):
+        return self._value
+
+
+class ComplexLike:
+    def __init__(self, value):
+        self._value = value
+
+    def __complex__(self):
+        return self._value
+
+
+class HasComplexTraits(HasTraits):
+    value = Complex()
+
+    # Assignment to the `Either` trait exercises a different C code path (see
+    # validate_trait_complex in ctraits.c). This use of "Either" should not
+    # be replaced with "Union", since "Union" does not exercise that same
+    # code path.
+    value_or_none = Either(None, Complex())
+
+
+class HasBaseComplexTraits(HasTraits):
+    value = BaseComplex()
+
+    value_or_none = Either(None, BaseComplex())
+
+
+class CommonComplexTests(object):
+    """ Common tests for Complex and BaseComplex. """
+
+    def test_default_value(self):
+        a = self.test_class()
+        self.assertIs(type(a.value), complex)
+        self.assertEqual(a.value, complex(0.0, 0.0))
+
+    def test_rejects_str(self):
+        a = self.test_class()
+        with self.assertRaises(TraitError):
+            a.value = "3j"
+
+    def test_accepts_int(self):
+        a = self.test_class()
+        a.value = 7
+        self.assertIs(type(a.value), complex)
+        self.assertEqual(a.value, complex(7.0, 0.0))
+
+    def test_accepts_float(self):
+        a = self.test_class()
+        a.value = 7.0
+        self.assertIs(type(a.value), complex)
+        self.assertEqual(a.value, complex(7.0, 0.0))
+
+    def test_accepts_complex(self):
+        a = self.test_class()
+        a.value = 7j
+        self.assertIs(type(a.value), complex)
+        self.assertEqual(a.value, complex(0.0, 7.0))
+
+    def test_accepts_complex_subclass(self):
+        class ComplexSubclass(complex):
+            pass
+
+        a = self.test_class()
+        a.value = ComplexSubclass(5.0, 12.0)
+        self.assertIs(type(a.value), complex)
+        self.assertEqual(a.value, complex(5.0, 12.0))
+
+    @unittest.skipUnless(
+        complex_accepts_index,
+        "complex does not support __index__ for this Python version",
+    )
+    def test_accepts_integer_like(self):
+        a = self.test_class()
+        a.value = IntegerLike(3)
+        self.assertIs(type(a.value), complex)
+        self.assertEqual(a.value, complex(3.0, 0.0))
+
+    def test_accepts_float_like(self):
+        a = self.test_class()
+        a.value = FloatLike(3.2)
+        self.assertIs(type(a.value), complex)
+        self.assertEqual(a.value, complex(3.2, 0.0))
+
+    def test_accepts_complex_like(self):
+        a = self.test_class()
+        a.value = ComplexLike(3.0 + 4j)
+        self.assertIs(type(a.value), complex)
+        self.assertEqual(a.value, complex(3.0, 4.0))
+
+    @requires_numpy
+    def test_accepts_numpy_values(self):
+        test_values = [
+            numpy.int32(23),
+            numpy.float32(3.7),
+            numpy.float64(2.3),
+            numpy.complex64(1.2 - 3.8j),
+            numpy.complex128(3.1 + 4.7j),
+        ]
+        for value in test_values:
+            with self.subTest(value=value):
+                a = self.test_class()
+                a.value = value
+                self.assertIs(type(a.value), complex)
+                self.assertEqual(a.value, complex(value))
+
+    def test_validate_trait_complex_code_path(self):
+        a = self.test_class()
+        a.value_or_none = 3.0 + 4j
+        self.assertIs(type(a.value_or_none), complex)
+        self.assertEqual(a.value_or_none, complex(3.0, 4.0))
+
+    def test_exceptions_propagated(self):
+        class CustomException(Exception):
+            pass
+
+        class BadComplexLike:
+            def __complex__(self):
+                raise CustomException("something went wrong")
+
+        a = self.test_class()
+        with self.assertRaises(CustomException):
+            a.value = BadComplexLike()
+
+
+class TestComplex(unittest.TestCase, CommonComplexTests):
+    def setUp(self):
+        self.test_class = HasComplexTraits
+
+
+class TestBaseComplex(unittest.TestCase, CommonComplexTests):
+    def setUp(self):
+        self.test_class = HasBaseComplexTraits

--- a/traits/tests/test_complex.py
+++ b/traits/tests/test_complex.py
@@ -29,7 +29,7 @@ class IntegerLike:
 # Python versions < 3.8 don't support conversion of something with __index__
 # to complex.
 try:
-    complex(IntegerLike())
+    complex(IntegerLike(3))
 except TypeError:
     complex_accepts_index = False
 else:

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -24,7 +24,7 @@ import uuid
 import warnings
 
 from .constants import DefaultValue, TraitKind, ValidateTrait
-from .ctraits import _number_to_complex
+from .ctraits import _validate_complex_number
 from .trait_base import (
     strx,
     get_module_name,
@@ -389,7 +389,7 @@ class BaseComplex(TraitType):
         Note: The 'fast validator' version performs this check in C.
         """
         try:
-            return _number_to_complex(value)
+            return _validate_complex_number(value)
         except TypeError:
             self.error(object, name, value)
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -24,6 +24,7 @@ import uuid
 import warnings
 
 from .constants import DefaultValue, TraitKind, ValidateTrait
+from .ctraits import _number_to_complex
 from .trait_base import (
     strx,
     get_module_name,
@@ -387,13 +388,10 @@ class BaseComplex(TraitType):
 
         Note: The 'fast validator' version performs this check in C.
         """
-        if isinstance(value, complex):
-            return value
-
-        if isinstance(value, (float, int)):
-            return complex(value)
-
-        self.error(object, name, value)
+        try:
+            return _number_to_complex(value)
+        except TypeError:
+            self.error(object, name, value)
 
     def create_editor(self):
         """ Returns the default traits UI editor for this type of trait.
@@ -409,7 +407,7 @@ class Complex(BaseComplex):
     """
 
     #: The C-level fast validator to use:
-    fast_validate = complex_fast_validate
+    fast_validate = (ValidateTrait.complex_number,)
 
 
 class BaseStr(TraitType):


### PR DESCRIPTION
This PR changes the validation of the `Complex` trait type to use a duck-typed approach instead of the current white-list-of-accepted-types approach. All values that were previously accepted in a `Complex` trait will continue to be accepted, but objects whose type implements `__complex__` will now also be accepted. Essentially, `Complex` will accept any non-string-type that the `complex` built-in accepts.

This parallels similar changes made a while ago for the `Int` and `Float` trait types (see #104, #393), both of which already do duck-typed checks. It makes it clearer that the behaviour of the `Complex` trait type does not depend on whether NumPy is available or not, and it ensures that `Complex` will accept complex-like objects from other frameworks.

Implementation notes:

- I've added a new "fast_validate" code, code 23, for validating complex numbers. Unfortunately we already have a "complex" element of the `ValidateTraits` enumeration, but the "complex" there refers to compound trait types (e.g., created using `Either`) rather than complex numbers. So the new enumeration value is called `complex_number` instead of `complex`.
- For the `BaseComplex` validation, it's rather hard to write pure Python code that matches the behaviour we want (essentially, we want to accept exactly the set of things that the std. lib. `cmath` module functions accept - that's roughly the same as things that the `complex` constructor accepts, but excluding strings). Instead, I've added a C implementation of that logic, and a private function `_validate_complex_number` in `traits.ctraits` that exposes the logic to Python.

**Checklist**
- [x] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)
- [ ] Update User manual (`docs/source/traits_user_manual`)
~- [ ] Update type annotation hints in `traits-stubs`~ N/A
