### PR TITLE
Fix Trait documenter tests for Sphinx >= 7.2

### DIFF
--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -27,7 +27,6 @@ from traits.testing.optional_dependencies import sphinx, requires_sphinx
 if sphinx is not None:
     from sphinx.ext.autodoc import ClassDocumenter, INSTANCEATTR, Options
     from sphinx.ext.autodoc.directive import DocumenterBridge
-    from sphinx.testing.path import path
     from sphinx.testing.util import SphinxTestApp
     from sphinx.util.docutils import LoggingReporter
 
@@ -36,6 +35,11 @@ if sphinx is not None:
         trait_definition,
         TraitDocumenter,
     )
+
+    if sphinx.version_info < (7, 2):
+        from sphinx.testing.path import path as Path
+    else:
+        from pathlib import Path
 
 
 # Configuration file content for testing.
@@ -223,7 +227,7 @@ class TestTraitDocumenter(unittest.TestCase):
             with open(conf_file, "w", encoding="utf-8") as f:
                 f.write(CONF_PY)
 
-            app = SphinxTestApp(srcdir=path(tmpdir))
+            app = SphinxTestApp(srcdir=Path(tmpdir))
             app.builder.env.app = app
             app.builder.env.temp_data["docname"] = "dummy"
 


### PR DESCRIPTION
This PR fixes the Trait documenter test for Sphinx >= 7.2. For that version of Sphinx, the `srcdir` argument to `SphinxTestApp` needs to be a `pathlib.Path` object rather than a `sphinx.testing.path.path` object.
