### PR TITLE
Fix inconsistent spacing style in docs

### DIFF
--- a/docs/source/traits_user_manual/advanced.rst
+++ b/docs/source/traits_user_manual/advanced.rst
@@ -171,7 +171,7 @@ specifying only the wildcard character for the attribute name::
     # all_wildcard.py --- Example of trait attribute wildcard rules
     from traits.api import Any, HasTraits, Int, Str
 
-    class Person ( HasTraits ):
+    class Person(HasTraits):
 
         # Normal, explicitly defined trait:
         name = Str
@@ -194,7 +194,7 @@ specifying only the wildcard character for the attribute name::
       File "all_wildcard.py", line 33, in <module>
         bill.age = 'middle age'
       File "c:\wrk\src\lib\enthought\traits\\trait_handlers.py", line 163, in error
-        raise TraitError( object, name, self.info(), value )
+        raise TraitError(object, name, self.info(), value)
     TraitError: The 'age' trait of a Person instance must be an integer, but a value
      of 'middle age' <type 'str'> was specified.
     """
@@ -503,11 +503,11 @@ definition. For example::
     @provides(IName)
     class Person(HasTraits):
 
-        first_name = Str( 'John' )
-        last_name  = Str( 'Doe' )
+        first_name = Str('John')
+        last_name  = Str('Doe')
 
         # Implementation of the 'IName' interface:
-        def get_name ( self ):
+        def get_name(self):
             ''' Returns the name of an object. '''
             name = '{first} {last}'
             return name.format(name=self.first_name, last=self.last_name)
@@ -550,7 +550,7 @@ The most common way to use interfaces is with the
     >>> class Apartment(HasTraits):
     ...     renter = Instance(IName)
     >>> william = Person(first_name='William', last_name='Adams')
-    >>> apt1 = Apartment( renter=william )
+    >>> apt1 = Apartment(renter=william)
     >>> print 'Renter is: ', apt1.renter.get_name()
     Renter is: William Adams
 
@@ -698,7 +698,7 @@ The following code example shows a definition of a simple adapter class::
         adaptee = Instance(Person)
 
         # Implement the 'IName' interface on behalf of its client:
-        def get_name ( self ):
+        def get_name(self):
             name = '{first} {last}'.format(first=self.adaptee.first_name,
                                            last=self.adaptee.last_name)
             return name
@@ -742,7 +742,7 @@ This is the example from the previous section, were the adapter is registered::
         adaptee = Instance(Person)
 
         # Implement the 'IName' interface on behalf of its client:
-        def get_name ( self ):
+        def get_name(self):
             name = '{first} {last}'.format(first=self.adaptee.first_name,
                                            last=self.adaptee.last_name)
             return name
@@ -1118,7 +1118,7 @@ Property Factory Function
 The Property() function has the following signature:
 
 .. currentmodule:: traits.traits
-.. function:: Property( [fget=None, fset=None, fvalidate=None, force=False, handler=None, trait=None, **metadata] )
+.. function:: Property([fget=None, fset=None, fvalidate=None, force=False, handler=None, trait=None, **metadata])
    :noindex:
 
 All parameters are optional, including the *fget* "getter", *fvalidate*
@@ -1133,7 +1133,7 @@ that trait's handler supersedes the *handler* argument, if any. Because the
 *fget* parameter accepts either a method or a trait, you can define a Property
 trait by simply passing another trait. For example::
 
-    source = Property( Code )
+    source = Property(Code)
 
 This line defines a trait whose value is validated by the Code trait, and whose
 getter and setter methods are defined elsewhere on the same class.
@@ -1241,12 +1241,12 @@ For example::
     # transient_metadata.py -- Example of using 'transient' metadata
     from traits.api import HasTraits, File, Any
 
-    class DataBase ( HasTraits ):
+    class DataBase(HasTraits):
         # The name of the data base file:
         file_name = File
 
         # The open file handle used to access the data base:
-        file = Any( transient = True )
+        file = Any(transient = True)
 
 In this example, the DataBase class's file trait is marked as transient because
 it normally contains an open file handle used to access a data base. Since file
@@ -1290,12 +1290,12 @@ metadata.
 However, in cases where this strategy is insufficient, use the following pattern
 to override __getstate__() to remove items that should not be persisted::
 
-    def __getstate__ ( self ):
+    def __getstate__(self):
         state = super().__getstate__()
 
-        for key in [ 'foo', 'bar' ]:
+        for key in ['foo', 'bar']:
             if key in state:
-                del state[ key ]
+                del state[key]
 
         return state
 

--- a/docs/source/traits_user_manual/custom.rst
+++ b/docs/source/traits_user_manual/custom.rst
@@ -35,7 +35,7 @@ Here's an example of subclassing a predefined trait class::
     # trait_subclass.py -- Example of subclassing a trait class
     from traits.api import BaseInt
 
-    class OddInt ( BaseInt ):
+    class OddInt(BaseInt):
 
         # Define the default value
         default_value = 1
@@ -43,12 +43,12 @@ Here's an example of subclassing a predefined trait class::
         # Describe the trait type
         info_text = 'an odd integer'
 
-        def validate ( self, object, name, value ):
+        def validate(self, object, name, value):
             value = super().validate(object, name, value)
             if (value % 2) == 1:
                 return value
 
-            self.error( object, name, value )
+            self.error(object, name, value)
 
 The OddInt class defines a trait that must be an odd integer. It derives from
 BaseInt, rather than Int, as you might initially expect. BaseInt and Int are
@@ -101,8 +101,8 @@ performs additional processing after a value has been validated and assigned.
 
 The signatures of these methods are:
 
-.. method:: validate( object, name, value )
-.. method:: post_setattr( object, name, value )
+.. method:: validate(object, name, value)
+.. method:: post_setattr(object, name, value)
 
 The parameters of these methods are:
 
@@ -136,8 +136,8 @@ definition it might have for validate() is ignored.
 
 The signatures of these methods are:
 
-.. method:: get( object, name)
-.. method:: set( object, name, value)
+.. method:: get(object, name)
+.. method:: set(object, name, value)
 
 In these signatures, the parameters are:
 
@@ -235,7 +235,7 @@ Reference*.
 The most general form of the Trait() function is:
 
 .. currentmodule:: traits.traits
-.. function:: Trait(default_value, {type | constant_value | dictionary | class | function | trait_handler | trait }+ )
+.. function:: Trait(default_value, {type | constant_value | dictionary | class | function | trait_handler | trait}+)
     :noindex:
 
 .. index:: compound traits
@@ -255,11 +255,11 @@ The following is an example of a compound trait with multiple criteria::
     # compound.py -- Example of multiple criteria in a trait definition
     from traits.api import HasTraits, Trait, Range
 
-    class Die ( HasTraits ):
+    class Die(HasTraits):
 
         # Define a compound trait definition:
-        value = Trait( 1, Range( 1, 6 ),
-                      'one', 'two', 'three', 'four', 'five', 'six' )
+        value = Trait(1, Range(1, 6),
+                      'one', 'two', 'three', 'four', 'five', 'six')
 
 The Die class has a **value trait**, which has a default value of 1, and can have
 any of the following values:
@@ -383,7 +383,7 @@ representing red, green, blue, and transparency values::
                    'violet':      (0.31, 0.184, 0.31, 1.0),
                    'yellow':      (1.0, 1.0, 0.0, 1.0),
                    'white':       (1.0, 1.0, 1.0, 1.0),
-                   'transparent': (1.0, 1.0, 1.0, 0.0) } )
+                   'transparent': (1.0, 1.0, 1.0, 0.0)})
 
     red_color = Trait ('red', standard_color)
 

--- a/docs/source/traits_user_manual/deferring.rst
+++ b/docs/source/traits_user_manual/deferring.rst
@@ -77,7 +77,7 @@ DelegatesTo object. Consider the following example::
     """
     >>> tony  = Parent(first_name='Anthony', last_name='Jones')
     >>> alice = Parent(first_name='Alice', last_name='Smith')
