### PR TITLE
Modernize the PyPI release workflow

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -76,5 +76,5 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python -m twine check --strict dist/*.tar.gz
-        python -m twine upload dist/*.tar.gz
+        python -m twine check --strict dist/*
+        python -m twine upload dist/*

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -16,23 +16,23 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       with:
         platforms: arm64
       if: runner.os == 'Linux'
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install Python packages needed for wheel build and upload
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install twine wheel
+        python -m pip install --upgrade pip
+        python -m pip install twine
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.9.0
@@ -55,21 +55,21 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install Python packages needed for sdist build and upload
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install twine
+        python -m pip install --upgrade pip
+        python -m pip install build twine
 
     - name: Build sdist
       run: |
-        python setup.py sdist
+        python -m build --sdist
 
     - name: Publish sdist to PyPI
       env:

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -30,9 +30,7 @@ jobs:
         python-version: '3.10'
 
     - name: Install Python packages needed for wheel build and upload
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install twine
+      run: python -m pip install twine
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.9.0
@@ -63,13 +61,10 @@ jobs:
         python-version: '3.10'
 
     - name: Install Python packages needed for sdist build and upload
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install build twine
+      run: python -m pip install build twine
 
     - name: Build sdist
-      run: |
-        python -m build --sdist
+      run: python -m build --sdist
 
     - name: Publish sdist to PyPI
       env:


### PR DESCRIPTION
This PR brings the wheel-build-and-PyPI-upload workflow in line with modern standards.

* Future proofing: use latest versions of Python and the various actions, so that with luck we don't need to update this workflow again for a while.
* Use `python -m build --sdist` instead of `python setup.py sdist` to build packages
* Remove unnecessary package installs.