### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest

--- a/setup.py
+++ b/setup.py
@@ -281,6 +281,7 @@ setuptools.setup(
         Programming Language :: Python :: 3.8
         Programming Language :: Python :: 3.9
         Programming Language :: Python :: 3.10
+        Programming Language :: Python :: 3.11
         Programming Language :: Python :: Implementation :: CPython
         Topic :: Scientific/Engineering
         Topic :: Software Development


### PR DESCRIPTION
Preliminary PR for 3.11 support:

- Run tests on 3.11-dev on GitHub Actions
- Add 3.11 to the trove classifiers.

I'm not expecting this to pass first time.