### PR TITLE
Fix silent mypy failures

### DIFF
--- a/traits/stubs_tests/util.py
+++ b/traits/stubs_tests/util.py
@@ -108,7 +108,7 @@ def run_mypy(filepath):
         dest_filename = os.path.basename(filepath)
         dest = shutil.copyfile(filepath, os.path.join(tempdir, dest_filename))
         normal_report, error_report, exit_status = mypy_api.run(
-            [dest, '--show-error-code', '--follow-imports=skip'])
+            [dest, '--show-error-codes', '--follow-imports=skip'])
     return normal_report, error_report, exit_status
 
 

--- a/traits/stubs_tests/util.py
+++ b/traits/stubs_tests/util.py
@@ -169,7 +169,14 @@ class MypyAssertions:
 
         for line, error_codes in parsed_mypy_output.items():
             if line not in line_error_map or sorted(
-                    line_error_map[line]) != sorted(list(error_codes)):
+                    line_error_map.pop(line)) != sorted(list(error_codes)):
                 s = "Unexpected error on line {}\n{}\n{}".format(
                     line, str(filepath), normal_report)
                 raise AssertionError(s)
+
+        if line_error_map:
+            raise AssertionError(
+                f"expected errors on lines "
+                f"{', '.join(map(str, line_error_map))}, "
+                f"but no mypy errors were reported for those lines"
+            )

--- a/traits/stubs_tests/util.py
+++ b/traits/stubs_tests/util.py
@@ -160,6 +160,11 @@ class MypyAssertions:
         """
         line_error_map = parse_py_file(filepath)
         normal_report, error_report, exit_status = run_mypy(filepath)
+        if error_report:
+            raise AssertionError(
+                f"Unexpected output on stderr: {error_report}"
+            )
+
         parsed_mypy_output = parse_mypy_output(normal_report)
 
         for line, error_codes in parsed_mypy_output.items():


### PR DESCRIPTION
The traits stubs tests have been passing without actually running mypy on the target example files, since:

- we're passing `--show-error-code` to `mypy`,
- that generates a usage error about an ambiguous option (on stderr) with no output on stdout,
- so our code deduces that there were no mypy errors reported

Aside from the `--show-error-code` mistake (it should be `--show-error-codes`), there are two other problems that allowed this to go undetected:

- we don't check the stderr output in `assertRaisesMypyError`
- we don't check that we got all of the _expected_ failures in `assertRaisesMypyError`

This PR:

- adds an extra check in `assertMypyError` to make sure that we catch this and future similar usage errors as report them as test failures
- adds another extra check in `assertMypyError` to verify that all of the expected errors were actually reported by mypy (we're currently only checking that the reported errors are expected)
- fixes the original cause of the missing checks, by replacing `--show-error-code` with `--show-error-codes`.