### PR TITLE
Remove deprecated Date, Time and Datetime behaviour

### DIFF
--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -307,7 +307,7 @@ the table.
 | Constant         | Constant(*value*\ [, \*\*\ *metadata*])                  |
 +------------------+----------------------------------------------------------+
 | Date             | Date(*value*\ [, *default_value* = None,                 |
-|                  | *allow_datetime* = None, *allow_none* = None,            |
+|                  | *allow_datetime* = False, *allow_none* = None,           |
 |                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
 | Datetime         | Datetime(*value*\ [, *default_value* = None,             |

--- a/docs/source/traits_user_manual/defining.rst
+++ b/docs/source/traits_user_manual/defining.rst
@@ -307,11 +307,11 @@ the table.
 | Constant         | Constant(*value*\ [, \*\*\ *metadata*])                  |
 +------------------+----------------------------------------------------------+
 | Date             | Date(*value*\ [, *default_value* = None,                 |
-|                  | *allow_datetime* = False, *allow_none* = None,           |
+|                  | *allow_datetime* = False, *allow_none* = False,          |
 |                  | \*\*\ *metadata*])                                       |
 +------------------+----------------------------------------------------------+
 | Datetime         | Datetime(*value*\ [, *default_value* = None,             |
-|                  | *allow_none* = None, \*\*\ *metadata*])                  |
+|                  | *allow_none* = False, \*\*\ *metadata*])                 |
 +------------------+----------------------------------------------------------+
 | Dict             | Dict([*key_trait* = None, *value_trait* = None,          |
 |                  | *value* = None, *items* = True, \*\*\ *metadata*])       |
@@ -394,7 +394,7 @@ the table.
 | This             | n/a                                                      |
 +------------------+----------------------------------------------------------+
 | Time             | Time(*value*\ [, *default_value* = None,                 |
-|                  | *allow_none* = None, \*\*\ *metadata*])                  |
+|                  | *allow_none* = False, \*\*\ *metadata*])                 |
 +------------------+----------------------------------------------------------+
 | ToolbarButton    | ToolbarButton([*label* = '', *image* = None, *style* =   |
 |                  | 'toolbar', *orientation* = 'vertical', *width_padding* = |

--- a/traits/tests/test_date.py
+++ b/traits/tests/test_date.py
@@ -71,7 +71,7 @@ class TestDate(unittest.TestCase):
         with self.assertRaises(TraitError) as exception_context:
             obj.simple_date = "1975-2-13"
         message = str(exception_context.exception)
-        self.assertIn("must be a date or None, but", message)
+        self.assertIn("must be a non-datetime date or None, but", message)
 
     def test_assign_none_with_allow_none_not_given(self):
         obj = HasDateTraits(simple_date=UNIX_EPOCH)
@@ -92,7 +92,7 @@ class TestDate(unittest.TestCase):
         with self.assertRaises(TraitError) as exception_context:
             obj.none_prohibited = None
         message = str(exception_context.exception)
-        self.assertIn("must be a date, but", message)
+        self.assertIn("must be a non-datetime date, but", message)
 
     def test_assign_none_with_allow_none_true(self):
         obj = HasDateTraits(none_allowed=UNIX_EPOCH)
@@ -117,21 +117,14 @@ class TestDate(unittest.TestCase):
     def test_assign_datetime_with_allow_datetime_not_given(self):
         # For traits where "allow_datetime" is not specified, a
         # DeprecationWarning should be issued on assignment of datetime.
+        test_date = datetime.date(2023, 1, 11)
         test_datetime = datetime.datetime(1975, 2, 13)
-        obj = HasDateTraits()
-        with self.assertWarns(DeprecationWarning) as warnings_cm:
-            # Note: the warning depends on the type, not the value; this case
-            # should warn even though the time component of the datetime is
-            # zero.
+        obj = HasDateTraits(simple_date=test_date)
+        with self.assertRaises(TraitError) as exception_context:
             obj.simple_date = test_datetime
-        self.assertEqual(obj.simple_date, test_datetime)
-
-        _, _, this_module = __name__.rpartition(".")
-        self.assertIn(this_module, warnings_cm.filename)
-        self.assertIn(
-            "datetime instances will no longer be accepted",
-            str(warnings_cm.warning),
-        )
+        self.assertEqual(obj.simple_date, test_date)
+        message = str(exception_context.exception)
+        self.assertIn("must be a non-datetime date or None, but", message)
 
     def test_allow_none_false_allow_datetime_false(self):
         obj = HasDateTraits(strict=UNIX_EPOCH)

--- a/traits/tests/test_date.py
+++ b/traits/tests/test_date.py
@@ -71,21 +71,15 @@ class TestDate(unittest.TestCase):
         with self.assertRaises(TraitError) as exception_context:
             obj.simple_date = "1975-2-13"
         message = str(exception_context.exception)
-        self.assertIn("must be a non-datetime date or None, but", message)
+        self.assertIn("must be a non-datetime date, but", message)
 
     def test_assign_none_with_allow_none_not_given(self):
         obj = HasDateTraits(simple_date=UNIX_EPOCH)
-        self.assertIsNotNone(obj.simple_date)
-        with self.assertWarns(DeprecationWarning) as warnings_cm:
+        with self.assertRaises(TraitError) as exception_context:
             obj.simple_date = None
-        self.assertIsNone(obj.simple_date)
-
-        _, _, this_module = __name__.rpartition(".")
-        self.assertIn(this_module, warnings_cm.filename)
-        self.assertIn(
-            "None will no longer be accepted",
-            str(warnings_cm.warning),
-        )
+        self.assertEqual(obj.simple_date, UNIX_EPOCH)
+        message = str(exception_context.exception)
+        self.assertIn("must be a non-datetime date, but", message)
 
     def test_assign_none_with_allow_none_false(self):
         obj = HasDateTraits(none_prohibited=UNIX_EPOCH)
@@ -106,7 +100,7 @@ class TestDate(unittest.TestCase):
         with self.assertRaises(TraitError) as exception_context:
             obj.datetime_prohibited = test_datetime
         message = str(exception_context.exception)
-        self.assertIn("must be a non-datetime date or None, but", message)
+        self.assertIn("must be a non-datetime date, but", message)
 
     def test_assign_datetime_with_allow_datetime_true(self):
         test_datetime = datetime.datetime(1975, 2, 13)
@@ -124,7 +118,7 @@ class TestDate(unittest.TestCase):
             obj.simple_date = test_datetime
         self.assertEqual(obj.simple_date, test_date)
         message = str(exception_context.exception)
-        self.assertIn("must be a non-datetime date or None, but", message)
+        self.assertIn("must be a non-datetime date, but", message)
 
     def test_allow_none_false_allow_datetime_false(self):
         obj = HasDateTraits(strict=UNIX_EPOCH)

--- a/traits/tests/test_datetime.py
+++ b/traits/tests/test_datetime.py
@@ -63,34 +63,29 @@ class TestDatetime(unittest.TestCase):
         with self.assertRaises(TraitError) as exception_context:
             obj.simple_datetime = "2021-02-05 12:00:00"
         message = str(exception_context.exception)
-        self.assertIn("must be a datetime or None, but", message)
+        self.assertIn("must be a datetime, but", message)
 
     def test_assign_date(self):
         obj = HasDatetimeTraits()
         with self.assertRaises(TraitError) as exception_context:
             obj.simple_datetime = datetime.date(1975, 2, 13)
         message = str(exception_context.exception)
-        self.assertIn("must be a datetime or None, but", message)
+        self.assertIn("must be a datetime, but", message)
         self.assertIsNone(obj.simple_datetime)
 
     def test_assign_none_with_allow_none_not_given(self):
         obj = HasDatetimeTraits(simple_datetime=UNIX_EPOCH)
-        self.assertIsNotNone(obj.simple_datetime)
-        with self.assertWarns(DeprecationWarning) as warnings_cm:
+        with self.assertRaises(TraitError) as exception_context:
             obj.simple_datetime = None
-        self.assertIsNone(obj.simple_datetime)
-
-        _, _, this_module = __name__.rpartition(".")
-        self.assertIn(this_module, warnings_cm.filename)
-        self.assertIn(
-            "None will no longer be accepted",
-            str(warnings_cm.warning),
-        )
+        self.assertEqual(obj.simple_datetime, UNIX_EPOCH)
+        message = str(exception_context.exception)
+        self.assertIn("must be a datetime, but", message)
 
     def test_assign_none_with_allow_none_false(self):
         obj = HasDatetimeTraits(none_prohibited=UNIX_EPOCH)
         with self.assertRaises(TraitError) as exception_context:
             obj.none_prohibited = None
+        self.assertEqual(obj.none_prohibited, UNIX_EPOCH)
         message = str(exception_context.exception)
         self.assertIn("must be a datetime, but", message)
 

--- a/traits/tests/test_time.py
+++ b/traits/tests/test_time.py
@@ -63,34 +63,29 @@ class TestTime(unittest.TestCase):
         with self.assertRaises(TraitError) as exception_context:
             obj.simple_time = "12:00:00"
         message = str(exception_context.exception)
-        self.assertIn("must be a time or None, but", message)
+        self.assertIn("must be a time, but", message)
 
     def test_assign_datetime(self):
         obj = HasTimeTraits()
         with self.assertRaises(TraitError) as exception_context:
             obj.simple_time = datetime.datetime(1975, 2, 13)
         message = str(exception_context.exception)
-        self.assertIn("must be a time or None, but", message)
+        self.assertIn("must be a time, but", message)
         self.assertIsNone(obj.simple_time)
 
     def test_assign_none_with_allow_none_not_given(self):
         obj = HasTimeTraits(simple_time=UNIX_EPOCH)
-        self.assertIsNotNone(obj.simple_time)
-        with self.assertWarns(DeprecationWarning) as warnings_cm:
+        with self.assertRaises(TraitError) as exception_context:
             obj.simple_time = None
-        self.assertIsNone(obj.simple_time)
-
-        _, _, this_module = __name__.rpartition(".")
-        self.assertIn(this_module, warnings_cm.filename)
-        self.assertIn(
-            "None will no longer be accepted",
-            str(warnings_cm.warning),
-        )
+        self.assertEqual(obj.simple_time, UNIX_EPOCH)
+        message = str(exception_context.exception)
+        self.assertIn("must be a time, but", message)
 
     def test_assign_none_with_allow_none_false(self):
         obj = HasTimeTraits(none_prohibited=UNIX_EPOCH)
         with self.assertRaises(TraitError) as exception_context:
             obj.none_prohibited = None
+        self.assertEqual(obj.none_prohibited, UNIX_EPOCH)
         message = str(exception_context.exception)
         self.assertIn("must be a time, but", message)
 

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4498,14 +4498,14 @@ class Date(TraitType):
     """ A trait type whose value must be a date.
 
     The value must be an instance of :class:`datetime.date`. Note that
-    :class:`datetime.datetime` is a subclass of :class:`datetime.date`, so
-    by default instances of :class:`datetime.datetime` are also permitted.
-    Use ``Date(allow_datetime=False)`` to exclude this possibility.
+    :class:`datetime.datetime` is a subclass of :class:`datetime.date`, but by
+    default instances of :class:`datetime.datetime` are not permitted. Use
+    ``Date(allow_datetime=True)`` to allow :class:`datetime.datetime` instances
+    to be assigned to a ``Date`` trait.
 
-    .. deprecated:: 6.3.0
-        In the future, :class:`datetime.datetime` instances will not be valid
-        values for this trait type unless "allow_datetime=True" is explicitly
-        given.
+    .. versionchanged:: 7.0.0
+        :class:`datetime.datetime` instances are no longer valid values for
+        this trait type unless "allow_datetime=True" is explicitly given.
 
     .. deprecated:: 6.3.0
         In the future, ``None`` will not be a valid value for this trait type
@@ -4517,12 +4517,9 @@ class Date(TraitType):
         The default value for this trait. If no default is provided, the
         default is ``None``.
     allow_datetime : bool, optional
-        If ``False``, instances of ``datetime.datetime`` are not valid
-        values for this Trait. If ``True``, ``datetime.datetime`` instances
-        are explicitly permitted. If this argument is not given,
-        ``datetime.datetime`` instances will be accepted, but a
-        ``DeprecationWarning`` will be issued; in some future version of
-        Traits, ``datetime.datetime`` instances will not be permitted.
+        If ``False``, instances of ``datetime.datetime`` are not considered
+        valid values for this Trait. If ``True``, ``datetime.datetime``
+        instances are permitted. The default is ``False``.
     allow_none : bool, optional
         If ``False``, it's not permitted to assign ``None`` to this trait.
         If ``True``, ``None`` instances are permitted. If this argument is
@@ -4540,7 +4537,7 @@ class Date(TraitType):
         self,
         default_value=None,
         *,
-        allow_datetime=None,
+        allow_datetime=False,
         allow_none=None,
         **metadata,
     ):
@@ -4569,19 +4566,6 @@ class Date(TraitType):
         elif isinstance(value, datetime.datetime):
             if self.allow_datetime:
                 return value
-            elif self.allow_datetime is None:
-                warnings.warn(
-                    (
-                        "In the future, datetime.datetime instances will no "
-                        "longer be accepted by this trait type. To accept "
-                        "datetimes and silence this warning, use "
-                        "Date(allow_datetime=True) or "
-                        "Union(Datetime(), Date())."
-                    ),
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return value
 
         elif isinstance(value, datetime.date):
             return value
@@ -4592,7 +4576,7 @@ class Date(TraitType):
         """
         Return text description of this trait.
         """
-        if self.allow_datetime or self.allow_datetime is None:
+        if self.allow_datetime:
             datetime_qualifier = ""
         else:
             datetime_qualifier = " non-datetime"

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -4507,9 +4507,9 @@ class Date(TraitType):
         :class:`datetime.datetime` instances are no longer valid values for
         this trait type unless "allow_datetime=True" is explicitly given.
 
-    .. deprecated:: 6.3.0
-        In the future, ``None`` will not be a valid value for this trait type
-        unless "allow_none=True" is explicitly given.
+    .. versionchanged:: 7.0.0
+        ``None`` is no longer a valid value for this trait type unless
+        "allow_none=True" is explicitly given.
 
     Parameters
     ----------
@@ -4522,10 +4522,8 @@ class Date(TraitType):
         instances are permitted. The default is ``False``.
     allow_none : bool, optional
         If ``False``, it's not permitted to assign ``None`` to this trait.
-        If ``True``, ``None`` instances are permitted. If this argument is
-        not given, ``None`` instances will be accepted but a
-        ``DeprecationWarning`` will be issued; in some future verison of
-        Traits, ``None`` may no longer be permitted.
+        If ``True``, ``None`` instances are permitted. The default is
+        ``False``.
     **metadata: dict
         Additional metadata.
     """
@@ -4538,7 +4536,7 @@ class Date(TraitType):
         default_value=None,
         *,
         allow_datetime=False,
-        allow_none=None,
+        allow_none=False,
         **metadata,
     ):
         super().__init__(default_value, **metadata)
@@ -4550,17 +4548,6 @@ class Date(TraitType):
         """
         if value is None:
             if self.allow_none:
-                return value
-            elif self.allow_none is None:
-                warnings.warn(
-                    (
-                        "In the future, None will no longer be accepted by "
-                        "this trait type. To allow None and silence this "
-                        "warning, use Date(allow_none=True)."
-                    ),
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
                 return value
 
         elif isinstance(value, datetime.datetime):
@@ -4581,7 +4568,7 @@ class Date(TraitType):
         else:
             datetime_qualifier = " non-datetime"
 
-        if self.allow_none or self.allow_none is None:
+        if self.allow_none:
             none_qualifier = " or None"
         else:
             none_qualifier = ""
@@ -4599,9 +4586,9 @@ class Datetime(TraitType):
 
     The value must be an instance of :class:`datetime.datetime`.
 
-    .. deprecated:: 6.3.0
-        In the future, ``None`` will not be a valid value for this trait type
-        unless "allow_none=True" is explicitly given.
+    .. versionchanged:: 7.0.0
+        ``None`` is no longer a valid value for this trait type unless
+        "allow_none=True" is explicitly given.
 
     Parameters
     ----------
@@ -4610,10 +4597,8 @@ class Datetime(TraitType):
         default is ``None``.
     allow_none : bool, optional
         If ``False``, it's not permitted to assign ``None`` to this trait.
-        If ``True``, ``None`` instances are permitted. If this argument is
-        not given, ``None`` instances will be accepted but a
-        ``DeprecationWarning`` will be issued; in some future verison of
-        Traits, ``None`` may no longer be permitted.
+        If ``True``, ``None`` instances are permitted. The default is
+        ``False``.
     **metadata: dict
         Additional metadata.
     """
@@ -4625,7 +4610,7 @@ class Datetime(TraitType):
         self,
         default_value=None,
         *,
-        allow_none=None,
+        allow_none=False,
         **metadata,
     ):
         super().__init__(default_value, **metadata)
