### PR TITLE
Support MacOS Big Sur on CI by setting the appropriate Qt env var

### DIFF
--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -4,6 +4,9 @@ on:
 - pull_request
 - workflow_dispatch
 
+env:
+  QT_MAC_WANTS_LAYER: 1
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -6,6 +6,9 @@ on:
     # Run at 03:27 UTC on the 8th and 22nd of every month
     - cron: '27 3 8,22 * *'
 
+env:
+  QT_MAC_WANTS_LAYER: 1
+
 jobs:
   test-pypi-sdist:
     strategy:


### PR DESCRIPTION
Similar to https://github.com/enthought/traitsui/pull/1789/
I suspect this is the reason why the cron job - https://github.com/enthought/traits/runs/4602763635?check_suite_focus=true - failed.

I'm re-ran the cron job from this branch - https://github.com/enthought/traits/actions/runs/1609786940

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
