### PR TITLE
Update CI and workflows for Python 3.12 support

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -33,7 +33,7 @@ jobs:
       run: python -m pip install twine
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.9.0
+      uses: pypa/cibuildwheel@v2.15.0
 
     - name: Check and upload wheels
       env:

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install local package
       run: |
         # Uninstall setuptools so that the tests will catch any accidental

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -28,7 +28,7 @@ jobs:
         # dependence of the Traits source on setuptools. Note that in future
         # setuptools may not exist in a newly-created venv
         # https://github.com/python/cpython/issues/95299
-        python -m pip uninstall -y setuptools
+        # python -m pip uninstall -y setuptools
         python -m pip install .
         python -m pip list
     - name: Test Traits package

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -28,7 +28,7 @@ jobs:
         # dependence of the Traits source on setuptools. Note that in future
         # setuptools may not exist in a newly-created venv
         # https://github.com/python/cpython/issues/95299
-        # python -m pip uninstall -y setuptools
+        python -m pip uninstall -y setuptools
         python -m pip install .
         python -m pip list
     - name: Test Traits package

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -37,6 +37,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies and local packages
       run: |
         python -m pip install .[test]

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -5,7 +5,7 @@ on:
 - workflow_dispatch
 
 env:
-  # Temporary workaround prior to release of Traits 8.0
+  # Temporary workaround prior to release of TraitsUI 8.0
   # xref: enthought/traits#1742
   ETS_QT4_IMPORTS: 1
 
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Install Linux packages for Qt 5 support
+    - name: Install Linux packages for Qt support
       run: |
         sudo apt-get update
         sudo apt-get install libegl1

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Linux packages for Qt 5 support
+    - name: Install Linux packages for Qt support
       run: |
         sudo apt-get update
         sudo apt-get install libegl1
@@ -79,7 +79,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Linux packages for Qt 5 support
+    - name: Install Linux packages for Qt support
       run: |
         sudo apt-get update
         sudo apt-get install libegl1

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -48,11 +48,11 @@ jobs:
     - name: Install test dependencies and Traits from PyPI sdist (no PySide6)
       run: |
         python -m pip install --no-binary traits Cython numpy Sphinx traits traitsui
-      if: matrix.python-version == '3.11' || matrix.python-architecture == 'x86'
+      if: matrix.python-version == '3.12' || matrix.python-architecture == 'x86'
     - name: Install test dependencies and Traits from PyPI sdist (PySide6)
       run: |
         python -m pip install --no-binary traits Cython numpy PySide6 Sphinx traits traitsui
-      if: matrix.python-version != '3.11' && matrix.python-architecture != 'x86'
+      if: matrix.python-version != '3.12' && matrix.python-architecture != 'x86'
     - name: Create clean test directory
       run: |
         mkdir testdir
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         python-architecture: [x86, x64]
         exclude:
         - os: macos-latest
@@ -99,11 +99,11 @@ jobs:
     - name: Install test dependencies and Traits from PyPI wheel (no PySide6)
       run: |
         python -m pip install --only-binary traits Cython numpy Sphinx traits traitsui
-      if: matrix.python-version == '3.11' || matrix.python-architecture == 'x86'
+      if: matrix.python-version == '3.12' || matrix.python-architecture == 'x86'
     - name: Install test dependencies and Traits from PyPI wheel (PySide6)
       run: |
         python -m pip install --only-binary traits Cython numpy PySide6 Sphinx traits traitsui
-      if: matrix.python-version != '3.11' && matrix.python-architecture != 'x86'
+      if: matrix.python-version != '3.12' && matrix.python-architecture != 'x86'
     - name: Create clean test directory
       run: |
         mkdir testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -45,6 +45,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
+        allow-prereleases: true
     - name: Install test dependencies and Traits from PyPI sdist (no PySide6)
       run: |
         python -m pip install --no-binary traits Cython numpy Sphinx traits traitsui
@@ -96,6 +97,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
+        allow-prereleases: true
     - name: Install test dependencies and Traits from PyPI wheel (no PySide6)
       run: |
         python -m pip install --only-binary traits Cython numpy Sphinx traits traitsui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools<65.2', 'wheel']
+requires = ['setuptools', 'wheel']
 build-backend = 'setuptools.build_meta'
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -282,6 +282,7 @@ setuptools.setup(
         Programming Language :: Python :: 3.9
         Programming Language :: Python :: 3.10
         Programming Language :: Python :: 3.11
+        Programming Language :: Python :: 3.12
         Programming Language :: Python :: Implementation :: CPython
         Topic :: Scientific/Engineering
         Topic :: Software Development
@@ -318,7 +319,7 @@ setuptools.setup(
             "mypy",
             "numpy",
             "pyface",
-            "PySide6; python_version >= '3.7' and python_version < '3.11'",
+            "PySide6; python_version >= '3.7' and python_version < '3.12'",
             "setuptools",
             "Sphinx>=2.1.0",
             "traitsui",

--- a/setup.py
+++ b/setup.py
@@ -317,7 +317,9 @@ setuptools.setup(
             "flake8",
             "flake8-ets",
             "mypy",
-            "numpy",
+            # NumPy is not yet available for Python 3.12, but that should be
+            # fixed soon: https://github.com/numpy/numpy/issues/23808
+            "numpy; python_version < '3.12'",
             "pyface",
             "PySide6; python_version >= '3.7' and python_version < '3.12'",
             "setuptools",


### PR DESCRIPTION
Python 3.12 is imminent. This is an experimental PR to add Python 3.12 support:

- Add 3.12 to the trove classifiers
- Add 3.12 to CI test matrices
- Allow running tests with PySide6 on Python 3.11, but not on Python 3.12
- Update cibuildwheel to latest version so that Python 3.12 eggs are built when making a release

Making this as a draft PR for now, since the possible failure modes are many and varied.