### PR TITLE
Allow running the main test workflow manually

### DIFF
--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -1,6 +1,8 @@
 name: Tests
 
-on: [pull_request, workflow_dispatch]
+on:
+- pull_request
+- workflow_dispatch
 
 jobs:
   tests:

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -1,8 +1,6 @@
 name: Tests
 
-on:
-  pull_request
-  workflow_dispatch
+on: [pull_request, workflow_dispatch]
 
 jobs:
   tests:

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   pull_request
+  workflow_dispatch
 
 jobs:
   tests:


### PR DESCRIPTION
It's occasionally useful to be able to run the main test workflow manually (e.g., if there have been environmental changes, like the recent change from macOS 10 to macOS 11 for GitHub Actions workers).

This PR adds a "workflow_dispatch" trigger to the main workflow.