### PR TITLE
Rework ui_dispatch tests to avoid need for Qt

### DIFF
--- a/traits/api.py
+++ b/traits/api.py
@@ -34,6 +34,8 @@ from .trait_errors import (
 )
 
 from .trait_notifiers import (
+    get_ui_handler,
+    set_ui_handler,
     push_exception_handler,
     pop_exception_handler,
     TraitChangeNotifyWrapper,

--- a/traits/api.pyi
+++ b/traits/api.pyi
@@ -178,3 +178,8 @@ from .trait_numeric import (
     ArrayOrNone as ArrayOrNone,
     CArray as CArray,
 )
+
+from .trait_notifiers import (
+    get_ui_handler as get_ui_handler,
+    set_ui_handler as set_ui_handler,
+)

--- a/traits/tests/test_new_notifiers.py
+++ b/traits/tests/test_new_notifiers.py
@@ -74,8 +74,8 @@ class TestNewNotifiers(UnittestTools, unittest.TestCase):
         receiver = Receiver()
 
         def on_foo_notifications(obj, name, old, new):
-            thread_id = threading.current_thread().ident
-            event = (thread_id, obj, name, old, new)
+            thread = threading.current_thread()
+            event = (thread, obj, name, old, new)
             receiver.notifications.append(event)
 
         obj = Foo()
@@ -97,5 +97,5 @@ class TestNewNotifiers(UnittestTools, unittest.TestCase):
         self.assertEqual(len(notifications), 1)
         self.assertEqual(notifications[0][1:], (obj, "foo", 0, 3))
 
-        this_thread_id = threading.current_thread().ident
-        self.assertNotEqual(this_thread_id, notifications[0][0])
+        this_thread = threading.current_thread()
+        self.assertNotEqual(this_thread, notifications[0][0])

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -27,27 +27,33 @@ from .trait_errors import TraitNotificationError
 
 # Global Data
 
-# The thread ID for the user interface thread
-ui_thread = -1
+# The currently active handler for notifications that must be run on the UI
+# thread, or None if no handler has been set.
+_ui_handler = None
 
-# The handler for notifications that must be run on the UI thread
-ui_handler = None
+
+def get_ui_handler():
+    """
+    Return the current user interface thread handler.
+    """
+    return _ui_handler
 
 
 def set_ui_handler(handler):
     """ Sets up the user interface thread handler.
     """
-    global ui_handler, ui_thread
+    global _ui_handler
 
-    ui_handler = handler
-    ui_thread = threading.current_thread().ident
+    _ui_handler = handler
 
 
 def ui_dispatch(handler, *args, **kw):
     if threading.current_thread() == threading.main_thread():
         handler(*args, **kw)
+    elif _ui_handler is None:
+        raise RuntimeError("No UI handler has been set.")
     else:
-        ui_handler(handler, *args, **kw)
+        _ui_handler(handler, *args, **kw)
 
 
 class NotificationExceptionHandlerState(object):
@@ -153,11 +159,7 @@ class NotificationExceptionHandler(object):
             thread.
         """
         thread_local = self.thread_local
-        if isinstance(thread_local, dict):
-            id = threading.current_thread().ident
-            handlers = thread_local.get(id)
-        else:
-            handlers = getattr(thread_local, "handlers", None)
+        handlers = getattr(thread_local, "handlers", None)
 
         if handlers is None:
             if self.main_thread is not None:
@@ -167,10 +169,7 @@ class NotificationExceptionHandler(object):
                     self._log_exception, False, False
                 )
             handlers = [handler]
-            if isinstance(thread_local, dict):
-                thread_local[id] = handlers
-            else:
-                thread_local.handlers = handlers
+            thread_local.handlers = handlers
 
         return handlers
 
@@ -615,10 +614,10 @@ class FastUITraitChangeNotifyWrapper(TraitChangeNotifyWrapper):
     """
 
     def dispatch(self, handler, *args):
-        if threading.current_thread().ident == ui_thread:
+        if threading.current_thread() == threading.main_thread():
             handler(*args)
         else:
-            ui_handler(handler, *args)
+            _ui_handler(handler, *args)
 
 
 class NewTraitChangeNotifyWrapper(TraitChangeNotifyWrapper):

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -51,7 +51,7 @@ def ui_dispatch(handler, *args, **kw):
     if threading.current_thread() == threading.main_thread():
         handler(*args, **kw)
     elif _ui_handler is None:
-        raise RuntimeError("No UI handler has been set.")
+        raise RuntimeError("no UI handler registered for dispatch='ui'")
     else:
         _ui_handler(handler, *args, **kw)
 
@@ -616,6 +616,8 @@ class FastUITraitChangeNotifyWrapper(TraitChangeNotifyWrapper):
     def dispatch(self, handler, *args):
         if threading.current_thread() == threading.main_thread():
             handler(*args)
+        elif _ui_handler is None:
+            raise RuntimeError("no UI handler registered for dispatch='ui'")
         else:
             _ui_handler(handler, *args)
 

--- a/traits/traits_notifiers.pyi
+++ b/traits/traits_notifiers.pyi
@@ -1,0 +1,8 @@
+from typing import Callable
+
+_UI_Handler = Callable[..., None] | None
+
+
+def get_ui_handler() -> _UI_Handler: ...
+
+def set_ui_handler(handler: _UI_Handler) -> None: ...


### PR DESCRIPTION
Since #1788, we have only one test module that makes use of the Qt event loop. That test module contains tests for the behaviour of handlers that use `dispatch='ui'` mechanism to redispatch off-thread notifications to the ui thread.

This PR reworks that test module, with some significant collateral damage along the way.

In detail:

- reworks that test module (`test_ui_notifiers`) to avoid the need for the Qt event loop; instead, it tests against a `ui_handler` based on asyncio, which redispatches to the running asyncio event loop
- adds a `get_ui_handler` counterpart to `set_ui_handler`, and exposes both functions in `traits.api`
- adds type hints for `get_ui_handler` and `set_ui_handler`
- removes two public module globals from `trait_notifiers`: `ui_handler` has been made private, while `ui_thread` is removed altogether
- fixes a bug where ui dispatch didn't do the right thing (PR #1740 was incomplete; this bug should have been caught at review time on that PR)
- makes another couple of drive-by cleanups, removing a very old check for `threading.local()` being a dict (which it hasn't been in living memory), and tidying up some uses of thread identity.
