### PR TITLE
Export event types in traits.observation.api.

### DIFF
--- a/changelog.d/20240621_105210_mdickinson_add_event_types_to_api.rst
+++ b/changelog.d/20240621_105210_mdickinson_add_event_types_to_api.rst
@@ -1,0 +1,36 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+Added
+-----
+
+- Event types for the ``event`` received by observers have been made
+  available in ``traits.observation.api``. This is useful for those
+  wanting to use the types in type annotations.
+
+.. Changed
+.. -------
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/changelog.d/20240621_105210_mdickinson_add_event_types_to_api.rst
+++ b/changelog.d/20240621_105210_mdickinson_add_event_types_to_api.rst
@@ -12,7 +12,7 @@ Added
 
 - Event types for the ``event`` received by observers have been made
   available in ``traits.observation.api``. This is useful for those
-  wanting to use the types in type annotations.
+  wanting to use the types in type annotations. (#1805)
 
 .. Changed
 .. -------

--- a/traits/observation/api.py
+++ b/traits/observation/api.py
@@ -8,6 +8,13 @@
 #
 # Thanks for using Enthought open source!
 
+from traits.observation.events import (
+    DictChangeEvent,
+    ListChangeEvent,
+    SetChangeEvent,
+    TraitChangeEvent,
+)
+
 from traits.observation.exception_handling import (
     pop_exception_handler,
     push_exception_handler,

--- a/traits/observation/tests/test_dict_change_event.py
+++ b/traits/observation/tests/test_dict_change_event.py
@@ -10,10 +10,8 @@
 
 import unittest
 
-from traits.observation._dict_change_event import (
-    DictChangeEvent,
-    dict_event_factory,
-)
+from traits.observation.api import DictChangeEvent
+from traits.observation._dict_change_event import dict_event_factory,
 from traits.trait_dict_object import TraitDict
 
 

--- a/traits/observation/tests/test_dict_change_event.py
+++ b/traits/observation/tests/test_dict_change_event.py
@@ -11,7 +11,7 @@
 import unittest
 
 from traits.observation.api import DictChangeEvent
-from traits.observation._dict_change_event import dict_event_factory,
+from traits.observation._dict_change_event import dict_event_factory
 from traits.trait_dict_object import TraitDict
 
 

--- a/traits/observation/tests/test_list_change_event.py
+++ b/traits/observation/tests/test_list_change_event.py
@@ -10,10 +10,8 @@
 
 import unittest
 
-from traits.observation._list_change_event import (
-    ListChangeEvent,
-    list_event_factory,
-)
+from traits.observation.api import ListChangeEvent
+from traits.observation._list_change_event import list_event_factory
 from traits.trait_list_object import TraitList
 
 

--- a/traits/observation/tests/test_set_change_event.py
+++ b/traits/observation/tests/test_set_change_event.py
@@ -10,10 +10,8 @@
 
 import unittest
 
-from traits.observation._set_change_event import (
-    SetChangeEvent,
-    set_event_factory,
-)
+from traits.observation.api import SetChangeEvent
+from traits.observation._set_change_event import set_event_factory
 from traits.trait_set_object import TraitSet
 
 

--- a/traits/observation/tests/test_trait_change_event.py
+++ b/traits/observation/tests/test_trait_change_event.py
@@ -12,10 +12,8 @@ import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Int
-from traits.observation._trait_change_event import (
-    trait_event_factory,
-    TraitChangeEvent,
-)
+from traits.observation.api import TraitChangeEvent
+from traits.observation._trait_change_event import trait_event_factory
 
 
 class TestTraitChangeEvent(unittest.TestCase):


### PR DESCRIPTION
This PR exports observer event types (`TraitChangeEvent`, `ListChangeEvent`, `DictChangeEvent`, `SetChangeEvent`) in `traits.observation.api`, so that they can be easily used in type hints in client code.

The event types are already documented. I've updated some tests to ensure that the test suite exercises the import from `test.observation.api`.

Closes #1802
