### PR TITLE
Fix Cython tests on Python 3.12

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -48,13 +48,11 @@ jobs:
         allow-prereleases: true
     - name: Install test dependencies and Traits from PyPI sdist (no PySide6)
       run: |
-        # Cython tests currently fail because cython.inline fails on
-        # Python 3.12. cf: https://github.com/cython/cython/issues/5751
-        python -m pip install --no-binary traits numpy Sphinx traits traitsui
+        python -m pip install --no-binary traits Cython numpy setuptools Sphinx traits traitsui
       if: matrix.python-version == '3.12' || matrix.python-architecture == 'x86'
     - name: Install test dependencies and Traits from PyPI sdist (PySide6)
       run: |
-        python -m pip install --no-binary traits Cython numpy PySide6 Sphinx traits traitsui
+        python -m pip install --no-binary traits Cython numpy PySide6 setuptools Sphinx traits traitsui
       if: matrix.python-version != '3.12' && matrix.python-architecture != 'x86'
     - name: Create clean test directory
       run: |
@@ -102,13 +100,11 @@ jobs:
         allow-prereleases: true
     - name: Install test dependencies and Traits from PyPI wheel (no PySide6)
       run: |
-        # Cython tests currently fail because cython.inline fails on
-        # Python 3.12. cf: https://github.com/cython/cython/issues/5751
-        python -m pip install --only-binary traits numpy Sphinx traits traitsui
+        python -m pip install --only-binary traits Cython numpy setuptools Sphinx traits traitsui
       if: matrix.python-version == '3.12' || matrix.python-architecture == 'x86'
     - name: Install test dependencies and Traits from PyPI wheel (PySide6)
       run: |
-        python -m pip install --only-binary traits Cython numpy PySide6 Sphinx traits traitsui
+        python -m pip install --only-binary traits Cython numpy PySide6 setuptools Sphinx traits traitsui
       if: matrix.python-version != '3.12' && matrix.python-architecture != 'x86'
     - name: Create clean test directory
       run: |

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -48,7 +48,9 @@ jobs:
         allow-prereleases: true
     - name: Install test dependencies and Traits from PyPI sdist (no PySide6)
       run: |
-        python -m pip install --no-binary traits Cython numpy Sphinx traits traitsui
+        # Cython tests currently fail because cython.inline fails on
+        # Python 3.12. cf: https://github.com/cython/cython/issues/5751
+        python -m pip install --no-binary traits numpy Sphinx traits traitsui
       if: matrix.python-version == '3.12' || matrix.python-architecture == 'x86'
     - name: Install test dependencies and Traits from PyPI sdist (PySide6)
       run: |
@@ -100,7 +102,9 @@ jobs:
         allow-prereleases: true
     - name: Install test dependencies and Traits from PyPI wheel (no PySide6)
       run: |
-        python -m pip install --only-binary traits Cython numpy Sphinx traits traitsui
+        # Cython tests currently fail because cython.inline fails on
+        # Python 3.12. cf: https://github.com/cython/cython/issues/5751
+        python -m pip install --only-binary traits numpy Sphinx traits traitsui
       if: matrix.python-version == '3.12' || matrix.python-architecture == 'x86'
     - name: Install test dependencies and Traits from PyPI wheel (PySide6)
       run: |


### PR DESCRIPTION
Our "test from PyPI" workflow was failing with Python 3.12 because it exercised the Cython tests, which use `cython.inline`, and `cython.inline` in turn uses `distutils`, which no longer exists in the Python 3.12 standard library.

As a temporary workaround, this PR adds `setuptools` to the list of packages installed into the test environment; `setuptools` provides a shim for `distutils`.

I'd guess that at some point in the reasonably near future the dependence of Cython on `distutils` will be fixed.

Closely related upstream issue: https://github.com/cython/cython/issues/5751
