### PR TITLE
Fix warning messages from PyDict_GetItem

### DIFF
--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -3639,7 +3639,7 @@ validate_trait_map(
     PyObject *value)
 {
     PyObject *type_info = trait->py_validate;
-    if (PyDict_GetItem(PyTuple_GET_ITEM(type_info, 1), value) != NULL) {
+    if (PyDict_GetItemWithError(PyTuple_GET_ITEM(type_info, 1), value) != NULL) {
         Py_INCREF(value);
         return value;
     }
@@ -4065,7 +4065,7 @@ validate_trait_complex(
                 PyErr_Clear();
                 break;
             case 6: /* Mapped item check: */
-                if (PyDict_GetItem(PyTuple_GET_ITEM(type_info, 1), value)
+                if (PyDict_GetItemWithError(PyTuple_GET_ITEM(type_info, 1), value)
                     != NULL) {
                     goto done;
                 }


### PR DESCRIPTION
This PR silences warning messages from `PyDict_GetItem` in cases where we're trying to look up something that's not hashable.

Note that replacing `PyDict_GetItem` with `PyDict_GetItemWithError` means replacing something that can't raise an exception with something that can, but in both cases we already have error paths present that handle the case where an exception is set. (In the `validate_trait_map` case, `raise_traits_error` takes care of clearing any existing error. Arguably it should chain the errors instead, but that's a separate discussion.)

Closes #1817
