### PR TITLE
Remove deleter for the kiva_backend property (which is readonly)

### DIFF
--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -338,10 +338,6 @@ class ETSConfig(object):
 
         return self._kiva_backend
 
-    @kiva_backend.deleter
-    def kiva_backend(self):
-        self._kiva_backend = None
-
     @property
     def user_data(self):
         """

--- a/traits/etsconfig/tests/test_etsconfig.py
+++ b/traits/etsconfig/tests/test_etsconfig.py
@@ -293,14 +293,6 @@ class ETSConfigTestCase(unittest.TestCase):
         self.ETSConfig.toolkit = "wx.celiagg"
         self.assertEqual(self.ETSConfig.kiva_backend, "celiagg")
 
-    def test_delete_kiva_backend(self):
-        # given
-        self.ETSConfig.toolkit = "wx.celiagg"
-        self.assertEqual(self.ETSConfig.kiva_backend, "celiagg")
-
-        # check that the property can be deleted
-        del self.ETSConfig.kiva_backend
-
     def test_mock_kiva_backend(self):
         # when
         with patch.object(self.ETSConfig, "toolkit", new="test.foo"):


### PR DESCRIPTION
PR #1670 added deleters for various `ETSConfig` attributes. However, the `kiva_backend` property is readonly, with value derived from the `toolkit` attribute, so we shouldn't be providing a deleter for it. The right way to mock `kiva_backend` is to set the `toolkit` attribute (and in fact there's already a test for that).

This PR removes the deleter for the `kiva_backend` attribute.