-    >>> sally = Child( first_name='Sally', father=tony, mother=alice)
+    >>> sally = Child(first_name='Sally', father=tony, mother=alice)
     >>> print(sally.last_name)
     Jones
     >>> sally.last_name = 'Cooper' # Updates delegatee
@@ -88,7 +88,7 @@ DelegatesTo object. Consider the following example::
       File "<stdin>", line 1, in ?
       File "c:\src\trunk\enthought\traits\trait_handlers.py", line
     163, in error
-        raise TraitError( object, name, self.info(), value )
+        raise TraitErrorobject, name, self.info(), value)
     traits.trait_errors.TraitError:  The 'last_name' trait of a
     Parent instance must be a string, but a value of <__main__.Parent object at
     0x014D6D80> <class '__main__.Parent'> was specified.
@@ -173,11 +173,11 @@ PrototypedFrom::
         mother     = Instance(Parent)
 
     """
-    >>> fred = Parent( first_name = 'Fred', family_name = 'Lopez', \
-    ... favorite_first_name = 'Diego', child_allowance = 5.0 )
+    >>> fred = Parent(first_name = 'Fred', family_name = 'Lopez', \
+    ... favorite_first_name = 'Diego', child_allowance = 5.0)
     >>> maria = Parent(first_name = 'Maria', family_name = 'Gonzalez',\
-    ... favorite_first_name = 'Tomas', child_allowance = 10.0 )
-    >>> nino = Child( father=fred, mother=maria )
+    ... favorite_first_name = 'Tomas', child_allowance = 10.0)
+    >>> nino = Child(father=fred, mother=maria)
     >>> print('%s %s gets $%.2f for allowance' % (nino.first_name, \ ... nino.last_name, nino.allowance))
     Tomas Lopez gets $5.00 for allowance
     """
@@ -230,7 +230,7 @@ example::
     from traits.api \
         import HasTraits, Instance, PrototypedFrom, Str
 
-    class Parent ( HasTraits ):
+    class Parent(HasTraits):
 
         first_name = Str
         last_name  = Str
@@ -238,19 +238,19 @@ example::
         def _last_name_changed(self, new):
             print("Parent's last name changed to %s." % new)
 
-    class Child ( HasTraits ):
+    class Child(HasTraits):
 
-        father = Instance( Parent )
+        father = Instance(Parent)
         first_name = Str
