### PR TITLE
Add minimal pyproject.toml for the traits-stubs package

### DIFF
--- a/traits-stubs/pyproject.toml
+++ b/traits-stubs/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools', 'wheel']
+build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
This PR adds a minimal `pyproject.toml` for the traits-stubs package; without this, `pip` enters "legacy mode" when trying to build the stubs, and it's conceivable that at some point in the future that legacy mode will go away altogether.