### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.13'
 
@@ -27,7 +27,7 @@ jobs:
       run: python -m pip install twine
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v3.3.1
+      uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
 
     - name: Check wheels
       run: python -m twine check --strict wheelhouse/*.whl
@@ -45,10 +45,10 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.13'
 

--- a/.github/workflows/run-core-traits-tests.yml
+++ b/.github/workflows/run-core-traits-tests.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true

--- a/.github/workflows/run-style-checks-strict.yml
+++ b/.github/workflows/run-style-checks-strict.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.13'
     - name: Install dependencies and local packages

--- a/.github/workflows/run-style-checks.yml
+++ b/.github/workflows/run-style-checks.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.13'
     - name: Install dependencies and local packages

--- a/.github/workflows/run-traits-tests.yml
+++ b/.github/workflows/run-traits-tests.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true

--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.10'
     - name: Install dependencies and local packages

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }} (${{ matrix.platform.architecture }})
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.platform.architecture }}
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }} (${{ matrix.platform.architecture }})
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.platform.architecture }}


### PR DESCRIPTION
Security hardening for the GitHub Actions setup, following the reference pattern in enthought/envisage.

## Changes

- **Dependabot cooldown**: add a 7-day `cooldown` (`default-days: 7`) so freshly-published action releases aren't proposed immediately.
- **SHA-pinned actions**: replace mutable version tags with full 40-character commit hashes (keeping a `# vX.Y.Z` comment) across all workflows. Actions are pinned to the version currently in use — this is hardening, not an upgrade.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v6` | `@d23441a…af803 # v6.1.0` |
| `actions/setup-python` | `@v6` | `@ece7cb06…8c61a1 # v6.3.0` |
| `pypa/cibuildwheel` | `@v3.3.1` | `@298ed2fb…dd3a7e # v3.3.1` |

Tags were resolved against the GitHub API; the `setup-python` pin matches the one used in envisage. Dependabot will continue to update these while keeping the SHA authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)