### PR TITLE
Return "PyErr_Format" calls in "traits/ctraits.c"

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2917,12 +2917,11 @@ trait_new(PyTypeObject *trait_type, PyObject *args, PyObject *kw)
         return (PyObject *)trait;
     }
 
-    PyErr_Format(
+    return PyErr_Format(
         TraitError,
         "Invalid argument to trait constructor. The argument `kind` "
         "must be an integer between 0 and 8 but a value of %d was provided.",
         kind);
-    return NULL;
 }
 
 /*-----------------------------------------------------------------------------

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -491,7 +491,7 @@ set_delete_property_error(has_traits_object *obj, PyObject *name)
 static void
 unknown_attribute_error(has_traits_object *obj, PyObject *name)
 {
-    PyErr_Format(
+    return PyErr_Format(
         PyExc_AttributeError, "'%.50s' object has no attribute '%.400U'",
         Py_TYPE(obj)->tp_name, name);
 }
@@ -1885,13 +1885,11 @@ getattr_generic(trait_object *trait, has_traits_object *obj, PyObject *name)
 static PyObject *
 getattr_event(trait_object *trait, has_traits_object *obj, PyObject *name)
 {
-    PyErr_Format(
+    return PyErr_Format(
         PyExc_AttributeError,
         "The %.400U"
         " trait of a %.50s instance is an 'event', which is write only.",
         name, Py_TYPE(obj)->tp_name);
-
-    return NULL;
 }
 
 /*-----------------------------------------------------------------------------
@@ -2919,12 +2917,11 @@ trait_new(PyTypeObject *trait_type, PyObject *args, PyObject *kw)
         return trait;
     }
 
-    PyErr_Format(
+    return PyErr_Format(
         TraitError,
         "Invalid argument to trait constructor. The argument `kind` "
         "must be an integer between 0 and 8 but a value of %d was provided.",
         kind);
-    return NULL;
 }
 
 /*-----------------------------------------------------------------------------
@@ -3057,11 +3054,10 @@ _trait_set_default_value(trait_object *trait, PyObject *args)
     }
 
     if ((value_type < 0) || (value_type > MAXIMUM_DEFAULT_VALUE_TYPE)) {
-        PyErr_Format(
+        return PyErr_Format(
             PyExc_ValueError,
             "The default value type must be 0..%d, but %d was specified.",
             MAXIMUM_DEFAULT_VALUE_TYPE, value_type);
-        return NULL;
     }
 
     /* Validate the value */

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2899,7 +2899,6 @@ PyObject *
 trait_new(PyTypeObject *trait_type, PyObject *args, PyObject *kw)
 {
     int kind = 0;
-    PyObject *trait;
 
     if (kw != NULL && PyDict_Size(kw) != (Py_ssize_t) 0) {
         PyErr_SetString(TraitError, "CTrait takes no keyword arguments");
@@ -2911,10 +2910,10 @@ trait_new(PyTypeObject *trait_type, PyObject *args, PyObject *kw)
     }
 
     if ((kind >= 0) && (kind <= 8)) {
-        trait = (PyObject *)PyType_GenericNew(trait_type, args, kw);
+        trait = (trait_object *)PyType_GenericNew(trait_type, args, kw);
         trait->getattr = getattr_handlers[kind];
         trait->setattr = setattr_handlers[kind];
-        return trait;
+        return (PyObject *)trait;
     }
 
     PyErr_Format(

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2895,11 +2895,11 @@ static trait_setattr setattr_handlers[] = {
     NULL};
 
 
-trait_object *
+PyObject *
 trait_new(PyTypeObject *trait_type, PyObject *args, PyObject *kw)
 {
     int kind = 0;
-    trait_object *trait;
+    PyObject *trait;
 
     if (kw != NULL && PyDict_Size(kw) != (Py_ssize_t) 0) {
         PyErr_SetString(TraitError, "CTrait takes no keyword arguments");
@@ -2911,7 +2911,7 @@ trait_new(PyTypeObject *trait_type, PyObject *args, PyObject *kw)
     }
 
     if ((kind >= 0) && (kind <= 8)) {
-        trait = (trait_object *)PyType_GenericNew(trait_type, args, kw);
+        trait = (PyObject *)PyType_GenericNew(trait_type, args, kw);
         trait->getattr = getattr_handlers[kind];
         trait->setattr = setattr_handlers[kind];
         return trait;
@@ -5579,7 +5579,7 @@ static PyTypeObject trait_type = {
     sizeof(trait_object) - sizeof(PyObject *), /* tp_dictoffset */
     0,                                         /* tp_init */
     0,                                         /* tp_alloc */
-    (newfunc)trait_new                         /* tp_new */
+    trait_new                                  /* tp_new */
 };
 
 /*-----------------------------------------------------------------------------

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -491,7 +491,7 @@ set_delete_property_error(has_traits_object *obj, PyObject *name)
 static void
 unknown_attribute_error(has_traits_object *obj, PyObject *name)
 {
-    return PyErr_Format(
+    PyErr_Format(
         PyExc_AttributeError, "'%.50s' object has no attribute '%.400U'",
         Py_TYPE(obj)->tp_name, name);
 }

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2899,6 +2899,7 @@ PyObject *
 trait_new(PyTypeObject *trait_type, PyObject *args, PyObject *kw)
 {
     int kind = 0;
+    trait_object *trait;
 
     if (kw != NULL && PyDict_Size(kw) != (Py_ssize_t) 0) {
         PyErr_SetString(TraitError, "CTrait takes no keyword arguments");

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -2917,11 +2917,12 @@ trait_new(PyTypeObject *trait_type, PyObject *args, PyObject *kw)
         return trait;
     }
 
-    return PyErr_Format(
+    PyErr_Format(
         TraitError,
         "Invalid argument to trait constructor. The argument `kind` "
         "must be an integer between 0 and 8 but a value of %d was provided.",
         kind);
+    return NULL;
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
As mentioned in an earlier comment https://github.com/enthought/traits/pull/1631#discussion_r853688685, this PR returns `PyErr_Format` instead of explicitly returning `NULL`.

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
