### PR TITLE
Make TraitListObject use the CTrait to validate items, not the handler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,30 @@
 Traits CHANGELOG
 ================
 
+Release 7.0.0
+-------------
+
+TBD Release summary
+
+Released: XXXX-XX-XX
+
+Migrating from earlier versions of Traits
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Traits 7.0 should be largely backwards compatible with earlier versions
+of Traits, but there are some things to watch out for.
+
+* Validation of items within a container (e.g., ``foos = List(MyTraitType)``)
+  now always matches the validation used for the item trait at top level (e.g.,
+  ``foo = MyTraitType``). Previously, the validation methods used could differ,
+  thanks to a bug in the container implementations. For most trait types this
+  will make no difference, but for the ``Tuple`` trait type this change has the
+  consequence that lists will no longer be accepted as valid for ``Tuple``
+  traits inside list items. See issue #1619 and PR #1625 for more information.
+
+TBD Release details
+
+
 Release 6.3.2
 -------------
 

--- a/traits/trait_dict_object.py
+++ b/traits/trait_dict_object.py
@@ -450,7 +450,7 @@ class TraitDictObject(TraitDict):
                          notifiers=[self.notifier])
 
     def _key_validator(self, key):
-        """ Calls the trait's key_trait.handler.validate.
+        """ Key validator based on the Dict's key_trait.
 
         Parameters
         ----------
@@ -476,7 +476,7 @@ class TraitDictObject(TraitDict):
         if trait is None or object is None:
             return key
 
-        validate = trait.key_trait.handler.validate
+        validate = trait.key_trait.validate
         if validate is None:
             return key
 
@@ -487,7 +487,7 @@ class TraitDictObject(TraitDict):
             raise excep
 
     def _value_validator(self, value):
-        """ Calls the trait's value_handler.validate
+        """ Value validator based on the Dict's value_trait.
 
         Parameters
         ----------
@@ -513,7 +513,7 @@ class TraitDictObject(TraitDict):
         if trait is None or object is None:
             return value
 
-        validate = trait.value_handler.validate
+        validate = trait.value_trait.validate
         if validate is None:
             return value
 

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -859,7 +859,7 @@ class TraitListObject(TraitList):
         if object is None:
             return value
 
-        trait_validator = self.trait.item_trait.handler.validate
+        trait_validator = self.trait.item_trait.validate
         if trait_validator is None:
             return value
 

--- a/traits/trait_set_object.py
+++ b/traits/trait_set_object.py
@@ -511,7 +511,7 @@ class TraitSetObject(TraitSet):
         object = object_ref()
 
         # validate the new value(s)
-        validate = trait.item_trait.handler.validate
+        validate = trait.item_trait.validate
 
         if validate is None:
             return value

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -3043,6 +3043,8 @@ class Dict(TraitType):
         if (handler is not None) and handler.has_items:
             handler = handler.clone()
             handler.has_items = False
+        # This attribute isn't actually used for anything, but we keep it
+        # for backwards compatibility.
         self.value_handler = handler
 
         super().__init__(value, **metadata)


### PR DESCRIPTION
This PR fixes `TraitListObject`, `TraitSetObject` and `TraitDictObject` to perform item / key / value validation using the `validate` method of the appropriate `CTrait` instance instead of the `validate` method of the handler. Using the handler's validation is not the right thing to do, because the CTrait validation may or may not delegate to the handler's validate method : in particular, in the case where there's a fast validator, CTrait validation uses that fast validator, and so should the list / set / dict validation.

This fixes one of the issues identified in #1619. (In particular, it fixes the particular example that @mdsmarte gives in that issue.)

**Checklist**
- [x] Tests
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~ N/A
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~ N/A
- [ ] ~Update type annotation hints in `traits-stubs`~ N/A
