### PR TITLE
Bump version for the 6.3.2 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 6
 MINOR = 3
 MICRO = 2
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This PR bumps the version for the 6.3.2 release. When CI passes, I'll tag the single commit of this release as 6.3.2.

Note: this PR will not be merged into the maint/6.3 branch.