-        last_name  = PrototypedFrom( 'father' )
+        last_name  = PrototypedFrom('father')
 
         def _last_name_changed(self, new):
             print("Child's last name changed to %s." % new)
 
     """
-    >>> dad = Parent( first_name='William', last_name='Chase' )
+    >>> dad = Parent(first_name='William', last_name='Chase')
     Parent's last name changed to Chase.
-    >>> son = Child( first_name='John', father=dad )
+    >>> son = Child(first_name='John', father=dad)
     Child's last name changed to Chase.
     >>> dad.last_name='Jones'
     Parent's last name changed to Jones.
@@ -278,4 +278,3 @@ notif
 .. [5] Both of these class es inherit from the Delegate class. Explicit use of
    Delegate is deprecated, as its name and default behavior (prototyping) are
    incongruous.
-

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -230,7 +230,7 @@ The following example illustrates the difference between coercing traits and
 casting traits::
 
     >>> from traits.api import HasTraits, Float, CFloat
-    >>> class Person ( HasTraits ):
+    >>> class Person(HasTraits):
     ...    weight  = Float
     ...    cweight = CFloat
     ...
@@ -278,142 +278,142 @@ the table.
 +------------------+----------------------------------------------------------+
 | Name             | Callable Signature                                       |
 +==================+==========================================================+
-| Any              | Any( [*default_value* = None, \*,                        |
+| Any              | Any([*default_value* = None, \*,                         |
 |                  | *factory* = None, *args* = (), *kw* = {},                |
-|                  | \*\*\ *metadata*] )                                      |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| Array            | Array( [*dtype* = None, *shape* = None, *value* = None,  |
-|                  | \*\*\ *metadata*] )                                      |
+| Array            | Array([*dtype* = None, *shape* = None, *value* = None,   |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| ArrayOrNone      | ArrayOrNone( [*dtype* = None, *shape* = None,            |
-|                  | *value* = None, \*\*\ *metadata*] )                      |
+| ArrayOrNone      | ArrayOrNone([*dtype* = None, *shape* = None,             |
+|                  | *value* = None, \*\*\ *metadata*])                       |
 +------------------+----------------------------------------------------------+
-| Button           | Button( [*label* = '', *image* = None, *style* =         |
+| Button           | Button([*label* = '', *image* = None, *style* =          |
 |                  | 'button', *orientation* = 'vertical', *width_padding* =  |
-|                  | 7, *height_padding* = 5, \*\*\ *metadata*] )             |
+|                  | 7, *height_padding* = 5, \*\*\ *metadata*])              |
 +------------------+----------------------------------------------------------+
-| Callable         | Callable( [*value* = None, \*\*\ *metadata*] )           |
+| Callable         | Callable([*value* = None, \*\*\ *metadata*])             |
 +------------------+----------------------------------------------------------+
-| CArray           | CArray( [*dtype* = None, *shape* = None, *value* = None, |
-|                  | \*\*\ *metadata*] )                                      |
+| CArray           | CArray([*dtype* = None, *shape* = None, *value* = None,  |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| Code             | Code( [*value* = '', *minlen* = 0,                       |
+| Code             | Code([*value* = '', *minlen* = 0,                        |
 |                  | *maxlen* = sys.maxsize, *regex* = '',                    |
-|                  | \*\*\ *metadata*] )                                      |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| CSet             | CSet( [*trait* = None, *value* = None, *items* = True,   |
-|                  | \*\*\ *metadata*] )                                      |
+| CSet             | CSet([*trait* = None, *value* = None, *items* = True,    |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| Constant         | Constant( *value*\ [, \*\*\ *metadata*] )                |
+| Constant         | Constant(*value*\ [, \*\*\ *metadata*])                  |
 +------------------+----------------------------------------------------------+
-| Date             | Date( *value*\ [, *default_value* = None,                |
+| Date             | Date(*value*\ [, *default_value* = None,                 |
 |                  | *allow_datetime* = None, *allow_none* = None,            |
-|                  | \*\*\ *metadata*] )                                      |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| Datetime         | Datetime( *value*\ [, *default_value* = None,            |
+| Datetime         | Datetime(*value*\ [, *default_value* = None,             |
 |                  | *allow_none* = None, \*\*\ *metadata*])                  |
 +------------------+----------------------------------------------------------+
-| Dict             | Dict( [*key_trait* = None, *value_trait* = None,         |
-|                  | *value* = None, *items* = True, \*\*\ *metadata*] )      |
+| Dict             | Dict([*key_trait* = None, *value_trait* = None,          |
+|                  | *value* = None, *items* = True, \*\*\ *metadata*])       |
 +------------------+----------------------------------------------------------+
-| Directory        | Directory( [*value* = '', *auto_set* = False, *entries* =|
-|                  | 10, *exists* = False, \*\*\ *metadata*] )                |
+| Directory        | Directory([*value* = '', *auto_set* = False, *entries* = |
+|                  | 10, *exists* = False, \*\*\ *metadata*])                 |
 +------------------+----------------------------------------------------------+
 | Disallow         | n/a                                                      |
 +------------------+----------------------------------------------------------+
-| Either [2]_      | Either( *val1*\ [, *val2*, ..., *valN*,                  |
-|                  | \*\*\ *metadata*] )                                      |
+| Either [2]_      | Either(*val1*\ [, *val2*, ..., *valN*,                   |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| Enum             | Enum( *values*\ [, \*\*\ *metadata*] )                   |
+| Enum             | Enum(*values*\ [, \*\*\ *metadata*])                     |
 +------------------+----------------------------------------------------------+
-| Event            | Event( [*trait* = None, \*\*\ *metadata*] )              |
+| Event            | Event([*trait* = None, \*\*\ *metadata*])                |
 +------------------+----------------------------------------------------------+
-| Expression       | Expression( [*value* = '0', \*\*\ *metadata*] )          |
+| Expression       | Expression([*value* = '0', \*\*\ *metadata*])            |
 +------------------+----------------------------------------------------------+
-| File             | File( [*value* = '', *filter* = None, *auto_set* = False,|
-|                  | *entries* = 10, *exists* = False,  \*\*\ *metadata* ] )  |
+| File             | File([*value* = '', *filter* = None, *auto_set* = False, |
+|                  | *entries* = 10, *exists* = False,  \*\*\ *metadata*])    |
 +------------------+----------------------------------------------------------+
-| Function [3]_    | Function( [*value* = None, \*\*\ *metadata*] )           |
+| Function [3]_    | Function([*value* = None, \*\*\ *metadata*])             |
 +------------------+----------------------------------------------------------+
 | generic_trait    | n/a                                                      |
 +------------------+----------------------------------------------------------+
-| HTML             | HTML( [*value* = '', *minlen* = 0,                       |
+| HTML             | HTML([*value* = '', *minlen* = 0,                        |
 |                  | *maxlen* = sys.maxsize, *regex* = '',                    |
-|                  | \*\*\ *metadata* ] )                                     |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| Instance         | Instance( [*klass* = None, *factory* = None, *args* =    |
+| Instance         | Instance([*klass* = None, *factory* = None, *args* =     |
 |                  | None, *kw* = None, *allow_none* = True, *adapt* = None,  |
-|                  | *module* = None, \*\*\ *metadata*] )                     |
+|                  | *module* = None, \*\*\ *metadata*])                      |
 +------------------+----------------------------------------------------------+
-| List             | List( [*trait* = None, *value* = None, *minlen* = 0,     |
+| List             | List([*trait* = None, *value* = None, *minlen* = 0,      |
 |                  | *maxlen* = sys.maxsize, *items* = True,                  |
-|                  | \*\*\ *metadata*] )                                      |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| Map              | Map( *map*\ [, \*\*\ *metadata*] )                       |
+| Map              | Map(*map*\ [, \*\*\ *metadata*])                         |
 +------------------+----------------------------------------------------------+
-| Method [3]_      | Method ([\*\*\ *metadata*] )                             |
+| Method [3]_      | Method([\*\*\ *metadata*])                               |
 +------------------+----------------------------------------------------------+
-| Module           | Module ( [\*\*\ *metadata*] )                            |
+| Module           | Module([\*\*\ *metadata*])                               |
 +------------------+----------------------------------------------------------+
-| Password         | Password( [*value* = '', *minlen* = 0, *maxlen* =        |
-|                  | sys.maxsize, *regex* = '', \*\*\ *metadata*] )           |
+| Password         | Password([*value* = '', *minlen* = 0, *maxlen* =         |
+|                  | sys.maxsize, *regex* = '', \*\*\ *metadata*])            |
 +------------------+----------------------------------------------------------+
-| PrefixList       | PrefixList( *values*\ [, \*\*\ *metadata*] )             |
+| PrefixList       | PrefixList(*values*\ [, \*\*\ *metadata*])               |
 +------------------+----------------------------------------------------------+
-| PrefixMap        | PrefixMap( *map*\ [, \*\*\ *metadata*] )                 |
+| PrefixMap        | PrefixMap(*map*\ [, \*\*\ *metadata*])                   |
 +------------------+----------------------------------------------------------+
-| Property         | Property( [*fget* = None, *fset* = None, *fvalidate* =   |
+| Property         | Property([*fget* = None, *fset* = None, *fvalidate* =    |
 |                  | None, *force* = False, *handler* = None, *trait* = None, |
-|                  | \*\*\ *metadata*] )                                      |
+|                  | \*\*\ *metadata*])                                       |
 |                  |                                                          |
 |                  | See :ref:`property-traits`, for details.                 |
 +------------------+----------------------------------------------------------+
-| Python           | Python ( [*value* = None, \*\*\ *metadata*] )            |
+| Python           | Python([*value* = None, \*\*\ *metadata*])               |
 +------------------+----------------------------------------------------------+
-| PythonValue      | PythonValue( [*value* = None, \*\*\ *metadata*] )        |
+| PythonValue      | PythonValue([*value* = None, \*\*\ *metadata*])          |
 +------------------+----------------------------------------------------------+
-| Range            | Range( [*low* = None, *high* = None, *value* = None,     |
+| Range            | Range([*low* = None, *high* = None, *value* = None,      |
 |                  | *exclude_low* = False, *exclude_high* = False,           |
-|                  | \*\ *metadata*] )                                        |
+|                  | \*\ *metadata*])                                         |
 +------------------+----------------------------------------------------------+
-| ReadOnly         | ReadOnly( [*value* = Undefined, \*\*\ *metadata*] )      |
+| ReadOnly         | ReadOnly([*value* = Undefined, \*\*\ *metadata*])        |
 +------------------+----------------------------------------------------------+
-| Regex            | Regex( [*value* = '', *regex* = '.\*', \*\*\ *metadata*])|
+| Regex            | Regex([*value* = '', *regex* = '.\*', \*\*\ *metadata*]) |
 +------------------+----------------------------------------------------------+
 | self             | n/a                                                      |
 +------------------+----------------------------------------------------------+
-| Set              | Set( [*trait* = None, *value* = None, *items* = True,    |
-|                  | \*\*\ *metadata*] )                                      |
+| Set              | Set([*trait* = None, *value* = None, *items* = True,     |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| String           | String( [*value* = '', *minlen* = 0, *maxlen* =          |
-|                  | sys.maxsize, *regex* = '', \*\*\ *metadata*] )           |
+| String           | String([*value* = '', *minlen* = 0, *maxlen* =           |
+|                  | sys.maxsize, *regex* = '', \*\*\ *metadata*])            |
 +------------------+----------------------------------------------------------+
-| Subclass         | Subclass( [*value* = None, *klass* = None, *allow_none* =|
-|                  | True, \*\*\ *metadata*] )                                |
+| Subclass         | Subclass([*value* = None, *klass* = None, *allow_none* = |
+|                  | True, \*\*\ *metadata*])                                 |
 +------------------+----------------------------------------------------------+
 | This             | n/a                                                      |
 +------------------+----------------------------------------------------------+
-| Time             | Time( *value*\ [, *default_value* = None,                |
+| Time             | Time(*value*\ [, *default_value* = None,                 |
 |                  | *allow_none* = None, \*\*\ *metadata*])                  |
 +------------------+----------------------------------------------------------+
-| ToolbarButton    | ToolbarButton( [*label* = '', *image* = None, *style* =  |
+| ToolbarButton    | ToolbarButton([*label* = '', *image* = None, *style* =   |
 |                  | 'toolbar', *orientation* = 'vertical', *width_padding* = |
-|                  | 2, *height_padding* = 2, \*\*\ *metadata*] )             |
+|                  | 2, *height_padding* = 2, \*\*\ *metadata*])              |
 +------------------+----------------------------------------------------------+
-| Tuple            | Tuple( [\*\ *traits*, \*\*\ *metadata*] )                |
+| Tuple            | Tuple([\*\ *traits*, \*\*\ *metadata*])                  |
 +------------------+----------------------------------------------------------+
-| Type             | Type( [*value* = None, *klass* = None, *allow_none* =    |
-|                  | True, \*\*\ *metadata*] )                                |
+| Type             | Type([*value* = None, *klass* = None, *allow_none* =     |
+|                  | True, \*\*\ *metadata*])                                 |
 +------------------+----------------------------------------------------------+
-| Union            | Union( *val1*\ [, *val2*, ..., *valN*,                   |
-|                  | \*\*\ *metadata*] )                                      |
+| Union            | Union(*val1*\ [, *val2*, ..., *valN*,                    |
+|                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
-| UUID             | UUID( [\*\*\ *metadata*] )                               |
+| UUID             | UUID([\*\*\ *metadata*])                                 |
 +------------------+----------------------------------------------------------+
-| ValidatedTuple   | ValidatedTuple( [\*\ *traits*, *fvalidate* = None,       |
-|                  | *fvalidate_info* = '' , \*\*\ *metadata*] )              |
+| ValidatedTuple   | ValidatedTuple([\*\ *traits*, *fvalidate* = None,        |
+|                  | *fvalidate_info* = '' , \*\*\ *metadata*])               |
 +------------------+----------------------------------------------------------+
-| WeakRef          | WeakRef( [*klass* = 'traits.HasTraits',                  |
+| WeakRef          | WeakRef([*klass* = 'traits.HasTraits',                   |
 |                  | *allow_none* = False, *adapt* = 'yes', \*\*\ *metadata*])|
 +------------------+----------------------------------------------------------+
 
@@ -545,7 +545,7 @@ The following is an example of using Map::
     from traits.api import HasTraits, Map
 
     class Person(HasTraits):
-        married = Map({'yes': 1, 'no': 0 }, default_value="yes")
+        married = Map({'yes': 1, 'no': 0}, default_value="yes")
 
 This example defines a Person class which has a **married** trait
 attribute which accepts values "yes" and "no". The default value
@@ -582,7 +582,7 @@ The following is an example of using PrefixMap::
     from traits.api import HasTraits, PrefixMap
 
     class Person(HasTraits):
-        married = PrefixMap({'yes': 1, 'no': 0 }, default_value="yes")
+        married = PrefixMap({'yes': 1, 'no': 0}, default_value="yes")
 
 This example defines a Person class which has a **married** trait
 attribute which accepts values "yes" and "no" or any unique
@@ -1009,42 +1009,42 @@ the metadata attribute::
     from traits.api import HasTraits, Int, List, Float, Str, \
                                      Instance, Any, TraitType
 
-    class Foo( HasTraits ): pass
+    class Foo(HasTraits): pass
 
-    class Test( HasTraits ):
+    class Test(HasTraits):
         i = Int(99)
         lf = List(Float)
-        foo = Instance( Foo, () )
-        any = Any( "123" )
+        foo = Instance(Foo, ())
+        any = Any("123")
 
     t = Test()
 
-    print(t.trait( 'i' ).default)                      # 99
-    print(t.trait( 'i' ).default_kind)                 # value
-    print(t.trait( 'i' ).inner_traits)                 # ()
-    print(t.trait( 'i' ).is_trait_type( Int ))         # True
-    print(t.trait( 'i' ).is_trait_type( Float ))       # False
+    print(t.trait('i').default)                        # 99
+    print(t.trait('i').default_kind)                   # value
+    print(t.trait('i').inner_traits)                   # ()
+    print(t.trait('i').is_trait_type(Int))             # True
+    print(t.trait('i').is_trait_type(Float))           # False
 
-    print(t.trait( 'lf' ).default)                     # []
-    print(t.trait( 'lf' ).default_kind)                # list
-    print(t.trait( 'lf' ).inner_traits)
+    print(t.trait('lf').default)                       # []
+    print(t.trait('lf').default_kind)                  # list
+    print(t.trait('lf').inner_traits)
              # (<traits.traits.CTrait object at 0x01B24138>,)
-    print(t.trait( 'lf' ).is_trait_type( List ))       # True
-    print(t.trait( 'lf' ).is_trait_type( TraitType ))  # True
-    print(t.trait( 'lf' ).is_trait_type( Float ))      # False
-    print(t.trait( 'lf' ).inner_traits[0].is_trait_type( Float )) # True
+    print(t.trait('lf').is_trait_type(List))           # True
+    print(t.trait('lf').is_trait_type(TraitType))      # True
+    print(t.trait('lf').is_trait_type(Float))          # False
+    print(t.trait('lf').inner_traits[0].is_trait_type(Float)) # True
 
-    print(t.trait( 'foo' ).default)                    # <undefined>
-    print(t.trait( 'foo' ).default_kind)               # factory
-    print(t.trait( 'foo' ).inner_traits)               # ()
-    print(t.trait( 'foo' ).is_trait_type( Instance ))  # True
-    print(t.trait( 'foo' ).is_trait_type( List  ))     # False
+    print(t.trait('foo').default)                      # <undefined>
+    print(t.trait('foo').default_kind)                 # factory
+    print(t.trait('foo').inner_traits)                 # ()
+    print(t.trait('foo').is_trait_type(Instance))      # True
+    print(t.trait('foo').is_trait_type(List))          # False
 
-    print(t.trait( 'any' ).default)                    # 123
-    print(t.trait( 'any' ).default_kind)               # value
-    print(t.trait( 'any' ).inner_traits)               # ()
-    print(t.trait( 'any' ).is_trait_type( Any ))       # True
-    print(t.trait( 'any' ).is_trait_type( Str ))       # False
+    print(t.trait('any').default)                      # 123
+    print(t.trait('any').default_kind)                 # value
+    print(t.trait('any').inner_traits)                 # ()
+    print(t.trait('any').is_trait_type(Any))           # True
+    print(t.trait('any').is_trait_type(Str))           # False
 
 .. rubric:: Footnotes
 .. [1] Most callable predefined traits are classes, but a few are functions.

--- a/docs/source/traits_user_manual/intro.rst
+++ b/docs/source/traits_user_manual/intro.rst
@@ -68,25 +68,25 @@ package. These features are elaborated in the rest of this guide.
 
     from traits.api import Delegate, HasTraits, Instance,\
                                      Int, Str
-    class Parent ( HasTraits ):
+    class Parent(HasTraits):
 
         # INITIALIZATION: last_name' is initialized to '':
-        last_name = Str( '' )
+        last_name = Str('')
 
 
-    class Child ( HasTraits ):
+    class Child(HasTraits):
 
         age = Int
 
         # VALIDATION: 'father' must be a Parent instance:
-        father = Instance( Parent )
+        father = Instance(Parent)
 
         # DELEGATION: 'last_name' is delegated to father's 'last_name':
-        last_name = Delegate( 'father' )
+        last_name = Delegate('father')
 
         # NOTIFICATION: This method is called when 'age' changes:
-        def _age_changed ( self, old, new ):
-            print('Age changed from %s to %s ' % ( old, new ))
+        def _age_changed(self, old, new):
+            print('Age changed from %s to %s ' % (old, new))
 
     # Set up the example:
     joe = Parent()
@@ -128,7 +128,7 @@ as legal values for the color red:
 
 * 'red'
 * 0xFF0000
-* ( 1.0, 0.0, 0.0, 1.0 )
+* (1.0, 0.0, 0.0, 1.0)
 
 Thus, the user might write::
 
@@ -149,7 +149,7 @@ So, one of the main goals of the Traits package is to provide a form of type
 checking that:
 
 * Allows for flexibility in the set of values an attribute can have, such as
-  allowing 'red', 0xFF0000 and ( 1.0, 0.0, 0.0, 1.0 ) as equivalent ways of
+  allowing 'red', 0xFF0000 and (1.0, 0.0, 0.0, 1.0) as equivalent ways of
   expressing the color red.
 * Catches illegal value assignments at the point of error, and provides a
   meaningful and useful explanation of the error and the set of allowable

--- a/docs/source/traits_user_manual/listening.rst
+++ b/docs/source/traits_user_manual/listening.rst
@@ -135,7 +135,7 @@ Extended names use the following syntax:
 
 .. productionList::
    xname: xname2['.'xname2]*
-   xname2: ( xname3 | '['xname3[','xname3]*']' ) ['*']
+   xname2: (xname3 | '['xname3[','xname3]*']') ['*']
    xname3: xname | ['+'|'-'][name] | name['?' | ('+'|'-')[name]]
 
 A *name* is any valid Python attribute name.
@@ -378,7 +378,7 @@ some aspect of the extended trait name syntax in the name specifier.
 
     class Employee: pass
 
-    class Department( HasTraits ):
+    class Department(HasTraits):
         employees = List(Employee)
 
     def a_handler(): print("A handler")
@@ -393,13 +393,13 @@ some aspect of the extended trait name syntax in the name specifier.
 
     # "Old style" name syntax
     # a_handler is called only if the list is replaced:
-    dept.on_trait_change( a_handler, 'employees' )
+    dept.on_trait_change(a_handler, 'employees')
     # b_handler is called if the membership of the list changes:
-    dept.on_trait_change( b_handler, 'employees_items')
+    dept.on_trait_change(b_handler, 'employees_items')
 
     # "New style" name syntax
     # c_handler is called if 'employees' or its membership change:
-    dept.on_trait_change( c_handler, 'employees[]' )
+    dept.on_trait_change(c_handler, 'employees[]')
 
     print("Changing list items")
     dept.employees[1] = donna     # Calls B and C
@@ -453,8 +453,8 @@ Decorator Syntax
 
 The syntax for the decorator is::
 
-    @on_trait_change( 'extended_trait_name' )
-    def any_method_name( self, ...):
+    @on_trait_change('extended_trait_name')
+    def any_method_name(self, ...):
     ...
 
 In this case, *extended_trait_name* is a specifier for one or more trait
@@ -599,11 +599,11 @@ Note that these signatures follow a different pattern for argument
 interpretation from dynamic handlers and decorated static handlers. Both of
 the following methods define a handler for an object's **name** trait::
 
-    def _name_changed( self, arg1, arg2, arg3):
+    def _name_changed(self, arg1, arg2, arg3):
         pass
 
     @on_trait_change('name')
-    def some_method( self, arg1, arg2, arg3):
+    def some_method(self, arg1, arg2, arg3):
         pass
 
 However, the interpretation of arguments to these methods differs, as shown in

--- a/examples/tutorials/doc_examples/examples/delegate.py
+++ b/examples/tutorials/doc_examples/examples/delegate.py
@@ -54,7 +54,7 @@ The exception printed will look similar to the following:
 Traceback (most recent call last):
   File "<stdin>", line 1, in ?
   File "c:\src\trunk\enthought\traits\trait_handlers.py", line 163, in error
-    raise TraitError( object, name, self.info(), value )
+    raise TraitError(object, name, self.info(), value)
 traits.trait_errors.TraitError: The 'last_name' trait of a Child
 instance must be a value of type 'str', but a value of <__main__.Parent object
 at 0x009DD6F0> was specified.

--- a/examples/tutorials/traits_4.0/getstate_setstate/getstate.py
+++ b/examples/tutorials/traits_4.0/getstate_setstate/getstate.py
@@ -98,9 +98,9 @@ not be persisted::
     def __getstate__(self):
         state = super().__getstate__()
 
-        for key in [ 'foo', 'bar' ]:
+        for key in ['foo', 'bar']:
             if key in state:
-                del state[ key ]
+                del state[key]
 
         return state
 

--- a/traits/base_trait_handler.py
+++ b/traits/base_trait_handler.py
@@ -155,7 +155,7 @@ class BaseTraitHandler(object):
             trait handlers do not have any inner traits, and so will return an
             empty tuple. The exceptions are **List** and **Dict** trait types,
             which have inner traits used to validate the values assigned to the
-            trait. For example, in *List( Int )*, the *inner traits* for
-            **List** are ( **Int**, ).
+            trait. For example, in *List(Int)*, the *inner traits* for
+            **List** are (**Int**,).
         """
         return ()

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -971,7 +971,7 @@ def property_depends_on(dependency, settable=False, flushable=False):
             file_name = File
             file_contents = Property
 
