### PR TITLE
Fix TraitDocumenter crash on module-level traits

### DIFF
--- a/traits/util/tests/test_trait_documenter.py
+++ b/traits/util/tests/test_trait_documenter.py
@@ -58,6 +58,10 @@ autodoc_mock_imports = [
 """
 
 
+#: A module-level trait, for the regression test for enthought/traits#1883.
+module_level_trait = Int(42)
+
+
 class MyTestClass(HasTraits):
     """
     Class-level docstring.
@@ -225,6 +229,37 @@ class TestTraitDocumenter(unittest.TestCase):
             (f'   :{no_index}:', '<autodoc>'),
             ('   :module: traits.util.tests.test_trait_documenter', '<autodoc>'),  # noqa
             ('   :annotation: = Int(42, desc=""" First line …', '<autodoc>')]  # noqa
+        if no_index_entry:
+            expected.insert(2, ('   :no-index-entry:', '<autodoc>'))
+        calls = documenter.add_line.call_args_list
+        for index, line in enumerate(expected):
+            self.assertEqual(calls[index][0], line)
+
+    def test_module_level_trait(self):
+        # Regression test for enthought/traits#1883: documenting a
+        # module-level trait used to crash because the parent (the module)
+        # has no __bases__.
+        import traits.util.tests.test_trait_documenter as this_module
+
+        # given
+        documenter = TraitDocumenter(mock.Mock(), 'test')
+        documenter.parent = this_module
+        documenter.object_name = 'module_level_trait'
+        documenter.modname = 'traits.util.tests.test_trait_documenter'
+        documenter.get_sourcename = mock.Mock(return_value='<autodoc>')
+        documenter.objpath = ['module_level_trait']
+        documenter.add_line = mock.Mock()
+
+        # when
+        documenter.add_directive_header('')
+
+        # then
+        self.assertEqual(documenter.directive.warn.call_args_list, [])
+        expected = [
+            ('.. py:attribute:: module_level_trait', '<autodoc>'),
+            (f'   :{no_index}:', '<autodoc>'),
+            ('   :module: traits.util.tests.test_trait_documenter', '<autodoc>'),  # noqa
+            ('   :annotation: = Int(42)', '<autodoc>')]
         if no_index_entry:
             expected.insert(2, ('   :no-index-entry:', '<autodoc>'))
         calls = documenter.add_line.call_args_list

--- a/traits/util/trait_documenter.py
+++ b/traits/util/trait_documenter.py
@@ -113,10 +113,13 @@ class TraitDocumenter(AttributeDocumenter):
         option set to the trait definition.
 
         """
-        # Look into the class and parent classes:
         parent = self.parent
-        classes = list(types.resolve_bases(parent.__bases__))
-        classes.insert(0, parent)
+        if inspect.isclass(parent):
+            classes = list(types.resolve_bases(parent.__bases__))
+            classes.insert(0, parent)
+        else:
+            # Module-level trait: the parent is the containing module.
+            classes = [parent]
         for cls in classes:
             try:
                 definition = trait_definition(


### PR DESCRIPTION
Fixes #1883.

## Problem

Since traits 7.1.0 (specifically the rewrite of `add_directive_header` in #1866), `traits.util.trait_documenter.TraitDocumenter` crashes when Sphinx autodoc documents a **module-level** trait, aborting the whole documentation build:

```
File ".../traits/util/trait_documenter.py", line 118, in add_directive_header
    classes = list(types.resolve_bases(parent.__bases__))
AttributeError: module 'mypackage.mymodule' has no attribute '__bases__'
```

`can_document_member` accepts both class-level and module-level traits, but the new base-class walk assumes `self.parent` is a class. For a module-level trait `self.parent` is the module, which has no `__bases__`.

## Fix

Guard the base-class walk: only walk `parent.__bases__` when the parent is actually a class (`isinstance(parent, type)`); otherwise (a module) use the parent alone. This restores the pre-7.1.0 behaviour for module-level traits while keeping the base-class resolution added in #1866 for class-level traits.

## Tests

Added `test_module_level_trait`, which documents a module-level trait and checks the emitted directive header. Verified it reproduces the exact `AttributeError` from the issue without the fix and passes with it. The full `test_trait_documenter` suite (9 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)