### PR TITLE
Remove 3.11-dev from test-pypi-wheel matrix

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest


### PR DESCRIPTION
The run https://github.com/enthought/traits/actions/runs/2716205488 of the test-from-pypi workflow has started failing, as a result of #1660.

It doesn't make a lot of sense to test the 3.11 wheels when there aren't any 3.11 wheels ...

This PR removes 3.11-dev from the test matrix for the binary install. Separately, though, we should build 3.11 wheels at some point.

