### PR TITLE
Add basic support for async dispatch

### DIFF
--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -313,6 +313,39 @@ it is invoked. The following example shows the first option:
    :start-at: from traits.api
 
 
+Async Notification Handlers
+```````````````````````````
+
+Since Traits 8.0 you can use an async coroutine as an observe handler, either
+with an |@observe| decorator::
+
+    class AsyncExample(HasTraits):
+        value = Str()
+
+        @observe('value')
+        async def _value_updated(self, event):
+            await asyncio.sleep(0)
+            print("value changed")
+
+or via the |HasTraits.observe| method::
+
+    async def async_observer(self, event):
+        await asyncio.sleep(0)
+        print("value changed")
+    
+    async_example = AsyncExample()
+    async_example.observe(async_observer, "value")
+
+
+When a trait change event occurs which is observed by an async handler while
+in an asyncio event loop, a task will be created to call the handler at a later
+time.  If the event loop is not running an exception will be raised.
+
+.. warning::
+
+    This is an experimental feature, and behavior may change in the future.
+
+
 Features and fixes provided by |@observe|
 -----------------------------------------
 

--- a/docs/source/traits_user_manual/notification.rst
+++ b/docs/source/traits_user_manual/notification.rst
@@ -316,7 +316,7 @@ it is invoked. The following example shows the first option:
 Async Notification Handlers
 ```````````````````````````
 
-Since Traits 8.0 you can use an async coroutine as an observe handler, either
+Since Traits 7.0 you can use an async coroutine as an observe handler, either
 with an |@observe| decorator::
 
     class AsyncExample(HasTraits):

--- a/traits/observation/observe.py
+++ b/traits/observation/observe.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 import asyncio
+import inspect
 
 from traits.observation._observe import add_or_remove_notifiers
 from traits.observation.expression import compile_expr
