### PR TITLE
Avoid incompatibility between setuptools >= 65.2 and EDM runtimes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'wheel']
+requires = ['setuptools<65.2', 'wheel']
 build-backend = 'setuptools.build_meta'
 
 [tool.black]


### PR DESCRIPTION
There's an incompatibility between setuptools version 65.2 and later and current EDM runtimes. Until that incompatibility is resolved, building Traits (with `pip install .`) in an EDM environment fails.

As a temporary workaround, we constrain the setuptools version in `pyproject.toml`.

Should fix #1721.