### PR TITLE
Deprecate acceptance of lists by Tuple traits

### DIFF
--- a/traits/tests/test_tuple.py
+++ b/traits/tests/test_tuple.py
@@ -73,3 +73,22 @@ class TupleTestCase(TupleTestMixin, unittest.TestCase):
         b = A()
         self.assertEqual(a.foo, (0, ("", 0)))
         self.assertIs(a.foo, b.foo)
+
+    def test_lists_not_accepted(self):
+
+        class A(HasTraits):
+            foo = Tuple(Int(), Int())
+
+        a = A()
+        with self.assertRaises(TraitError):
+            a.foo = [2, 3]
+
+    def test_deprecated_list_validation(self):
+        class A(HasTraits):
+            foo = Tuple()
+
+        a = A()
+        with self.assertWarns(DeprecationWarning):
+            a.foo = [2, 3]
+
+        self.assertEqual(a.foo, (2, 3))

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2515,7 +2515,7 @@ class Tuple(BaseTuple):
         """
         if self.no_type_check:
             if isinstance(value, tuple):
-                return tuple(value)
+                return value
             elif isinstance(value, list):
                 warnings.warn(
                     "In the future, lists will no longer be accepted by "


### PR DESCRIPTION
This PR changes the `Tuple` trait type so that it only ever accepts instances of type `tuple`. Previously, the argument-less trait type `Tuple()` would accept (and coerce) `list` instances in addition to `tuple` instances, while with arguments (e.g., `Tuple(Int(), Int())`, only tuples would be accepted.

Work towards #1626, but this PR doesn't change the behaviour of the `BaseTuple` trait type at all.

**Checklist**
- [x] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)  N/A
- [ ] Update User manual (`docs/source/traits_user_manual`)  N/A
- [ ] Update type annotation hints in `traits-stubs`  N/A
