### PR TITLE
Include Python 3.13 in all workflows

### DIFF
--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -10,7 +10,7 @@ jobs:
   test-pypi-sdist:
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         platform:
           - os: ubuntu-latest
             architecture: x64
@@ -44,7 +44,7 @@ jobs:
   test-pypi-wheel:
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         platform:
           - os: ubuntu-latest
             architecture: x64


### PR DESCRIPTION
This PR updates all workflows to support 3.13.

We may run into issues with the full test workflow on Python 3.13.