### PR TITLE
Document that TraitPrefixMap and TraitPrefixList are deprecated

### DIFF
--- a/docs/source/traits_user_manual/custom.rst
+++ b/docs/source/traits_user_manual/custom.rst
@@ -462,6 +462,10 @@ the traits.trait_handlers module.
 TraitPrefixList
 ```````````````
 
+.. note::
+    :class:`~.TraitPrefixList` is scheduled for removal
+    in Traits 7.0. Use the :class:`~.PrefixList` trait type instead.
+
 The TraitPrefixList handler accepts not only a specified set of strings as
 values, but also any unique prefix substring of those values. The value assigned
 to the trait attribute is the full string that the substring matches.
@@ -500,6 +504,10 @@ For example::
 
 TraitPrefixMap
 ``````````````
+
+.. note::
+    :class:`~.TraitPrefixMap` is scheduled for removal
+    in Traits 7.0. Use the :class:`~.PrefixMap` trait type instead.
 
 The TraitPrefixMap handler combines the TraitPrefixList with mapped traits. Its
 constructor takes a parameter that is a dictionary whose keys are strings. A

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -522,7 +522,7 @@ class TraitPrefixList(TraitHandler):
     list of specified string values, or is a unique prefix of one of those
     values.
 
-    .. note::
+    .. deprecated:: 6.1
         :class:`~.TraitPrefixList` is scheduled for removal in Traits
         7.0. Use the :class:`~.PrefixList` trait type instead.
 
@@ -707,7 +707,7 @@ class TraitMap(TraitHandler):
 class TraitPrefixMap(TraitMap):
     """A cross between the TraitPrefixList and TraitMap classes.
 
-    .. note::
+    .. deprecated:: 6.1
         :class:`~.TraitPrefixMap` is scheduled for removal
         in Traits 7.0. Use the :class:`~.PrefixMap` trait type instead.
 

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -522,6 +522,10 @@ class TraitPrefixList(TraitHandler):
     list of specified string values, or is a unique prefix of one of those
     values.
 
+    .. note::
+        :class:`~.TraitPrefixList` is scheduled for removal in Traits
+        7.0. Use the :class:`~.PrefixList` trait type instead.
+
     TraitPrefixList is a variation on TraitEnum. The values that can be
     assigned to a trait attribute defined using a TraitPrefixList handler is
     the set of all strings supplied to the TraitPrefixList constructor, as well
@@ -702,6 +706,10 @@ class TraitMap(TraitHandler):
 
 class TraitPrefixMap(TraitMap):
     """A cross between the TraitPrefixList and TraitMap classes.
+
+    .. note::
+        :class:`~.TraitPrefixMap` is scheduled for removal
+        in Traits 7.0. Use the :class:`~.PrefixMap` trait type instead.
 
     Like TraitMap, TraitPrefixMap is created using a dictionary, but in this
     case, the keys of the dictionary must be strings. Like TraitPrefixList,


### PR DESCRIPTION
`TraitPrefixMap` and `TraitPrefixList` were deprecated in Traits 6.1, and will be removed in Traits 7.0. This PR updates the docs to make that deprecation clearer.
