### PR TITLE
Make ui_handler publicly available again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Traits CHANGELOG
 ================
 
+Release 7.0.2
+-------------
+
+Released: 2025-01-24
+
+This is a bugfix release of the Traits package that fixes an interoperability
+issue with Pyface (a regression since Traits 6.4.3).
+
+Fixes
+~~~~~
+* Make ``traits.trait_notifiers.ui_handler`` public again, since
+  Pyface relies on importing it directly. (#1827)
+
+
 Release 7.0.1
 -------------
 

--- a/traits/trait_notifiers.py
+++ b/traits/trait_notifiers.py
@@ -29,31 +29,33 @@ from .trait_errors import TraitNotificationError
 
 # The currently active handler for notifications that must be run on the UI
 # thread, or None if no handler has been set.
-_ui_handler = None
+# Note: the Pyface library current accesses the `ui_handler` attribute
+# directly, so we can't make it private yet.
+ui_handler = None
 
 
 def get_ui_handler():
     """
     Return the current user interface thread handler.
     """
-    return _ui_handler
+    return ui_handler
 
 
 def set_ui_handler(handler):
     """ Sets up the user interface thread handler.
     """
-    global _ui_handler
+    global ui_handler
 
-    _ui_handler = handler
+    ui_handler = handler
 
 
 def ui_dispatch(handler, *args, **kw):
     if threading.current_thread() == threading.main_thread():
         handler(*args, **kw)
-    elif _ui_handler is None:
+    elif ui_handler is None:
         raise RuntimeError("no UI handler registered for dispatch='ui'")
     else:
-        _ui_handler(handler, *args, **kw)
+        ui_handler(handler, *args, **kw)
 
 
 class NotificationExceptionHandlerState(object):
@@ -616,10 +618,10 @@ class FastUITraitChangeNotifyWrapper(TraitChangeNotifyWrapper):
     def dispatch(self, handler, *args):
         if threading.current_thread() == threading.main_thread():
             handler(*args)
-        elif _ui_handler is None:
+        elif ui_handler is None:
             raise RuntimeError("no UI handler registered for dispatch='ui'")
         else:
-            _ui_handler(handler, *args)
+            ui_handler(handler, *args)
 
 
 class NewTraitChangeNotifyWrapper(TraitChangeNotifyWrapper):


### PR DESCRIPTION
In #1792 we made `traits.trait_notifiers.ui_handler` private, renaming it to `_ui_handler`. However, it turns out that Pyface wants to access the value of `ui_handler` directly, so this change breaks current Pyface.

This PR reverts that change.

Pyface code links:
- https://github.com/enthought/pyface/blob/46f700999284c8104fb2a5468f549677dfadf063/pyface/ui/qt/init.py#L15
- https://github.com/enthought/pyface/blob/46f700999284c8104fb2a5468f549677dfadf063/pyface/ui/wx/init.py#L14
