### PR TITLE
Remove deprecated Color, RGBColor and Font traits

### DIFF
--- a/docs/source/traits_api_reference/traits.rst
+++ b/docs/source/traits_api_reference/traits.rst
@@ -21,12 +21,6 @@ Functions
 
 .. autofunction:: Property
 
-.. autofunction:: Color
-
-.. autofunction:: RGBColor
-
-.. autofunction:: Font
-
 
 Private Classes
 ---------------

--- a/traits/api.py
+++ b/traits/api.py
@@ -45,9 +45,6 @@ from .traits import (
     Trait,
     Property,
     Default,
-    Color,
-    RGBColor,
-    Font,
 )
 
 from .trait_types import (

--- a/traits/api.pyi
+++ b/traits/api.pyi
@@ -25,11 +25,8 @@ from .trait_errors import (
 )
 
 from .traits import (
-    Color as Color,
     Default as Default,
-    Font as Font,
     Property as Property,
-    RGBColor as RGBColor,
     Trait as Trait
 )
 

--- a/traits/tests/test_traits.py
+++ b/traits/tests/test_traits.py
@@ -19,16 +19,13 @@ from traits.api import (
     CFloat,
     CInt,
     ComparisonMode,
-    Color,
     Delegate,
     Float,
-    Font,
     HasTraits,
     Instance,
     Int,
     List,
     Range,
-    RGBColor,
     Str,
     This,
     Trait,
@@ -37,7 +34,6 @@ from traits.api import (
     pop_exception_handler,
     push_exception_handler,
 )
-from traits.testing.optional_dependencies import requires_traitsui
 
 #  Base unit test classes:
 
@@ -1075,20 +1071,3 @@ class ComparisonModeTests(unittest.TestCase):
         self.assertEqual(len(events), 1)
         old_compare.bar = [4, 5, 6]
         self.assertEqual(len(events), 2)
-
-
-@requires_traitsui
-class TestDeprecatedTraits(unittest.TestCase):
-
-    def test_color_deprecated(self):
-        with self.assertWarnsRegex(DeprecationWarning, "'Color' in 'traits'"):
-            Color()
-
-    def test_rgb_color_deprecated(self):
-        with self.assertWarnsRegex(DeprecationWarning,
-                                   "'RGBColor' in 'traits'"):
-            RGBColor()
-
-    def test_font_deprecated(self):
-        with self.assertWarnsRegex(DeprecationWarning, "'Font' in 'traits'"):
-            Font()

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -71,7 +71,6 @@ from .trait_handlers import (
 from .trait_factory import (
     TraitFactory,
 )
-from .util.deprecated import deprecated
 
 # Constants
 
@@ -635,57 +634,3 @@ class ForwardProperty(object):
 
 # Generic trait with 'object' behavior:
 generic_trait = CTrait(TraitKind.generic)
-
-
-# User interface related color and font traits
-
-@deprecated("'Color' in 'traits' package has been deprecated. "
-            "Use 'Color' from 'traitsui' package instead.")
-def Color(*args, **metadata):
-    """ Returns a trait whose value must be a GUI toolkit-specific color.
-
-    .. deprecated:: 6.1.0
-        ``Color`` trait in this package will be removed in the future. It is
-        replaced by ``Color`` trait in TraitsUI package.
-    """
-    from traitsui.toolkit_traits import ColorTrait
-
-    return ColorTrait(*args, **metadata)
-
-
-Color = TraitFactory(Color)
-
-
-@deprecated("'RGBColor' in 'traits' package has been deprecated. "
-            "Use 'RGBColor' from 'traitsui' package instead.")
-def RGBColor(*args, **metadata):
-    """ Returns a trait whose value must be a GUI toolkit-specific RGB-based
-    color.
-
-    .. deprecated:: 6.1.0
-        ``RGBColor`` trait in this package will be removed in the future. It is
-        replaced by ``RGBColor`` trait in TraitsUI package.
-    """
-    from traitsui.toolkit_traits import RGBColorTrait
-
-    return RGBColorTrait(*args, **metadata)
-
-
-RGBColor = TraitFactory(RGBColor)
-
-
-@deprecated("'Font' in 'traits' package has been deprecated. "
-            "Use 'Font' from 'traitsui' package instead.")
-def Font(*args, **metadata):
-    """ Returns a trait whose value must be a GUI toolkit-specific font.
-
-    .. deprecated:: 6.1.0
-        ``Font`` trait in this package will be removed in the future. It is
-        replaced by ``Font`` trait in TraitsUI package.
-    """
-    from traitsui.toolkit_traits import FontTrait
-
-    return FontTrait(*args, **metadata)
-
-
-Font = TraitFactory(Font)

--- a/traits/traits.pyi
+++ b/traits/traits.pyi
@@ -59,12 +59,3 @@ class ForwardProperty:
 
 
 generic_trait: _Any
-
-
-def Color(*args: _Any, **metadata: _DictType[str, _Any]): ...
-
-
-def RGBColor(*args: _Any, **metadata: _DictType[str, _Any]): ...
-
-
-def Font(*args: _Any, **metadata: _DictType[str, _Any]): ...


### PR DESCRIPTION
This PR removes the deprecated GUI-related `Color`, `Font` and `RGBColor` traits. For code that needs them, these traits can be imported from TraitsUI.

**Checklist**
- [x] Tests
- [x] Update API reference (`docs/source/traits_api_reference`)
- [x] Update User manual (`docs/source/traits_user_manual`)
- [x] Update type annotation hints in stub files