@@ -34,7 +35,7 @@ def dispatch_same(handler, event):
     event : object
         The event object to be given to handler.
     """
-    if asyncio.iscoroutinefunction(handler):
+    if inspect.iscoroutinefunction(handler):
         task = asyncio.create_task(handler(event))
         _active_handler_tasks.add(task)
         task.add_done_callback(_active_handler_tasks.discard)

--- a/traits/observation/tests/test_observe.py
+++ b/traits/observation/tests/test_observe.py
@@ -711,8 +711,7 @@ class TestAsyncDispatchSame(unittest.IsolatedAsyncioTestCase):
 
         with self.assertWarns(RuntimeWarning):
             with self.assertRaises(RuntimeError):
-                async with asyncio.timeout(0.1):
-                    dispatch_same(handler, event)
+                dispatch_same(handler, event)
 
         self.assertFalse(event.is_set())
 

--- a/traits/observation/tests/test_observe.py
+++ b/traits/observation/tests/test_observe.py
@@ -690,17 +690,15 @@ class TestAsyncDispatchSame(unittest.IsolatedAsyncioTestCase):
 
         async def handler(event):
             raise Exception("Bad handler")
-            event.set()
 
         def exception_handler(loop, context):
             exceptions.append(context["exception"].args[0])
+            event.set()
 
         with self.asyncio_exception_handler(exception_handler):
-            with self.assertRaises(asyncio.exceptions.TimeoutError):
-                dispatch_same(handler, event)
-                await asyncio.wait_for(event.wait(), timeout=0.1)
+            dispatch_same(handler, event)
+            await asyncio.wait_for(event.wait(), timeout=10.0)
 
-        self.assertFalse(event.is_set())
         self.assertEqual(exceptions, ["Bad handler"])
 
     def test_async_dispatch_no_loop(self):

--- a/traits/observation/tests/test_observe.py
+++ b/traits/observation/tests/test_observe.py
@@ -678,9 +678,9 @@ class TestAsyncDispatchSame(unittest.IsolatedAsyncioTestCase):
         async def handler(event):
             event.set()
 
-        async with asyncio.timeout(10):
-            dispatch_same(handler, event)
-            await event.wait()
+        dispatch_same(handler, event)
+
+        await asyncio.wait_for(event.wait(), timeout=10)
 
         self.assertTrue(event.is_set())
 
@@ -696,9 +696,9 @@ class TestAsyncDispatchSame(unittest.IsolatedAsyncioTestCase):
             exceptions.append(context["exception"].args[0])
 
         with self.asyncio_exception_handler(exception_handler):
-            async with asyncio.timeout(0.1):
+            with self.assertRaises(TimeoutError):
                 dispatch_same(handler, event)
-                await event.wait()
+                await asyncio.wait_for(event.wait(), timeout=0.1)
 
         self.assertFalse(event.is_set())
         self.assertEqual(exceptions, ["Bad handler"])

--- a/traits/observation/tests/test_observe.py
+++ b/traits/observation/tests/test_observe.py
@@ -673,8 +673,6 @@ class TestAsyncDispatchSame(unittest.IsolatedAsyncioTestCase):
         self.addCleanup(pop_exception_handler)
 
     async def test_async_dispatch(self):
-
-    async def test_async_dispatch(self):
         event = asyncio.Event()
 
         async def handler(event):

--- a/traits/observation/tests/test_observe.py
+++ b/traits/observation/tests/test_observe.py
@@ -696,7 +696,7 @@ class TestAsyncDispatchSame(unittest.IsolatedAsyncioTestCase):
             exceptions.append(context["exception"].args[0])
 
         with self.asyncio_exception_handler(exception_handler):
-            with self.assertRaises(TimeoutError):
+            with self.assertRaises(asyncio.exceptions.TimeoutError):
                 dispatch_same(handler, event)
                 await asyncio.wait_for(event.wait(), timeout=0.1)
 

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -963,20 +963,21 @@ class TestAsyncObserverDecorator(unittest.IsolatedAsyncioTestCase):
 
         obj = SimpleAsyncExample(value='initial', event=event)
 
-        async with asyncio.timeout(10):
-            self.assertEqual(len(obj.events), 0)
-            await event.wait()
+        self.assertEqual(len(obj.events), 0)
+
+        await asyncio.wait_for(event.wait(), timeout=10)
 
         self.assertEqual(len(obj.events), 1)
         self.assertEqual(obj.events[0].name, 'value')
         self.assertEqual(obj.events[0].new, 'initial')
 
-        event.reset()
+        event.clear()
 
-        async with asyncio.timeout(10):
-            obj.value = 'changed'
-            self.assertEqual(len(obj.events), 1)
-            await event.wait()
+        obj.value = 'changed'
+
+        self.assertEqual(len(obj.events), 1)
+
+        await asyncio.wait_for(event.wait(), timeout=10)
 
         self.assertEqual(len(obj.events), 2)
         self.assertEqual(obj.events[1].name, 'value')

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -941,7 +941,7 @@ class SimpleAsyncExample(HasTraits):
     value = Str()
 
     events = List()
-    
+
     event = Instance(asyncio.Event)
 
     @observe('value')

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -942,7 +942,7 @@ class SimpleAsyncExample(HasTraits):
 
     events = List()
     
-    event = Instance(asyncio.Event))
+    event = Instance(asyncio.Event)
 
     @observe('value')
     async def value_changed_async(self, event):

--- a/traits/tests/test_observe.py
+++ b/traits/tests/test_observe.py
@@ -959,7 +959,7 @@ class TestAsyncObserverDecorator(unittest.IsolatedAsyncioTestCase):
         self.addCleanup(_active_handler_tasks.clear)
 
     async def test_async_dispatch(self):
-        event = Event()
+        event = asyncio.Event()
 
         obj = SimpleAsyncExample(value='initial', event=event)
 


### PR DESCRIPTION
This adds basic support for async coroutines as trait observe handlers, as discussed in #1770 

This is designed to be the smallest thing that will work.

**Checklist**
- [x] Tests
- [ ] Update API reference (`docs/source/traits_api_reference`) -- don't think there are any changes here
- [x] Update User manual (`docs/source/traits_user_manual`)
- [ ] Update type annotation hints in stub files -- also no changes here
