### PR TITLE
Fix missing changelog entry for #1826

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Fixes
 * Make ``traits.trait_notifiers.ui_handler`` public again, since
   Pyface relies on importing it directly. (#1827)
 
+Build
+~~~~~
+* Include Python 3.13 in all test workflows. (#1826)
+
 
 Release 7.0.1
 -------------


### PR DESCRIPTION
This changelog entry should have gone in before #1826 was backported.