### PR TITLE
Switch Slack channel used to report failures

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Notify Slack channel on failure
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          channel_id: ${{ secrets.ETS_SLACK_CHANNEL_ID }}
           status: FAILED
           color: danger
         env:


### PR DESCRIPTION
Results of our scheduled GitHub Action builds (and particularly failures) risk going unnoticed.

This PR changes the notifications for failure reports to a more visible Slack channel. Success reports are still sent to the noisy-bots channel.