### PR TITLE
Fix and rename requires_numpy_typing decorator

### DIFF
--- a/traits-stubs/traits_stubs_tests/test_all.py
+++ b/traits-stubs/traits_stubs_tests/test_all.py
@@ -15,7 +15,7 @@ from unittest import TestCase
 from traits.testing.optional_dependencies import (
     pkg_resources,
     requires_mypy,
-    requires_numpy_testing,
+    requires_numpy_typing,
     requires_pkg_resources,
 )
 from traits_stubs_tests.util import MypyAssertions
@@ -43,7 +43,7 @@ class TestAnnotations(TestCase, MypyAssertions):
             with self.subTest(file_path=file_path):
                 self.assertRaisesMypyError(file_path)
 
-    @requires_numpy_testing
+    @requires_numpy_typing
     def test_numpy_examples(self):
         """ Run mypy for files contained in traits_stubs_tests/numpy_examples
         directory.

--- a/traits/testing/optional_dependencies.py
+++ b/traits/testing/optional_dependencies.py
@@ -45,9 +45,9 @@ requires_mypy = unittest.skipIf(mypy is None, "Mypy not available")
 numpy = optional_import("numpy")
 requires_numpy = unittest.skipIf(numpy is None, "NumPy not available")
 
-numpy_testing = optional_import("numpy.testing")
-requires_numpy_testing = unittest.skipIf(
-    numpy_testing is None, "numpy.testing not available")
+numpy_typing = optional_import("numpy.typing")
+requires_numpy_typing = unittest.skipIf(
+    numpy_typing is None, "numpy.typing not available")
 
 pkg_resources = optional_import("pkg_resources")
 requires_pkg_resources = unittest.skipIf(


### PR DESCRIPTION
PR #1682 introduced what should have been a check for `numpy.typing`, that ended up as a check for `numpy.testing` instead. This PR fixes that.

Also, PR #1682 _should_ have failed on Python 3.6 because of the above, since on Python 3.6 the latest version of NumPy available doesn't have type hints. It didn't fail because we weren't populating the package data with the new `numpy_examples` directory, so the numpy-based tests weren't run. That's fixed in #1709.

