### PR TITLE
Fix notification docs to mention Set as well as List and Dict

### DIFF
--- a/docs/source/traits_user_manual/listening.rst
+++ b/docs/source/traits_user_manual/listening.rst
@@ -314,12 +314,14 @@ These signatures use the following parameters:
 .. index:: new parameter to the notification handlers
 
 * *new*: The new value of the trait attribute that changed. For changes to
-  List and Dict objects, this is a list of items that were added.
+  List and Dict objects, this is a list of items that were added. For changes
+  to Set objects, this is a set of items that were added.
 
 .. index:: old parameter to the notification handlers
 
 * *old*: The old value of the trait attribute that changed. For changes to List
-  and Dict object, this is a list of items that were deleted. For event traits,
+  and Dict object, this is a list of items that were deleted. For changes to
+  Set objects, this is a set of items that were deleted. For event traits,
   this is Undefined.
 
 If the handler is a bound method, it also implicitly has *self* as a first

--- a/docs/source/traits_user_manual/listening.rst
+++ b/docs/source/traits_user_manual/listening.rst
@@ -320,7 +320,7 @@ These signatures use the following parameters:
 .. index:: old parameter to the notification handlers
 
 * *old*: The old value of the trait attribute that changed. For changes to List
-  and Dict object, this is a list of items that were deleted. For changes to
+  and Dict objects, this is a list of items that were deleted. For changes to
   Set objects, this is a set of items that were deleted. For event traits,
   this is Undefined.
 


### PR DESCRIPTION
This PR fixes an omission in the `on_trait_change` notification docs: `Set`s behave in essentially the same way as `List`s and `Dict`s.