### PR TITLE
Ignore the traits-stubs build directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Build directories
 *.egg-info/
 /build/
+/traits-stubs/build/
 /dist/
 /docs/build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@
 # Build directories
 *.egg-info/
 /build/
-/traits-stubs/build/
 /dist/
+/traits-stubs/build/
+/traits-stubs/dist/
 /docs/build/
 
 # Coverage artifacts


### PR DESCRIPTION
This PR updates `.gitignore` to ignore the traits-stubs build directory in addition to the main Traits build directory.