### PR TITLE
Update wheel building workflow to only upload on actual release

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -9,7 +9,7 @@ jobs:
   build-wheels:
     strategy:
       matrix:
-        os: [windows-latest, macos-13, macos-14, ubuntu-latest]
+        os: [windows-latest, macos-15-intel, macos-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
One pain point with Traits releases has been that we get as far as making the release, only for the wheel build to fail.

This PR makes it easier to do a dry run of the wheel building _before_ making a release: the key change is that if the `release-to-pypi` workflow is triggered via workflow dispatch, then wheel building is performed but upload to PyPI is not performed.

This makes it harder to trigger a release via workflow dispatch, but I think that's okay: we've almost never needed to do that, and in cases where there's something that needs to be changed we can usually make a new release.

Incidental changes:
- I've updated the Python version used for working with `build` and `twine` to Python 3.13.

