### PR TITLE
Remove the deprecated adapt-by-calling ability of Interfaces

### DIFF
--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -25,7 +25,6 @@ import weakref
 from types import FunctionType
 
 from . import __version__ as TraitsVersion
-from .adaptation.adaptation_error import AdaptationError
 from .constants import DefaultValue, TraitKind
 from .ctrait import CTrait, __newobj__
 from .ctraits import CHasTraits
@@ -3679,25 +3678,10 @@ VetoableEvent = Event(Vetoable)
 class MetaInterface(ABCMetaHasTraits):
     """ Meta class for interfaces.
 
-    Interfaces are simple ABCs with the following features:-
-
-    1) They cannot be instantiated (they are interfaces, not implementations!).
-    2) Calling them is equivalent to calling 'adapt'.
-
+    Historically, there were some differences between interfaces
+    and ABCs in Traits, but now Interface is a near synonym for
+    ABCHasTraits.
     """
-
-    @deprecated('use "adapt(adaptee, protocol)" instead.')
-    def __call__(self, adaptee, default=AdaptationError):
-        """ Attempt to adapt the adaptee to this interface.
-
-        Note that this means that (intentionally ;^) that interfaces
-        cannot be instantiated!
-
-        """
-
-        from traits.adaptation.api import adapt
-
-        return adapt(adaptee, self, default=default)
 
 
 class Interface(HasTraits, metaclass=MetaInterface):

--- a/traits/tests/test_interface_checker.py
+++ b/traits/tests/test_interface_checker.py
@@ -12,11 +12,11 @@
 
 # Standard library imports.
 import unittest
-import warnings
 
 # Enthought library imports.
 from traits.adaptation.api import reset_global_adaptation_manager
 from traits.api import (
+    adapt,
     Adapter,
     HasTraits,
     Instance,
@@ -388,15 +388,7 @@ class InterfaceCheckerTestCase(unittest.TestCase):
 
         # Adaptation via direct instantiation of interfaces is deprecated, so
         # catch the warning to keep the test run output clean.
-        with warnings.catch_warnings(record=True) as warn_msgs:
-            warnings.simplefilter("always", DeprecationWarning)
-            self.assertEqual(f, IFoo(f))
-
-        self.assertEqual(len(warn_msgs), 1)
-        warn_msg = warn_msgs[0]
-        self.assertIn(
-            'use "adapt(adaptee, protocol)" instead', str(warn_msg.message))
-        self.assertIn("test_interface_checker", warn_msg.filename)
+        self.assertEqual(f, adapt(f, IFoo))
 
     def test_adaptation(self):
         """ adaptation """
@@ -415,17 +407,8 @@ class InterfaceCheckerTestCase(unittest.TestCase):
 
         f = Foo()
 
-        # Make sure adaptation works. Adaptation via direct instantiation of
-        # Interface classes is deprecated, so suppress the warning.
-        with warnings.catch_warnings(record=True) as warn_msgs:
-            warnings.simplefilter("always", DeprecationWarning)
-            i_foo = IFoo(f)
+        # Make sure adaptation works.
+        i_foo = adapt(f, IFoo)
 
-        self.assertNotEqual(None, i_foo)
+        self.assertIsNotNone(i_foo)
         self.assertEqual(FooToIFooAdapter, type(i_foo))
-
-        self.assertEqual(len(warn_msgs), 1)
-        warn_msg = warn_msgs[0]
-        self.assertIn(
-            'use "adapt(adaptee, protocol)" instead', str(warn_msg.message))
-        self.assertIn("test_interface_checker", warn_msg.filename)

--- a/traits/tests/test_interface_checker.py
+++ b/traits/tests/test_interface_checker.py
@@ -386,8 +386,6 @@ class InterfaceCheckerTestCase(unittest.TestCase):
 
         f = Foo()
 
-        # Adaptation via direct instantiation of interfaces is deprecated, so
-        # catch the warning to keep the test run output clean.
         self.assertEqual(f, adapt(f, IFoo))
 
     def test_adaptation(self):


### PR DESCRIPTION
This PR removes the long-deprecated ability to do adaptation by calling an interface class (i.e., doing `adapted = IFoo(myobject)` instead of `adapted = adapt(myobject, IFoo)`).