-            @property_depends_on( 'file_name' )
+            @property_depends_on('file_name')
             def _get_file_contents(self):
                 with open(self.file_name, 'rb') as fh:
                     return fh.read()
@@ -2433,11 +2433,11 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         An *xname2* is of the form::
 
-            ( xname3 | '['xname3[','xname3]*']' ) ['*']
+            (xname3 | '['xname3[','xname3]*']') ['*']
 
         An *xname3* is of the form::
 
-             xname | ['+'|'-'][name] | name['?' | ('+'|'-')[name]]
+            xname | ['+'|'-'][name] | name['?' | ('+'|'-')[name]]
 
         A *name* is any valid Python attribute name. The semantic meaning of
         this notation is as follows:
@@ -2459,7 +2459,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                                          changes to *item1* do not (i.e., the
                                          ':' indicates that changes to the
                                          *link* object should not be reported).
-        ``[ item1, item2, ..., itemN ]`` A list which matches any of the
+        ``[item1, item2, ..., itemN]``   A list which matches any of the
                                          specified items. Note that at the
                                          topmost level, the surrounding square
                                          brackets are optional.
@@ -3303,7 +3303,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 new.on_trait_change(*args)
 
     def _list_changed_handler(self, name, old, new):
-        """ Handles adding/removing listeners for a generic 'List( Instance )'
+        """ Handles adding/removing listeners for a generic 'List(Instance)'
             trait.
         """
         arg_lists = self._get_instance_handlers(name)
@@ -3317,7 +3317,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 item.on_trait_change(*args)
 
     def _list_items_changed_handler(self, name, not_used, event):
-        """ Handles adding/removing listeners for a generic 'List( Instance )'
+        """ Handles adding/removing listeners for a generic 'List(Instance)'
             trait.
         """
         arg_lists = self._get_instance_handlers(name[:-6])
