### PR TITLE
Add pyproject.toml

### DIFF
--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         # Uninstall setuptools so that the tests will catch any accidental
         # dependence of the Traits source on setuptools.
-        python -m pip uninstall setuptools
+        python -m pip uninstall -y setuptools
         python -m pip install .
     - name: Test Traits package
       run: |

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -25,9 +25,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # Uninstall setuptools so that the tests will catch any accidental
-        # dependence of the Traits source on setuptools.
+        # dependence of the Traits source on setuptools. Note that in future
+        # setuptools may not exist in a newly-created venv
+        # https://github.com/python/cpython/issues/95299
         python -m pip uninstall -y setuptools
         python -m pip install .
+        python -m pip list
     - name: Test Traits package
       run: |
         mkdir testdir

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -24,10 +24,10 @@ jobs:
     - name: Install local package
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .
         # Uninstall setuptools so that the tests will catch any accidental
         # dependence of the Traits source on setuptools.
         python -m pip uninstall setuptools
+        python -m pip install .
     - name: Test Traits package
       run: |
         mkdir testdir

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -25,7 +25,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install .
-        python -m pip list
+        # Uninstall setuptools so that the tests will catch any accidental
+        # dependence of the Traits source on setuptools.
+        python -m pip uninstall setuptools
     - name: Test Traits package
       run: |
         mkdir testdir

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -23,9 +23,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install local package
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install .
-        python -m pip uninstall -y setuptools wheel
+        python -m pip list
     - name: Test Traits package
       run: |
         mkdir testdir

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install .[test]
         python -m pip install traits-stubs/[test]
     - name: Create clean test directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ['setuptools', 'wheel']
+build-backend = 'setuptools.build_meta'
+
+[tool.black]
+line-length = 79
+target-version = ['py36']
+
+[tool.isort]
+profile = 'black'
+line_length = 79
+order_by_type = 'False'


### PR DESCRIPTION
Long overdue PR to add a `pyproject.toml`, containing build configuration and basic `black` and `isort` configurations, for those who want to use `black` and `isort` on new files in this repository. (Note that many existing files don't conform to those configurations. We have no immediate plans to rectify that, but the configurations may be useful for new code.)

With the build dependencies explicitly mentioned in `pyproject.toml`, there should be no need to pre-install `setuptools` and/or `wheel` in the test environments, so we've updated the workflows accordingly.