### PR TITLE
Make ETSConfig class documentation visible in the API docs

### DIFF
--- a/docs/source/traits_api_reference/traits.etsconfig.rst
+++ b/docs/source/traits_api_reference/traits.etsconfig.rst
@@ -10,6 +10,6 @@
 .. automodule:: traits.etsconfig.etsconfig
     :no-members:
 
-.. autoclass:: ETSConfigFactory
+.. autoclass:: ETSConfigType
 
 .. autodata:: ETSConfig

--- a/docs/source/traits_api_reference/traits.etsconfig.rst
+++ b/docs/source/traits_api_reference/traits.etsconfig.rst
@@ -10,4 +10,6 @@
 .. automodule:: traits.etsconfig.etsconfig
     :no-members:
 
+.. autoclass:: ETSConfigFactory
+
 .. autodata:: ETSConfig

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -42,14 +42,20 @@ class ETSToolkitError(RuntimeError):
         self.args = args
 
 
-class ETSConfig(object):
+class ETSConfigFactory:
     """
     Enthought Tool Suite configuration information.
 
-    This class should not use ANY other package in the tool suite so that it
-    will always work no matter which other packages are present.
+    Instances of this class record state useful for ETS-using applications,
+    including the current GUI toolkit in use, and data and home directory
+    setttings.
 
+    Users typically shouldn't make use of this class directly. Instead, use the
+    module-level :data:`~.ETSConfig` instance of this class, which is shared
+    between the various ETS packages.
     """
+    # This class should not use ANY other package in the tool suite so that it
+    # will always work no matter which other packages are present.
 
     ###########################################################################
     # 'object' interface.
@@ -525,7 +531,10 @@ class ETSConfig(object):
         return usr_dir
 
 
-# We very purposefully only have one object and do not export the class. We
-# could have just made everything class methods, but that always seems a bit
-# gorpy, especially with properties etc.
-ETSConfig = ETSConfig()
+#: This single instance of :class:`~.ETSConfigFactory` is shared between the
+#: various ETS packages, and used to store global state relevant to
+#: ETS-using applications.
+#:
+#: See https://github.com/enthought/traits/discussions/1666 for a discussion
+#: of writing tests that depend on :data:`~.ETSConfig` state.
+ETSConfig = ETSConfigFactory()

--- a/traits/etsconfig/etsconfig.py
+++ b/traits/etsconfig/etsconfig.py
@@ -42,7 +42,7 @@ class ETSToolkitError(RuntimeError):
         self.args = args
 
 
-class ETSConfigFactory:
+class ETSConfigType:
     """
     Enthought Tool Suite configuration information.
 
@@ -531,10 +531,10 @@ class ETSConfigFactory:
         return usr_dir
 
 
-#: This single instance of :class:`~.ETSConfigFactory` is shared between the
+#: This single instance of :class:`~.ETSConfigType` is shared between the
 #: various ETS packages, and used to store global state relevant to
 #: ETS-using applications.
 #:
 #: See https://github.com/enthought/traits/discussions/1666 for a discussion
 #: of writing tests that depend on :data:`~.ETSConfig` state.
-ETSConfig = ETSConfigFactory()
+ETSConfig = ETSConfigType()


### PR DESCRIPTION
This PR provides an alternative to #1669. The goal is to make the `ETSConfig` docstrings available in the API docs, so that a search for `ETSConfig` in the online documentation gives useful results.

To that end, this PR:

- Renames the `ETSConfig` _class_ to `ETSConfigFactory`
- Keeps the `ETSConfig` instance the same as before (previously, the created instance shadowed the class)
- Updates the main docstrings of `ETSConfigFactory` and `ETSConfig`.

There shouldn't be backwards-compatibility concerns with the rename: the `ETSConfig` class wasn't available before (since it was shadowed by the instance), and the trick of using `type(ETSConfig)` to get the class will still work.

I'm deliberately not exposing `ETSConfigFactory` in `traits.api`, since in most circumstances it shouldn't be used directly.

Screenshots: before

![Screenshot 2022-08-08 at 15 04 40](https://user-images.githubusercontent.com/662003/183436817-83a69c54-1c5a-47bf-b352-5f3b0f819250.png)

and after (only a portion of the docs shown):

![Screenshot 2022-08-08 at 14 57 30](https://user-images.githubusercontent.com/662003/183436140-680d306a-4fcb-470e-aad8-db8f963ff041.png)