@@ -3331,8 +3331,8 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
                 item.on_trait_change(*args)
 
     def _get_instance_handlers(self, name):
-        """ Returns a list of ( name, method ) pairs for a specified 'Instance'
-            or 'List( Instance )' trait name:
+        """ Returns a list of (name, method) pairs for a specified 'Instance'
+            or 'List(Instance)' trait name:
         """
         return [
             (getattr(self, method_name), item_name)

--- a/traits/observation/expression.py
+++ b/traits/observation/expression.py
@@ -59,7 +59,7 @@ class ObserverExpression:
         """ Create a new expression by extending this expression with
         the given expression.
 
-        e.g. ``trait("child").then( trait("age") | trait("number") )``
+        e.g. ``trait("child").then(trait("age") | trait("number"))``
         on an object matches ``child.age`` or ``child.number`` on the object.
 
         Parameters

--- a/traits/stubs_tests/examples/Instance.py
+++ b/traits/stubs_tests/examples/Instance.py
@@ -37,7 +37,7 @@ class TestClass(HasTraits):
     itm_args = Instance(Fruit, ('different info',))
     itm_kw = Instance(Fruit, {'info': 'different info'})
     itm_factory = Instance(Fruit, fruit_factory)
-    itm_factory_args = Instance(Fruit, fruit_factory, ('different info',), )
+    itm_factory_args = Instance(Fruit, fruit_factory, ('different info',))
     itm_factory_args_kw = Instance(
         Fruit,
         fruit_factory,

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -536,7 +536,7 @@ class TraitMap(TraitHandler):
     The following example defines a ``Person`` class::
 
         >>> class Person(HasTraits):
-        ...     married = Trait('yes', TraitMap({'yes': 1, 'no': 0 })
+        ...     married = Trait('yes', TraitMap({'yes': 1, 'no': 0})
         ...
         >>> bob = Person()
         >>> print bob.married

--- a/traits/trait_type.py
+++ b/traits/trait_type.py
@@ -176,7 +176,7 @@ class TraitType(BaseTraitHandler):
         the ``value`` being assigned. It should return ``True`` if the value is
         valid, and ``False`` otherwise.
 
-    ``value_for ( self, value )``
+    ``value_for(self, value)``
 
         As another alternative to implementing the ``validate`` method, you
         can instead implement the ``value_for`` method, which receives only

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -2771,7 +2771,7 @@ class PrefixList(TraitType):
     type is the set of all strings supplied to the PrefixList constructor,
     as well as any unique prefix of those strings. That is, if the set of
     strings supplied to the constructor is described by
-    [*s*\ :sub:`1`\ , *s*\ :sub:`2`\ , ..., *s*\ :sub:`n`\ ], then the
+    [*s*\ :sub:`1`\ , *s*\ :sub:`2`\ , ..., *s*\ :sub:`n`], then the
     string *v* is a valid value for the trait if *v* == *s*\ :sub:`i[:j]`
     for one and only one pair of values (i, j). If *v* is a valid value,
     then the actual value assigned to the trait attribute is the
@@ -3161,7 +3161,7 @@ class Map(TraitType):
         The following example defines a ``Person`` class::
 
             >>> class Person(HasTraits):
-            ...     married = Map({'yes': 1, 'no': 0 }, default_value="yes")
+            ...     married = Map({'yes': 1, 'no': 0}, default_value="yes")
             ...
             >>> bob = Person()
             >>> print(bob.married)
@@ -3256,7 +3256,7 @@ class PrefixMap(TraitType):
     -------
     ::
 
-        mapping = {'true': 1, 'yes': 1, 'false': 0, 'no': 0 }
+        mapping = {'true': 1, 'yes': 1, 'false': 0, 'no': 0}
         boolean_map = PrefixMap(mapping)
 
     This example defines a Boolean trait that accepts any prefix of 'true',
@@ -3885,7 +3885,7 @@ class Type(BaseClass):
         return result
 
     def get_default_value(self):
-        """ Returns a tuple of the form: ( default_value_type, default_value )
+        """ Returns a tuple of the form: (default_value_type, default_value)
         which describes the default value for this trait.
         """
         if not isinstance(self.default_value, str):

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -207,16 +207,16 @@ def Trait(*value_type, **metadata):
     |                   |   Trait(i)    |                                     |
     +-------------------+---------------+-------------------------------------+
     | Trait(*handler*)  | Trait(        | Assignment to this trait is         |
-    |                   | TraitEnum )   | validated by an object derived from |
+    |                   | TraitEnum)    | validated by an object derived from |
     |                   |               | **traits.TraitHandler**.            |
     +-------------------+---------------+-------------------------------------+
     | Trait(*default*,  | Trait(0.0, 0.0| This is the most general form of    |
-    | { *type* |        | 'stuff',      | the function. The notation:         |
+    | {*type* |         | 'stuff',      | the function. The notation:         |
     | *constant* |      | TupleType)    | ``{...|...|...}+`` means a list of  |
     | *dict* | *class* ||               | one or more of any of the items     |
     | *function* |      |               | listed between the braces. Thus, the|
     | *handler* |       |               | most general form of the function   |
-    | *trait* }+ )      |               | consists of a default value,        |
+    | *trait*}+)        |               | consists of a default value,        |
     |                   |               | followed by one or more of several  |
     |                   |               | possible items. A trait defined by  |
     |                   |               | multiple items is called a          |

--- a/traits/traits_listener.py
+++ b/traits/traits_listener.py
@@ -60,7 +60,7 @@ ListenerType = {
     4: SRC_LISTENER,
 }
 
-# Invalid destination ( object, name ) reference marker (i.e. ambiguous):
+# Invalid destination (object, name) reference marker (i.e. ambiguous):
 INVALID_DESTINATION = (None, None)
 
 # Regular expressions used by the parser:


### PR DESCRIPTION
This PR fixes inconsistent code styling for parentheses, brackets and braces in reST docs and `.py` file docstrings.