### PR TITLE
Warn if a Trait default method raises AttributeError

### DIFF
--- a/traits/tests/test_property_notifications.py
+++ b/traits/tests/test_property_notifications.py
@@ -407,9 +407,12 @@ class TestHasTraitsPropertyObserves(unittest.TestCase):
     def test_property_default_initializer_with_value_in_init(self):
         # With "depends_on", instantiation will fail.
         # enthought/traits#709
-        with self.assertRaises(AttributeError):
-            ClassWithPropertyDependsOnInit(
-                info_without_default=PersonInfo(age=30))
+        with self.assertWarnsRegex(
+            UserWarning, "default value resolution raised an AttributeError"
+        ):
+            with self.assertRaises(AttributeError):
+                ClassWithPropertyDependsOnInit(
+                    info_without_default=PersonInfo(age=30))
 
         # With "observe", initialization works.
         instance = ClassWithPropertyObservesInit(

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -31,6 +31,7 @@ from traits.trait_types import (
     Either,
     Enum,
     Expression,
+    Float,
     Instance,
     Int,
     List,
@@ -555,6 +556,28 @@ class TestRegression(unittest.TestCase):
         with self.assertRaises(TraitError):
             class OverrideDisallow(SubclassDefaultsSuper):
                 disallow_default = "a default value"
+
+    def test_warn_on_attribute_error_in_default_method(self):
+        # Given a misspelled reference to a trait in a _default method ...
+        class HasBrokenDefault(HasStrictTraits):
+            weight = Float(12.3)
+
+            mass = Float()
+
+            def _mass_default(self):
+                # Deliberately misspelled!
+                return self.wieght / 9.81
+
+        # When we try to get all trait values on an instance,
+        # Then a warning is issued ...
+        obj = HasBrokenDefault()
+        with self.assertWarnsRegex(
+            UserWarning, "default value resolution raised an AttributeError"
+        ):
+            traits = obj.trait_get()
+
+        # ... and the returned dictionary does not include the mass.
+        self.assertEqual(traits, {"weight": 12.3})
 
 
 class NestedContainerClass(HasTraits):

--- a/traits/tests/test_regression.py
+++ b/traits/tests/test_regression.py
@@ -579,6 +579,26 @@ class TestRegression(unittest.TestCase):
         # ... and the returned dictionary does not include the mass.
         self.assertEqual(traits, {"weight": 12.3})
 
+    def test_warn_on_attribute_error_in_factory(self):
+
+        def bad_range(start, stop):
+            self.this_attribute_doesnt_exist
+            return range(start, stop)
+
+        class HasBrokenFactory(HasStrictTraits):
+            ticks = Instance(range, factory=bad_range, args=(0, 10))
+
+        # When we try to get all trait values on an instance,
+        # Then a warning is issued ...
+        obj = HasBrokenFactory()
+        with self.assertWarnsRegex(
+            UserWarning, "default value resolution raised an AttributeError"
+        ):
+            traits = obj.trait_get()
+
+        # ... and the returned dictionary does not include the bad trait
+        self.assertEqual(traits, {})
+
 
 class NestedContainerClass(HasTraits):
     # Used in regression test for changes to nested containers


### PR DESCRIPTION
Closes #1747 

This PR issues a `UserWarning` when a `*_default` trait default method raises an `AttributeError`, to help detect an otherwise easy-to-miss failure mode.

**Checklist**
- [x] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`)
- [ ] Update User manual (`docs/source/traits_user_manual`)
- [ ] Update type annotation hints in stub files
