### PR TITLE
Document "Date", "Datetime" and "Time" trait types

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -311,7 +311,7 @@ the table.
 |                  | \*\*\ *metadata*] )                                      |
 +------------------+----------------------------------------------------------+
 | Datetime         | Datetime( *value*\ [, *default_value* = None,            |
-|                  | ,  *allow_none* = None, \*\*\ *metadata*])               |
+|                  | *allow_none* = None, \*\*\ *metadata*])                  |
 +------------------+----------------------------------------------------------+
 | Dict             | Dict( [*key_trait* = None, *value_trait* = None,         |
 |                  | *value* = None, *items* = True, \*\*\ *metadata*] )      |
@@ -391,10 +391,10 @@ the table.
 | Subclass         | Subclass( [*value* = None, *klass* = None, *allow_none* =|
 |                  | True, \*\*\ *metadata*] )                                |
 +------------------+----------------------------------------------------------+
-| Time             | Time( *value*\ [, *default_value* = None,                |
-|                  | ,  *allow_none* = None, \*\*\ *metadata*])               |
-+------------------+----------------------------------------------------------+
 | This             | n/a                                                      |
++------------------+----------------------------------------------------------+
+| Time             | Time( *value*\ [, *default_value* = None,                |
+|                  | *allow_none* = None, \*\*\ *metadata*])                  |
 +------------------+----------------------------------------------------------+
 | ToolbarButton    | ToolbarButton( [*label* = '', *image* = None, *style* =  |
 |                  | 'toolbar', *orientation* = 'vertical', *width_padding* = |

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -261,13 +261,13 @@ trait cannot be used as a simple name, it is omitted from the Name column of
 the table.
 
 .. index:: Any(), Array(), Button(), Callable(), CArray(), Code()
-.. index:: CSet(), Constant(), Dict()
+.. index:: CSet(), Constant(), Date(), Datetime(), Dict()
 .. index:: Directory(), Disallow, Either(), Enum()
 .. index:: Event(), Expression(), false, File()
 .. index:: Instance(), List(), Method(), Module()
 .. index:: Password(), Property(), Python()
 .. index:: PythonValue(), Range(), ReadOnly(), Regex()
-.. index:: Set() String(), This,
+.. index:: Set() String(), This, Time()
 .. index:: ToolbarButton(), true, Tuple(), Type()
 .. index:: undefined, UUID(), ValidatedTuple(), WeakRef()
 
@@ -280,7 +280,7 @@ the table.
 +==================+==========================================================+
 | Any              | Any( [*default_value* = None, \*,                        |
 |                  | *factory* = None, *args* = (), *kw* = {},                |
-|                  | \*\*\ *metadata* )                                       |
+|                  | \*\*\ *metadata*] )                                      |
 +------------------+----------------------------------------------------------+
 | Array            | Array( [*dtype* = None, *shape* = None, *value* = None,  |
 |                  | \*\*\ *metadata*] )                                      |
@@ -305,6 +305,13 @@ the table.
 |                  | \*\*\ *metadata*] )                                      |
 +------------------+----------------------------------------------------------+
 | Constant         | Constant( *value*\ [, \*\*\ *metadata*] )                |
++------------------+----------------------------------------------------------+
+| Date             | Date( *value*\ [, *default_value* = None,                |
+|                  | *allow_datetime* = None, *allow_none* = None,            |
+|                  | \*\*\ *metadata*] )                                      |
++------------------+----------------------------------------------------------+
+| Datetime         | Datetime( *value*\ [, *default_value* = None,            |
+|                  | ,  *allow_none* = None, \*\*\ *metadata*])               |
 +------------------+----------------------------------------------------------+
 | Dict             | Dict( [*key_trait* = None, *value_trait* = None,         |
 |                  | *value* = None, *items* = True, \*\*\ *metadata*] )      |
@@ -383,6 +390,9 @@ the table.
 +------------------+----------------------------------------------------------+
 | Subclass         | Subclass( [*value* = None, *klass* = None, *allow_none* =|
 |                  | True, \*\*\ *metadata*] )                                |
++------------------+----------------------------------------------------------+
+| Time             | Time( *value*\ [, *default_value* = None,                |
+|                  | ,  *allow_none* = None, \*\*\ *metadata*])               |
 +------------------+----------------------------------------------------------+
 | This             | n/a                                                      |
 +------------------+----------------------------------------------------------+


### PR DESCRIPTION
fixes #1445

This PR documents the `Date`, `Datetime` and `Time` trait types in the "Predefined Trait Types" section of the user documentation.

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~ These traits are already documented in the API docs.
- [x] Update User manual (`docs/source/traits_user_manual`)
- [ ] ~Update type annotation hints in `traits-stubs`~