### PR TITLE
Update wheel-building workflow to include Python 3.11

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -40,6 +40,7 @@ jobs:
         CIBW_SKIP: 'pp*'
         CIBW_ARCHS_LINUX: "auto aarch64"
         CIBW_ARCHS_MACOS: "auto universal2"
+        CIBW_PRERELEASE_PYTHONS: "True"
 
     - name: Check and upload wheels
       env:


### PR DESCRIPTION
We're planning to make a Traits release later this week. Python 3.11 is now at release candidate stage, which means that the ABI should be stable, so it makes sense to upload wheels for 3.11 as well as for earlier versions of Python.

This PR adds the `CIBW_PRERELEASE_PYTHONS` environment variable, which should ensure that wheels for Python 3.11 are built.

Note: the [docs](https://cibuildwheel.readthedocs.io/en/stable/options/#prerelease-pythons) for cibuildwheel currently say:

> This option is provided for testing purposes only. It is not recommended to distribute wheels built when CIBW_PRERELEASE_PYTHONS is set, such as uploading to PyPI. Please do not upload these wheels to PyPI, as they are not guaranteed to work with the final Python release.

But then they also say:

> Once Python is ABI stable and enters the release candidate phase, that version of Python will become available without this flag.

The first RC for Python 3.11 only got released yesterday, so I imagine it'll take a few days for cibuildwheel to catch up with that. So I think the best path forward is for us to temporarily add `CIBW_PRERELEASE_PYTHONS` to our config, and then to remember to remove it later.

Upstream issue: https://github.com/pypa/cibuildwheel/issues/1221