### PR TITLE
Fix architectures in PyPI workflow

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -47,19 +47,21 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        include:
-        - os: windows-latest
-          python-architecture: x86
-        - os: windows-latest
-          python-architecture: x64
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-architecture: [x86, x64, arm64]
+        exclude:
         - os: ubuntu-latest
-          python-architecture: x86
-        - os: ubuntu-latest
-          python-architecture: x64
-        - os: macos-latest
           python-architecture: arm64
-        - os: macos-13
+        - os: windows-latest
+          python-architecture: arm64
+        - os: macos-latest
+          python-architecture: x86
+        - os: macos-latest
           python-architecture: x64
+        - os: macos-13
+          python-architecture: x86
+        - os: macos-13
+          python-architecture: arm64
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -6,112 +6,75 @@ on:
     # Run at 03:27 UTC on the 8th and 22nd of every month
     - cron: '27 3 8,22 * *'
 
-env:
-  # Temporary workaround prior to release of Traits 8.0
-  # xref: enthought/traits#1742
-  ETS_QT4_IMPORTS: 1
-
 jobs:
   test-pypi-sdist:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        python-architecture: [x86, x64]
+        python-architecture: [x86, x64, arm64]
         exclude:
         - os: macos-latest
           python-architecture: x86
+        - os: macos-latest
+          python-architecture: x64
+        - os: macos-13
+          python-architecture: x86
+        - os: macos-13
+          python-architecture: arm64
         - os: ubuntu-latest
           python-architecture: x86
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Linux packages for Qt support
-      run: |
-        sudo apt-get update
-        sudo apt-get install libegl1
-        sudo apt-get install libxkbcommon-x11-0
-        sudo apt-get install libxcb-cursor0
-        sudo apt-get install libxcb-icccm4
-        sudo apt-get install libxcb-image0
-        sudo apt-get install libxcb-keysyms1
-        sudo apt-get install libxcb-randr0
-        sudo apt-get install libxcb-render-util0
-        sudo apt-get install libxcb-shape0
-      if: runner.os == 'Linux'
     - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
         allow-prereleases: true
-    - name: Install test dependencies and Traits from PyPI sdist (no PySide6)
+    - name: Install test dependencies and Traits from PyPI sdist
       run: |
         python -m pip install --no-binary traits numpy setuptools Sphinx traits traitsui
-      if: matrix.python-version == '3.12' || matrix.python-architecture == 'x86'
-    - name: Install test dependencies and Traits from PyPI sdist (PySide6)
-      run: |
-        python -m pip install --no-binary traits numpy PySide6 setuptools Sphinx traits traitsui
-      if: matrix.python-version != '3.12' && matrix.python-architecture != 'x86'
     - name: Create clean test directory
       run: |
         mkdir testdir
-    - name: Test Traits package (Linux)
-      run: cd testdir && xvfb-run -a python -m unittest discover -v traits
-      if: matrix.os == 'ubuntu-latest'
-    - name: Test Traits package (Windows/macOS)
+    - name: Test Traits package
       run: cd testdir && python -m unittest discover -v traits
-      if: matrix.os != 'ubuntu-latest'
 
   test-pypi-wheel:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        python-architecture: [x86, x64]
+        python-architecture: [x86, x64, arm64]
         exclude:
         - os: macos-latest
           python-architecture: x86
+        - os: macos-latest
+          python-architecture: x64
+        - os: macos-13
+          python-architecture: x86
+        - os: macos-13
+          python-architecture: arm64
         - os: ubuntu-latest
           python-architecture: x86
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Linux packages for Qt support
-      run: |
-        sudo apt-get update
-        sudo apt-get install libegl1
-        sudo apt-get install libxkbcommon-x11-0
-        sudo apt-get install libxcb-cursor0
-        sudo apt-get install libxcb-icccm4
-        sudo apt-get install libxcb-image0
-        sudo apt-get install libxcb-keysyms1
-        sudo apt-get install libxcb-randr0
-        sudo apt-get install libxcb-render-util0
-        sudo apt-get install libxcb-shape0
-      if: runner.os == 'Linux'
     - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
         allow-prereleases: true
-    - name: Install test dependencies and Traits from PyPI wheel (no PySide6)
+    - name: Install test dependencies and Traits from PyPI wheel
       run: |
         python -m pip install --only-binary traits numpy setuptools Sphinx traits traitsui
