### PR TITLE
Fix some ETSConfig and test nits

### DIFF
--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -12,10 +12,9 @@
 
 
 # Standard library imports.
-import sys
+import contextlib
 import os
-from os import path
-from contextlib import contextmanager
+import sys
 
 
 class ETSToolkitError(RuntimeError):
@@ -157,7 +156,7 @@ class ETSConfig(object):
 
         """
         if self._application_home is None:
-            self._application_home = path.join(
+            self._application_home = os.path.join(
                 self.get_application_data(create=create),
                 self._get_application_dirname(),
             )
@@ -208,7 +207,7 @@ class ETSConfig(object):
     def company(self):
         self._company = None
 
-    @contextmanager
+    @contextlib.contextmanager
     def provisional_toolkit(self, toolkit):
         """ Perform an operation with toolkit provisionally set
 
@@ -401,8 +400,8 @@ class ETSConfig(object):
         main_mod = sys.modules.get("__main__", None)
         if main_mod is not None:
             if hasattr(main_mod, "__file__"):
-                main_mod_file = path.abspath(main_mod.__file__)
-                dirname = path.basename(path.dirname(main_mod_file))
+                main_mod_file = os.path.abspath(main_mod.__file__)
+                dirname = os.path.basename(os.path.dirname(main_mod_file))
 
         return dirname
 

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -94,7 +94,7 @@ class ETSConfig(object):
 
             - The actual location differs between operating systems.
 
-       """
+        """
         if self._application_data is None:
             self._application_data = self._initialize_application_data(
                 create=create
@@ -151,7 +151,7 @@ class ETSConfig(object):
 
             - The actual location differs between operating systems.
 
-       """
+        """
         if self._application_home is None:
             self._application_home = path.join(
                 self.get_application_data(create=create),

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -13,6 +13,7 @@
 # Standard library imports.
 import contextlib
 import os
+import pathlib
 import shutil
 import sys
 import tempfile
@@ -209,10 +210,10 @@ class ETSConfigTestCase(unittest.TestCase):
         (dirname, app_name) = os.path.split(app_home)
 
         self.assertEqual(dirname, self.ETSConfig.application_data)
-
-        # The assumption here is that the test was run using unittest and not
-        # a different test runner e.g. using "python -m unittest ...".
-        self.assertEqual(app_name, "unittest")
+        self.assertEqual(
+            app_name,
+            pathlib.Path(sys.modules["__main__"].__file__).parts[-2]
+        )
 
     def test_toolkit_default_kiva_backend(self):
         self.ETSConfig.toolkit = "qt4"

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -69,7 +69,7 @@ def temporary_home_directory():
     with temporary_directory() as temp_home:
         with restore_mapping_entry(os.environ, home_var):
             os.environ[home_var] = temp_home
-            yield
+            yield temp_home
 
 
 @contextlib.contextmanager
@@ -109,11 +109,9 @@ class ETSConfigTestCase(unittest.TestCase):
 
         # Make a fresh instance each time.
         self.ETSConfig = type(ETSConfig)()
-
-    def run(self, result=None):
-        # Extend TestCase.run to use a temporary home directory.
-        with temporary_home_directory():
-            super().run(result)
+        with contextlib.ExitStack() as stack:
+            self._temp_home = stack.enter_context(temporary_home_directory())
+            self.addCleanup(stack.pop_all().close)
 
     ###########################################################################
     # 'ETSConfigTestCase' interface.


### PR DESCRIPTION
Fix some nits noticed during reviewing #1670. (But sufficiently unrelated to #1670 that I couldn't justify squeezing them into that PR.)

- Fix weird docstring end-quote indentations
- Fix overriding of `TestCase.run`, which implicitly assumes that we'll be using `unittest` as our test runner.
- Fix another test that assumed that the test runner would be unittest.
