### PR TITLE
Remove pin on Python 3.13 version

### DIFF
--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13.0-alpha.3']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
We'd pinned Python 3.13 to avoid an issue on Windows with the 3.13.0a4 build.

Now that 3.13.0a5 is available, that issue should be resolved, so that we can remove the pin.