-      if: matrix.python-version == '3.12' || matrix.python-architecture == 'x86'
-    - name: Install test dependencies and Traits from PyPI wheel (PySide6)
-      run: |
-        python -m pip install --only-binary traits numpy PySide6 setuptools Sphinx traits traitsui
-      if: matrix.python-version != '3.12' && matrix.python-architecture != 'x86'
     - name: Create clean test directory
       run: |
         mkdir testdir
-    - name: Test Traits package (Linux)
-      run: cd testdir && xvfb-run -a python -m unittest discover -v traits
-      if: matrix.os == 'ubuntu-latest'
-    - name: Test Traits package (Windows/macOS)
+    - name: Test Traits package
       run: cd testdir && python -m unittest discover -v traits
-      if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -7,59 +7,59 @@ on:
     - cron: '27 3 8,22 * *'
 
 jobs:
-  test-pypi-sdist:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        python-architecture: [x86, x64, arm64]
-        exclude:
-        - os: macos-latest
-          python-architecture: x86
-        - os: macos-latest
-          python-architecture: x64
-        - os: macos-13
-          python-architecture: x86
-        - os: macos-13
-          python-architecture: arm64
-        - os: ubuntu-latest
-          python-architecture: x86
+  # test-pypi-sdist:
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+  #       python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+  #       python-architecture: [x86, x64, arm64]
+  #       exclude:
+  #       - os: macos-latest
+  #         python-architecture: x86
+  #       - os: macos-latest
+  #         python-architecture: x64
+  #       - os: macos-13
+  #         python-architecture: x86
+  #       - os: macos-13
+  #         python-architecture: arm64
+  #       - os: ubuntu-latest
+  #         python-architecture: x86
 
-    runs-on: ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
 
-    steps:
-    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: ${{ matrix.python-architecture }}
-        allow-prereleases: true
-    - name: Install test dependencies and Traits from PyPI sdist
-      run: |
-        python -m pip install --no-binary traits numpy setuptools Sphinx traits traitsui
-    - name: Create clean test directory
-      run: |
-        mkdir testdir
-    - name: Test Traits package
-      run: cd testdir && python -m unittest discover -v traits
+  #   steps:
+  #   - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
+  #       architecture: ${{ matrix.python-architecture }}
+  #       allow-prereleases: true
+  #   - name: Install test dependencies and Traits from PyPI sdist
+  #     run: |
+  #       python -m pip install --no-binary traits numpy setuptools Sphinx traits traitsui
+  #   - name: Create clean test directory
+  #     run: |
+  #       mkdir testdir
+  #   - name: Test Traits package
+  #     run: cd testdir && python -m unittest discover -v traits
 
   test-pypi-wheel:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        python-architecture: [x86, x64, arm64]
-        exclude:
-        - os: macos-latest
+        include:
+        - os: windows-latest
           python-architecture: x86
-        - os: macos-latest
+        - os: windows-latest
           python-architecture: x64
-        - os: macos-13
-          python-architecture: x86
-        - os: macos-13
-          python-architecture: arm64
         - os: ubuntu-latest
           python-architecture: x86
+        - os: ubuntu-latest
+          python-architecture: x64
+        - os: macos-latest
+          python-architecture: arm64
+        - os: macos-13
+          python-architecture: x64
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -36,7 +36,7 @@ jobs:
   #       allow-prereleases: true
   #   - name: Install test dependencies and Traits from PyPI sdist
   #     run: |
-  #       python -m pip install --no-binary traits numpy setuptools Sphinx traits traitsui
+  #       python -m pip install --no-binary traits defusedxml numpy setuptools Sphinx traits traitsui
   #   - name: Create clean test directory
   #     run: |
   #       mkdir testdir
@@ -76,7 +76,7 @@ jobs:
         allow-prereleases: true
     - name: Install test dependencies and Traits from PyPI wheel
       run: |
-        python -m pip install --only-binary traits numpy setuptools Sphinx traits traitsui
+        python -m pip install --only-binary traits defusedxml numpy setuptools Sphinx traits traitsui
     - name: Create clean test directory
       run: |
         mkdir testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,32 +11,26 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-architecture: [x86, x64, arm64]
-        exclude:
-        - os: ubuntu-latest
-          python-architecture: arm64
-        - os: ubuntu-latest
-          python-architecture: x86
-        - os: windows-latest
-          python-architecture: arm64
-        - os: macos-latest
-          python-architecture: x86
-        - os: macos-latest
-          python-architecture: x64
-        - os: macos-13
-          python-architecture: x86
-        - os: macos-13
-          python-architecture: arm64
+        platform:
+          - os: ubuntu-latest
+            architecture: x64
+          - os: windows-latest
+            architecture: x64
+          - os: windows-latest
+            architecture: x86
+          - os: macos-latest
+            architecture: arm64
+          - os: macos-13
+            architecture: x64
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.os }}
 
     steps:
