### PR TITLE
Rename various test-related classes to avoid pytest treating them as tests

### DIFF
--- a/traits/testing/tests/test_unittest_tools.py
+++ b/traits/testing/tests/test_unittest_tools.py
@@ -38,7 +38,7 @@ def old_and_dull():
     pass
 
 
-class TestObject(HasTraits):
+class ExampleObject(HasTraits):
 
     number = Float(2.0)
     list_of_numbers = List(Float)
@@ -54,7 +54,7 @@ class TestObject(HasTraits):
 
 class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
     def setUp(self):
-        self.test_object = TestObject()
+        self.test_object = ExampleObject()
 
     def test_when_using_with(self):
         """ Check normal use cases as a context manager.
@@ -224,7 +224,7 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
         """ Make sure that the traits context manager does not stop
         regular assertions inside the managed code block from happening.
         """
-        test_object = TestObject(number=16.0)
+        test_object = ExampleObject(number=16.0)
 
         with self.assertTraitDoesNotChange(test_object, "number"):
             self.assertEqual(test_object.number, 16.0)
@@ -236,7 +236,7 @@ class UnittestToolsTestCase(unittest.TestCase, UnittestTools):
     def test_special_case_for_count(self):
         """ Count equal to 0 should be valid but it is discouraged.
         """
-        test_object = TestObject(number=16.0)
+        test_object = ExampleObject(number=16.0)
 
         with self.assertTraitChanges(test_object, "number", count=0):
             test_object.flag = True

--- a/traits/tests/test_automatic_adaptation.py
+++ b/traits/tests/test_automatic_adaptation.py
@@ -38,7 +38,7 @@ def default_foo():
     return Foo(default=True)
 
 
-class TestAutomaticAdaptationBase:
+class AutomaticAdaptationTestMixin:
     """
     Mixin for tests to be applied to both Instance and BaseInstance.
 
@@ -128,7 +128,7 @@ class TestAutomaticAdaptationBase:
 
 
 class TestAutomaticAdaptationInstance(
-    TestAutomaticAdaptationBase, unittest.TestCase
+    AutomaticAdaptationTestMixin, unittest.TestCase
 ):
     """
     Tests for automatic adaptation with Instance.
@@ -139,7 +139,7 @@ class TestAutomaticAdaptationInstance(
 
 
 class TestAutomaticAdaptationBaseInstance(
-    TestAutomaticAdaptationBase, unittest.TestCase
+    AutomaticAdaptationTestMixin, unittest.TestCase
 ):
     """
     Tests for automatic adaptation with BaseInstance.

--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -35,7 +35,7 @@ from traits.observation.api import (
 )
 
 
-class Test(HasTraits):
+class HasProperty(HasTraits):
 
     output_buffer = Any()
 
@@ -51,7 +51,7 @@ class Test(HasTraits):
     value = Property(__value_get, __value_set)
 
 
-class Test_1(Test):
+class HasPropertySubclass(HasProperty):
     def _value_changed(self, value):
         self.output_buffer.write(value)
 
@@ -60,7 +60,7 @@ class TestPropertyNotifications(unittest.TestCase):
     def test_property_notifications(self):
         output_buffer = io.StringIO()
 
-        test_obj = Test_1(output_buffer=output_buffer)
+        test_obj = HasPropertySubclass(output_buffer=output_buffer)
         test_obj.value = "value_1"
         self.assertEqual(output_buffer.getvalue(), "value_1")
 

--- a/traits/util/tests/test_record_events.py
+++ b/traits/util/tests/test_record_events.py
@@ -25,7 +25,7 @@ from traits.util.event_tracer import (
 )
 
 
-class TestObject(HasTraits):
+class ExampleObject(HasTraits):
 
     number = Float(2.0)
     list_of_numbers = List(Float())
@@ -47,7 +47,7 @@ class TestRecordEvents(unittest.TestCase):
         shutil.rmtree(self.directory)
 
     def test_change_event_recorder(self):
-        test_object = TestObject()
+        test_object = ExampleObject()
         container = RecordContainer()
         recorder = ChangeEventRecorder(container=container)
         trait_notifiers.set_change_event_tracers(
@@ -65,14 +65,14 @@ class TestRecordEvents(unittest.TestCase):
             self.assertEqual(len(lines), 4)
             # very basic checking
             self.assertTrue(
-                "-> 'number' changed from 2.0 to 5.0 in 'TestObject'\n"
+                "-> 'number' changed from 2.0 to 5.0 in 'ExampleObject'\n"
                 in lines[0]
             )
             self.assertTrue("CALLING" in lines[1])
             self.assertTrue("EXIT" in lines[2])
 
     def test_multi_thread_change_event_recorder(self):
-        test_object = TestObject()
+        test_object = ExampleObject()
         container = MultiThreadRecordContainer()
         recorder = MultiThreadChangeEventRecorder(container=container)
         trait_notifiers.set_change_event_tracers(
@@ -99,19 +99,19 @@ class TestRecordEvents(unittest.TestCase):
             # very basic checking
             if "MainThread.trace" in filename:
                 self.assertTrue(
-                    "-> 'number' changed from 2.0 to 5.0 in 'TestObject'\n"
+                    "-> 'number' changed from 2.0 to 5.0 in 'ExampleObject'\n"
                     in lines[0]
                 )
             else:
                 self.assertTrue(
-                    "-> 'number' changed from 5.0 to 10.0 in 'TestObject'\n"
+                    "-> 'number' changed from 5.0 to 10.0 in 'ExampleObject'\n"
                     in lines[0]
                 )
             self.assertTrue("CALLING" in lines[1])
             self.assertTrue("EXIT" in lines[2])
 
     def test_record_events(self):
-        test_object = TestObject()
+        test_object = ExampleObject()
         with record_events() as container:
             test_object.number = 5.0
             thread = threading.Thread(
@@ -130,12 +130,12 @@ class TestRecordEvents(unittest.TestCase):
             # very basic checking
             if "MainThread.trace" in filename:
                 self.assertTrue(
-                    "-> 'number' changed from 2.0 to 5.0 in 'TestObject'\n"
+                    "-> 'number' changed from 2.0 to 5.0 in 'ExampleObject'\n"
                     in lines[0]
                 )
             else:
                 self.assertTrue(
-                    "-> 'number' changed from 5.0 to 8.0 in 'TestObject'\n"
+                    "-> 'number' changed from 5.0 to 8.0 in 'ExampleObject'\n"
                     in lines[0]
                 )
             self.assertTrue("CALLING" in lines[1])


### PR DESCRIPTION
This PR renames a mixin class to avoid Pytest trying to run it as a test class in its own right.

EDIT: Updated to rename a few more classes that Pytest otherwise tries to interpret as test classes.