### PR TITLE
Don't configure the "sphinx-copybutton" extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,13 +117,6 @@ autodoc_default_options = {
 
 autodoc_member_order = "bysource"
 
-# Options for Sphinx copybutton extension
-# ---------------------------------------
-
-# Matches prompts - "$ ", ">>>" and "..."
-copybutton_prompt_text = r">>> |\.\.\. |\$ "
-copybutton_prompt_is_regexp = True
-
 # Options for HTML output
 # -----------------------
 


### PR DESCRIPTION
This PR simply removes the `sphinx-copybutton` extension-specific configuration from the sphinx configuration file.

This is because the configuration was in some cases returning bad data. See for example the `all_wildcard.py` code block at https://traits.readthedocs.io/en/latest/traits_user_manual/advanced.html#trait-attribute-name-wildcard. Trying to copy that codeblock returns only the code within `"""` and not the actual class. The prompt text configuration seems complicated and difficult to get "right" to support the wide range of code samples we have in the documentation.

For now, having a copy button that copies the entire code sample is better than a smart copy button that only copies the "right" piece of code

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
