### PR TITLE
Fix documentation build on Python 3.13 / Sphinx 9

### DIFF
--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.13'
     - name: Install dependencies and local packages
       run: python -m pip install .[docs]
     - name: Build HTML documentation with Sphinx

--- a/setup.py
+++ b/setup.py
@@ -296,7 +296,9 @@ setuptools.setup(
     },
     extras_require={
         "docs": [
-            "enthought-sphinx-theme",
+            # enthought-sphinx-theme 0.7.4 is the first release compatible
+            # with Sphinx 9 (xref: enthought/traits#1872).
+            "enthought-sphinx-theme>=0.7.4",
             "Sphinx>=2.1.0",
             "sphinx-copybutton",
         ],

--- a/traits/adaptation/adaptation_manager.py
+++ b/traits/adaptation/adaptation_manager.py
@@ -104,11 +104,11 @@ class AdaptationManager(HasTraits):
 
         Parameters
         ----------
-        adaptee : object
+        adaptee : any object
             The object that we want to adapt.
         to_protocol : type or interface
             The protocol that the want to adapt *adaptee* to.
-        default : object, optional
+        default : any object, optional
             Object to return if no adaptation is possible. If no default is
             provided, and adaptation fails, an ``AdaptationError`` is raised.
 

--- a/traits/base_trait_handler.py
+++ b/traits/base_trait_handler.py
@@ -64,11 +64,11 @@ class BaseTraitHandler(object):
 
         Parameters
         ----------
-        object : object
+        object : HasTraits
             The object whose attribute is being assigned.
         name : str
             The name of the attribute being assigned.
-        value : object
+        value : any object
             The proposed new value for the attribute.
         """
         raise TraitError(
@@ -94,11 +94,11 @@ class BaseTraitHandler(object):
 
         Parameters
         ----------
-        object : object
+        object : HasTraits
             The object whose attribute is being assigned.
         name : str
             The name of the attribute being assigned.
-        value :
+        value : any object
             The proposed new value for the attribute.
         """
         return self.info()

--- a/traits/ctraits.c
+++ b/traits/ctraits.c
@@ -1470,7 +1470,7 @@ PyDoc_STRVAR(
     "name : str\n"
     "    Name of the item trait for which an event is being fired. (The name\n"
     "    will usually end in '_items'.)\n"
-    "event_object : object\n"
+    "event_object : any object\n"
     "    Object of type ``TraitListEvent``, ``TraitDictEvent`` or ``TraitSetEvent``\n"
     "    describing the changes to the underlying collection trait value.\n"
     "event_trait : CTrait\n"
@@ -5152,7 +5152,7 @@ PyDoc_STRVAR(
     "-------\n"
     "default_value_type : int\n"
     "    An integer representing the kind of the default value\n"
-    "default_value : value\n"
+    "default_value : any object\n"
     "    A value or callable providing the default\n");
 
 PyDoc_STRVAR(
@@ -5165,7 +5165,7 @@ PyDoc_STRVAR(
     "----------\n"
     "default_value_type : int\n"
     "    An integer representing the kind of the default value\n"
-    "default_value : value\n"
+    "default_value : any object\n"
     "    A value or callable providing the default\n");
 
 PyDoc_STRVAR(
@@ -5184,7 +5184,7 @@ PyDoc_STRVAR(
     "\n"
     "Returns\n"
     "-------\n"
-    "default_value : value\n"
+    "default_value : any object\n"
     "    The default value for the given object and name.\n");
 
 PyDoc_STRVAR(
@@ -5241,7 +5241,7 @@ PyDoc_STRVAR(
     "    The HasTraits object that validation is being performed for.\n"
     "name : str\n"
     "    The name of the trait.\n"
-    "value : object\n"
+    "value : any object\n"
     "    The value to be validated.\n"
     "\n"
     "Returns\n"

--- a/traits/has_traits.py
+++ b/traits/has_traits.py
@@ -1550,7 +1550,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         Parameters
         ----------
-        other : object
+        other : HasTraits
             The object whose trait attribute values should be copied.
         traits : list of strings
             A list of names of trait attributes to copy. If None or
@@ -1658,7 +1658,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
         Returns
         -------
-        new :
+        new : HasTraits
             The newly cloned object.
         """
         if memo is None:
@@ -1723,7 +1723,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
             **traitsui.view.kind_trait** trait for values and
             their meanings. If *kind* is unspecified or None, the **kind**
             attribute of the View object is used.
-        context : object or dictionary
+        context : any object or dictionary
             A single object or a dictionary of string/object pairs, whose trait
             attributes are to be edited. If not specified, the current object
             is used.
@@ -2054,7 +2054,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
 
             .. deprecated:: 6.2.0
 
-        context : object or dictionary
+        context : any object or dictionary
             A single object or a dictionary of string/object pairs, whose trait
             attributes are to be edited. If not specified, the current object
             is used
@@ -2665,7 +2665,7 @@ class HasTraits(CHasTraits, metaclass=MetaHasTraits):
         ----------
         name : str
             Name of the trait attribute on this object.
-        object : object
+        object : HasTraits
             The object with which to synchronize.
         alias : str
             Name of the trait attribute on *other*; if None or omitted, same

--- a/traits/observation/exception_handling.py
+++ b/traits/observation/exception_handling.py
@@ -39,7 +39,7 @@ class ObserverExceptionHandler:
 
         Parameters
         ----------
-        event : object
+        event : any object
             An event object emitted by the notification.
         """
         _logger.exception(
@@ -95,7 +95,7 @@ class ObserverExceptionHandlerStack:
 
         Parameters
         ----------
-        event : object
+        event : any object
             An event object emitted by the notification.
         """
         _, excp, _ = sys.exc_info()

--- a/traits/testing/optional_dependencies.py
+++ b/traits/testing/optional_dependencies.py
@@ -23,7 +23,7 @@ def optional_import(name):
 
     Returns
     -------
-    None or module
+    None or types.ModuleType
         None if the module is not available, and the module otherwise.
 
     """

--- a/traits/trait_handlers.py
+++ b/traits/trait_handlers.py
@@ -104,7 +104,7 @@ class TraitCoerceType(TraitHandler):
 
     Parameters
     ----------
-    aType : type or object
+    aType : type or any object
         Either a Python type or a Python value.  If this is an object, it is
         mapped to its corresponding type. For example, the string 'cat' is
         automatically mapped to ``str``.
@@ -256,7 +256,7 @@ class TraitInstance(TraitHandler):
 
     Parameters
     ----------
-    aClass : type, object or str
+    aClass : type, instance or str
         A Python type or a string that identifies the type, or an object.
         If this is an object, it is mapped to the class it is an instance of.
         If this is a str, it is either the name  of a class in the module

--- a/traits/trait_list_object.py
+++ b/traits/trait_list_object.py
@@ -394,7 +394,7 @@ class TraitList(list):
         ----------
         index : integer
             The position at which to insert.
-        object : object
+        object : any object
             The object to insert.
         """
 
@@ -418,7 +418,7 @@ class TraitList(list):
 
         Returns
         -------
-        item : object
+        item : any object
             The removed item.
 
         Raises
@@ -443,7 +443,7 @@ class TraitList(list):
 
         Parameters
         ----------
-        value : object
+        value : any object
             Value to be removed.
 
         Raises
@@ -754,7 +754,7 @@ class TraitListObject(TraitList):
         ----------
         index : integer
             The position at which to insert.
-        object : object
+        object : any object
             The object to insert.
         """
 
@@ -772,7 +772,7 @@ class TraitListObject(TraitList):
 
         Returns
         -------
-        item : object
+        item : any object
             The removed item.
 
         Raises
@@ -793,7 +793,7 @@ class TraitListObject(TraitList):
 
         Parameters
         ----------
-        value : object
+        value : any object
             Value to be removed.
 
         Raises

--- a/traits/trait_types.py
+++ b/traits/trait_types.py
@@ -152,7 +152,7 @@ class Any(TraitType):
 
     Parameters
     ----------
-    default_value : object, optional
+    default_value : any object, optional
         The default value for the trait. If this is an instance of either
         :class:`list` or :class:`dict` then a copy of the default value
         is made for each instance. Otherwise, the default is shared between
@@ -2575,7 +2575,7 @@ class List(TraitType):
 
     Attributes
     ----------
-    item_trait : trait
+    item_trait : CTrait
         The type of item that the list contains.
     minlen : integer
         The minimum length of a list that can be assigned to the trait.
@@ -2850,7 +2850,7 @@ class Set(TraitType):
 
     Attributes
     ----------
-    item_trait : a trait or value that can be converted to a trait
+    item_trait : CTrait
         The type of item that the set contains. If not specified, the set
         can contain items of any type.
     has_items : bool
@@ -2978,10 +2978,10 @@ class Dict(TraitType):
 
     Attributes
     ----------
-    key_trait : a trait
+    key_trait : CTrait
         The trait type for keys in the dictionary; if not specified, any
         values can be used as keys.
-    value_trait : a trait
+    value_trait : CTrait
         The trait type for values in the dictionary; if not specified, any
         values can be used as dictionary values.
     value_trait_handler : TraitHandler
@@ -3120,7 +3120,7 @@ class Map(TraitType):
             A dictionary whose keys are valid values for the trait attribute,
             and whose corresponding values are the values for the shadow
             trait attribute.
-        default_value : object, optional
+        default_value : any object, optional
             The default value for the trait. If given, this should be a key
             from the mapping. If not given, the first key from the mapping (in
             normal dictionary iteration order) will be used as the default.
@@ -3207,7 +3207,7 @@ class PrefixMap(TraitType):
         A dictionary whose keys are strings that are valid values for the
         trait attribute, and whose corresponding values are the values for
         the shadow trait attribute.
-    default_value : object, optional
+    default_value : any object, optional
         The default value for the trait. If given, this should be either a key
         from the mapping or a unique prefix of a key from the mapping. If not
         given, the first key from the mapping (in normal dictionary iteration

--- a/traits/traits.py
+++ b/traits/traits.py
@@ -550,7 +550,7 @@ def Property(
         **fget** and **fset**, and not look elsewhere on the class.
     handler : function
         A trait handler function for the trait.
-    trait : Trait or value
+    trait : Trait or any object
         A trait definition or a value that can be converted to a trait that
         constrains the values of the property trait.
     """


### PR DESCRIPTION
Fixes #1872.

Recent Python versions pull in Sphinx 9 for the documentation build, which broke it in two ways. This PR addresses both, so the doc-build CI (which runs under `-W`) passes again.

## 1. Theme crash

`enthought-sphinx-theme` versions before 0.7.4 use the deprecated str interface for Sphinx's `_CascadingStyleSheet`/`_JavaScript` assets, which was removed in Sphinx 9. The build aborted early with:

```
Theme error!
TypeError("argument of type '_CascadingStyleSheet' is not iterable")
```

0.7.4 (via enthought/enthought-sphinx-theme#25) fixes this, so `setup.py`'s `docs` extra now requires `enthought-sphinx-theme >= 0.7.4`.

## 2. Ambiguous cross-reference warnings

Sphinx 9's Python domain is stricter about cross-references. A docstring type annotation that is a bare identifier (`object`, `value`, `trait`, `module`, `new`) is resolved as a reference, and now warns `more than one target found` when it matches multiple documented attributes (`TraitListObject.object`, `TraitSetObject.value`, …). Under `-W` these 28 warnings became build errors.

The offending type annotations are disambiguated at the source:
- `HasTraits` where the value is the trait-owning object,
- the non-linkified phrase `any object` where the value is arbitrary,
- clearer unambiguous forms for the few remaining cases (`None or types.ModuleType`, `type, instance or str`, the `List.item_trait` attribute, and the `clone_traits` return).

This touches `ctraits.c` docstrings as well as the Python modules.

## Also included

- Bump the doc-build workflow to Python 3.13 (cherry-picked from the earlier `test-sphinx-theme-fix` investigation).

## Verification

Built the docs locally with Python 3.13, Sphinx 9.1.0, and enthought-sphinx-theme 0.7.4, exactly as CI does (`python -m sphinx -b html -W source build`): **build succeeds, exit 0, zero warnings**. `flake8` is clean, and a rebuilt-`ctraits` smoke test still validates and raises `TraitError` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)