### PR TITLE
Remove unused fast validation tuples

### DIFF
--- a/traits-stubs/traits-stubs/trait_types.pyi
+++ b/traits-stubs/traits-stubs/trait_types.pyi
@@ -27,9 +27,6 @@ from uuid import UUID as _UUID
 from .trait_type import _TraitType
 
 SetTypes: _Any
-int_fast_validate: _Any
-float_fast_validate: _Any
-complex_fast_validate: _Any
 bool_fast_validate: _Any
 
 

--- a/traits/tests/test_trait_types.py
+++ b/traits/tests/test_trait_types.py
@@ -53,10 +53,10 @@ class TraitTypesTest(unittest.TestCase):
         # If 'numpy' is available, the numpy validators should be loaded,
         # even if numpy is imported after traits.
         test_script = textwrap.dedent("""
-            from traits.trait_types import float_fast_validate
+            from traits.trait_types import bool_fast_validate
             import numpy
 
-            if numpy.floating in float_fast_validate:
+            if numpy.bool_ in bool_fast_validate:
                 print("Success")
             else:
                 print("Failure")

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -95,35 +95,13 @@ SetTypes = SequenceTypes + (set,)
 
 try:
     # The numpy enhanced definitions:
-    from numpy import integer, floating, complexfloating, bool_
+    from numpy import bool_
 
-    int_fast_validate = (ValidateTrait.coerce, int, integer)
-    float_fast_validate = (
-        ValidateTrait.coerce,
-        float,
-        floating,
-        None,
-        int,
-        integer,
-    )
-    complex_fast_validate = (
-        ValidateTrait.coerce,
-        complex,
-        complexfloating,
-        None,
-        float,
-        floating,
-        int,
-        integer,
-    )
     bool_fast_validate = (ValidateTrait.coerce, bool, None, bool_)
     # Tuple or single type suitable for an isinstance check.
     _BOOL_TYPES = (bool, bool_)
 except ImportError:
     # The standard python definitions (without numpy):
-    int_fast_validate = (ValidateTrait.coerce, int)
-    float_fast_validate = (ValidateTrait.coerce, float, None, int)
-    complex_fast_validate = (ValidateTrait.coerce, complex, None, float, int)
     bool_fast_validate = (ValidateTrait.coerce, bool)
     # Tuple or single type suitable for an isinstance check.
     _BOOL_TYPES = bool


### PR DESCRIPTION
This PR removes some constants that are no longer needed within Traits, namely `int_fast_validate`, `float_fast_validate` and `complex_fast_validate`. The need for `complex_fast_validate` was removed in #1594. The other constants haven't been used for some time, except that `float_fast_validate` is used in a test that verifies validation in the presence of NumPy - I've switched that test to check `bool_fast_validate` instead.

These constants aren't exported in any of the `api` modules, so they shouldn't be being used by any other package. A check through the source available to me shows no uses in other packages.