### PR TITLE
Upgrade workflows to use Python 3.11 final

### DIFF
--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest


### PR DESCRIPTION
Python 3.11 is now supported by the setup-python action (see https://github.com/actions/python-versions/pull/193). This PR replaces uses of 3.11-dev with 3.11 final.