### PR TITLE
Add extra libxcb package required by the newest PySide6 versions

### DIFF
--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -20,6 +20,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-cursor0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -27,6 +27,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-cursor0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1
@@ -77,6 +78,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-cursor0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1


### PR DESCRIPTION
This PR adds `libxcb-image0` to the list of packages that are `apt-get` installed in the various GitHub Actions workflows. The `libxcb-image0` package is needed for the latest PySide6 versions.