### PR TITLE
Fix use of the deprecated datetime.utcnow method

### DIFF
--- a/traits/util/event_tracer.py
+++ b/traits/util/event_tracer.py
@@ -15,7 +15,7 @@ import inspect
 import os
 import threading
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 
 from traits import trait_notifiers
 
@@ -228,7 +228,7 @@ class ChangeEventRecorder(object):
 
         """
         indent = self.indent
-        time = datetime.utcnow().isoformat(" ")
+        time = datetime.now(timezone.utc).isoformat(" ")
         container = self.container
         container.record(
             ChangeMessageRecord(
@@ -255,7 +255,7 @@ class ChangeEventRecorder(object):
         """ Record a string representation of the trait change return
 
         """
-        time = datetime.utcnow().isoformat(" ")
+        time = datetime.now(timezone.utc).isoformat(" ")
         self.indent -= 1
         indent = self.indent
         if exception:


### PR DESCRIPTION
This PR replaces uses of the deprecated (as of Python 3.12) `datetime.utcnow` method. Note that this isn't quite a like-for-like change: there's a slight difference in the output format. Given that the event tracer is barely used in practice, I doubt this change matters much.

```
>>> from datetime import datetime, timezone
>>> datetime.now(timezone.utc).isoformat(" ")
'2023-09-11 16:31:35.534330+00:00'
>>> datetime.utcnow().isoformat(" ")
'2023-09-11 16:31:56.798474'
```