### PR TITLE
Update cibuildwheel to the latest version

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pip install twine wheel
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.1.2
+      uses: pypa/cibuildwheel@v2.9.0
       env:
         CIBW_SKIP: 'pp*'
         CIBW_ARCHS_LINUX: "auto aarch64"


### PR DESCRIPTION
This PR updates `cibuildwheel` to the latest version, so that we can build Python 3.11 wheels when the time comes.