@@ -4637,17 +4622,6 @@ class Datetime(TraitType):
         if value is None:
             if self.allow_none:
                 return value
-            elif self.allow_none is None:
-                warnings.warn(
-                    (
-                        "In the future, None will no longer be accepted by "
-                        "this trait type. To allow None and silence this "
-                        "warning, use Datetime(allow_none=True)."
-                    ),
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return value
 
         elif isinstance(value, datetime.datetime):
             return value
@@ -4658,7 +4632,7 @@ class Datetime(TraitType):
         """
         Return text description of this trait.
         """
-        if self.allow_none or self.allow_none is None:
+        if self.allow_none:
             none_qualifier = " or None"
         else:
             none_qualifier = ""
@@ -4676,9 +4650,9 @@ class Time(TraitType):
 
     The value must be an instance of :class:`datetime.time`.
 
-    .. deprecated:: 6.3.0
-        In the future, ``None`` will not be a valid value for this trait type
-        unless "allow_none=True" is explicitly given.
+    .. versionchanged:: 7.0.0
+        ``None`` is no longer a valid value for this trait type unless
+        "allow_none=True" is explicitly given.
 
     Parameters
     ----------
@@ -4687,10 +4661,8 @@ class Time(TraitType):
         default is ``None``.
     allow_none : bool, optional
         If ``False``, it's not permitted to assign ``None`` to this trait.
-        If ``True``, ``None`` instances are permitted. If this argument is
-        not given, ``None`` instances will be accepted but a
-        ``DeprecationWarning`` will be issued; in some future verison of
-        Traits, ``None`` may no longer be permitted.
+        If ``True``, ``None`` instances are permitted. The default is
+        ``False``.
     **metadata: dict
         Additional metadata.
     """
@@ -4702,7 +4674,7 @@ class Time(TraitType):
         self,
         default_value=None,
         *,
-        allow_none=None,
+        allow_none=False,
         **metadata,
     ):
         super().__init__(default_value, **metadata)
@@ -4714,17 +4686,6 @@ class Time(TraitType):
         if value is None:
             if self.allow_none:
                 return value
-            elif self.allow_none is None:
-                warnings.warn(
-                    (
-                        "In the future, None will no longer be accepted by "
-                        "this trait type. To allow None and silence this "
-                        "warning, use Time(allow_none=True)."
-                    ),
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return value
 
         elif isinstance(value, datetime.time):
             return value
@@ -4735,7 +4696,7 @@ class Time(TraitType):
         """
         Return text description of this trait.
         """
-        if self.allow_none or self.allow_none is None:
+        if self.allow_none:
             none_qualifier = " or None"
         else:
             none_qualifier = ""


### PR DESCRIPTION
This PR updates the `Date`, `Time` and `Datetime` trait types for previous deprecations:

- the `Date` trait type will now no longer accept `datetime` instances unless `allow_datetime=True` is used
- the `Date`, `Time` and `Datetime` trait types will now no longer accept a value of `None` unless `allow_none=True` is used

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`) - no changes needed
- [x] Update User manual (`docs/source/traits_user_manual`)
- [x] Update type annotation hints in stub files - no changes needed
