### PR TITLE
Comment out a test that behaves differently with different versions of mypy

### DIFF
--- a/traits/stubs_tests/examples/Any.py
+++ b/traits/stubs_tests/examples/Any.py
@@ -54,6 +54,9 @@ class Superclass(HasTraits):
     x = Any()
 
 
-class Subclass(Superclass):
-    x = Instance(Foo)  # E: assignment
-    y = Int()
+# Note: mypy < 1.16 complains if we override `x = Any()` with `x = Instance(Foo)`, but
+# mypy >= 1.16 thinks it's fine. For now, we skip the test.
+
+# class Subclass(Superclass):
+#     x = Instance(Foo)  # E: assignment
+#     y = Int()


### PR DESCRIPTION
Overriding an Any() trait with something more specific produces a type error on mypy < 1.16.0, but is fine with mypy >= 1.16.0. Since we can't reasonably require mypy >= 1.16.0 yet, we comment out the test for now.

(Alternatively, we could pin the version of mypy that we use for type stub testing.)

Fixes #1854.
