### PR TITLE
Fix an overzealous test

### DIFF
--- a/traits/tests/test_configure_traits.py
+++ b/traits/tests/test_configure_traits.py
@@ -155,4 +155,8 @@ class TestConfigureTraits(unittest.TestCase):
                 warnings.simplefilter("always", DeprecationWarning)
                 model.configure_traits()
         mock_view.assert_called_once()
-        self.assertEqual(len(captured_warnings), 0)
+
+        all_warnings = "".join(
+            str(warning.message) for warning in captured_warnings
+        )
+        self.assertNotIn("edit argument", all_warnings)


### PR DESCRIPTION
This PR fixes one part of the cause of #1748, namely that a test was failing on warnings that were unrelated to the test purpose.