### PR TITLE
Use earlier macOS for earlier Python versions

### DIFF
--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -15,6 +15,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        # Python 3.8 and 3.9 are no longer available on macos-latest, so
+        # use an earlier version.
+        # xref: https://github.com/actions/setup-python/issues/850
+        exclude:
+          - python-version: "3.8"
+            os: "macos-latest"
+          - python-version: "3.9"
+            os: "macos-latest"
+        include:
+          - python-version: "3.8"
+            os: "macos-13"
+          - python-version: "3.9"
+            os: "macos-13"
+
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -29,7 +29,6 @@ jobs:
           - python-version: "3.9"
             os: "macos-13"
 
-
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -302,6 +302,9 @@ setuptools.setup(
         ],
         "test": [
             "Cython",
+            # defusedxml is required by the Sphinx test machinery
+            # for recent versions of Sphinx (including 7.3.7)
+            "defusedxml",
             "flake8",
             "flake8-ets",
             "mypy",

--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,9 @@ setuptools.setup(
             "mypy",
             "numpy",
             "pyface",
-            "PySide6",
+            # TraitsUI is currently broken with PySide 6.7.0
+            # xref: https://github.com/enthought/traitsui/issues/2045
+            "PySide6<6.7",
             "setuptools",
             "Sphinx>=2.1.0",
             "traitsui",


### PR DESCRIPTION
This PR should get the CI back to a working baseline state. It fixes one of the various reasons that CI is currently failing on the main branch: GitHub Actions switched to ARM runners for macos-latest, and the `setup-python` action doesn't have Python 3.8 and 3.9 builds available for those ARM runners.

The PR also includes a version constraint on PySide6, to work around #1787, and the addition of `defusedxml` to the test dependencies, since it's needed by the most recent versions of Sphinx.
