### PR TITLE
Fix spelling of lark_parser dependency in etstool.py

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -92,7 +92,7 @@ common_dependencies = {
     "enthought_sphinx_theme",
     "flake8",
     "flake8_ets",
-    "lark-parser",
+    "lark_parser",
     "mypy",
     "numpy",
     "Sphinx",


### PR DESCRIPTION
`lark-parser` is an invalid EDS dependency; it should be `lark_parser`. This PR fixes that.

Prior to this fix, `python etstool.py install` failed; I've verified that it works after the fix.