### PR TITLE
Remove a test that uses UITester

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -302,6 +302,9 @@ setuptools.setup(
         ],
         "test": [
             "Cython",
+            # defusedxml is required by the Sphinx test machinery
+            # for recent versions of Sphinx (including 7.3.7)
+            "defusedxml",
             "flake8",
             "flake8-ets",
             "mypy",

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -14,6 +14,7 @@ import unittest
 from traits.api import (
     Any, BaseEnum, Enum, HasTraits, Int, List, Property, Set, TraitError,
     Tuple)
+from traits.testing.optional_dependencies import requires_traitsui
 
 
 class FooEnum(enum.Enum):
@@ -109,13 +110,6 @@ class EnumCollectionExample(HasTraits):
     single_digit = Enum(8)
 
     slow_enum = BaseEnum("yes", "no", "maybe")
-
-
-class EnumCollectionGUIExample(EnumCollectionExample):
-    # Override attributes that may fail GUI test
-    # until traitsui #781 is fixed.
-    int_set_enum = Enum("int", "set")
-    correct_int_set_enum = Enum("int", "set")
 
 
 class EnumTestCase(unittest.TestCase):
@@ -336,3 +330,17 @@ class EnumTestCase(unittest.TestCase):
         model.digit_sequence = [-1, 0, 1, 1]
         with self.assertRaises(TraitError):
             model.digit_sequence = [-1, 0, 2, 1]
+
+
+@requires_traitsui
+class TestEnumCreateEditor(unittest.TestCase):
+    def test_create_editor(self):
+        import traitsui.editor_factory
+
+        obj = EnumListExample()
+        trait = obj.trait("value")
+        editor_factory = trait.trait_type.create_editor()
+        self.assertIsInstance(
+            editor_factory,
+            traitsui.editor_factory.EditorFactory
+        )

--- a/traits/tests/test_enum.py
+++ b/traits/tests/test_enum.py
@@ -14,10 +14,6 @@ import unittest
 from traits.api import (
     Any, BaseEnum, Enum, HasTraits, Int, List, Property, Set, TraitError,
     Tuple)
-from traits.etsconfig.api import ETSConfig
-from traits.testing.optional_dependencies import requires_traitsui
-
-is_null = ETSConfig.toolkit == 'null'
 
 
 class FooEnum(enum.Enum):
@@ -340,15 +336,3 @@ class EnumTestCase(unittest.TestCase):
         model.digit_sequence = [-1, 0, 1, 1]
         with self.assertRaises(TraitError):
             model.digit_sequence = [-1, 0, 2, 1]
-
-
-@requires_traitsui
-@unittest.skipIf(is_null, "GUI toolkit not available")
-class TestGui(unittest.TestCase):
-
-    def test_create_editor(self):
-        from traitsui.testing.api import UITester
-
-        obj = EnumCollectionGUIExample()
-        with UITester().create_ui(obj):
-            pass


### PR DESCRIPTION
This PR removes a test that's using `UITester` from TraitsUI. This test exposed the Traits test suite to a class of possible issues with 3rd party GUI frameworks (in this case PySide6); historically, `UITester` has also been a particularly fragile part of TraitsUI.

In its place is a test that at least executes the `Enum.create_editor` method, but doesn't attempt to create an instance of the editor.

We also fix an issue with test dependencies and the latest release of Sphinx: `defusedxml` is now required to run the tests for the Traits documenter.

Closes #1787 

