### PR TITLE
Fix the wheel-building workflow

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -9,7 +9,7 @@ jobs:
   build-wheels:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-13, macos-14, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -17,12 +17,6 @@ jobs:
 
     - name: Check out the release commit
       uses: actions/checkout@v4
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: arm64
-      if: runner.os == 'Linux'
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -1,6 +1,7 @@
 name: Release to PyPI
 
 on:
+  pull_request:
   workflow_dispatch:
   release:
     types: [published]
@@ -29,37 +30,37 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.22.0
 
-    - name: Check and upload wheels
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m twine check --strict wheelhouse/*.whl
-        python -m twine upload wheelhouse/*.whl
+    # - name: Check and upload wheels
+    #   env:
+    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    #   run: |
+    #     python -m twine check --strict wheelhouse/*.whl
+    #     python -m twine upload wheelhouse/*.whl
 
-  build-sdist:
-    runs-on: ubuntu-latest
+  # build-sdist:
+  #   runs-on: ubuntu-latest
 
-    steps:
+  #   steps:
 
-    - name: Check out the release commit
-      uses: actions/checkout@v4
+  #   - name: Check out the release commit
+  #     uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.10'
 
-    - name: Install Python packages needed for sdist build and upload
-      run: python -m pip install build twine
+  #   - name: Install Python packages needed for sdist build and upload
+  #     run: python -m pip install build twine
 
-    - name: Build sdist
-      run: python -m build --sdist
+  #   - name: Build sdist
+  #     run: python -m build --sdist
 
-    - name: Publish sdist to PyPI
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m twine check --strict dist/*
-        python -m twine upload dist/*
+  #   - name: Publish sdist to PyPI
+  #     env:
+  #       TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+  #       TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  #     run: |
+  #       python -m twine check --strict dist/*
+  #       python -m twine upload dist/*

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -1,7 +1,6 @@
 name: Release to PyPI
 
 on:
-  pull_request:
   workflow_dispatch:
   release:
     types: [published]
@@ -30,37 +29,37 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.22.0
 
-    # - name: Check and upload wheels
-    #   env:
-    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    #   run: |
-    #     python -m twine check --strict wheelhouse/*.whl
-    #     python -m twine upload wheelhouse/*.whl
+    - name: Check and upload wheels
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine check --strict wheelhouse/*.whl
+        python -m twine upload wheelhouse/*.whl
 
-  # build-sdist:
-  #   runs-on: ubuntu-latest
+  build-sdist:
+    runs-on: ubuntu-latest
 
-  #   steps:
+    steps:
 
-  #   - name: Check out the release commit
-  #     uses: actions/checkout@v4
+    - name: Check out the release commit
+      uses: actions/checkout@v4
 
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.10'
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
 
-  #   - name: Install Python packages needed for sdist build and upload
-  #     run: python -m pip install build twine
+    - name: Install Python packages needed for sdist build and upload
+      run: python -m pip install build twine
 
-  #   - name: Build sdist
-  #     run: python -m build --sdist
+    - name: Build sdist
+      run: python -m build --sdist
 
-  #   - name: Publish sdist to PyPI
-  #     env:
-  #       TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-  #       TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-  #     run: |
-  #       python -m twine check --strict dist/*
-  #       python -m twine upload dist/*
+    - name: Publish sdist to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine check --strict dist/*
+        python -m twine upload dist/*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Traits CHANGELOG
 ================
 
+Release 7.0.1
+-------------
+
+Released: 2025-01-24
+
+This is a bugfix release of the Traits package that adjusts the wheel
+building configuration. There are no non-packaging-related changes
+in this release.
+
+Changes
+~~~~~~~
+
+
+
 Release 7.0.0
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,8 @@ in this release.
 
 Changes
 ~~~~~~~
-
-
+* Drop problematic manylinux/aarch64 wheel builds; build separate wheels
+  for macOS/arm64 and macOS/x86_64. (#1822)
 
 Release 7.0.0
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,3 @@ order_by_type = 'False'
 
 [tool.cibuildwheel]
 skip = 'pp*'
-
-[tool.cibuildwheel.macos]
-archs = ['auto', 'universal2']
-
-[tool.cibuildwheel.linux]
-archs = ['auto', 'aarch64']

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import setuptools
 # into the package source.
 MAJOR = 7
 MINOR = 0
-MICRO = 0
+MICRO = 1
 PRERELEASE = ""
 IS_RELEASED = True
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import setuptools
 # into the package source.
 MAJOR = 7
 MINOR = 0
-MICRO = 1
+MICRO = 0
 PRERELEASE = ""
 IS_RELEASED = True
 


### PR DESCRIPTION
This PR attempts to fix the current wheel-building workflow. That workflow is failing on manylinux-aarch64 builds with a gcc internal compiler error, so until we can understand the problem better we'll drop those builds and the QEMU emulation.

While we're here, we also perform separate macOS Intel and ARM builds.