### PR TITLE
Fix some long lines in docstrings

### DIFF
--- a/traits/observation/_observer_change_notifier.py
+++ b/traits/observation/_observer_change_notifier.py
@@ -153,7 +153,7 @@ class ObserverChangeNotifier:
         )
 
     def equals(self, other):
-        """ Return true if the other value is a notifier equivalent to this one.
+        """ Return true if other is a notifier equivalent to this one.
 
         Parameters
         ----------

--- a/traits/observation/exception_handling.py
+++ b/traits/observation/exception_handling.py
@@ -91,7 +91,7 @@ class ObserverExceptionHandlerStack:
         return self.handlers.pop()
 
     def handle_exception(self, event):
-        """ Handles a traits notification exception using the handler last pushed.
+        """ Handle a notification exception using the handler last pushed.
 
         Parameters
         ----------


### PR DESCRIPTION
The most recent version of flake8 (v5.0.4) picks up some long line errors that weren't picked up by previous versions. This PR fixes those long lines.