### PR TITLE
Reveal and fix a masked test

### DIFF
--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -362,14 +362,3 @@ class ETSConfigTestCase(unittest.TestCase):
         os.remove(path)
 
         self.assertEqual(data, result)
-
-
-# For running as an individual set of tests.
-if __name__ == "__main__":
-
-    # Add the non-default test of application_home...non-default because it
-    # must be run using this module as a script to be valid.
-    suite = unittest.TestLoader().loadTestsFromTestCase(ETSConfigTestCase)
-    suite.addTest(ETSConfigTestCase("_test_default_application_home"))
-
-    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -202,7 +202,7 @@ class ETSConfigTestCase(unittest.TestCase):
         self.ETSConfig.company = old
         self.assertEqual(old, self.ETSConfig.company)
 
-    def _test_default_application_home(self):
+    def test_default_application_home(self):
         """
         application home
 

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -207,15 +207,14 @@ class ETSConfigTestCase(unittest.TestCase):
         application home
 
         """
-
-        # This test is only valid when run with the 'main' at the end of this
-        # file: "python app_dat_locator_test_case.py", in which case the
-        # app_name will be the directory this file is in ('tests').
         app_home = self.ETSConfig.application_home
         (dirname, app_name) = os.path.split(app_home)
 
         self.assertEqual(dirname, self.ETSConfig.application_data)
-        self.assertEqual(app_name, "tests")
+
+        # The assumption here is that the test was run using unittest and not
+        # a different test runner e.g. using "python -m unittest ...".
+        self.assertEqual(app_name, "unittest")
 
     def test_toolkit_default_kiva_backend(self):
         self.ETSConfig.toolkit = "qt4"


### PR DESCRIPTION
The test name started with an underscore which is why unittest wasnt discovering it.

Once the leading underscore is removed, we noticed that the test assertion fails - because the `app_name` that the code infers by default is different.

We update the assertion to pass - with the strong assumption that the tests are run using `unittest` - which traits uses for test discovery and to run the tests.

**Checklist**
- [ ] ~Tests~
- [ ] ~Update API reference (`docs/source/traits_api_reference`)~
- [ ] ~Update User manual (`docs/source/traits_user_manual`)~
- [ ] ~Update type annotation hints in `traits-stubs`~
