### PR TITLE
Pin copyright end year and add a strict, non-blocking style check

### DIFF
--- a/.github/workflows/run-style-checks-strict.yml
+++ b/.github/workflows/run-style-checks-strict.yml
@@ -1,9 +1,9 @@
-name: Style check
+name: Strict style check
 
 on: [pull_request, workflow_dispatch]
 
 jobs:
-  style:
+  strict-style:
     runs-on: ubuntu-latest
 
     steps:
@@ -16,6 +16,6 @@ jobs:
       run: |
         python -m pip install flake8
         python -m pip install "flake8-ets >= 1.1.0"
-    - name: Run style checks
+    - name: Report on out-of-date copyright end years
       run: |
-        python -m flake8
+        python -m flake8 --select H102 --copyright-end-year current

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,8 @@
 [flake8]
-exclude = traits/observation/_generated_parser.py,build
+extend-exclude = traits/observation/_generated_parser.py,build,.venv
 ignore = E266,W503,E722,E731,E741
+# Pin the year so style checks don't fail when the year rolls over.
+copyright-end-year = 2026
 per-file-ignores =
     */api.py:F401
     # Suppress flake8 complaints about black's formatting of .pyi files


### PR DESCRIPTION
Clean up copyright-year checking, following the approach from enthought/envisage#596 and enthought/envisage#607, to make it robust across year boundaries.

Previously the merge-blocking style check ran `flake8` with `flake8-ets`'s H102 rule against the *current* year, so the first PR of each new year would fail CI until every copyright header was bumped.

## Changes

- **Pin the copyright end year** in `setup.cfg` (`copyright-end-year = 2026`) as the single source of truth, used by both the regular style check and local `flake8` runs. The regular (merge-blocking) check now validates against this fixed year, so it no longer starts failing when the year rolls over.
- **Add a separate "Strict style check" workflow** that runs `flake8 --select H102 --copyright-end-year current`. This keeps out-of-date copyright headers conspicuous (so they still get updated early each year / before releases) without blocking merges — it's a distinct, non-required check.
- **Require `flake8-ets >= 1.1.0`**, the version that supports the `current` value for `--copyright-end-year`.
- **Switch `exclude` → `extend-exclude`** and add `.venv`, so local runs skip the virtualenv while keeping flake8's default excludes.

## Verification

Using an environment with `flake8-ets 1.1.0`:

- Regular check (pinned 2026): passes.
- Strict check (`--copyright-end-year current`, currently 2026): passes.
- Simulated year rollover (`--copyright-end-year 2027`): the strict check fails with `H102 Copyright end year (2026) should be 2027`, while the pinned regular check keeps CI green — confirming the intended behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)