### PR TITLE
Set up scriv for changelog management

### DIFF
--- a/changelog.d/20240621_104251_mdickinson_introduce_scriv.rst
+++ b/changelog.d/20240621_104251_mdickinson_introduce_scriv.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+.. Added
+.. -----
+..
+.. - A bullet item for the Added category.
+..
+Changed
+-------
+
+- We now use the ``scriv`` package for changelog maintenance. (#12345)
+
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/changelog.d/20240621_104251_mdickinson_introduce_scriv.rst
+++ b/changelog.d/20240621_104251_mdickinson_introduce_scriv.rst
@@ -15,7 +15,7 @@
 Changed
 -------
 
-- We now use the ``scriv`` package for changelog maintenance. (#12345)
+- We now use the ``scriv`` package for changelog maintenance. (#1804)
 
 .. Deprecated
 .. ----------

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,3 @@
+This directory is used to collect changelog snippets for user-visible
+changes to the Traits source. We use the `scriv` package for
+changelog management.


### PR DESCRIPTION
Let's use `scriv` for changelog management. This is very similar to the setup that we have in TraitsUI and apptools, except that it seems better to use `scriv` than grow our own tool.

`scriv` is relatively unopinionated, flexible and easy to use; it simply lets you assemble changelog snippets in separate files under `changelog.d` until you're ready to collect those snippets together to assemble a changelog entry for a release. It seems like a good fit for Traits.

We're currently lacking a good place to record the information that we're expecting to use `scriv` for changelog management. See #1803.

xref: https://scriv.readthedocs.io/en/1.5.1/