### PR TITLE
Fix some compiler warnings

### DIFF
--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -29,7 +29,7 @@ jobs:
         # setuptools may not exist in a newly-created venv
         # https://github.com/python/cpython/issues/95299
         python -m pip uninstall -y setuptools
-        python -m pip install .
+        python -m pip install -v .
         python -m pip list
     - name: Test Traits package
       run: |

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -38,9 +38,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
-    - name: Install dependencies and local packages
+    - name: Install test dependencies and local package
       run: |
-        python -m pip install .[test]
+        python -m pip install -v .[test]
     - name: Create clean test directory
       run: |
         mkdir testdir


### PR DESCRIPTION
This PR fixes some compiler warnings that I noticed in the failed Windows build in PR #1773. There are two classes of fixes:

- Fix occurrences of `int` used to represent the size of a tuple / list / dict. Those should be `Py_ssize_t`
- Fix two functions that treat a mask as having type `int`, when it should be `unsigned int`. All the actual masks used have type `unsigned int`.

The warnings themselves are relatively harmless, but silencing them gives us a better chance of noticing warnings that we _should_ be taking notice of.

The PR also adds a `-v` flag to the `pip install` commands that install Traits, so that compiler warnings will always be visible in the build log. Without the `-v`, we only get to see the warnings for failed builds.