### PR TITLE
Fix a race condition in a multithreaded test

### DIFF
--- a/traits/tests/test_ui_notifiers.py
+++ b/traits/tests/test_ui_notifiers.py
@@ -157,10 +157,11 @@ class BaseTestUINotifiers(object):
         # Given no registered ui handler
         self.enterContext(clear_ui_handler())
 
-        # When we set obj.foo to 3 on a separate thread.
+        # When we set obj.foo to 3 on a separate thread, and wait for
+        # that thread to complete.
         background_thread = threading.Thread(target=self.modify_obj)
         background_thread.start()
-        self.addCleanup(background_thread.join)
+        background_thread.join()
 
         # Then no notification is processed ...
         self.assertEqual(self.notifications, [])


### PR DESCRIPTION
This PR fixes an obvious race condition in a test - we're firing off an action in a background thread, but not waiting for that background thread to complete before checking for the side-effects that we're expecting.

This caused a CI failure in a recent Windows run: https://github.com/enthought/traits/actions/runs/9164818354/job/25196928783?pr=1797