-    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
+    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.platform.architecture }})
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: ${{ matrix.python-architecture }}
+        architecture: ${{ matrix.platform.architecture }}
         allow-prereleases: true
     - name: Install test dependencies and Traits from PyPI sdist
       run: |

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -7,41 +7,45 @@ on:
     - cron: '27 3 8,22 * *'
 
 jobs:
-  # test-pypi-sdist:
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-  #       python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-  #       python-architecture: [x86, x64, arm64]
-  #       exclude:
-  #       - os: macos-latest
-  #         python-architecture: x86
-  #       - os: macos-latest
-  #         python-architecture: x64
-  #       - os: macos-13
-  #         python-architecture: x86
-  #       - os: macos-13
-  #         python-architecture: arm64
-  #       - os: ubuntu-latest
-  #         python-architecture: x86
+  test-pypi-sdist:
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-architecture: [x86, x64, arm64]
+        exclude:
+        - os: ubuntu-latest
+          python-architecture: arm64
+        - os: ubuntu-latest
+          python-architecture: x86
+        - os: windows-latest
+          python-architecture: arm64
+        - os: macos-latest
+          python-architecture: x86
+        - os: macos-latest
+          python-architecture: x64
+        - os: macos-13
+          python-architecture: x86
+        - os: macos-13
+          python-architecture: arm64
 
-  #   runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
-  #   steps:
-  #   - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
-  #       architecture: ${{ matrix.python-architecture }}
-  #       allow-prereleases: true
-  #   - name: Install test dependencies and Traits from PyPI sdist
-  #     run: |
-  #       python -m pip install --no-binary traits defusedxml numpy setuptools Sphinx traits traitsui
-  #   - name: Create clean test directory
-  #     run: |
-  #       mkdir testdir
-  #   - name: Test Traits package
-  #     run: cd testdir && python -m unittest discover -v traits
+    steps:
+    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+        allow-prereleases: true
+    - name: Install test dependencies and Traits from PyPI sdist
+      run: |
+        python -m pip install --no-binary traits defusedxml numpy setuptools Sphinx traits traitsui
+    - name: Create clean test directory
+      run: |
+        mkdir testdir
+    - name: Test Traits package
+      run: cd testdir && python -m unittest discover -v traits
 
   test-pypi-wheel:
     strategy:

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -52,6 +52,8 @@ jobs:
         exclude:
         - os: ubuntu-latest
           python-architecture: arm64
+        - os: ubuntu-latest
+          python-architecture: x86
         - os: windows-latest
           python-architecture: arm64
         - os: macos-latest

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -45,32 +45,26 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-architecture: [x86, x64, arm64]
-        exclude:
-        - os: ubuntu-latest
-          python-architecture: arm64
-        - os: ubuntu-latest
-          python-architecture: x86
-        - os: windows-latest
-          python-architecture: arm64
-        - os: macos-latest
-          python-architecture: x86
-        - os: macos-latest
-          python-architecture: x64
-        - os: macos-13
-          python-architecture: x86
-        - os: macos-13
-          python-architecture: arm64
+        platform:
+          - os: ubuntu-latest
+            architecture: x64
+          - os: windows-latest
+            architecture: x64
+          - os: windows-latest
+            architecture: x86
+          - os: macos-latest
+            architecture: arm64
+          - os: macos-13
+            architecture: x64
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.os }}
 
     steps:
-    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.python-architecture }})
+    - name: Set up Python ${{ matrix.python-version }} (${{ matrix.platform.architecture }})
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: ${{ matrix.python-architecture }}
+        architecture: ${{ matrix.platform.architecture }}
         allow-prereleases: true
     - name: Install test dependencies and Traits from PyPI wheel
       run: |


### PR DESCRIPTION
This PR attempts to fix the architectures in the test-from-pypi.yml workflow. The intent is to run tests on the following combinations:

- windows-latest: x86 and x64
- ubuntu-latest: x64
- macos-latest: arm64
- macos-13: x64

We also:
- clean up the workflow to remove PySide6-related pieces that are no longer necessary
- add defusedxml as a test dependency

Test run: https://github.com/enthought/traits/actions/runs/8998474167
