### PR TITLE
Exclude build directory in flake8 configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-exclude = traits/observation/_generated_parser.py
+exclude = traits/observation/_generated_parser.py,build
 ignore = E266,W503,E722,E731,E741
 per-file-ignores = */api.py:F401


### PR DESCRIPTION
A combination of recent versions of `setuptools` and `pip` results in `pip install -e .` creating a local `build` directory. This PR prevents flake8 from attempting to check files in that directory.

**Checklist**
- [ ] Tests - N/A
- [ ] Update API reference (`docs/source/traits_api_reference`) - N/A
- [ ] Update User manual (`docs/source/traits_user_manual`) - N/A
- [ ] Update type annotation hints in `traits-stubs` - N/A
