### PR TITLE
Don't collect traits-stubs tests under pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ target-version = ['py36']
 profile = 'black'
 line_length = 79
 order_by_type = 'False'
+
+[tool.pytest.ini_options]
+addopts = '--ignore=traits-stubs'


### PR DESCRIPTION
This PR adds a pytest configuration to ignore traits-stubs when running the Traits tests. (It's fine to run the traits-stubs tests under pytest, but it needs to be done from the traits-stubs directory as a separate test run.)

Together with #1684 and #1683, this closes #1288.
