### PR TITLE
Update Python version for the documentation build to 3.13

### DIFF
--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.13'
     - name: Install dependencies and local packages
       run: python -m pip install .[docs]
     - name: Build HTML documentation with Sphinx

--- a/setup.py
+++ b/setup.py
@@ -296,7 +296,7 @@ setuptools.setup(
     },
     extras_require={
         "docs": [
-            "enthought-sphinx-theme @ git+https://github.com/enthought/enthought-sphinx-theme.git@d86b5039c61d2a8e104bc2f351a9db17fc32396b",
+            "enthought-sphinx-theme",
             "Sphinx>=2.1.0",
             "sphinx-copybutton",
         ],

--- a/setup.py
+++ b/setup.py
@@ -296,7 +296,7 @@ setuptools.setup(
     },
     extras_require={
         "docs": [
-            "enthought-sphinx-theme",
+            "enthought-sphinx-theme @ git+https://github.com/enthought/enthought-sphinx-theme.git@d86b5039c61d2a8e104bc2f351a9db17fc32396b",
             "Sphinx>=2.1.0",
             "sphinx-copybutton",
         ],


### PR DESCRIPTION
DO NOT MERGE!

This is a test to see whether the changes in https://github.com/enthought/enthought-sphinx-theme/pull/25 are sufficient to get the Traits doc build working again.