### PR TITLE
Run core tests on Python 3.11

### DIFF
--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This PR extends the run-core-traits-tests workflow to include testing on Python 3.11-dev.
