### PR TITLE
Remove unnecessary uses of 'global'

### DIFF
--- a/traits/adaptation/adaptation_manager.py
+++ b/traits/adaptation/adaptation_manager.py
@@ -397,7 +397,6 @@ def reset_global_adaptation_manager():
 
 def get_global_adaptation_manager():
     """ Set a reference to the global adaptation manager. """
-    global adaptation_manager
     return adaptation_manager
 
 

--- a/traits/tests/check_timing.py
+++ b/traits/tests/check_timing.py
@@ -120,7 +120,6 @@ class global_value(new_style_value):
             gvalue = i
 
     def do_get(self):
-        global gvalue
         for i in range(n):
             gvalue
 

--- a/traits/trait_factory.py
+++ b/traits/trait_factory.py
@@ -61,8 +61,6 @@ class TraitImportError(TraitFactory):
 
 def trait_factory(trait):
     """ Returns a trait created from a TraitFactory instance """
-    global _trait_factory_instances
-
     tid = id(trait)
     if tid not in _trait_factory_instances:
         _trait_factory_instances[tid] = trait()


### PR DESCRIPTION
A recent release of `flake8` started complaining about redundant uses of `global` inside functions/methods, causing `flake8` errors in the Traits style checks. (The relevant change is in pyflakes 3.3.0: see https://github.com/PyCQA/pyflakes/pull/825.)

This PR removes those `global` declarations.