### PR TITLE
Remove outdated alias

### DIFF
--- a/traits/trait_base.py
+++ b/traits/trait_base.py
@@ -20,9 +20,6 @@ from weakref import ref
 
 from .etsconfig.api import ETSConfig
 
-# backwards compatibility: trait_base used to provide a patched enumerate
-enumerate = enumerate
-
 # Constants
 
 SequenceTypes = (list, tuple)


### PR DESCRIPTION
This PR removes an `enumerate = enumerate` assignment that should no longer be necessary.

Technically, this is a backwards incompatible change: anyone who imports `enumerate` from `traits.trait_base` will no longer be able to do so. However, the workaround is immediate (just delete that import so that you pick up the built-in `enumerate`), and code that's doing this is already wrong on so many levels, so I don't feel bad about making this change without a deprecation period.

**Checklist**
- [ ] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)
- [ ] Update User manual (`docs/source/traits_user_manual`)
- [ ] Update type annotation hints in `traits-stubs`
